### PR TITLE
Prevent error-prone logic from running on import

### DIFF
--- a/ansible_base/channels/middleware.py
+++ b/ansible_base/channels/middleware.py
@@ -6,17 +6,15 @@ from channels.auth import get_user as get_session_user
 from channels.db import database_sync_to_async
 from channels.security.websocket import WebsocketDenier
 from channels.sessions import CookieMiddleware, SessionMiddleware
-from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from rest_framework.request import Request
 from rest_framework.settings import api_settings
 
 logger = logging.getLogger(__name__)
-User = get_user_model()
 
 
 @database_sync_to_async
-def _get_authenticated_user(scope: dict) -> Optional[User]:
+def _get_authenticated_user(scope: dict):
     request = HttpRequest()
     request.META = {_http_key(k.decode()): v.decode() for (k, v) in scope["headers"]}
     auth_classes = [auth() for auth in api_settings.DEFAULT_AUTHENTICATION_CLASSES]

--- a/ansible_base/channels/middleware.py
+++ b/ansible_base/channels/middleware.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from channels.auth import AuthMiddleware
 from channels.auth import get_user as get_session_user

--- a/ansible_base/channels/middleware.py
+++ b/ansible_base/channels/middleware.py
@@ -6,6 +6,7 @@ from channels.auth import get_user as get_session_user
 from channels.db import database_sync_to_async
 from channels.security.websocket import WebsocketDenier
 from channels.sessions import CookieMiddleware, SessionMiddleware
+from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from rest_framework.request import Request
 from rest_framework.settings import api_settings
@@ -32,7 +33,7 @@ class DrfAuthMiddleware(AuthMiddleware):
         else:
             user = await _get_authenticated_user(scope)
 
-        if not user or not isinstance(user, User):
+        if not user or not isinstance(user, get_user_model()):
             logger.error("Websocket connection does not provide valid authentication")
             denier = WebsocketDenier()
             return await denier(scope, receive, send)

--- a/ansible_base/management/commands/authenticators.py
+++ b/ansible_base/management/commands/authenticators.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     HAS_TABULATE = False
 
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.timezone import now
 
@@ -59,7 +60,7 @@ class Command(BaseCommand):
         self.stdout.write('')
 
     def initialize_authenticators(self):
-        admin_user = User.objects.filter(username="admin").first()
+        admin_user = get_user_model().objects.filter(username="admin").first()
         if not admin_user:
             self.stderr.write("No admin user exists")
             exit(255)

--- a/ansible_base/management/commands/authenticators.py
+++ b/ansible_base/management/commands/authenticators.py
@@ -7,13 +7,10 @@ try:
 except ImportError:
     HAS_TABULATE = False
 
-from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.timezone import now
 
 from ansible_base.models import Authenticator, AuthenticatorUser
-
-User = get_user_model()
 
 
 class Command(BaseCommand):

--- a/ansible_base/models/common.py
+++ b/ansible_base/models/common.py
@@ -1,8 +1,8 @@
 import logging
 
 from crum import get_current_user
-from django.contrib.auth import get_user_model
 from django.db import models
+from django.conf import settings
 from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone
 from inflection import underscore
@@ -29,7 +29,7 @@ class CommonModel(models.Model):
         help_text="The date/time this resource was created",
     )
     created_by = models.ForeignKey(
-        get_user_model(),
+        settings.AUTH_USER_MODEL,
         related_name='%(app_label)s_%(class)s_created+',
         default=None,
         null=True,
@@ -43,7 +43,7 @@ class CommonModel(models.Model):
         help_text="The date/time this resource was created",
     )
     modified_by = models.ForeignKey(
-        get_user_model(),
+        settings.AUTH_USER_MODEL,
         related_name='%(app_label)s_%(class)s_modified+',
         default=None,
         null=True,

--- a/ansible_base/models/common.py
+++ b/ansible_base/models/common.py
@@ -1,8 +1,8 @@
 import logging
 
 from crum import get_current_user
-from django.db import models
 from django.conf import settings
+from django.db import models
 from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone
 from inflection import underscore

--- a/ansible_base/models/social_auth.py
+++ b/ansible_base/models/social_auth.py
@@ -1,10 +1,8 @@
-from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.db import models
 from social_django.models import AbstractUserSocialAuth
 
 from ansible_base.models import Authenticator
-
-USER_MODEL = get_user_model()
 
 
 class AuthenticatorUser(AbstractUserSocialAuth):
@@ -14,7 +12,7 @@ class AuthenticatorUser(AbstractUserSocialAuth):
     """
 
     provider = models.ForeignKey(Authenticator, to_field='slug', on_delete=models.PROTECT, related_name="authenticator_user")
-    user = models.ForeignKey(USER_MODEL, related_name="authenticator_user", on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="authenticator_user", on_delete=models.CASCADE)
     # TODO: set self.authenticated based on the provider that is passed to this method.
     # the provider should be the name of the Authenticator model instance
     claims = models.JSONField(default=dict, null=False)

--- a/ansible_base/serializers/fields.py
+++ b/ansible_base/serializers/fields.py
@@ -6,8 +6,6 @@ from rest_framework import serializers
 from ansible_base.utils.encryption import ENCRYPTED_STRING
 from ansible_base.utils.validation import validate_url, validate_url_list
 
-User = get_user_model()
-
 
 class UILabelMixIn:
     def __init__(self, **kwargs):
@@ -79,7 +77,7 @@ class UserAttrMap(UILabelMixIn, serializers.DictField):
             valid_user_attr_fields = set(["email", "username", "first_name", "last_name"])
             given_fields = set(list(value.keys()))
 
-            missing_required_fields = set(User.REQUIRED_FIELDS) - given_fields
+            missing_required_fields = set(get_user_model().REQUIRED_FIELDS) - given_fields
             for field in missing_required_fields:
                 errors[field] = "Must be present"
 

--- a/ansible_base/tests/settings_overrides.py
+++ b/ansible_base/tests/settings_overrides.py
@@ -109,3 +109,5 @@ ANSIBLE_BASE_TEAM_MODEL = 'test_app.Team'
 STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = 'auth.User'
+
+SECRET_KEY = ""

--- a/ansible_base/tests/settings_overrides.py
+++ b/ansible_base/tests/settings_overrides.py
@@ -109,5 +109,3 @@ ANSIBLE_BASE_TEAM_MODEL = 'test_app.Team'
 STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = 'auth.User'
-
-SECRET_KEY = ""

--- a/ansible_base/tests/unit/models/test_organization.py
+++ b/ansible_base/tests/unit/models/test_organization.py
@@ -6,8 +6,6 @@ from django.db import IntegrityError
 
 from test_app.models import Organization, Team
 
-User = get_user_model()
-
 
 @pytest.mark.django_db
 def test_organization_model():
@@ -30,7 +28,7 @@ def test_organization_model_unique():
 
 @pytest.mark.django_db
 def test_organization_model_users():
-    user = User.objects.create(username="alice")
+    user = get_user_model().objects.create(username="alice")
     org = Organization.objects.create(name="acme")
     org.users.add(user)
 

--- a/ansible_base/utils/encryption.py
+++ b/ansible_base/utils/encryption.py
@@ -5,6 +5,7 @@ from cryptography.fernet import Fernet
 from cryptography.hazmat.backends import default_backend
 from django.conf import settings
 from django.utils.encoding import smart_bytes, smart_str
+from django.utils.functional import SimpleLazyObject
 
 __all__ = [
     'ENCRYPTED_STRING',
@@ -69,4 +70,4 @@ class Fernet256(Fernet):
         return smart_str(value)
 
 
-ansible_encryption = Fernet256()
+ansible_encryption = SimpleLazyObject(func = lambda: Fernet256())

--- a/ansible_base/utils/encryption.py
+++ b/ansible_base/utils/encryption.py
@@ -70,4 +70,4 @@ class Fernet256(Fernet):
         return smart_str(value)
 
 
-ansible_encryption = SimpleLazyObject(func = lambda: Fernet256())
+ansible_encryption = SimpleLazyObject(func=lambda: Fernet256())


### PR DESCRIPTION
The Django docs say to use the settings for AUTH_USER_MODEL when defining fields, but `get_user_model` basically when running code. Having the user model available in the imports and for type annotations is not addressed, so I'm saying that's unsupported, thus we shouldn't do it.

The other bit with `SimpleLazyObject` is addressing a report that `awx-manage collectstatic` could give an error. Reproducer with test_app:

```
python manage.py --help
```

This will error if I insert `SECRET_KEY = ""` in the test settings. But with this change it works.