### PR TITLE
Update security definition for EDA JWT Auth

### DIFF
--- a/ansible_base/jwt_consumer/eda/auth.py
+++ b/ansible_base/jwt_consumer/eda/auth.py
@@ -33,4 +33,4 @@ class EDAJWTAuthScheme(OpenApiAuthenticationExtension):
     name = "EDAJWTAuthentication"
 
     def get_security_definition(self, auto_schema):
-        return {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
+        return {"type": "apiKey", "name": "X-DAB-JW-TOKEN", "in": "header"}

--- a/ansible_base/jwt_consumer/eda/auth.py
+++ b/ansible_base/jwt_consumer/eda/auth.py
@@ -33,9 +33,4 @@ class EDAJWTAuthScheme(OpenApiAuthenticationExtension):
     name = "EDAJWTAuthentication"
 
     def get_security_definition(self, auto_schema):
-        return {
-            "type": "token",
-            "in": "header",
-            "name": "JWT Authorization",
-            "description": "Token-based authentication",
-        }
+        return {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}

--- a/test_app/tests/jwt_consumer/eda/test_auth.py
+++ b/test_app/tests/jwt_consumer/eda/test_auth.py
@@ -18,7 +18,7 @@ def test_eda_jwt_auth_scheme():
 
     scheme = EDAJWTAuthScheme(None)
     response = scheme.get_security_definition(None)
-    assert 'name' in response and response['name'] == 'JWT Authorization'
+    assert 'name' in response and response['name'] == 'X-DAB-JW-TOKEN'
 
 
 def filter_function(name):


### PR DESCRIPTION
EDA e2e tests are failing due to EDAJWTAuthentication class security type being invalid. This PR sets the type to 'http'.