### PR TITLE
Fix exception thrown in logger message

### DIFF
--- a/ansible_base/lib/utils/settings.py
+++ b/ansible_base/lib/utils/settings.py
@@ -39,7 +39,7 @@ def get_function_from_setting(setting_name: str) -> Any:
         return None
 
     try:
-        module_name, _, function_name = setting.rpartition('.')
+        module_name, _junk, function_name = setting.rpartition('.')
         the_function = getattr(importlib.import_module(module_name), function_name)
         return the_function
     except Exception:

--- a/test_app/tests/lib/utils/test_settings.py
+++ b/test_app/tests/lib/utils/test_settings.py
@@ -14,7 +14,7 @@ def test_unset_setting():
 
 
 @mock.patch("ansible_base.lib.utils.settings.logger")
-@override_settings(ANSIBLE_BASE_SETTINGS_FUNCTION='junk')
+@override_settings(ANSIBLE_BASE_SETTINGS_FUNCTION='test_app.tests.lib.utils.test_views.version_function_issue')
 @pytest.mark.parametrize('log_exception_flag', [False, True])
 def test_invalid_settings_function(logger, log_exception_flag):
     default_value = 'default_value'

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -110,10 +110,11 @@ def version_function_issue():
     [
         (None, 'Unknown', ''),
         ('test_app.tests.lib.utils.test_views.version_function', version_function(), ''),
-        ('junk', 'Unknown', 'Failed to load function from'),
-        ('does.not.exist', 'Unknown', 'Failed to load function from'),
+        ('junk', 'Unknown', 'set but we were unable to import its reference as a function'),
+        ('does.not.exist', 'Unknown', 'set but we were unable to import its reference as a function'),
         ('test_app.tests.lib.utils.test_views.version_function_issue', 'Unknown', 'was set but calling it as a function'),
     ],
+    ids=['none', 'valid_function', 'invalid_import', 'invalid_module', 'function_exception'],
 )
 def test_ansible_base_view_version(view_with_headers, mock_request, admin_user, setting, value, log_message, caplog):
     mock_request.user = admin_user


### PR DESCRIPTION
This fixes an exception seen:

```
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/lib/utils/settings.py", line 43, in get_function_from_setting
    the_function = getattr(importlib.import_module(module_name), function_name)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1201, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1114, in _sanity_check
ValueError: Empty module name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/lib/utils/views/ansible_base.py", line 30, in finalize_response
    the_function = get_function_from_setting(setting)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/lib/utils/settings.py", line 46, in get_function_from_setting
    logger.exception(_('{setting_name} was set but we were unable to import its reference as a function.').format(setting_name=setting_name))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'str' object is not callable
```

Some of this is intended, but `_` was unexpectedly a string (not the Django translation function). So this changes it to reflect the original intent, which is that this method returns `None` when the import is invalid, and this triggers test changes.