### PR TITLE
Add flag to skip logging during get_setting

### DIFF
--- a/ansible_base/lib/utils/settings.py
+++ b/ansible_base/lib/utils/settings.py
@@ -12,7 +12,7 @@ class SettingNotSetException(Exception):
     pass
 
 
-def get_setting(name: str, default: Any = None) -> Any:
+def get_setting(name: str, default: Any = None, log_exception: bool = True) -> Any:
     try:
         the_function = get_function_from_setting('ANSIBLE_BASE_SETTINGS_FUNCTION')
         if the_function:
@@ -22,9 +22,13 @@ def get_setting(name: str, default: Any = None) -> Any:
         # If the setting was not set thats ok, we will fall through to trying to get it from the django setting or the default value
         pass
     except Exception:
-        logger.exception(
-            _('ANSIBLE_BASE_SETTINGS_FUNCTION was set but calling it as a function failed (see exception), ignoring error and attempting to load from settings')
-        )
+        if log_exception:
+            logger.exception(
+                _(
+                    'ANSIBLE_BASE_SETTINGS_FUNCTION was set but calling it as a function failed (see exception), '
+                    'ignoring error and attempting to load from settings'
+                )
+            )
 
     return getattr(settings, name, default)
 

--- a/test_app/tests/lib/utils/test_settings.py
+++ b/test_app/tests/lib/utils/test_settings.py
@@ -15,13 +15,18 @@ def test_unset_setting():
 
 @mock.patch("ansible_base.lib.utils.settings.logger")
 @override_settings(ANSIBLE_BASE_SETTINGS_FUNCTION='junk')
-def test_invalid_settings_function(logger):
+@pytest.mark.parametrize('log_exception_flag', [False, True])
+def test_invalid_settings_function(logger, log_exception_flag):
     default_value = 'default_value'
-    value = get_setting('UNDEFINED_SETTING', default_value)
+    value = get_setting('UNDEFINED_SETTING', default_value, log_exception_flag)
     assert value == default_value
-    logger.exception.assert_called_once_with(
-        "ANSIBLE_BASE_SETTINGS_FUNCTION was set but calling it as a function failed (see exception), ignoring error and attempting to load from settings"
-    )
+
+    if log_exception_flag:
+        logger.exception.assert_called_once_with(
+            "ANSIBLE_BASE_SETTINGS_FUNCTION was set but calling it as a function failed (see exception), ignoring error and attempting to load from settings"
+        )
+    else:
+        logger.exception.assert_not_called()
 
 
 def setting_getter_function(setting_name):


### PR DESCRIPTION
It's needed to have a possibility to skip exception logging during "get_setting" because it can cause a exception loop.

DAB is using `logger.debug` several times during modules import phase, i.e. here: https://github.com/ansible/django-ansible-base/blob/25d39c407e43fc93dd79edd4a37e45d8c09963d6/ansible_base/lib/dynamic_config/dynamic_urls.py#L16

In first run, it tries to debug **before** the database is initialized and migrated.

With external logging implemented, it requires to get the setting if it's enabled - for gateway it's a dynamic preference. 
So logger wants the db settings, which calls get_setting, which raises exception, which wants to log ==> which wants the db settings etc. etc. 

So we need to avoid the loop.

* prerequisity for: [external loggers](https://github.com/ansible/aap-gateway/pull/226)