### PR TITLE
Catch any kind of exception when attempting to load an authenticatior

### DIFF
--- a/ansible_base/authenticator_plugins/utils.py
+++ b/ansible_base/authenticator_plugins/utils.py
@@ -30,7 +30,7 @@ def get_authenticator_class(authenticator_type: str):
         logger.debug(f"Attempting to load class {authenticator_type}")
         auth_class = __import__(authenticator_type, globals(), locals(), ['AuthenticatorPlugin'], 0)
         return auth_class.AuthenticatorPlugin
-    except (ImportError, SyntaxError) as e:
+    except Exception as e:
         logger.exception(f"The specified authenticator type {authenticator_type} could not be loaded")
         raise ImportError(f"The specified authenticator type {authenticator_type} could not be loaded") from e
 


### PR DESCRIPTION
After trying both ImportError and SyntaxError another condition was found where the module had a bad import inside it. This change will allow us to catch any kind of exception a bad module could throw. 