### PR TITLE
Allow opting out of nonexistent sys user warning

### DIFF
--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -55,8 +55,7 @@ class CommonModel(models.Model):
         help_text="The user who last modified this resource",
     )
 
-    def save(self, *args, warn_nonexistent_system_user=True, **kwargs):
-        update_fields = list(kwargs.get('update_fields', []))
+    def _attributable_user(self):
         user = get_current_user()
         if user is None:
             # If no user is logged in, we try attributing the action to the system user
@@ -69,6 +68,12 @@ class CommonModel(models.Model):
                     if warn_nonexistent_system_user:
                         logger.warn(f"SYSTEM_USERNAME is set to {system_username} but no user with that username exists. User attribution will be None.")
                     user = None
+        return user
+
+
+    def save(self, *args, warn_nonexistent_system_user=True, **kwargs):
+        update_fields = list(kwargs.get('update_fields', []))
+        user = self._attributable_user()
 
         # Manually perform auto_now_add and auto_now logic.
         now = timezone.now()

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -55,7 +55,7 @@ class CommonModel(models.Model):
         help_text="The user who last modified this resource",
     )
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, warn_nonexistent_system_user=True, **kwargs):
         update_fields = list(kwargs.get('update_fields', []))
         user = get_current_user()
         if user is None:
@@ -66,7 +66,8 @@ class CommonModel(models.Model):
                 try:
                     user = get_user_model().objects.get(username=system_username)
                 except get_user_model().DoesNotExist:
-                    logger.error(f"SYSTEM_USERNAME is set to {system_username} but no user with that username exists. User attribution will be None.")
+                    if warn_nonexistent_system_user:
+                        logger.warn(f"SYSTEM_USERNAME is set to {system_username} but no user with that username exists. User attribution will be None.")
                     user = None
 
         # Manually perform auto_now_add and auto_now logic.

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -55,7 +55,7 @@ class CommonModel(models.Model):
         help_text="The user who last modified this resource",
     )
 
-    def _attributable_user(self):
+    def _attributable_user(self, warn_nonexistent_system_user):
         user = get_current_user()
         if user is None:
             # If no user is logged in, we try attributing the action to the system user
@@ -70,10 +70,9 @@ class CommonModel(models.Model):
                     user = None
         return user
 
-
     def save(self, *args, warn_nonexistent_system_user=True, **kwargs):
         update_fields = list(kwargs.get('update_fields', []))
-        user = self._attributable_user()
+        user = self._attributable_user(warn_nonexistent_system_user)
 
         # Manually perform auto_now_add and auto_now logic.
         now = timezone.now()

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -138,14 +138,17 @@ def expected_log(no_log_messages):
     """
 
     @contextmanager
-    def f(patch, severity, substr):
+    def f(patch, severity, substr, assert_not_called=False):
         with mock.patch(patch) as logger:
             with no_log_messages():
                 yield
             sev_logger = getattr(logger, severity)
-            sev_logger.assert_called_once()
-            args, kwargs = sev_logger.call_args
-            assert substr in args[0]
+            if assert_not_called:
+                sev_logger.assert_not_called()
+            else:
+                sev_logger.assert_called_once()
+                args, kwargs = sev_logger.call_args
+                assert substr in args[0]
 
     return f
 

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -36,14 +36,18 @@ def test_save_attribution_no_system_username():
 
 @pytest.mark.django_db
 @override_settings(SYSTEM_USERNAME='_system')
-def test_save_attribution_with_system_username_set_but_nonexistent(organization, expected_log):
+@pytest.mark.parametrize(
+    'warn_nonexistent_system_user',
+    (True, False),
+)
+def test_save_attribution_with_system_username_set_but_nonexistent(organization, expected_log, warn_nonexistent_system_user):
     expected_log = partial(expected_log, "ansible_base.lib.abstract_models.common.logger")
 
     assert organization.created_by is None
     assert organization.modified_by is None
 
-    with expected_log("error", "no user with that username exists"):
-        organization.save()
+    with expected_log("warn", "no user with that username exists", assert_not_called=not warn_nonexistent_system_user):
+        organization.save(warn_nonexistent_system_user=warn_nonexistent_system_user)
 
     assert organization.created_by is None
     assert organization.modified_by is None


### PR DESCRIPTION
Follow-up to #98.

This makes it so that apps setting up their system user have a way to call .save() without getting warned.

Also drops the severity from error to warning.