### PR TITLE
Settings changes to allow database reuse with tests

### DIFF
--- a/ansible_base/tests/settings_overrides.py
+++ b/ansible_base/tests/settings_overrides.py
@@ -64,3 +64,19 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES = ['ansible_base.authenticator_plugins']
+
+# Must be defined to use management commands with test settings
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
+            ]
+        },
+    },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ exclude = [ 'ansible_base/migrations/*', '.tox', 'build']
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "ansible_base.tests.settings_overrides"
-addopts = "--strict-markers --reuse-db --create-db --migrations -s -vvv"
+addopts = "--strict-markers --reuse-db --migrations -s -vvv"
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
I found these changes were needed to get running locally with the tests. With this, you can do things like:

```
DJANGO_SETTINGS_MODULE=ansible_base.tests.settings_overrides python manage.py showmigrations
```

This will not show the migration status stored from the last test run, because you're using 2 different databases in your test settings for normal versus for running tests, which is cool. Totally fine.

But what I really wanted to establish is this:

```
time py.test ansible_base/tests/functional/authentication/test_ldap.py -k test_ldap_auth_failed
```

This will finish the test in 1.8 seconds on my machine. From Django Con @chrismeyersfsu and others and I talked a lot about options, and we converged on reusing the database as being the most practical to make development really fast.