### PR TITLE
Use existing org and team models if they exist

### DIFF
--- a/ansible_base/settings/dynamic_settings.py
+++ b/ansible_base/settings/dynamic_settings.py
@@ -4,9 +4,16 @@
 #     Add a new requirements/requirements_<section>.in /even if its an empty file/
 #
 
-# These settings will cause errors if not set, even if abstract models referencing them are not used
-ANSIBLE_BASE_TEAM_MODEL = 'auth.Group'
-ANSIBLE_BASE_ORGANIZATION_MODEL = 'auth.Group'
+# The org and team abstract models cause errors if not set, even if not used
+try:
+    ANSIBLE_BASE_TEAM_MODEL
+except NameError:
+    ANSIBLE_BASE_TEAM_MODEL = 'auth.Group'
+
+try:
+    ANSIBLE_BASE_ORGANIZATION_MODEL
+except NameError:
+    ANSIBLE_BASE_ORGANIZATION_MODEL = 'auth.Group'
 
 
 if ANSIBLE_BASE_FEATURES.get('AUTHENTICATION', False):  # noqa: F821


### PR DESCRIPTION
The try/NameError pattern is already all over this file and has become a de-facto standard. As such, we do not want these two settings to behave differently. That has nothing to do with the unconditionality of them (not feature-dependent) which their addition was intended to address.