### PR TITLE
[CI] Avoid using pyfakefs's fs fixture

### DIFF
--- a/ansible_base/tests/functional/authentication/test_authenticator_plugins_view.py
+++ b/ansible_base/tests/functional/authentication/test_authenticator_plugins_view.py
@@ -1,6 +1,7 @@
 import sys
 
 from django.urls import reverse
+from pyfakefs.fake_filesystem_unittest import Patcher
 
 
 def test_plugin_authenticator_view(admin_api_client):
@@ -18,17 +19,21 @@ def test_plugin_authenticator_view(admin_api_client):
     assert 'ansible_base.authenticator_plugins.local' in auth_types
 
 
-def test_plugin_authenticator_view_import_error(admin_api_client, fs, shut_up_logging):
+def test_plugin_authenticator_view_import_error(admin_api_client, shut_up_logging):
     """
     Test that import errors are returned as expected.
     """
-    # We use pyfakefs here, copy in the real directory, and then create a fake broken file.
-    fs.add_real_directory(sys.modules['ansible_base.authenticator_plugins'].__path__[0])
-    fs.create_file(sys.modules['ansible_base.authenticator_plugins'].__path__[0] + '/broken.py', contents='invalid')
-    fs.create_file(sys.modules['ansible_base.authenticator_plugins'].__path__[0] + '/really_broken.py', contents='invalid')
 
+    # We use pyfakefs here, copy in the real directory, and then create a fake broken file.
+    # We *avoid* the 'fs' fixture because it *breaks DRF in weird ways*.
     url = reverse("authenticator_plugin-view")
-    response = admin_api_client.get(url)
+
+    with Patcher() as patcher:
+        patcher.fs.add_real_directory(sys.modules['ansible_base.authenticator_plugins'].__path__[0])
+        patcher.fs.create_file(sys.modules['ansible_base.authenticator_plugins'].__path__[0] + '/broken.py', contents='invalid')
+        patcher.fs.create_file(sys.modules['ansible_base.authenticator_plugins'].__path__[0] + '/really_broken.py', contents='invalid')
+        response = admin_api_client.get(url)
+
     assert response.status_code == 200
     assert 'authenticators' in response.data
 


### PR DESCRIPTION
This took roughly a work day to track down. This issue only presented itself in certain conditions, based on how pytest-xdist split up the tests being run, into workers (e.g. a certain number of tests, and a certain value for -n). Originally the issue only showed up on GHA, but after much experimenting and shelling into the GHA Runner and playing around, I finally found that I was able to reproduce it locally as well by forcing -n to 4. But only on a branch that had more than a certain number of tests so that the grouping worked out to trigger the issue.

The issue manifested itself with this, seemingly completely unrelated error:

```
>       assert renderer, ".accepted_renderer not set on Response"
E       AssertionError: .accepted_renderer not set on Response

.tox/py311/lib/python3.11/site-packages/rest_framework/response.py:55: AssertionError
```

What is happening here is that the 'fs' fixture makes global changes to mock out the filesystem, and ultimately the issue is that it doesn't seem to clean up after itself (tear down) properly.

The exact details are a bit fuzzy to me still - and I've spent enough time trying to track this down - but what seems to be happening is that when it doesn't teardown properly, every other test in the same pytest-xdist worker that is expecting an error response fails spectacularly. In the end, Django tries to render an error template but it can't even find that, because the mocked filesystem is still in play.

The seemingly easy solution here, which seems to work fine, is to stop using the 'fs' fixture, and instead use a context manager to set up the files we need for this particular test. The context manager properly cleans up after itself, and things end up being green again.