### PR TITLE
Fix up Django admin for auth customizations

### DIFF
--- a/test_app/admin.py
+++ b/test_app/admin.py
@@ -1,7 +1,11 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import Group
 
-from test_app.models import EncryptionModel, Organization, Team
+from test_app.models import EncryptionModel, Organization, Team, User
 
 admin.site.register(EncryptionModel)
 admin.site.register(Organization)
 admin.site.register(Team)
+admin.site.register(User, UserAdmin)
+admin.site.unregister(Group)


### PR DESCRIPTION
Before this, I noticed it was still showing the auth app in the side bar, but the only model listed was `Group`, which is... a model that we don't use in any way in any app.

So this unregisters that model and adds the user model. So now we have a nicely organized trifecta of org/user/team in the admin page. I find this very pleasing with the demo data from `./test_app/scripts/bootstrap.sh`

![Screenshot from 2024-01-31 08-27-27](https://github.com/ansible/django-ansible-base/assets/1385596/626c0763-2d98-49a0-b639-b40f8d3063e7)
