### PR TITLE
Fix summary_fields for the User model, document expectations

### DIFF
--- a/ansible_base/authentication/apps.py
+++ b/ansible_base/authentication/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
 
 import ansible_base.lib.checks  # noqa: F401 - register checks
+from ansible_base.lib.utils.models import decorate_user_model
 
 
 class AuthenticationConfig(AppConfig):
@@ -8,3 +9,11 @@ class AuthenticationConfig(AppConfig):
     name = 'ansible_base.authentication'
     label = 'dab_authentication'
     verbose_name = 'Pluggable Authentication'
+
+    def ready(self):
+        """
+        This app offers an API and has relational links to the user model
+        so we must call this so that the User model has needed utility methods
+        expected by the common serializers.
+        """
+        decorate_user_model()

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -2,6 +2,8 @@ from itertools import chain
 
 from inflection import underscore
 
+from django.contrib.auth import get_user_model
+
 
 def get_all_field_names(model):
     # Implements compatibility with _meta.get_all_field_names
@@ -42,3 +44,17 @@ def prevent_search(relation):
     """
     setattr(relation, '__prevent_search__', True)
     return relation
+
+
+def user_summary_fields(user):
+    sf = {}
+    # field names come from from AWX awx.api.serializers
+    for field_name in ('id', 'username', 'first_name', 'last_name'):
+        sf[field_name] = getattr(user, field_name)
+    return sf
+
+
+def decorate_user_model():
+    user_cls = get_user_model()
+    if not hasattr(user_cls, 'summary_fields'):
+        user_cls.add_to_class('summary_fields', user_summary_fields)

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -47,7 +47,6 @@ def prevent_search(relation):
 
 def user_summary_fields(user):
     sf = {}
-    # field names come from from AWX awx.api.serializers
     for field_name in ('id', 'username', 'first_name', 'last_name'):
         sf[field_name] = getattr(user, field_name)
     return sf

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -1,8 +1,7 @@
 from itertools import chain
 
-from inflection import underscore
-
 from django.contrib.auth import get_user_model
+from inflection import underscore
 
 
 def get_all_field_names(model):

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -67,3 +67,7 @@ urlpatterns = [
     path('', include(root_urls)),
 ]
 ```
+
+This will not set up views for the user model, which is expected to be done by your application.
+However, serializers will link your own user detail view when applicable, assuming the view name "user-detail" exists.
+See the test_app/ folder if you need an example setup.

--- a/test_app/migrations/0001_initial.py
+++ b/test_app/migrations/0001_initial.py
@@ -11,9 +11,36 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('auth', '__first__')
     ]
 
     operations = [
+        migrations.CreateModel(
+            name='User',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(blank=True, null=True, verbose_name='last login')),
+                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
+                ('username', models.CharField(error_messages={'unique': 'A user with that username already exists.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()], verbose_name='username')),
+                ('first_name', models.CharField(blank=True, max_length=150, verbose_name='first name')),
+                ('last_name', models.CharField(blank=True, max_length=150, verbose_name='last name')),
+                ('email', models.EmailField(blank=True, max_length=254, verbose_name='email address')),
+                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
+                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', related_name='user_set', related_query_name='user', to='auth.group', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', related_query_name='user', to='auth.permission', verbose_name='user permissions')),
+            ],
+            options={
+                'verbose_name': 'user',
+                'verbose_name_plural': 'users',
+                'abstract': False,
+            },
+            managers=[
+                ('objects', django.contrib.auth.models.UserManager()),
+            ],
+        ),
         migrations.CreateModel(
             name='EncryptionModel',
             fields=[

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth.models import AbstractUser
 
 from ansible_base.lib.abstract_models import AbstractOrganization, AbstractTeam
 from ansible_base.lib.abstract_models.common import NamedCommonModel
@@ -16,6 +17,11 @@ class EncryptionModel(NamedCommonModel):
 
 class Organization(AbstractOrganization):
     pass
+
+
+class User(AbstractUser):
+    def summary_fields(self):
+        return {'username': self.username}
 
 
 class Team(AbstractTeam):

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -20,8 +20,7 @@ class Organization(AbstractOrganization):
 
 
 class User(AbstractUser):
-    def summary_fields(self):
-        return {'username': self.username}
+    pass
 
 
 class Team(AbstractTeam):

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -1,5 +1,5 @@
-from django.db import models
 from django.contrib.auth.models import AbstractUser
+from django.db import models
 
 from ansible_base.lib.abstract_models import AbstractOrganization, AbstractTeam
 from ansible_base.lib.abstract_models.common import NamedCommonModel

--- a/test_app/serializers.py
+++ b/test_app/serializers.py
@@ -1,9 +1,7 @@
 from rest_framework.serializers import ModelSerializer
 
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
-
-from test_app.models import User
-from test_app.models import EncryptionModel
+from test_app.models import EncryptionModel, User
 
 
 class EncryptionTestSerializer(NamedCommonModelSerializer):

--- a/test_app/serializers.py
+++ b/test_app/serializers.py
@@ -1,4 +1,8 @@
+from rest_framework.serializers import ModelSerializer
+
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
+
+from test_app.models import User
 from test_app.models import EncryptionModel
 
 
@@ -8,3 +12,9 @@ class EncryptionTestSerializer(NamedCommonModelSerializer):
     class Meta:
         model = EncryptionModel
         fields = NamedCommonModelSerializer.Meta.fields + [x.name for x in EncryptionModel._meta.concrete_fields]
+
+
+class UserSerializer(ModelSerializer):
+    class Meta:
+        model = User
+        fields = '__all__'

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -77,6 +77,8 @@ DATABASES = {
     }
 }
 
+AUTH_USER_MODEL = 'test_app.User'
+
 ROOT_URLCONF = 'test_app.urls'
 
 TEMPLATES = [

--- a/test_app/tests/authentication/views/test_authenticator_map.py
+++ b/test_app/tests/authentication/views/test_authenticator_map.py
@@ -33,7 +33,6 @@ def test_authenticator_map_detail(admin_api_client, local_authenticator_map):
     assert response.status_code == 200
     assert response.data['id'] == local_authenticator_map.id
     assert response.data['triggers'] == local_authenticator_map.triggers
-    assert response.data['summary_fields'] == {'foo': 'bar'}
 
 
 @pytest.mark.parametrize(

--- a/test_app/tests/authentication/views/test_authenticator_map.py
+++ b/test_app/tests/authentication/views/test_authenticator_map.py
@@ -33,6 +33,7 @@ def test_authenticator_map_detail(admin_api_client, local_authenticator_map):
     assert response.status_code == 200
     assert response.data['id'] == local_authenticator_map.id
     assert response.data['triggers'] == local_authenticator_map.triggers
+    assert response.data['summary_fields'] == {'foo': 'bar'}
 
 
 @pytest.mark.parametrize(

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -27,7 +27,7 @@ class TestJWTCommonAuth:
             assert "X-DAB-JW-TOKEN header not set for JWT authentication" in caplog.text
 
     @pytest.mark.django_db
-    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes'])
+    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'test_app'])
     def test_parse_jwt_happy_path(self, mocked_http, test_encryption_public_key, shut_up_logging, jwt_token):
         with override_settings(ANSIBLE_BASE_JWT_KEY=test_encryption_public_key):
             my_auth = JWTCommonAuth()

--- a/test_app/tests/lib/serializers/test_common.py
+++ b/test_app/tests/lib/serializers/test_common.py
@@ -1,11 +1,9 @@
 import pytest
+from crum import impersonate
 
 from ansible_base.authentication.models import AuthenticatorMap
 from ansible_base.lib.serializers.common import CommonModelSerializer
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
-
-from crum import impersonate
-
 from test_app.models import EncryptionModel
 from test_app.serializers import EncryptionTestSerializer
 
@@ -98,5 +96,5 @@ def test_summary_of_model_with_created_user(user, ldap_authenticator):
     assert serializer._get_related(model) == {
         'authenticator': f'/api/v1/authenticators/{ldap_authenticator.pk}/',
         'created_by': f'/api/v1/users/{user.pk}/',
-        'modified_by': f'/api/v1/users/{user.pk}/'
+        'modified_by': f'/api/v1/users/{user.pk}/',
     }

--- a/test_app/tests/lib/serializers/test_common.py
+++ b/test_app/tests/lib/serializers/test_common.py
@@ -90,8 +90,9 @@ def test_summary_of_model_with_created_user(user, ldap_authenticator):
     serializer = CommonModelSerializer()
 
     summary_fields = serializer._get_summary_fields(model)
-    assert summary_fields['created_by'] == {'username': user.username}
-    assert summary_fields['modified_by'] == {'username': user.username}
+    expected_summary = {'username': user.username, 'first_name': user.first_name, 'last_name': user.last_name, 'id': user.id}
+    assert summary_fields['created_by'] == expected_summary
+    assert summary_fields['modified_by'] == expected_summary
 
     assert serializer._get_related(model) == {
         'authenticator': f'/api/v1/authenticators/{ldap_authenticator.pk}/',

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -3,8 +3,12 @@ from django.urls import include, path, re_path
 
 from ansible_base.lib.dynamic_config.dynamic_urls import api_urls, api_version_urls, root_urls
 
+from test_app.views import router as user_router
+
+
 urlpatterns = [
     path('api/v1/', include(api_version_urls)),
+    path('api/v1/', include(user_router.urls)),
     path('api/', include(api_urls)),
     path('', include(root_urls)),
     # Admin application

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -6,9 +6,10 @@ from test_app.views import router as user_router
 
 urlpatterns = [
     path('api/v1/', include(api_version_urls)),
-    path('api/v1/', include(user_router.urls)),
     path('api/', include(api_urls)),
     path('', include(root_urls)),
+    # views specific to test_app
+    path('api/v1/', include(user_router.urls)),
     # Admin application
     re_path(r"^admin/", admin.site.urls, name="admin"),
 ]

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -2,9 +2,7 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 
 from ansible_base.lib.dynamic_config.dynamic_urls import api_urls, api_version_urls, root_urls
-
 from test_app.views import router as user_router
-
 
 urlpatterns = [
     path('api/v1/', include(api_version_urls)),

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,14 +1,9 @@
-from rest_framework import permissions, serializers
+from rest_framework import permissions
 from rest_framework.routers import SimpleRouter
 from rest_framework.viewsets import ModelViewSet
 
 from test_app.models import User
-
-
-class UserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = '__all__'
+from test_app.serializers import UserSerializer
 
 
 class UserViewSet(ModelViewSet):

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,3 +1,23 @@
-from django.shortcuts import render  # noqa: F401
+from rest_framework import serializers
+from rest_framework import permissions
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.routers import SimpleRouter
 
-# Create your views here.
+from test_app.models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = '__all__'
+
+
+class UserViewSet(ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+router = SimpleRouter()
+
+router.register(r'users', UserViewSet)

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,7 +1,6 @@
-from rest_framework import serializers
-from rest_framework import permissions
-from rest_framework.viewsets import ModelViewSet
+from rest_framework import permissions, serializers
 from rest_framework.routers import SimpleRouter
+from rest_framework.viewsets import ModelViewSet
 
 from test_app.models import User
 


### PR DESCRIPTION
So this doesn't really fix anything at this point, but it gets us to at least identifying the problem. Here, as you can see, I define a customer user model that defines `summary_fields`. Maybe this is a sufficient argument to put in a new abstract user model (beyond the `is_system_auditor` which I closed, but probably shouldn't have).