### PR TITLE
[AAP-17878] Fix user NoneType error when local auth is used

### DIFF
--- a/ansible_base/authentication/common.py
+++ b/ansible_base/authentication/common.py
@@ -277,7 +277,7 @@ def get_or_create_authenticator_user(user_id, user_details, authenticator, extra
 
 def update_user_claims(user, database_authenticator, groups):
     if not user:
-        return
+        return None
 
     results = create_claims(database_authenticator, user.username, user.authenticator_user.extra, groups)
 

--- a/ansible_base/authentication/common.py
+++ b/ansible_base/authentication/common.py
@@ -276,6 +276,9 @@ def get_or_create_authenticator_user(user_id, user_details, authenticator, extra
 
 
 def update_user_claims(user, database_authenticator, groups):
+    if not user:
+        return
+
     results = create_claims(database_authenticator, user.username, user.authenticator_user.extra, groups)
 
     needs_save = False


### PR DESCRIPTION
This is to fix the following error when logging into EDA with its local auth with LDAP authenticator enabled:
```
2023-10-31 21:40:24,417 INFO     HTTP GET /api/eda/v1/auth/session/login/ 200 [0.03, 127.0.0.1:63061]
2023-10-31 21:40:24,589 ERROR    Encountered an error authenticating to LDAP Dev LDAP Container
Traceback (most recent call last):
  File "/Users/<user>/Library/Caches/pypoetry/virtualenvs/aap-eda-xKPBE2di-py3.11/lib/python3.11/site-packages/ansible_base/authenticator_plugins/ldap.py", line 316, in authenticate
    return update_user_claims(user_from_ldap, self.database_instance, users_groups)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/<user>/Library/Caches/pypoetry/virtualenvs/aap-eda-xKPBE2di-py3.11/lib/python3.11/site-packages/ansible_base/authentication/common.py", line 279, in update_user_claims
    results = create_claims(database_authenticator, user.username, user.authenticator_user.extra, groups)
                                                    ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'username'
```