### PR TITLE
Update ui_auth response to include custom login info and logo

### DIFF
--- a/ansible_base/tests/unit/utils/test_authentication.py
+++ b/ansible_base/tests/unit/utils/test_authentication.py
@@ -59,9 +59,10 @@ def test_generate_ui_auth_data_valid_login_info():
 
 @override_settings(custom_login_info=12343)
 @pytest.mark.django_db
-def test_generate_ui_auth_data_invalid_login_info(logger):
-    with pytest.raises(ValidationError):
+def test_generate_ui_auth_data_invalid_login_info():
+    with pytest.raises(ValidationError) as e:
         generate_ui_auth_data()
+    assert "custom_login_info was set but was not a valid string, ignoring" in str(e.value)
 
 
 @override_settings(custom_logo='data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=')

--- a/ansible_base/tests/unit/utils/test_authentication.py
+++ b/ansible_base/tests/unit/utils/test_authentication.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.test import override_settings
 
 from ansible_base.utils.authentication import generate_ui_auth_data
+from rest_framework.serializers import ValidationError
 
 
 @pytest.mark.django_db
@@ -56,12 +57,11 @@ def test_generate_ui_auth_data_valid_login_info():
     }
 
 
-@mock.patch("ansible_base.utils.authentication.logger")
 @override_settings(custom_login_info=12343)
 @pytest.mark.django_db
 def test_generate_ui_auth_data_invalid_login_info(logger):
-    generate_ui_auth_data()
-    logger.exception.assert_called_with('custom_login_info was set but was not a valid string, ignoring')
+    with pytest.raises(ValidationError) as e:
+        generate_ui_auth_data()
 
 
 @override_settings(custom_logo='data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=')
@@ -83,12 +83,12 @@ def test_generate_ui_auth_data_valid_logo_image():
 @pytest.mark.django_db
 def test_generate_ui_auth_data_invalid_logo_image_format(logger):
     generate_ui_auth_data()
-    logger.exception.assert_called_with('Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image.')
+    logger.exception.assert_called_with('custom_logo was set but was not a valid image data, ignoring')
 
 
 @mock.patch("ansible_base.utils.authentication.logger")
-@override_settings(custom_logo='data:image/gif;base64,badimagedata')
+@override_settings(custom_logo='data:image/gif;base64,baddata')
 @pytest.mark.django_db
 def test_generate_ui_auth_data_bad_logo_image_data(logger):
     generate_ui_auth_data()
-    logger.exception.assert_called_with('Invalid base64-encoded data in data URL.')
+    logger.exception.assert_called_with('custom_logo was set but was not a valid image data, ignoring')

--- a/ansible_base/tests/unit/utils/test_authentication.py
+++ b/ansible_base/tests/unit/utils/test_authentication.py
@@ -3,9 +3,9 @@ from unittest import mock
 import pytest
 from django.conf import settings
 from django.test import override_settings
+from rest_framework.serializers import ValidationError
 
 from ansible_base.utils.authentication import generate_ui_auth_data
-from rest_framework.serializers import ValidationError
 
 
 @pytest.mark.django_db
@@ -60,7 +60,7 @@ def test_generate_ui_auth_data_valid_login_info():
 @override_settings(custom_login_info=12343)
 @pytest.mark.django_db
 def test_generate_ui_auth_data_invalid_login_info(logger):
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(ValidationError):
         generate_ui_auth_data()
 
 

--- a/ansible_base/tests/unit/utils/test_authentication.py
+++ b/ansible_base/tests/unit/utils/test_authentication.py
@@ -15,6 +15,8 @@ def test_generate_ui_auth_data_no_authenticators_or_settings():
         'passwords': [],
         'show_login_form': False,
         'ssos': [],
+        'custom_login_info': '',
+        'custom_logo': '',
     }
 
 
@@ -27,6 +29,8 @@ def test_generate_ui_auth_data_valid_login_redirect():
         'passwords': [],
         'show_login_form': False,
         'ssos': [],
+        'custom_login_info': '',
+        'custom_logo': '',
     }
 
 
@@ -36,3 +40,55 @@ def test_generate_ui_auth_data_valid_login_redirect():
 def test_generate_ui_auth_data_invalid_login_redirect_function(logger):
     generate_ui_auth_data()
     logger.exception.assert_called_with('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
+
+
+@override_settings(custom_login_info='Login with your username and password')
+@pytest.mark.django_db
+def test_generate_ui_auth_data_valid_login_info():
+    response = generate_ui_auth_data()
+    assert response == {
+        'login_redirect_override': '',
+        'passwords': [],
+        'show_login_form': False,
+        'ssos': [],
+        'custom_login_info': 'Login with your username and password',
+        'custom_logo': '',
+    }
+
+
+@mock.patch("ansible_base.utils.authentication.logger")
+@override_settings(custom_login_info=12343)
+@pytest.mark.django_db
+def test_generate_ui_auth_data_invalid_login_info(logger):
+    generate_ui_auth_data()
+    logger.exception.assert_called_with('custom_login_info was set but was not a valid string, ignoring')
+
+
+@override_settings(custom_logo='data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=')
+@pytest.mark.django_db
+def test_generate_ui_auth_data_valid_logo_image():
+    response = generate_ui_auth_data()
+    assert response == {
+        'login_redirect_override': '',
+        'passwords': [],
+        'show_login_form': False,
+        'ssos': [],
+        'custom_login_info': '',
+        'custom_logo': 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=',
+    }
+
+
+@mock.patch("ansible_base.utils.authentication.logger")
+@override_settings(custom_logo='wrong formatted image data')
+@pytest.mark.django_db
+def test_generate_ui_auth_data_invalid_logo_image_format(logger):
+    generate_ui_auth_data()
+    logger.exception.assert_called_with('Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image.')
+
+
+@mock.patch("ansible_base.utils.authentication.logger")
+@override_settings(custom_logo='data:image/gif;base64,badimagedata')
+@pytest.mark.django_db
+def test_generate_ui_auth_data_bad_logo_image_data(logger):
+    generate_ui_auth_data()
+    logger.exception.assert_called_with('Invalid base64-encoded data in data URL.')

--- a/ansible_base/tests/unit/utils/test_validation.py
+++ b/ansible_base/tests/unit/utils/test_validation.py
@@ -95,10 +95,9 @@ def test_validate_image_data_with_wrong_format():
     Ensure that validate_image_data raises a ValidationError when data format doesn't match.
     """
     image_data = "image"
-    try:
+    with pytest.raises(ValidationError) as e:
         validate_image_data(image_data)
-    except ValidationError as ve:
-        assert ve.default_detail == "Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image."
+    assert "Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image." in str(e.value)
 
 
 def test_validate_image_data_with_bad_data():
@@ -106,10 +105,9 @@ def test_validate_image_data_with_bad_data():
     Ensure that validate_image_data raises a ValidationError when data is bad/corrupted.
     """
     image_data = "data:image/gif;base64,thisisbaddata"
-    try:
+    with pytest.raises(ValidationError) as e:
         validate_image_data(image_data)
-    except ValidationError as ve:
-        assert ve.default_detail == "Invalid base64-encoded data in data URL."
+    assert "Invalid base64-encoded data in data URL." in str(e.value)
 
 
 @pytest.mark.parametrize(

--- a/ansible_base/tests/unit/utils/test_validation.py
+++ b/ansible_base/tests/unit/utils/test_validation.py
@@ -1,7 +1,7 @@
 import pytest
 from rest_framework.exceptions import ValidationError
 
-from ansible_base.utils.validation import to_python_boolean, validate_cert_with_key, validate_url
+from ansible_base.utils.validation import to_python_boolean, validate_cert_with_key, validate_image_data, validate_url
 
 
 @pytest.mark.parametrize(
@@ -79,6 +79,37 @@ def test_validate_cert_with_key_mismatch(rsa_keypair_with_cert_1, rsa_keypair_wi
     with pytest.raises(ValidationError) as e:
         validate_cert_with_key(rsa_keypair_with_cert_1.certificate, rsa_keypair_with_cert_2.private)
     assert "The certificate and private key do not match" in str(e.value)
+
+
+def test_validate_image_data_with_valid_data():
+    """
+    Ensure that validate_image_data accepts valid data.
+    """
+    image_data = "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs="
+    res = validate_image_data(image_data)
+    assert res == None
+
+
+def test_validate_image_data_with_wrong_format():
+    """
+    Ensure that validate_image_data raises a ValidationError when data format doesn't match.
+    """
+    image_data = "image"
+    try:
+        validate_image_data(image_data)
+    except ValidationError as ve:
+        assert ve.default_detail == "Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image."
+
+
+def test_validate_image_data_with_bad_data():
+    """
+    Ensure that validate_image_data raises a ValidationError when data is bad/corrupted.
+    """
+    image_data = "data:image/gif;base64,thisisbaddata"
+    try:
+        validate_image_data(image_data)
+    except ValidationError as ve:
+        assert ve.default_detail == "Invalid base64-encoded data in data URL."
 
 
 @pytest.mark.parametrize(

--- a/ansible_base/tests/unit/utils/test_validation.py
+++ b/ansible_base/tests/unit/utils/test_validation.py
@@ -87,7 +87,7 @@ def test_validate_image_data_with_valid_data():
     """
     image_data = "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs="
     res = validate_image_data(image_data)
-    assert res == None
+    assert not res
 
 
 def test_validate_image_data_with_wrong_format():

--- a/ansible_base/utils/authentication.py
+++ b/ansible_base/utils/authentication.py
@@ -55,7 +55,7 @@ def generate_ui_auth_data():
         raise ValidationError("custom_login_info was set but was not a valid string, ignoring")
 
     try:
-        custom_logo = get_setting('custom_logo', None)
+        custom_logo = get_setting('custom_logo', '')
         validate_image_data(custom_logo)
         response['custom_logo'] = custom_logo
     except ValidationError:

--- a/ansible_base/utils/authentication.py
+++ b/ansible_base/utils/authentication.py
@@ -4,7 +4,7 @@ from rest_framework.serializers import ValidationError
 
 from ansible_base.models import Authenticator
 from ansible_base.utils.settings import get_setting
-from ansible_base.utils.validation import validate_url
+from ansible_base.utils.validation import validate_image_data, validate_url
 
 logger = logging.getLogger('ansible_base.utils.authentication')
 
@@ -16,6 +16,8 @@ def generate_ui_auth_data():
         'passwords': [],
         'ssos': [],
         'login_redirect_override': '',
+        'custom_login_info': '',
+        'custom_logo': '',
     }
 
     for authenticator in authenticators:
@@ -44,5 +46,19 @@ def generate_ui_auth_data():
         response['login_redirect_override'] = login_redirect_override
     except ValidationError:
         logger.exception('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
+
+    custom_login_info = get_setting('custom_login_info', '')
+    if isinstance(custom_login_info, str):
+        response['custom_login_info'] = custom_login_info
+    else:
+        logger.exception("custom_login_info was not a string")
+        raise ValidationError("custom_login_info was set but was not a valid string, ignoring")
+
+    try:
+        custom_logo = get_setting('custom_logo', None)
+        validate_image_data(custom_logo)
+        response['custom_logo'] = custom_logo
+    except ValidationError:
+        logger.exception("custom_logo was set but was not a valid image data, ignoring")
 
     return response

--- a/ansible_base/utils/validation.py
+++ b/ansible_base/utils/validation.py
@@ -113,12 +113,12 @@ def validate_image_data(data: str) -> None:
 
     match = CUSTOM_LOGO_RE.match(data)
     if not match:
-        raise ValidationError("Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image.")
+        raise ValidationError(_("Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image."))
     b64data = match.group(1)
     try:
         base64.b64decode(b64data)
     except (TypeError, binascii.Error):
-        raise ValidationError("Invalid base64-encoded data in data URL.")
+        raise ValidationError(_("Invalid base64-encoded data in data URL."))
 
 
 def to_python_boolean(value, allow_none=False):

--- a/ansible_base/utils/validation.py
+++ b/ansible_base/utils/validation.py
@@ -1,3 +1,6 @@
+import base64
+import binascii
+import re
 from urllib.parse import urlparse, urlunsplit
 
 from cryptography.exceptions import InvalidSignature
@@ -99,6 +102,19 @@ def validate_cert_with_key(public_cert_string, private_key_string):
         raise ValidationError(error)
 
     return True
+
+
+def validate_image_data(data: str) -> None:
+    CUSTOM_LOGO_RE = re.compile(r'^data:image/(?:png|jpeg|gif);base64,([A-Za-z0-9+/=]+?)$')
+
+    match = CUSTOM_LOGO_RE.match(data)
+    if not match:
+        raise ValidationError("Invalid format for custom logo. Must be a data URL with a base64-encoded GIF, PNG or JPEG image.")
+    b64data = match.group(1)
+    try:
+        base64.b64decode(b64data)
+    except (TypeError, binascii.Error):
+        raise ValidationError("Invalid base64-encoded data in data URL.")
 
 
 def to_python_boolean(value, allow_none=False):

--- a/ansible_base/utils/validation.py
+++ b/ansible_base/utils/validation.py
@@ -105,6 +105,10 @@ def validate_cert_with_key(public_cert_string, private_key_string):
 
 
 def validate_image_data(data: str) -> None:
+    # in case we are passed an empty string, we can skip validation
+    if not data:
+        return None
+
     CUSTOM_LOGO_RE = re.compile(r'^data:image/(?:png|jpeg|gif);base64,([A-Za-z0-9+/=]+?)$')
 
     match = CUSTOM_LOGO_RE.match(data)


### PR DESCRIPTION
* change `/ui_auth/` endpoint to return `custom_login_info` and `custom_logo` settings so the UI can consume it