### PR TITLE
Move the local service name into settings

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -26,6 +26,12 @@ except NameError:
     REST_FRAMEWORK = {}
 
 
+try:
+    ANSIBLE_BASE_SERVICE_PREFIX
+except NameError:
+    ANSIBLE_BASE_SERVICE_PREFIX = 'local'
+
+
 if 'ansible_base.api_documentation' in INSTALLED_APPS:
     if 'drf_spectacular' not in INSTALLED_APPS:
         INSTALLED_APPS.append('drf_spectacular')

--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -63,6 +63,11 @@ class ResourceConfig:
     name_field = None
 
     def __init__(self, model, shared_resource: SharedResource = None, parent_resources: List[ParentResource] = None, name_field: str = None):
+        if not hasattr(self, 'service_type'):
+            from django.conf import settings  # delay import until use to reduce chance of circular imports
+
+            self.service_type = settings.ANSIBLE_BASE_SERVICE_PREFIX
+
         model = get_concrete_model(model)
         self.model_label = model._meta.label
 

--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -18,7 +18,13 @@ class ServiceAPIConfig:
     This will be the interface for configuring the resource registry for each service.
     """
 
-    service_type = None
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not getattr(self, 'service_type', None):
+            from django.conf import settings  # delay import until use to reduce chance of circular imports
+
+            self.service_type = settings.ANSIBLE_BASE_SERVICE_PREFIX
 
 
 class ResourceInspector:
@@ -63,11 +69,6 @@ class ResourceConfig:
     name_field = None
 
     def __init__(self, model, shared_resource: SharedResource = None, parent_resources: List[ParentResource] = None, name_field: str = None):
-        if not hasattr(self, 'service_type'):
-            from django.conf import settings  # delay import until use to reduce chance of circular imports
-
-            self.service_type = settings.ANSIBLE_BASE_SERVICE_PREFIX
-
         model = get_concrete_model(model)
         self.model_label = model._meta.label
 

--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -108,7 +108,7 @@ class ResourceRegistry:
             - Viewsets have the correct serializer, pagination and filter classes
             - Service type is set to one of awx, galaxy, eda or aap
         """
-        assert config.service_type in ["aap", "awx", "galaxy", "eda"]
+        assert config.service_type in ["local", "aap", "awx", "galaxy", "eda"]
 
     def get_resources(self):
         return self.registry

--- a/docs/apps/resource_registry.md
+++ b/docs/apps/resource_registry.md
@@ -16,7 +16,7 @@ ANSIBLE_BASE_SERVICE_PREFIX = 'my_app'
 
 The name of the local service will prefix model names for local resources.
 An inventory model will be referred to as "my_app.inventory" in this example.
-The local service may be one of "awx", "galaxy" or "eda".
+The local service must be one of "local" (placeholder), "aap", "awx", "galaxy" or "eda".
 
 ### Configure the Resource List
 

--- a/docs/apps/resource_registry.md
+++ b/docs/apps/resource_registry.md
@@ -3,14 +3,20 @@
 ## Setup
 
 ### App Setup
-Add `ansible_base.resource_registry` to your installed apps:
+Add `ansible_base.resource_registry` to your installed apps and set the name of the local service.
 
 ```
 INSTALLED_APPS = [
     ...
     'ansible_base.resource_registry',
 ]
+
+ANSIBLE_BASE_SERVICE_PREFIX = 'my_app'
 ```
+
+The name of the local service will prefix model names for local resources.
+An inventory model will be referred to as "my_app.inventory" in this example.
+The local service may be one of "awx", "galaxy" or "eda".
 
 ### Configure the Resource List
 
@@ -26,7 +32,7 @@ from ansible_base.resource_registry.shared_types import TeamType, UserType
 
 
 class APIConfig(ServiceAPIConfig):
-    service_type = "aap"
+    pass
 
 
 RESOURCE_LIST = (
@@ -38,8 +44,6 @@ RESOURCE_LIST = (
     ResourceConfig(Authenticator),
 )
 ```
-
-`APIConfig.service_type` must be one of "awx", "galaxy" or "eda".
 
 `RESOURCE_LIST` must be a list or set of `ResourceConfig` objects. This object defines a model to be included in the resource registry, as well
 as a set of metadata from that resource. Right now it accepts the following args:

--- a/test_app/resource_api.py
+++ b/test_app/resource_api.py
@@ -7,7 +7,7 @@ from test_app.models import Organization, ResourceMigrationTestModel, Team
 
 
 class APIConfig(ServiceAPIConfig):
-    service_type = "aap"
+    pass
 
 
 RESOURCE_LIST = (

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -120,3 +120,5 @@ settings_file = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_
 include(settings_file)
 
 ANSIBLE_BASE_RESOURCE_CONFIG_MODULE = "test_app.resource_api"
+
+ANSIBLE_BASE_SERVICE_PREFIX = "aap"


### PR DESCRIPTION
The RBAC app will also need the service name setting, and the `get_registry` method will wind up importing more things as a side effect, and by design, isn't generally available on import.