### PR TITLE
Fix login redirect override error on empty string

### DIFF
--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -57,6 +57,7 @@ def generate_ui_auth_data():
         # ignore validation if login_redirect_override is None or empty string
         if login_redirect_override is not None and login_redirect_override != '':
             validate_url(url=login_redirect_override, allow_plain_hostname=True)
+            response['login_redirect_override'] = login_redirect_override
     except ValidationError:
         logger.error('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
 

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -53,7 +53,7 @@ def generate_ui_auth_data():
             logger.error(f"Don't know how to handle authenticator of type {authenticator.type}")
 
     try:
-        login_redirect_override = get_setting('LOGIN_REDIRECT_OVERRIDE', None)
+        login_redirect_override = get_setting('LOGIN_REDIRECT_OVERRIDE', '')
         validate_url(url=login_redirect_override, allow_plain_hostname=True)
         response['login_redirect_override'] = login_redirect_override
     except ValidationError:

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -54,8 +54,9 @@ def generate_ui_auth_data():
 
     try:
         login_redirect_override = get_setting('LOGIN_REDIRECT_OVERRIDE', '')
-        validate_url(url=login_redirect_override, allow_plain_hostname=True)
-        response['login_redirect_override'] = login_redirect_override
+        # ignore validation if login_redirect_override is None or empty string
+        if login_redirect_override is not None and login_redirect_override != '':
+            validate_url(url=login_redirect_override, allow_plain_hostname=True)
     except ValidationError:
         logger.error('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
 

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -57,13 +57,13 @@ def generate_ui_auth_data():
         validate_url(url=login_redirect_override, allow_plain_hostname=True)
         response['login_redirect_override'] = login_redirect_override
     except ValidationError:
-        logger.exception('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
+        logger.error('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
 
     custom_login_info = get_setting('custom_login_info', '')
     if isinstance(custom_login_info, str):
         response['custom_login_info'] = custom_login_info
     else:
-        logger.exception("custom_login_info was not a string")
+        logger.error("custom_login_info was not a string")
         raise ValidationError("custom_login_info was set but was not a valid string, ignoring")
 
     try:
@@ -71,6 +71,6 @@ def generate_ui_auth_data():
         validate_image_data(custom_logo)
         response['custom_logo'] = custom_logo
     except ValidationError:
-        logger.exception("custom_logo was set but was not a valid image data, ignoring")
+        logger.error("custom_logo was set but was not a valid image data, ignoring")
 
     return response

--- a/ansible_base/lib/utils/validation.py
+++ b/ansible_base/lib/utils/validation.py
@@ -33,6 +33,9 @@ def validate_url_list(urls: list, schemes: list = ['https'], allow_plain_hostnam
 
 
 def validate_url(url: str, schemes: list = ['https'], allow_plain_hostname: bool = False) -> None:
+    # this captures both None and '' empty string scenarios
+    if not url:
+        return None
     if type(url) is not str:
         raise ValidationError(VALID_STRING)
     if allow_plain_hostname:

--- a/ansible_base/lib/utils/validation.py
+++ b/ansible_base/lib/utils/validation.py
@@ -33,9 +33,6 @@ def validate_url_list(urls: list, schemes: list = ['https'], allow_plain_hostnam
 
 
 def validate_url(url: str, schemes: list = ['https'], allow_plain_hostname: bool = False) -> None:
-    # this captures both None and '' empty string scenarios
-    if not url:
-        return None
     if type(url) is not str:
         raise ValidationError(VALID_STRING)
     if allow_plain_hostname:

--- a/test_app/tests/authentication/views/test_ui_auth.py
+++ b/test_app/tests/authentication/views/test_ui_auth.py
@@ -40,7 +40,7 @@ def test_generate_ui_auth_data_valid_login_redirect():
 @pytest.mark.django_db
 def test_generate_ui_auth_data_invalid_login_redirect_function(logger):
     generate_ui_auth_data()
-    logger.exception.assert_called_with('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
+    logger.error.assert_called_with('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
 
 
 @override_settings(custom_login_info='Login with your username and password')
@@ -84,7 +84,7 @@ def test_generate_ui_auth_data_valid_logo_image():
 @pytest.mark.django_db
 def test_generate_ui_auth_data_invalid_logo_image_format(logger):
     generate_ui_auth_data()
-    logger.exception.assert_called_with('custom_logo was set but was not a valid image data, ignoring')
+    logger.error.assert_called_with('custom_logo was set but was not a valid image data, ignoring')
 
 
 @mock.patch("ansible_base.authentication.views.ui_auth.logger")
@@ -92,4 +92,4 @@ def test_generate_ui_auth_data_invalid_logo_image_format(logger):
 @pytest.mark.django_db
 def test_generate_ui_auth_data_bad_logo_image_data(logger):
     generate_ui_auth_data()
-    logger.exception.assert_called_with('custom_logo was set but was not a valid image data, ignoring')
+    logger.error.assert_called_with('custom_logo was set but was not a valid image data, ignoring')


### PR DESCRIPTION
This PR aims to resolve the following exception error stack when LOGIN_REDIRECT_OVERRIDE is an empty string:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/ansible_base/authentication/views/ui_auth.py", line 57, in generate_ui_auth_data
    validate_url(url=login_redirect_override, allow_plain_hostname=True)
  File "/usr/lib/python3.9/site-packages/ansible_base/lib/utils/validation.py", line 64, in validate_url
    raise ValidationError(e.message)
rest_framework.exceptions.ValidationError: [ErrorDetail(string='Enter a valid URL.', code='invalid')]
```