### PR TITLE
Allow using the admin pages to poke at models in test_app

### DIFF
--- a/ansible_base/tests/settings_overrides.py
+++ b/ansible_base/tests/settings_overrides.py
@@ -1,3 +1,5 @@
+DEBUG = True
+
 # noqa: F405
 DATABASES = {
     "default": {
@@ -80,6 +82,7 @@ SOCIAL_AUTH_LOGIN_REDIRECT_URL = "/api/v1/me"
 
 AUTHENTICATION_BACKENDS = [
     "ansible_base.authentication.backend.AnsibleBaseAuth",
+    "django.contrib.auth.backends.ModelBackend",  # for use by admin pages in test_app
 ]
 
 ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES = ['ansible_base.authenticator_plugins']
@@ -102,3 +105,7 @@ TEMPLATES = [
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 ANSIBLE_BASE_TEAM_MODEL = 'test_app.Team'
+
+STATIC_URL = '/static/'
+
+AUTH_USER_MODEL = 'auth.User'

--- a/ansible_base/tests/urls.py
+++ b/ansible_base/tests/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path, re_path
+from django.contrib import admin
 
 from ansible_base.urls import urls as base_urls
 
@@ -6,4 +7,5 @@ urlpatterns = [
     re_path(r'api/v1/', include(base_urls)),
     # Social auth
     path('api/social/', include('social_django.urls', namespace='social')),
+    re_path(r"^admin/", admin.site.urls, name="admin"),
 ]

--- a/ansible_base/tests/urls.py
+++ b/ansible_base/tests/urls.py
@@ -1,5 +1,5 @@
-from django.urls import include, path, re_path
 from django.contrib import admin
+from django.urls import include, path, re_path
 
 from ansible_base.urls import urls as base_urls
 

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ansible_base.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ansible_base.tests.settings_overrides')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/test_app/admin.py
+++ b/test_app/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 
-from test_app.models import EncryptionModel
+from test_app.models import EncryptionModel, Organization, Team
 
 
 admin.site.register(EncryptionModel)
+admin.site.register(Organization)
+admin.site.register(Team)

--- a/test_app/admin.py
+++ b/test_app/admin.py
@@ -1,3 +1,6 @@
-from django.contrib import admin  # noqa: F401
+from django.contrib import admin
 
-# Register your models here.
+from test_app.models import EncryptionModel
+
+
+admin.site.register(EncryptionModel)

--- a/test_app/admin.py
+++ b/test_app/admin.py
@@ -2,7 +2,6 @@ from django.contrib import admin
 
 from test_app.models import EncryptionModel, Organization, Team
 
-
 admin.site.register(EncryptionModel)
 admin.site.register(Organization)
 admin.site.register(Team)


### PR DESCRIPTION
This lets me make an encryption model in my browser.

![Screenshot from 2024-01-15 14-12-37](https://github.com/ansible/django-ansible-base/assets/1385596/7b909016-a62f-4ed8-a385-88aa05fab8ef)

Use of `AUTHENTICATION_BACKENDS` here may be controversial, so might as well put it out there.