### PR TITLE
chore: move auth log message to DEBUG level

### DIFF
--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -13,7 +13,7 @@ authentication_backends = OrderedDict()
 
 class AnsibleBaseAuth(ModelBackend):
     def authenticate(self, request, *args, **kwargs):
-        logger.info("Starting AnsibleBaseAuth authentication")
+        logger.debug("Starting AnsibleBaseAuth authentication")
 
         for database_authenticator in Authenticator.objects.filter(enabled=True):
             # Either get the existing object out of the backends or get a new one for us


### PR DESCRIPTION
For every request we have an entry log like: 
```
2024-01-12 13:28:18,153 ansible_base.authentication.backend INFO     Starting AnsibleBaseAuth authentication
```

We agreed to move it down to DEBUG. 