### PR TITLE
Add ViewWithHeaders which add custom headers

### DIFF
--- a/ansible_base/authentication/views/authenticator.py
+++ b/ansible_base/authentication/views/authenticator.py
@@ -6,11 +6,12 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap, AuthenticatorUser
 from ansible_base.authentication.serializers import AuthenticatorMapSerializer, AuthenticatorSerializer
+from ansible_base.lib.utils.views import ViewWithHeaders
 
 logger = logging.getLogger('ansible_base.authentication.views.authenticator')
 
 
-class AuthenticatorViewSet(ModelViewSet):
+class AuthenticatorViewSet(ModelViewSet, ViewWithHeaders):
     """
     API endpoint that allows authenticators to be viewed or edited.
     """
@@ -32,7 +33,7 @@ class AuthenticatorViewSet(ModelViewSet):
             return super().destroy(request, *args, **kwargs)
 
 
-class AuthenticatorAuthenticatorMapViewSet(ModelViewSet):
+class AuthenticatorAuthenticatorMapViewSet(ModelViewSet, ViewWithHeaders):
     serializer_class = AuthenticatorMapSerializer
 
     def get_queryset(self):

--- a/ansible_base/authentication/views/authenticator.py
+++ b/ansible_base/authentication/views/authenticator.py
@@ -6,12 +6,12 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap, AuthenticatorUser
 from ansible_base.authentication.serializers import AuthenticatorMapSerializer, AuthenticatorSerializer
-from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 logger = logging.getLogger('ansible_base.authentication.views.authenticator')
 
 
-class AuthenticatorViewSet(ModelViewSet, AnsibleBaseDjanoAppApiView):
+class AuthenticatorViewSet(ModelViewSet, AnsibleBaseDjangoAppApiView):
     """
     API endpoint that allows authenticators to be viewed or edited.
     """
@@ -33,7 +33,7 @@ class AuthenticatorViewSet(ModelViewSet, AnsibleBaseDjanoAppApiView):
             return super().destroy(request, *args, **kwargs)
 
 
-class AuthenticatorAuthenticatorMapViewSet(ModelViewSet, AnsibleBaseDjanoAppApiView):
+class AuthenticatorAuthenticatorMapViewSet(ModelViewSet, AnsibleBaseDjangoAppApiView):
     serializer_class = AuthenticatorMapSerializer
 
     def get_queryset(self):

--- a/ansible_base/authentication/views/authenticator.py
+++ b/ansible_base/authentication/views/authenticator.py
@@ -6,12 +6,12 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap, AuthenticatorUser
 from ansible_base.authentication.serializers import AuthenticatorMapSerializer, AuthenticatorSerializer
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
 
 logger = logging.getLogger('ansible_base.authentication.views.authenticator')
 
 
-class AuthenticatorViewSet(ModelViewSet, ViewWithHeaders):
+class AuthenticatorViewSet(ModelViewSet, AnsibleBaseDjanoAppApiView):
     """
     API endpoint that allows authenticators to be viewed or edited.
     """
@@ -33,7 +33,7 @@ class AuthenticatorViewSet(ModelViewSet, ViewWithHeaders):
             return super().destroy(request, *args, **kwargs)
 
 
-class AuthenticatorAuthenticatorMapViewSet(ModelViewSet, ViewWithHeaders):
+class AuthenticatorAuthenticatorMapViewSet(ModelViewSet, AnsibleBaseDjanoAppApiView):
     serializer_class = AuthenticatorMapSerializer
 
     def get_queryset(self):

--- a/ansible_base/authentication/views/authenticator_map.py
+++ b/ansible_base/authentication/views/authenticator_map.py
@@ -3,10 +3,10 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.authentication.models import AuthenticatorMap
 from ansible_base.authentication.serializers import AuthenticatorMapSerializer
-from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 
-class AuthenticatorMapViewSet(ModelViewSet, AnsibleBaseDjanoAppApiView):
+class AuthenticatorMapViewSet(ModelViewSet, AnsibleBaseDjangoAppApiView):
     """
     API endpoint that allows authenticator maps to be viewed or edited.
     """

--- a/ansible_base/authentication/views/authenticator_map.py
+++ b/ansible_base/authentication/views/authenticator_map.py
@@ -3,9 +3,10 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.authentication.models import AuthenticatorMap
 from ansible_base.authentication.serializers import AuthenticatorMapSerializer
+from ansible_base.lib.utils.views import ViewWithHeaders
 
 
-class AuthenticatorMapViewSet(ModelViewSet):
+class AuthenticatorMapViewSet(ModelViewSet, ViewWithHeaders):
     """
     API endpoint that allows authenticator maps to be viewed or edited.
     """

--- a/ansible_base/authentication/views/authenticator_map.py
+++ b/ansible_base/authentication/views/authenticator_map.py
@@ -3,10 +3,10 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.authentication.models import AuthenticatorMap
 from ansible_base.authentication.serializers import AuthenticatorMapSerializer
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
 
 
-class AuthenticatorMapViewSet(ModelViewSet, ViewWithHeaders):
+class AuthenticatorMapViewSet(ModelViewSet, AnsibleBaseDjanoAppApiView):
     """
     API endpoint that allows authenticator maps to be viewed or edited.
     """

--- a/ansible_base/authentication/views/authenticator_plugins.py
+++ b/ansible_base/authentication/views/authenticator_plugins.py
@@ -1,10 +1,10 @@
 from rest_framework.response import Response
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class, get_authenticator_plugins
-from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 
-class AuthenticatorPluginView(AnsibleBaseDjanoAppApiView):
+class AuthenticatorPluginView(AnsibleBaseDjangoAppApiView):
     def get(self, request, format=None):
         plugins = get_authenticator_plugins()
         resp = {"authenticators": []}

--- a/ansible_base/authentication/views/authenticator_plugins.py
+++ b/ansible_base/authentication/views/authenticator_plugins.py
@@ -1,10 +1,10 @@
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class, get_authenticator_plugins
+from ansible_base.lib.utils.views import ViewWithHeaders
 
 
-class AuthenticatorPluginView(APIView):
+class AuthenticatorPluginView(ViewWithHeaders):
     def get(self, request, format=None):
         plugins = get_authenticator_plugins()
         resp = {"authenticators": []}

--- a/ansible_base/authentication/views/authenticator_plugins.py
+++ b/ansible_base/authentication/views/authenticator_plugins.py
@@ -1,10 +1,10 @@
 from rest_framework.response import Response
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class, get_authenticator_plugins
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
 
 
-class AuthenticatorPluginView(ViewWithHeaders):
+class AuthenticatorPluginView(AnsibleBaseDjanoAppApiView):
     def get(self, request, format=None):
         plugins = get_authenticator_plugins()
         resp = {"authenticators": []}

--- a/ansible_base/authentication/views/trigger_definition.py
+++ b/ansible_base/authentication/views/trigger_definition.py
@@ -1,9 +1,9 @@
 from rest_framework.response import Response
 
 from ansible_base.authentication.utils.trigger_definition import TRIGGER_DEFINITION
-from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 
-class TriggerDefinitionView(AnsibleBaseDjanoAppApiView):
+class TriggerDefinitionView(AnsibleBaseDjangoAppApiView):
     def get(self, request, format=None):
         return Response(TRIGGER_DEFINITION)

--- a/ansible_base/authentication/views/trigger_definition.py
+++ b/ansible_base/authentication/views/trigger_definition.py
@@ -1,9 +1,9 @@
 from rest_framework.response import Response
 
 from ansible_base.authentication.utils.trigger_definition import TRIGGER_DEFINITION
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
 
 
-class TriggerDefinitionView(ViewWithHeaders):
+class TriggerDefinitionView(AnsibleBaseDjanoAppApiView):
     def get(self, request, format=None):
         return Response(TRIGGER_DEFINITION)

--- a/ansible_base/authentication/views/trigger_definition.py
+++ b/ansible_base/authentication/views/trigger_definition.py
@@ -1,9 +1,9 @@
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from ansible_base.authentication.utils.trigger_definition import TRIGGER_DEFINITION
+from ansible_base.lib.utils.views import ViewWithHeaders
 
 
-class TriggerDefinitionView(APIView):
+class TriggerDefinitionView(ViewWithHeaders):
     def get(self, request, format=None):
         return Response(TRIGGER_DEFINITION)

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -6,12 +6,12 @@ from rest_framework.serializers import ValidationError
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.lib.utils.validation import validate_image_data, validate_url
-from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 logger = logging.getLogger('ansible_base.authentication.views.ui_auth')
 
 
-class UIAuth(AnsibleBaseDjanoAppApiView):
+class UIAuth(AnsibleBaseDjangoAppApiView):
     authentication_classes = []
     permission_classes = []
 

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -6,12 +6,12 @@ from rest_framework.serializers import ValidationError
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.lib.utils.validation import validate_image_data, validate_url
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
 
 logger = logging.getLogger('ansible_base.authentication.views.ui_auth')
 
 
-class UIAuth(ViewWithHeaders):
+class UIAuth(AnsibleBaseDjanoAppApiView):
     authentication_classes = []
     permission_classes = []
 

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -2,16 +2,16 @@ import logging
 
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
-from rest_framework.views import APIView
 
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.lib.utils.validation import validate_image_data, validate_url
+from ansible_base.lib.utils.views import ViewWithHeaders
 
 logger = logging.getLogger('ansible_base.authentication.views.ui_auth')
 
 
-class UIAuth(APIView):
+class UIAuth(ViewWithHeaders):
     authentication_classes = []
     permission_classes = []
 

--- a/ansible_base/jwt_consumer/views.py
+++ b/ansible_base/jwt_consumer/views.py
@@ -9,12 +9,12 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, permissions
 
 from ansible_base.lib.utils.settings import get_setting
-from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 logger = logging.getLogger('ansible_base.jwt_consumer.views')
 
 
-class PlatformUIRedirectView(AnsibleBaseDjanoAppApiView):
+class PlatformUIRedirectView(AnsibleBaseDjangoAppApiView):
     authentication_classes = []
     permission_classes = (permissions.AllowAny,)
     metadata_class = None

--- a/ansible_base/jwt_consumer/views.py
+++ b/ansible_base/jwt_consumer/views.py
@@ -6,14 +6,15 @@ from urllib.parse import urlparse, urlunsplit
 from django.http import HttpResponse, HttpResponseNotFound
 from django.template import Context, Template
 from django.utils.translation import gettext_lazy as _
-from rest_framework import exceptions, permissions, views
+from rest_framework import exceptions, permissions
 
 from ansible_base.lib.utils.settings import get_setting
+from ansible_base.lib.utils.views import ViewWithHeaders
 
 logger = logging.getLogger('ansible_base.jwt_consumer.views')
 
 
-class PlatformUIRedirectView(views.APIView):
+class PlatformUIRedirectView(ViewWithHeaders):
     authentication_classes = []
     permission_classes = (permissions.AllowAny,)
     metadata_class = None

--- a/ansible_base/jwt_consumer/views.py
+++ b/ansible_base/jwt_consumer/views.py
@@ -9,12 +9,12 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, permissions
 
 from ansible_base.lib.utils.settings import get_setting
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
 
 logger = logging.getLogger('ansible_base.jwt_consumer.views')
 
 
-class PlatformUIRedirectView(ViewWithHeaders):
+class PlatformUIRedirectView(AnsibleBaseDjanoAppApiView):
     authentication_classes = []
     permission_classes = (permissions.AllowAny,)
     metadata_class = None

--- a/ansible_base/lib/utils/settings.py
+++ b/ansible_base/lib/utils/settings.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger('ansible_base.lib.utils.settings')
 
@@ -12,20 +13,31 @@ class SettingNotSetException(Exception):
 
 
 def get_setting(name: str, default: Any = None) -> Any:
-    settings_function = getattr(settings, 'ANSIBLE_BASE_SETTINGS_FUNCTION', None)
-    if settings_function:
-        try:
-            module_name, _, function_name = settings_function.rpartition('.')
-            the_function = getattr(importlib.import_module(module_name), function_name)
+    try:
+        the_function = get_function_from_setting('ANSIBLE_BASE_SETTINGS_FUNCTION')
+        if the_function:
             setting = the_function(name)
             return setting
-        except SettingNotSetException:
-            # If the setting was not set thats ok, we will fall through to trying to get it from the django setting or the default value
-            pass
-        except Exception:
-            logger.exception(
-                'ANSIBLE_BASE_SETTINGS_FUNCTION was set but calling it as a function failed (see exception), '
-                'ignoring error and attempting to load from settings'
-            )
+    except SettingNotSetException:
+        # If the setting was not set thats ok, we will fall through to trying to get it from the django setting or the default value
+        pass
+    except Exception:
+        logger.exception(
+            _('ANSIBLE_BASE_SETTINGS_FUNCTION was set but calling it as a function failed (see exception), ignoring error and attempting to load from settings')
+        )
 
     return getattr(settings, name, default)
+
+
+def get_function_from_setting(setting_name: str) -> Any:
+    setting = getattr(settings, setting_name, None)
+    if not setting:
+        return None
+
+    try:
+        module_name, _, function_name = setting.rpartition('.')
+        the_function = getattr(importlib.import_module(module_name), function_name)
+        return the_function
+    except Exception:
+        logger.exception(_('{setting_name} was set but we were unable to import its reference as a function.').format(setting_name=setting_name))
+        return None

--- a/ansible_base/lib/utils/views.py
+++ b/ansible_base/lib/utils/views.py
@@ -1,21 +1,84 @@
 import logging
+import time
 
 from django.conf import settings
+from django.db import connection
+from django.utils.translation import gettext_lazy as _
 from rest_framework import views
+from rest_framework.exceptions import AuthenticationFailed, ParseError, PermissionDenied, UnsupportedMediaType
+
+from ansible_base.lib.utils.settings import get_function_from_setting
 
 logger = logging.getLogger('ansible_base.lib.utils.views')
 
 
-setting = 'ANSIBLE_BASE_EXTRA_HEADERS'
+class AnsibleBaseView(views.APIView):
+    def initialize_request(self, request, *args, **kwargs):
+        """
+        Store the Django REST Framework Request object as an attribute on the
+        normal Django request, store time the request started.
+        """
+        self.time_started = time.time()
+        if getattr(settings, 'SQL_DEBUG', False):
+            self.queries_before = len(connection.queries)
 
+        # If there are any custom headers in REMOTE_HOST_HEADERS, make sure
+        # they respect the allowed proxy list
+        if all(
+            [
+                settings.PROXY_IP_ALLOWED_LIST,
+                request.environ.get('REMOTE_ADDR') not in settings.PROXY_IP_ALLOWED_LIST,
+                request.environ.get('REMOTE_HOST') not in settings.PROXY_IP_ALLOWED_LIST,
+            ]
+        ):
+            for custom_header in settings.REMOTE_HOST_HEADERS:
+                if custom_header.startswith('HTTP_'):
+                    request.environ.pop(custom_header, None)
 
-class ViewWithHeaders(views.APIView):
+        drf_request = super().initialize_request(request, *args, **kwargs)
+        request.drf_request = drf_request
+        try:
+            request.drf_request_user = getattr(drf_request, 'user', False)
+        except AuthenticationFailed:
+            request.drf_request_user = None
+        except (PermissionDenied, ParseError) as exc:
+            request.drf_request_user = None
+            self.__init_request_error__ = exc
+        except UnsupportedMediaType as exc:
+            exc.detail = _(
+                'You did not use correct Content-Type in your HTTP request. If you are using our REST API, the Content-Type must be application/json'
+            )
+            self.__init_request_error__ = exc
+        return drf_request
+
     def finalize_response(self, request, response, *args, **kwargs):
         response = super().finalize_response(request, response, *args, **kwargs)
-        for name, value in getattr(settings, setting, {}).items():
-            if isinstance(name, str) and isinstance(value, str):
-                response[name] = value
-            else:
-                logger.error(f"When adding a custom header expected (str,str) but got ({type(name)}, {type(value)}) please check your {setting} settings")
+
+        if request.user.is_authenticated:
+            version = 'Unknown'
+            try:
+                the_function = get_function_from_setting('ANSIBLE_BASE_PRODUCT_VERSION_FUNCTION')
+                version = the_function()
+            except Exception:
+                logger.exception(_('ANSIBLE_BASE_PRODUCT_VERSION_FUNCTION was set but calling it as a function failed (see exception).'))
+
+            response['X-API-Product-Version'] = version
+
+        response['X-API-Product-Name'] = getattr(settings, 'ANSIBLE_BASE_PRODUCT_NAME', _('Unnamed'))
+        response['X-API-Node'] = getattr(settings, 'CLUSTER_HOST_ID', _('Unknown'))
+
+        time_started = getattr(self, 'time_started', None)
+        if time_started:
+            time_elapsed = time.time() - self.time_started
+            response['X-API-Time'] = '%0.3fs' % time_elapsed
+
+        if getattr(settings, 'SQL_DEBUG', False):
+            queries_before = getattr(self, 'queries_before', 0)
+            q_times = [float(q['time']) for q in connection.queries[queries_before:]]
+            response['X-API-Query-Count'] = len(q_times)
+            response['X-API-Query-Time'] = '%0.3fs' % sum(q_times)
+
+        if getattr(self, 'deprecated', False):
+            response['Warning'] = _('This resource has been deprecated and will be removed in a future release.')
 
         return response

--- a/ansible_base/lib/utils/views.py
+++ b/ansible_base/lib/utils/views.py
@@ -3,9 +3,7 @@ import logging
 import time
 
 from django.conf import settings
-from django.db import connection
 from django.utils.translation import gettext_lazy as _
-from rest_framework.exceptions import AuthenticationFailed, ParseError, PermissionDenied, UnsupportedMediaType
 from rest_framework.views import APIView
 
 from ansible_base.lib.utils.settings import get_function_from_setting, get_setting
@@ -20,48 +18,26 @@ class AnsibleBaseView(APIView):
         normal Django request, store time the request started.
         """
         self.time_started = time.time()
-        if get_setting('SQL_DEBUG', False):
-            self.queries_before = len(connection.queries)
 
-        # If there are any custom headers in REMOTE_HOST_HEADERS, make sure
-        # they respect the allowed proxy list
-        proxy_ip_allowed_list = get_setting('PROXY_IP_ALLOWED_LIST', None)
-        if proxy_ip_allowed_list and all(
-            [
-                request.environ.get('REMOTE_ADDR') not in proxy_ip_allowed_list,
-                request.environ.get('REMOTE_HOST') not in proxy_ip_allowed_list,
-            ]
-        ):
-            for custom_header in get_setting('REMOTE_HOST_HEADERS', None):
-                if custom_header.startswith('HTTP_'):
-                    request.environ.pop(custom_header, None)
-
-        drf_request = super().initialize_request(request, *args, **kwargs)
-        request.drf_request = drf_request
-        try:
-            request.drf_request_user = getattr(drf_request, 'user', False)
-        except AuthenticationFailed:
-            request.drf_request_user = None
-        except (PermissionDenied, ParseError) as exc:
-            request.drf_request_user = None
-            self.__init_request_error__ = exc
-        except UnsupportedMediaType as exc:
-            exc.detail = _(
-                'You did not use correct Content-Type in your HTTP request. If you are using our REST API, the Content-Type must be application/json'
-            )
-            self.__init_request_error__ = exc
-        return drf_request
+        return super().initialize_request(request, *args, **kwargs)
 
     def finalize_response(self, request, response, *args, **kwargs):
         response = super().finalize_response(request, response, *args, **kwargs)
 
-        if request.user.is_authenticated:
+        if request.user and request.user.is_authenticated:
             version = 'Unknown'
+            setting = 'ANSIBLE_BASE_PRODUCT_VERSION_FUNCTION'
+            the_function = None
             try:
-                the_function = get_function_from_setting('ANSIBLE_BASE_PRODUCT_VERSION_FUNCTION')
-                version = the_function()
+                the_function = get_function_from_setting(setting)
             except Exception:
-                logger.exception(_('ANSIBLE_BASE_PRODUCT_VERSION_FUNCTION was set but calling it as a function failed (see exception).'))
+                logger.exception(_('Failed to load function from {setting} (see exception)'.format(setting=setting)))
+
+            if the_function:
+                try:
+                    version = the_function()
+                except Exception:
+                    logger.exception(_('{setting} was set but calling it as a function failed (see exception).'.format(setting=setting)))
 
             response['X-API-Product-Version'] = version
 
@@ -72,12 +48,6 @@ class AnsibleBaseView(APIView):
         if time_started:
             time_elapsed = time.time() - self.time_started
             response['X-API-Time'] = '%0.3fs' % time_elapsed
-
-        if get_setting('SQL_DEBUG', False):
-            queries_before = getattr(self, 'queries_before', 0)
-            q_times = [float(q['time']) for q in connection.queries[queries_before:]]
-            response['X-API-Query-Count'] = len(q_times)
-            response['X-API-Query-Time'] = '%0.3fs' % sum(q_times)
 
         if getattr(self, 'deprecated', False):
             response['Warning'] = _('This resource has been deprecated and will be removed in a future release.')
@@ -93,8 +63,11 @@ if parent_view:
     try:
         module_name, junk, class_name = parent_view.rpartition('.')
         logger.debug(f"Trying to import parent view {class_name} from package {module_name}")
-        module = importlib.import_module(module_name, package=class_name)
-        parent_view_class = getattr(parent_view_class, class_name)
+        if not module_name or not class_name:
+            logger.error("ANSIBLE_BASE_CUSTOM_VIEW_PARENT must be in the format package.subpackage.view, defaulting to AnsibleBaseView")
+        else:
+            module = importlib.import_module(module_name, package=class_name)
+            parent_view_class = getattr(module, class_name)
     except ModuleNotFoundError:
         logger.error(f"Failed to find parent view class {parent_view}, defaulting to AnsibleBaseView")
     except ImportError:

--- a/ansible_base/lib/utils/views.py
+++ b/ansible_base/lib/utils/views.py
@@ -1,0 +1,21 @@
+import logging
+
+from django.conf import settings
+from rest_framework import views
+
+logger = logging.getLogger('ansible_base.lib.utils.views')
+
+
+setting = 'ANSIBLE_BASE_EXTRA_HEADERS'
+
+
+class ViewWithHeaders(views.APIView):
+    def finalize_response(self, request, response, *args, **kwargs):
+        response = super().finalize_response(request, response, *args, **kwargs)
+        for name, value in getattr(settings, setting, {}).items():
+            if isinstance(name, str) and isinstance(value, str):
+                response[name] = value
+            else:
+                logger.error(f"When adding a custom header expected (str,str) but got ({type(name)}, {type(value)}) please check your {setting} settings")
+
+        return response

--- a/ansible_base/lib/utils/views.py
+++ b/ansible_base/lib/utils/views.py
@@ -1,37 +1,38 @@
+import importlib
 import logging
 import time
 
 from django.conf import settings
 from django.db import connection
 from django.utils.translation import gettext_lazy as _
-from rest_framework import views
 from rest_framework.exceptions import AuthenticationFailed, ParseError, PermissionDenied, UnsupportedMediaType
+from rest_framework.views import APIView
 
-from ansible_base.lib.utils.settings import get_function_from_setting
+from ansible_base.lib.utils.settings import get_function_from_setting, get_setting
 
 logger = logging.getLogger('ansible_base.lib.utils.views')
 
 
-class AnsibleBaseView(views.APIView):
+class AnsibleBaseView(APIView):
     def initialize_request(self, request, *args, **kwargs):
         """
         Store the Django REST Framework Request object as an attribute on the
         normal Django request, store time the request started.
         """
         self.time_started = time.time()
-        if getattr(settings, 'SQL_DEBUG', False):
+        if get_setting('SQL_DEBUG', False):
             self.queries_before = len(connection.queries)
 
         # If there are any custom headers in REMOTE_HOST_HEADERS, make sure
         # they respect the allowed proxy list
-        if all(
+        proxy_ip_allowed_list = get_setting('PROXY_IP_ALLOWED_LIST', None)
+        if proxy_ip_allowed_list and all(
             [
-                settings.PROXY_IP_ALLOWED_LIST,
-                request.environ.get('REMOTE_ADDR') not in settings.PROXY_IP_ALLOWED_LIST,
-                request.environ.get('REMOTE_HOST') not in settings.PROXY_IP_ALLOWED_LIST,
+                request.environ.get('REMOTE_ADDR') not in proxy_ip_allowed_list,
+                request.environ.get('REMOTE_HOST') not in proxy_ip_allowed_list,
             ]
         ):
-            for custom_header in settings.REMOTE_HOST_HEADERS:
+            for custom_header in get_setting('REMOTE_HOST_HEADERS', None):
                 if custom_header.startswith('HTTP_'):
                     request.environ.pop(custom_header, None)
 
@@ -64,15 +65,15 @@ class AnsibleBaseView(views.APIView):
 
             response['X-API-Product-Version'] = version
 
-        response['X-API-Product-Name'] = getattr(settings, 'ANSIBLE_BASE_PRODUCT_NAME', _('Unnamed'))
-        response['X-API-Node'] = getattr(settings, 'CLUSTER_HOST_ID', _('Unknown'))
+        response['X-API-Product-Name'] = get_setting('ANSIBLE_BASE_PRODUCT_NAME', _('Unnamed'))
+        response['X-API-Node'] = get_setting('CLUSTER_HOST_ID', _('Unknown'))
 
         time_started = getattr(self, 'time_started', None)
         if time_started:
             time_elapsed = time.time() - self.time_started
             response['X-API-Time'] = '%0.3fs' % time_elapsed
 
-        if getattr(settings, 'SQL_DEBUG', False):
+        if get_setting('SQL_DEBUG', False):
             queries_before = getattr(self, 'queries_before', 0)
             q_times = [float(q['time']) for q in connection.queries[queries_before:]]
             response['X-API-Query-Count'] = len(q_times)
@@ -82,3 +83,23 @@ class AnsibleBaseView(views.APIView):
             response['Warning'] = _('This resource has been deprecated and will be removed in a future release.')
 
         return response
+
+
+# Determine and load the parent view
+# If anything fails in here its a pretty low level exception so we don't catch anything and just let it raise
+parent_view = getattr(settings, 'ANSIBLE_BASE_CUSTOM_VIEW_PARENT', None)
+parent_view_class = AnsibleBaseView
+if parent_view:
+    try:
+        module_name, junk, class_name = parent_view.rpartition('.')
+        logger.debug(f"Trying to import parent view {class_name} from package {module_name}")
+        module = importlib.import_module(module_name, package=class_name)
+        parent_view_class = getattr(parent_view_class, class_name)
+    except ModuleNotFoundError:
+        logger.error(f"Failed to find parent view class {parent_view}, defaulting to AnsibleBaseView")
+    except ImportError:
+        logger.exception(f"Failed to import {parent_view}, defaulting to AnsibleBaseView")
+
+
+class AnsibleBaseDjanoAppApiView(parent_view_class):
+    pass

--- a/ansible_base/lib/utils/views/ansible_base.py
+++ b/ansible_base/lib/utils/views/ansible_base.py
@@ -1,14 +1,12 @@
-import importlib
 import logging
 import time
 
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework.views import APIView
 
 from ansible_base.lib.utils.settings import get_function_from_setting, get_setting
 
-logger = logging.getLogger('ansible_base.lib.utils.views')
+logger = logging.getLogger('ansible_base.lib.utils.views.ansible_base')
 
 
 class AnsibleBaseView(APIView):
@@ -25,7 +23,7 @@ class AnsibleBaseView(APIView):
         response = super().finalize_response(request, response, *args, **kwargs)
 
         if request.user and request.user.is_authenticated:
-            version = 'Unknown'
+            version = _('Unknown')
             setting = 'ANSIBLE_BASE_PRODUCT_VERSION_FUNCTION'
             the_function = None
             try:
@@ -53,26 +51,3 @@ class AnsibleBaseView(APIView):
             response['Warning'] = _('This resource has been deprecated and will be removed in a future release.')
 
         return response
-
-
-# Determine and load the parent view
-# If anything fails in here its a pretty low level exception so we don't catch anything and just let it raise
-parent_view = getattr(settings, 'ANSIBLE_BASE_CUSTOM_VIEW_PARENT', None)
-parent_view_class = AnsibleBaseView
-if parent_view:
-    try:
-        module_name, junk, class_name = parent_view.rpartition('.')
-        logger.debug(f"Trying to import parent view {class_name} from package {module_name}")
-        if not module_name or not class_name:
-            logger.error("ANSIBLE_BASE_CUSTOM_VIEW_PARENT must be in the format package.subpackage.view, defaulting to AnsibleBaseView")
-        else:
-            module = importlib.import_module(module_name, package=class_name)
-            parent_view_class = getattr(module, class_name)
-    except ModuleNotFoundError:
-        logger.error(f"Failed to find parent view class {parent_view}, defaulting to AnsibleBaseView")
-    except ImportError:
-        logger.exception(f"Failed to import {parent_view}, defaulting to AnsibleBaseView")
-
-
-class AnsibleBaseDjanoAppApiView(parent_view_class):
-    pass

--- a/ansible_base/lib/utils/views/django_app_api.py
+++ b/ansible_base/lib/utils/views/django_app_api.py
@@ -1,0 +1,32 @@
+import importlib
+import logging
+
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _
+
+from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
+
+logger = logging.getLogger('ansible_base.lib.utils.views.django_app_api')
+
+
+# Determine and load the parent view
+# If anything fails in here its a pretty low level exception so we don't catch anything and just let it raise
+parent_view = getattr(settings, 'ANSIBLE_BASE_CUSTOM_VIEW_PARENT', None)
+parent_view_class = AnsibleBaseView
+if parent_view:
+    try:
+        module_name, junk, class_name = parent_view.rpartition('.')
+        logger.debug(_("Trying to import parent view {class_name} from package {module_name}".format(class_name=class_name, module_name=module_name)))
+        if not module_name or not class_name:
+            logger.error(_("ANSIBLE_BASE_CUSTOM_VIEW_PARENT must be in the format package.subpackage.view, defaulting to AnsibleBaseView"))
+        else:
+            module = importlib.import_module(module_name, package=class_name)
+            parent_view_class = getattr(module, class_name)
+    except ModuleNotFoundError:
+        logger.error(_("Failed to find parent view class {parent_view}, defaulting to AnsibleBaseView".format(parent_view=parent_view)))
+    except ImportError:
+        logger.exception(_("Failed to import {parent_view}, defaulting to AnsibleBaseView".format(parent_view=parent_view)))
+
+
+class AnsibleBaseDjangoAppApiView(parent_view_class):
+    pass

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -5,7 +5,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, mixins
 
-from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 from ansible_base.resource_registry.models import Resource, ResourceType, service_id
 from ansible_base.resource_registry.registry import get_registry
 from ansible_base.resource_registry.serializers import ResourceListSerializer, ResourceSerializer, ResourceTypeSerializer, get_resource_detail_view
@@ -18,7 +18,7 @@ class ResourceViewSet(
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
-    AnsibleBaseDjanoAppApiView,
+    AnsibleBaseDjangoAppApiView,
 ):
     """
     Index of all the resources in the system.
@@ -61,7 +61,7 @@ class ResourceTypeViewSet(
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
-    AnsibleBaseDjanoAppApiView,
+    AnsibleBaseDjangoAppApiView,
 ):
     queryset = ResourceType.objects.all()
     serializer_class = ResourceTypeSerializer
@@ -70,7 +70,7 @@ class ResourceTypeViewSet(
     lookup_value_regex = "[^/]+"
 
 
-class ServiceMetadataView(AnsibleBaseDjanoAppApiView):
+class ServiceMetadataView(AnsibleBaseDjangoAppApiView):
     def get(self, request, **kwargs):
         registry = get_registry()
         return Response({"service_id": service_id(), "service_type": registry.api_config.service_type})

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -3,9 +3,9 @@ from django.shortcuts import get_object_or_404, redirect
 from rest_framework import permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet, mixins
 
+from ansible_base.lib.utils.views import ViewWithHeaders
 from ansible_base.resource_registry.models import Resource, ResourceType, service_id
 from ansible_base.resource_registry.registry import get_registry
 from ansible_base.resource_registry.serializers import ResourceListSerializer, ResourceSerializer, ResourceTypeSerializer, get_resource_detail_view
@@ -18,6 +18,7 @@ class ResourceViewSet(
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
+    ViewWithHeaders,
 ):
     """
     Index of all the resources in the system.
@@ -60,6 +61,7 @@ class ResourceTypeViewSet(
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
+    ViewWithHeaders,
 ):
     queryset = ResourceType.objects.all()
     serializer_class = ResourceTypeSerializer
@@ -68,7 +70,7 @@ class ResourceTypeViewSet(
     lookup_value_regex = "[^/]+"
 
 
-class ServiceMetadataView(APIView):
+class ServiceMetadataView(ViewWithHeaders):
     def get(self, request, **kwargs):
         registry = get_registry()
         return Response({"service_id": service_id(), "service_type": registry.api_config.service_type})

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -5,7 +5,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, mixins
 
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView
 from ansible_base.resource_registry.models import Resource, ResourceType, service_id
 from ansible_base.resource_registry.registry import get_registry
 from ansible_base.resource_registry.serializers import ResourceListSerializer, ResourceSerializer, ResourceTypeSerializer, get_resource_detail_view
@@ -18,7 +18,7 @@ class ResourceViewSet(
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
-    ViewWithHeaders,
+    AnsibleBaseDjanoAppApiView,
 ):
     """
     Index of all the resources in the system.
@@ -61,7 +61,7 @@ class ResourceTypeViewSet(
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
-    ViewWithHeaders,
+    AnsibleBaseDjanoAppApiView,
 ):
     queryset = ResourceType.objects.all()
     serializer_class = ResourceTypeSerializer
@@ -70,7 +70,7 @@ class ResourceTypeViewSet(
     lookup_value_regex = "[^/]+"
 
 
-class ServiceMetadataView(ViewWithHeaders):
+class ServiceMetadataView(AnsibleBaseDjanoAppApiView):
     def get(self, request, **kwargs):
         registry = get_registry()
         return Response({"service_id": service_id(), "service_type": registry.api_config.service_type})

--- a/docs/apps_or_lib.md
+++ b/docs/apps_or_lib.md
@@ -80,6 +80,8 @@ You can remove `tests.py` as we don't put tests in ansible_base. Additionally, y
 
 If you have views you can add them to `views.py` or, like models, remove `views.py` and create a `views` folder. If you don't plan to have views `views.py` can be deleted.
 
+NOTE: Any view should extend our built in view set `lib/views.py` for details.
+
 Finally, if your application will add endpoints to the API be sure to add `urls.py`. You can define three different types of urls in this file:
  * `api_version_urls`: These are intended to be on an endpoint like /api/<some name>/v1/. Most URLs should be added here.
  * `api_urls`: These are intended to be on an endpoint like /api/<some name>. An example of this its swaggers docs endpoint or social-auths social.

--- a/docs/apps_or_lib.md
+++ b/docs/apps_or_lib.md
@@ -97,6 +97,6 @@ app_name = <app class>.label
 
 ## Views in apps
 
-All views in a django app should inherit by default, from `ansible_base.lib.utils.views.AnsibleBaseDjanoAppApiView`. 
+All views in a django app should inherit by default, from `ansible_base.lib.utils.views.AnsibleBaseDjangoAppApiView`. 
 This view adds additional headers to all requests.
 See lib/views.md for more details.

--- a/docs/apps_or_lib.md
+++ b/docs/apps_or_lib.md
@@ -95,3 +95,8 @@ from ansible_base.<app_name>.apps import <app class>
 app_name = <app class>.label
 ```
 
+## Views in apps
+
+All views in a django app should inherit by default, from `ansible_base.lib.utils.views.AnsibleBaseDjanoAppApiView`. 
+This view adds additional headers to all requests.
+See lib/views.md for more details.

--- a/docs/lib/views.md
+++ b/docs/lib/views.md
@@ -1,12 +1,12 @@
 # AnsibleBaseView
 
-django-ansible-base provides a view called `ansible_base.lib.utils.views.AnsibleBaseView` which is indirectly parent class for all views in django-ansible-base.
+django-ansible-base provides a view called `ansible_base.lib.utils.views.ansible_base.AnsibleBaseView` which is indirectly parent class for all views in django-ansible-base.
 
 This view itself is subclassed from `rest_framework.views.APIView` and is intended to be subclassed from individual services like:
 
 ```
 from rest_framework.viewsets import ModelViewSet
-from ansible_base.lib.utils.views import AnsibleBaseView
+from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 
 class MyServiceBaseApiView(AnsibleBaseView):
     pass
@@ -17,7 +17,7 @@ class MyServiceModelViewSet(ModelViewSet, MyServiceBaseApiView):
 
 ## Changing the parent view
 
-All views in django-ansible-base actually inherit from a class called `ansible_base.lib.utils.views.AnsibleBaseDjanoAppApiView` which inherits, by default from `AnsibleBaseView`.
+All views in django-ansible-base actually inherit from a class called `ansible_base.lib.utils.views.django_app_api.AnsibleBaseDjangoAppApiView` which inherits, by default from `AnsibleBaseView`.
 
 However, if you already have an existing parent view with additional features you can override the view that `AnsibleBaseDjangoAppApiView` inherits from by setting the django setting `ANSIBLE_BASE_CUSTOM_VIEW_PARENT`.
 
@@ -36,11 +36,11 @@ And lets say all of your django views already inherit from this view. To make th
 ANSIBLE_BASE_CUSTOM_VIEW_PARENT = 'my_app.views.DefaultAPIView'
 ```
 
-This will force `AnsibleBaseDjangoAppApiView` to inherit from `my_app.views.DefaultAPIView` instead of `ansible_base.lib.utils.views.AnsibleBaseView`.
+This will force `AnsibleBaseDjangoAppApiView` to inherit from `my_app.views.DefaultAPIView` instead of `ansible_base.lib.utils.views.ansible_base.AnsibleBaseView`.
 
-If you want the goodness from `AnsibleBaseView` alongside your custom you, you can also make your custom view inherit from `ansible_base.lib.utils.views.AnsibleBaseView` like:
+If you want the goodness from `AnsibleBaseView` alongside your custom you, you can also make your custom view inherit from `ansible_base.lib.utils.views.ansible_base.AnsibleBaseView` like:
 ```
-from ansible_base.lib.utils.views import AnsibleBaseView
+from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 from rest_framework.views import APIView
 
 class DefaultAPIView(AnsibleBaseView):

--- a/docs/lib/views.md
+++ b/docs/lib/views.md
@@ -1,0 +1,5 @@
+# ViewWithHeaders
+
+django-ansible-base provides a view `ansible_base.lib.utils.views.ViewWithHeaders` that is of type `rest_framework.views.APIView`. This view will look for the setting `ANSIBLE_BASE_EXTRA_HEADERS` which is a dict of key/value pairs (both strings). The view will inject headers in the format of `key: value` into the response.
+
+The view can be subclassed by any view created to inject default headers.

--- a/docs/lib/views.md
+++ b/docs/lib/views.md
@@ -1,5 +1,50 @@
-# ViewWithHeaders
+# AnsibleBaseView
 
-django-ansible-base provides a view `ansible_base.lib.utils.views.ViewWithHeaders` that is of type `rest_framework.views.APIView`. This view will look for the setting `ANSIBLE_BASE_EXTRA_HEADERS` which is a dict of key/value pairs (both strings). The view will inject headers in the format of `key: value` into the response.
+django-ansible-base provides a view called `ansible_base.lib.utils.views.AnsibleBaseView` which is indirectly parent class for all views in django-ansible-base.
 
-The view can be subclassed by any view created to inject default headers.
+This view itself is subclassed from `rest_framework.views.APIView` and is intended to be subclassed from individual services like:
+
+```
+from rest_framework.viewsets import ModelViewSet
+from ansible_base.lib.utils.views import AnsibleBaseView
+
+class MyServiceBaseApiView(AnsibleBaseView):
+    pass
+
+class MyServiceModelViewSet(ModelViewSet, MyServiceBaseApiView):
+    pass
+```
+
+## Changing the parent view
+
+All views in django-ansible-base actually inherit from a class called `ansible_base.lib.utils.views.AnsibleBaseDjanoAppApiView` which inherits, by default from `AnsibleBaseView`.
+
+However, if you already have an existing parent view with additional features you can override the view that `AnsibleBaseDjangoAppApiView` inherits from by setting the django setting `ANSIBLE_BASE_CUSTOM_VIEW_PARENT`.
+
+For example, lets say you had a class like `my_app.views.DefaultAPIView` like:
+```
+from rest_framework.views import APIView
+
+class DefaultAPIView(APIView):
+    ...
+    all my good stuff
+    ...
+```
+
+And lets say all of your django views already inherit from this view. To make the django views in django-ansible-base inherit from this view simply add this to your settings:
+```
+ANSIBLE_BASE_CUSTOM_VIEW_PARENT = 'my_app.views.DefaultAPIView'
+```
+
+This will force `AnsibleBaseDjangoAppApiView` to inherit from `my_app.views.DefaultAPIView` instead of `ansible_base.lib.utils.views.AnsibleBaseView`.
+
+If you want the goodness from `AnsibleBaseView` alongside your custom you, you can also make your custom view inherit from `ansible_base.lib.utils.views.AnsibleBaseView` like:
+```
+from ansible_base.lib.utils.views import AnsibleBaseView
+from rest_framework.views import APIView
+
+class DefaultAPIView(AnsibleBaseView):
+    ...
+    all my good stuff
+    ...
+```

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from django.test.client import RequestFactory
 from rest_framework.views import APIView
 
-from ansible_base.lib.utils.views import AnsibleBaseView
+from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 
 
 @pytest.fixture
@@ -53,15 +53,15 @@ class DummyView(APIView):
 def test_ansible_base_view_parent_view(caplog, setting, log_message, default_parent):
     with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT=setting):
         with caplog.at_level(logging.ERROR):
-            import ansible_base.lib.utils.views
+            import ansible_base.lib.utils.views.django_app_api
 
-            importlib.reload(ansible_base.lib.utils.views)
-            from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView, AnsibleBaseView  # noqa: F401
+            importlib.reload(ansible_base.lib.utils.views.django_app_api)
+            from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
             if default_parent:
-                assert issubclass(AnsibleBaseDjanoAppApiView, AnsibleBaseView)
+                assert issubclass(AnsibleBaseDjangoAppApiView, AnsibleBaseView)
             else:
-                assert issubclass(AnsibleBaseDjanoAppApiView, DummyView)
+                assert issubclass(AnsibleBaseDjangoAppApiView, DummyView)
             assert log_message in caplog.text
 
 
@@ -69,12 +69,12 @@ def test_ansible_base_view_parent_view_exception(caplog):
     with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT='does.not.exist'):
         with caplog.at_level(logging.ERROR):
             with mock.patch('importlib.import_module', side_effect=ImportError("Test Exception")):
-                import ansible_base.lib.utils.views
+                import ansible_base.lib.utils.views.django_app_api
 
-                importlib.reload(ansible_base.lib.utils.views)
-                from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView, AnsibleBaseView  # noqa: F401
+                importlib.reload(ansible_base.lib.utils.views.django_app_api)
+                from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
-                assert issubclass(AnsibleBaseDjanoAppApiView, AnsibleBaseView)
+                assert issubclass(AnsibleBaseDjangoAppApiView, AnsibleBaseView)
                 assert 'Failed to import' in caplog.text
 
 

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -3,12 +3,12 @@ from django.http.response import HttpResponseBase
 from django.test import override_settings
 from django.test.client import RequestFactory
 
-from ansible_base.lib.utils.views import ViewWithHeaders
+from ansible_base.lib.utils.views import AnsibleBaseView
 
 
 @pytest.fixture
 def view_with_headers():
-    view = ViewWithHeaders()
+    view = AnsibleBaseView()
     view.headers = {}
     return view
 

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -1,0 +1,55 @@
+import pytest
+from django.http.response import HttpResponseBase
+from django.test import override_settings
+from django.test.client import RequestFactory
+
+from ansible_base.lib.utils.views import ViewWithHeaders
+
+
+@pytest.fixture
+def view_with_headers():
+    view = ViewWithHeaders()
+    view.headers = {}
+    return view
+
+
+@pytest.fixture
+def mock_request():
+    rf = RequestFactory()
+    get_request = rf.get('/hello/')
+    return get_request
+
+
+@pytest.fixture
+def default_headers():
+    return {'Content-Type': 'text/html; charset=utf-8'}
+
+
+def test_header_view_with_no_headers(view_with_headers, mock_request, default_headers):
+    initial_response = HttpResponseBase()
+    response = view_with_headers.finalize_response(mock_request, initial_response)
+    assert response.headers == default_headers
+
+
+@pytest.mark.parametrize(
+    "headers, expected_headers",
+    [
+        # Setting expected_headers to none will assume what goes in should come out
+        ({}, None),
+        ({"TEST": 'testing'}, None),
+        ({'TEST1': 'testing1', 'TEST2': 'testing2'}, None),
+        ({1: 'testing1'}, {}),
+        ({"TEST": 1}, {}),
+        ({1: 'testing1', 'TEST2': 'testing2'}, {'TEST2': 'testing2'}),
+        ({"TEST": 1, False: True, 'a_dict': {}, 'a_set': (), 'an_array': []}, {}),
+    ],
+)
+def test_header_view_with_headers(view_with_headers, mock_request, default_headers, headers, expected_headers):
+    with override_settings(ANSIBLE_BASE_EXTRA_HEADERS=headers):
+        initial_response = HttpResponseBase()
+        response = view_with_headers.finalize_response(mock_request, initial_response)
+        if expected_headers is None:
+            default_headers.update(headers)
+        else:
+            default_headers.update(expected_headers)
+        assert response.headers == default_headers

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -1,7 +1,13 @@
+import importlib
+import logging
+from unittest import mock
+
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.http.response import HttpResponseBase
 from django.test import override_settings
 from django.test.client import RequestFactory
+from rest_framework.views import APIView
 
 from ansible_base.lib.utils.views import AnsibleBaseView
 
@@ -17,39 +23,103 @@ def view_with_headers():
 def mock_request():
     rf = RequestFactory()
     get_request = rf.get('/hello/')
+    get_request.user = AnonymousUser()
     return get_request
 
 
 @pytest.fixture
 def default_headers():
-    return {'Content-Type': 'text/html; charset=utf-8'}
+    return {'Content-Type': 'text/html; charset=utf-8', 'X-API-Product-Name': 'Unnamed', 'X-API-Node': 'Unknown'}
 
 
-def test_header_view_with_no_headers(view_with_headers, mock_request, default_headers):
+def test_ansible_base_view_with_no_settings(view_with_headers, mock_request, default_headers):
     initial_response = HttpResponseBase()
     response = view_with_headers.finalize_response(mock_request, initial_response)
     assert response.headers == default_headers
 
 
+class DummyView(APIView):
+    pass
+
+
 @pytest.mark.parametrize(
-    "headers, expected_headers",
+    "setting,log_message,default_parent",
     [
-        # Setting expected_headers to none will assume what goes in should come out
-        ({}, None),
-        ({"TEST": 'testing'}, None),
-        ({'TEST1': 'testing1', 'TEST2': 'testing2'}, None),
-        ({1: 'testing1'}, {}),
-        ({"TEST": 1}, {}),
-        ({1: 'testing1', 'TEST2': 'testing2'}, {'TEST2': 'testing2'}),
-        ({"TEST": 1, False: True, 'a_dict': {}, 'a_set': (), 'an_array': []}, {}),
+        ('junk', 'must be in the format', True),
+        ('does.not.exist', 'Failed to find parent view class', True),
+        ('test_app.tests.lib.utils.test_views.DummyView', '', False),
     ],
 )
-def test_header_view_with_headers(view_with_headers, mock_request, default_headers, headers, expected_headers):
-    with override_settings(ANSIBLE_BASE_EXTRA_HEADERS=headers):
-        initial_response = HttpResponseBase()
-        response = view_with_headers.finalize_response(mock_request, initial_response)
-        if expected_headers is None:
-            default_headers.update(headers)
-        else:
-            default_headers.update(expected_headers)
-        assert response.headers == default_headers
+def test_ansible_base_view_parent_view(caplog, setting, log_message, default_parent):
+    with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT=setting):
+        with caplog.at_level(logging.ERROR):
+            import ansible_base.lib.utils.views
+
+            importlib.reload(ansible_base.lib.utils.views)
+            from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView, AnsibleBaseView  # noqa: F401
+
+            if default_parent:
+                assert issubclass(AnsibleBaseDjanoAppApiView, AnsibleBaseView)
+            else:
+                assert issubclass(AnsibleBaseDjanoAppApiView, DummyView)
+            assert log_message in caplog.text
+
+
+def test_ansible_base_view_parent_view_exception(caplog):
+    with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT='does.not.exist'):
+        with caplog.at_level(logging.ERROR):
+            with mock.patch('importlib.import_module', side_effect=ImportError("Test Exception")):
+                import ansible_base.lib.utils.views
+
+                importlib.reload(ansible_base.lib.utils.views)
+                from ansible_base.lib.utils.views import AnsibleBaseDjanoAppApiView, AnsibleBaseView  # noqa: F401
+
+                assert issubclass(AnsibleBaseDjanoAppApiView, AnsibleBaseView)
+                assert 'Failed to import' in caplog.text
+
+
+class DeprecatedView(AnsibleBaseView):
+    deprecated = True
+    headers = {}
+
+
+def test_ansible_base_view_deprecated_view(view_with_headers, mock_request, default_headers):
+    initial_response = HttpResponseBase()
+    view = DeprecatedView()
+    response = view.finalize_response(mock_request, initial_response)
+    assert 'Warning' in response
+
+
+def test_ansible_base_view_time_header(view_with_headers, mock_request):
+    initial_response = HttpResponseBase()
+    view_with_headers.initialize_request(mock_request)
+    response = view_with_headers.finalize_response(mock_request, initial_response)
+    assert 'X-API-Time' in response
+
+
+def version_function():
+    return "1.2.3"
+
+
+def version_function_issue():
+    raise Exception('Dang')
+
+
+@pytest.mark.parametrize(
+    "setting,value,log_message",
+    [
+        (None, 'Unknown', ''),
+        ('test_app.tests.lib.utils.test_views.version_function', version_function(), ''),
+        ('junk', 'Unknown', 'Failed to load function from'),
+        ('does.not.exist', 'Unknown', 'Failed to load function from'),
+        ('test_app.tests.lib.utils.test_views.version_function_issue', 'Unknown', 'was set but calling it as a function'),
+    ],
+)
+def test_ansible_base_view_version(view_with_headers, mock_request, admin_user, setting, value, log_message, caplog):
+    mock_request.user = admin_user
+    initial_response = HttpResponseBase()
+    with override_settings(ANSIBLE_BASE_PRODUCT_VERSION_FUNCTION=setting):
+        with caplog.at_level(logging.ERROR):
+            response = view_with_headers.finalize_response(mock_request, initial_response)
+            assert 'X-API-Product-Version' in response and response['X-API-Product-Version'] == value
+            assert log_message in caplog.text


### PR DESCRIPTION
This adds a base View called `ViewWithHeaders` that adds additional headers to responses. It also make all DAB django views use a specific parent view whose parent can be specified by a service.