### PR TITLE
Add UI labels for authenticator_plugin serializers

### DIFF
--- a/ansible_base/authenticator_plugins/base.py
+++ b/ansible_base/authenticator_plugins/base.py
@@ -3,9 +3,10 @@ import logging
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.fields import empty
-from rest_framework.serializers import JSONField, ValidationError
+from rest_framework.serializers import ValidationError
 
 from ansible_base.models import Authenticator
+from ansible_base.serializers.fields import JSONField
 
 logger = logging.getLogger('ansible_base.authentication.authenticator_lib')
 
@@ -13,9 +14,10 @@ logger = logging.getLogger('ansible_base.authentication.authenticator_lib')
 class BaseAuthenticatorConfiguration(serializers.Serializer):
     documentation_url = None
     ADDITIONAL_UNVERIFIED_ARGS = JSONField(
-        help_text="Any additional fields that this authenticator can take, they are not validated and passed directly back to the authenticator",
+        help_text=_("Any additional fields that this authenticator can take, they are not validated and passed directly back to the authenticator"),
         required=False,
         allow_null=True,
+        ui_field_label=_('Additional Authenticator Fields'),
     )
 
     def get_configuration_schema(self):
@@ -29,7 +31,16 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
             if field.default is not empty:
                 default = field.default
 
-            schema.append({"name": f, "help_text": field.help_text, "required": not field.allow_null, "default": default, "type": field.__class__.__name__})
+            schema.append(
+                {
+                    "name": f,
+                    "help_text": field.help_text,
+                    "required": not field.allow_null,
+                    "default": default,
+                    "type": field.__class__.__name__,
+                    "ui_field_label": getattr(field, 'ui_field_label', _('Undefined')),
+                }
+            )
         return schema
 
 

--- a/ansible_base/authenticator_plugins/keycloak.py
+++ b/ansible_base/authenticator_plugins/keycloak.py
@@ -1,12 +1,11 @@
 import logging
 
 from django.utils.translation import gettext_lazy as _
-from rest_framework import serializers
 from social_core.backends.keycloak import KeycloakOAuth2
 
 from ansible_base.authentication.social_auth import SocialAuthMixin
 from ansible_base.authenticator_plugins.base import AbstractAuthenticatorPlugin, BaseAuthenticatorConfiguration
-from ansible_base.serializers.fields import URLField
+from ansible_base.serializers.fields import CharField, URLField
 
 logger = logging.getLogger('ansible_base.authenticator_plugins.keycloak')
 
@@ -18,15 +17,29 @@ class KeycloakConfiguration(BaseAuthenticatorConfiguration):
         help_text=_("Location where this app can fetch the user's token from."),
         default="https://keycloak.example.com/auth/realms/<my_realm>/protocol/openid-connect/token",
         allow_null=False,
+        ui_field_label=_('Keycloak Access Token URL'),
     )
     AUTHORIZATION_URL = URLField(
         help_text=_("Location to redirect the user to during the login flow."),
         default="https://keycloak.example.com/auth/realms/<my_realm>/protocol/openid-connect/auth",
         allow_null=False,
+        ui_field_label=_('Keycloak Provider URL'),
     )
-    KEY = serializers.CharField(help_text=_("Keycloak Client ID."), allow_null=False)
-    PUBLIC_KEY = serializers.CharField(help_text=_("RS256 public key provided by your Keycloak ream."), allow_null=False)
-    SECRET = serializers.CharField(help_text=_("Keycloak Client secret."), allow_null=True)
+    KEY = CharField(
+        help_text=_("The OIDC key (Client ID) from your Keycloak installation."),
+        allow_null=False,
+        ui_field_label=_('Keycloak OIDC Key'),
+    )
+    PUBLIC_KEY = CharField(
+        help_text=_("RS256 public key provided by your Keycloak ream."),
+        allow_null=False,
+        ui_field_label=_('Keycloak Public Key'),
+    )
+    SECRET = CharField(
+        help_text=_("The OIDC secret (Client Secret) from your Keycloak installation."),
+        allow_null=True,
+        ui_field_label=_('Keycloak OIDC Secret'),
+    )
 
 
 class AuthenticatorPlugin(SocialAuthMixin, KeycloakOAuth2, AbstractAuthenticatorPlugin):

--- a/ansible_base/serializers/fields.py
+++ b/ansible_base/serializers/fields.py
@@ -6,7 +6,43 @@ from ansible_base.utils.validation import validate_url, validate_url_list
 User = get_user_model()
 
 
-class URLField(serializers.CharField):
+class UILabelMixIn:
+    def __init__(self, **kwargs):
+        self.ui_field_label = kwargs.pop('ui_field_label', 'Undefined')
+        super().__init__(**kwargs)
+
+
+class BooleanField(UILabelMixIn, serializers.BooleanField):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class CharField(UILabelMixIn, serializers.CharField):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ChoiceField(UILabelMixIn, serializers.ChoiceField):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DictField(UILabelMixIn, serializers.DictField):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ListField(UILabelMixIn, serializers.ListField):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class JSONField(UILabelMixIn, serializers.JSONField):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class URLField(UILabelMixIn, serializers.CharField):
     def __init__(self, **kwargs):
         self.schemes = kwargs.pop('schemes', ['https', 'http'])
         self.allow_plain_hostname = kwargs.pop('allow_plain_hostname', True)
@@ -18,7 +54,7 @@ class URLField(serializers.CharField):
         self.validators.append(validator)
 
 
-class URLListField(serializers.ListField):
+class URLListField(UILabelMixIn, serializers.ListField):
     def __init__(self, **kwargs):
         self.schemes = kwargs.pop('schemes', ['https', 'http'])
         self.allow_plain_hostname = kwargs.pop('allow_plain_hostname', True)
@@ -30,7 +66,7 @@ class URLListField(serializers.ListField):
         self.validators.append(validator)
 
 
-class UserAttrMap(serializers.DictField):
+class UserAttrMap(UILabelMixIn, serializers.DictField):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 


### PR DESCRIPTION
Introduce a MixIn class which will store the `ui_field_label` from the plugins' serializer fields.
Show the `ui_field_label` on the authenticator_plugin screen and default the value to `Undefined` if it was not properly added.
This field is for consumption by the UI to display the field names when configuring an authenticator_plugin.