### PR TITLE
Adding `choices` to the data shown by the serializer if it exists on the field (specifically for ChoiceField).

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -32,16 +32,18 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
             if field.default is not empty:
                 default = field.default
 
-            schema.append(
-                {
-                    "name": f,
-                    "help_text": field.help_text,
-                    "required": not field.allow_null,
-                    "default": default,
-                    "type": field.__class__.__name__,
-                    "ui_field_label": getattr(field, 'ui_field_label', _('Undefined')),
-                }
-            )
+            schema_data = {
+                "name": f,
+                "help_text": field.help_text,
+                "required": not field.allow_null,
+                "default": default,
+                "type": field.__class__.__name__,
+                "ui_field_label": getattr(field, 'ui_field_label', _('Undefined')),
+            }
+            if getattr(field, 'choices', None):
+                schema_data["choices"] = getattr(field, 'choices')
+
+            schema.append(schema_data)
         return schema
 
 

--- a/ansible_base/authentication/authenticator_plugins/utils.py
+++ b/ansible_base/authentication/authenticator_plugins/utils.py
@@ -46,7 +46,7 @@ def get_authenticator_urls(authenticator_type: str) -> list:
         urls = __import__(authenticator_type, globals(), locals(), ['urls'], 0)
         return urls
     except Exception as e:
-        logger.error(f"Failed to load urls form {authenticator_type} {e}")
+        logger.error(f"Failed to load urls from {authenticator_type} {e}")
     return None
 
 

--- a/ansible_base/lib/serializers/fields.py
+++ b/ansible_base/lib/serializers/fields.py
@@ -25,8 +25,6 @@ class CharField(UILabelMixIn, serializers.CharField):
 
 class ChoiceField(UILabelMixIn, serializers.ChoiceField):
     def __init__(self, **kwargs):
-        # TODO: SEE IF THIS WORKS FOR KEITH on the authenticator_plugin page see if its now shows options for the choice fields.
-        self.ui_field_label = kwargs.pop('ui_field_label', 'Undefined')
         super().__init__(**kwargs)
 
 


### PR DESCRIPTION
This allows for ChoiceFields to return their options through the serializers:
```
                {
                    "name": "GROUP_TYPE",
                    "help_text": "The group type may need to be changed based on the type of the LDAP server.  Values are listed at: https://django-auth-ldap.readthedocs.io/en/stable/groups.html#types-of-groups",
                    "required": true,
                    "default": null,
                    "type": "ChoiceField",
                    "ui_field_label": "LDAP Group Type",
                    "choices": {
                        "PosixGroupType": "PosixGroupType",
                        "MemberDNGroupType": "MemberDNGroupType",
                        "GroupOfNamesType": "GroupOfNamesType",
                        "GroupOfUniqueNamesType": "GroupOfUniqueNamesType",
                        "ActiveDirectoryGroupType": "ActiveDirectoryGroupType",
                        "OrganizationalRoleGroupType": "OrganizationalRoleGroupType",
                        "NestedMemberDNGroupType": "NestedMemberDNGroupType",
                        "NestedGroupOfNamesType": "NestedGroupOfNamesType",
                        "NestedGroupOfUniqueNamesType": "NestedGroupOfUniqueNamesType",
                        "NestedActiveDirectoryGroupType": "NestedActiveDirectoryGroupType",
                        "NestedOrganizationalRoleGroupType": "NestedOrganizationalRoleGroupType"
                    }
                },
```