### PR TITLE
fix: change authenticate to return None instead of tuple

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -196,7 +196,7 @@ class JWTAuthentication(BaseAuthentication):
 
             return user, None
         else:
-            return None, None
+            return None
 
     def process_user_data(self, user, token):
         common_auth = JWTCommonAuth(self.map_fields)

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -272,7 +272,7 @@ class TestJWTAuthentication:
         with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.parse_jwt_token') as mock_parse:
             mock_parse.return_value = (None, {})
             jwt_auth = JWTAuthentication()
-            created_user, _ = jwt_auth.authenticate(mock.MagicMock())
+            created_user = jwt_auth.authenticate(mock.MagicMock())
             assert created_user is None
 
     def test_process_user_data(self):


### PR DESCRIPTION
When a user is not authenticated, we get a response with 403 Forbidden instead of 401 Unauthorized. This PR fixes this issue. 

NOTE: we still need to write tests around this but this is a quick fix to unblock [my PR on EDA](https://github.com/ansible/eda-server/pull/622) to fix QE pipelines.