### PR TITLE
Add in defaults for team and org to avoid attribute errors

### DIFF
--- a/ansible_base/settings/dynamic_settings.py
+++ b/ansible_base/settings/dynamic_settings.py
@@ -4,6 +4,10 @@
 #     Add a new requirements/requirements_<section>.in /even if its an empty file/
 #
 
+# These settings will cause errors if not set, even if abstract models referencing them are not used
+ANSIBLE_BASE_TEAM_MODEL = 'auth.Group'
+ANSIBLE_BASE_ORGANIZATION_MODEL = 'auth.Group'
+
 
 if ANSIBLE_BASE_FEATURES.get('AUTHENTICATION', False):  # noqa: F821
     try:


### PR DESCRIPTION
Instead of documenting the problem like in https://github.com/ansible/django-ansible-base/pull/69, I think this mostly avoids it. As long as people are following @john-westcott-iv 's setup docs.

The org model won't work in practice, but this avoids people having to think about it if they're not even using the abstract bases.