### PR TITLE
AAP-17862 Fix SSO login

### DIFF
--- a/ansible_base/utils/middleware.py
+++ b/ansible_base/utils/middleware.py
@@ -1,16 +1,13 @@
-from django.conf import settings
 from django.contrib.auth import BACKEND_SESSION_KEY
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.deprecation import MiddlewareMixin
 
 from ansible_base.authenticator_plugins.utils import get_authenticator_plugins
-from ansible_base.authenticator_plugins.utils import setting as authenticator_prefix
 
 
 def get_authenticator_module_paths() -> list:
-    class_prefix = getattr(settings, authenticator_prefix, None)
     plugins = get_authenticator_plugins()
-    plugins = [f'{class_prefix}.{name}.AuthenticatorPlugin' for name in plugins]
+    plugins = [f'{name}.AuthenticatorPlugin' for name in plugins]
     return plugins
 
 


### PR DESCRIPTION
After changing authenticator types to fully qualified names the SSO login broke. This was due to not properly updating the middleware code that loaded the available plugins. This PR fixes the loading of the plugins.