### PR TITLE
Declare missing migration dependency

### DIFF
--- a/test_app/migrations/0002_set_up_resources_test_data.py
+++ b/test_app/migrations/0002_set_up_resources_test_data.py
@@ -26,6 +26,7 @@ def create_test_data(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ('test_app', '0001_initial'),
+        ('dab_resource_registry', '__first__'),
     ]
 
     operations = [


### PR DESCRIPTION
Above in this file it does `Resource = apps.get_model("dab_resource_registry", "Resource")`. This ordering doesn't normally happen, but if the initial "dab_resource_registry" first migration hasn't happened yet, then this line will error because that model in that app doesn't exist in that apps state.