### PR TITLE
Avoid importing ansible_encryption at start up

### DIFF
--- a/ansible_base/models/common.py
+++ b/ansible_base/models/common.py
@@ -8,8 +8,6 @@ from django.utils import timezone
 from inflection import underscore
 from rest_framework.reverse import reverse
 
-from ansible_base.utils.encryption import ENCRYPTED_STRING, ansible_encryption
-
 logger = logging.getLogger('ansible_base.models.common')
 
 
@@ -73,6 +71,8 @@ class CommonModel(models.Model):
             update_fields.append('modified_by')
 
         # Encrypt any fields
+        from ansible_base.utils.encryption import ansible_encryption
+
         for field in self.encrypted_fields:
             field_value = getattr(self, field, None)
             if field_value:
@@ -83,6 +83,8 @@ class CommonModel(models.Model):
     @classmethod
     def from_db(self, db, field_names, values):
         instance = super().from_db(db, field_names, values)
+
+        from ansible_base.utils.encryption import ENCRYPTED_STRING, ansible_encryption
 
         for field in self.encrypted_fields:
             field_value = getattr(instance, field, None)


### PR DESCRIPTION
Importing of ansible_encryption trigger code that requires settings.SECRET_KEY which is not present in CI environment.

Example CI failure https://github.com/ansible/awx/actions/runs/7546412726/job/20544110452

CI test PR for awx with the code change https://github.com/ansible/awx/pull/14773