### PR TITLE
Add validation to DAB

### DIFF
--- a/ansible_base/lib/serializers/common.py
+++ b/ansible_base/lib/serializers/common.py
@@ -5,12 +5,13 @@ from rest_framework import serializers
 from rest_framework.fields import empty
 
 from ansible_base.lib.abstract_models.common import get_url_for_object
+from ansible_base.lib.serializers.validation import ValidationSerializerMixin
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 
 logger = logging.getLogger('ansible_base.lib.serializers.common')
 
 
-class CommonModelSerializer(serializers.ModelSerializer):
+class CommonModelSerializer(ValidationSerializerMixin, serializers.ModelSerializer):
     url = serializers.SerializerMethodField()
     related = serializers.SerializerMethodField('_get_related')
     summary_fields = serializers.SerializerMethodField('_get_summary_fields')

--- a/ansible_base/lib/serializers/validation.py
+++ b/ansible_base/lib/serializers/validation.py
@@ -1,0 +1,32 @@
+import logging
+
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import APIException
+from rest_framework.fields import BooleanField
+
+from ansible_base.lib.utils.validation import to_python_boolean
+
+logger = logging.getLogger('ansible_base.lib.serializers.validation')
+
+validate_field = 'validate'
+
+
+class APIException202(APIException):
+    status_code = 202
+
+
+class ValidationSerializerMixin:
+    model_validate = BooleanField(default=False, write_only=True)
+
+    def save(self, **kwargs):
+        want_validate = to_python_boolean(self.context['request'].query_params.get(validate_field, False))
+
+        if not want_validate:
+            return super().save(**kwargs)
+
+        with transaction.atomic():
+            # If the save fails it will raise an exception and the transaction will be aborted
+            super().save(**kwargs)
+            # Otherwise we need to raise our own exception to roll back the transaction
+            raise APIException202(_("Request would have been accepted"))

--- a/ansible_base/rest_filters/rest_framework/field_lookup_backend.py
+++ b/ansible_base/rest_filters/rest_framework/field_lookup_backend.py
@@ -22,7 +22,7 @@ class FieldLookupBackend(BaseFilterBackend):
     Filter using field lookups provided via query string parameters.
     """
 
-    RESERVED_NAMES = ('page', 'page_size', 'format', 'order', 'order_by', 'search', 'type', 'host_filter', 'count_disabled', 'no_truncate', 'limit')
+    RESERVED_NAMES = ('page', 'page_size', 'format', 'order', 'order_by', 'search', 'type', 'host_filter', 'count_disabled', 'no_truncate', 'limit', 'validate')
 
     SUPPORTED_LOOKUPS = (
         'exact',

--- a/docs/lib/serializers.md
+++ b/docs/lib/serializers.md
@@ -3,3 +3,16 @@
 django-ansible-base can house common serializer fields. These are in `ansible_base.lib.serializers.fields`.
 
 `ansible_base.lib.serializers.fields.URLField` can handle doing URL validation (see validation.md).
+
+
+
+# ValidationSerializerMixin
+
+django-ansible-base offers a `ValidationSerializerMixin` for DRF serializers. This is in `ansible_base.lib.serializers.validation`.
+
+Adding this mixin to your serializers will allow for "validation" of a POST/PUT by returning a HTTP 202 response from the `.save()` method if the passed in object passes validation and could be saved.
+Validation is indicated to the serializer by passing a GET parameter of `validate=[True|False]`.
+* If unspecified validation will be false.
+* If multiple validate params are offered any being True turn on the validation login.
+
+*Note*: if you use the DRF filter class from DAB its already configured to ignore the validate parameters. If you are using your own filtering class you will need to ensure that the filter is not used as part of the lookup model. 

--- a/test_app/tests/lib/serializers/test_validate.py
+++ b/test_app/tests/lib/serializers/test_validate.py
@@ -1,0 +1,81 @@
+import pytest
+from django.urls import reverse
+
+authenticator_data = {
+    "name": "Local Database Authenticator",
+    "enabled": True,
+    "create_objects": True,
+    "users_unique": False,
+    "remove_users": False,
+    "configuration": {},
+    "type": "ansible_base.authentication.authenticator_plugins.local",
+    "order": 1,
+}
+
+
+@pytest.mark.parametrize(
+    "reverse_name,method,query_params,same_name,configuration,response_code,response_body",
+    [
+        ("authenticator-detail", "put", "", True, {}, 200, None),
+        ("authenticator-detail", "put", "validate=False", True, {}, 200, None),
+        ("authenticator-detail", "put", "validate=True", True, {}, 202, None),
+        ("authenticator-detail", "put", "validate=False", True, {"a": "b"}, 400, {'a': ['a is not a supported configuration option.']}),
+        ("authenticator-detail", "put", "validate=True", True, {"a": "b"}, 400, {'a': ['a is not a supported configuration option.']}),
+        ("authenticator-list", "post", "validate=True", False, {"a": "b"}, 400, {'a': ['a is not a supported configuration option.']}),
+        ("authenticator-list", "post", "validate=True", True, {}, 400, None),
+        ("authenticator-list", "post", "validate=False", False, {"a": "b"}, 400, {'a': ['a is not a supported configuration option.']}),
+        ("authenticator-list", "post", "validate=False", True, {}, 400, None),
+        ("authenticator-list", "post", "validate=True", False, {}, 202, None),
+        ("authenticator-detail", "patch", "", True, {}, 200, None),
+        ("authenticator-detail", "patch", "validate=False", True, {}, 200, None),
+        ("authenticator-detail", "patch", "validate=True", True, {}, 202, None),
+        ("authenticator-detail", "patch", "validate=False", True, {"a": "b"}, 400, {'a': ['a is not a supported configuration option.']}),
+        ("authenticator-detail", "patch", "validate=True", True, {"a": "b"}, 400, {'a': ['a is not a supported configuration option.']}),
+        ("authenticator-detail", "put", "validate=False&validate=True", True, {}, 202, None),
+        ("authenticator-detail", "put", "validate=False&validate=False", True, {}, 200, None),
+        ("authenticator-detail", "put", "validate=True&validate=True", True, {}, 202, None),
+        ("authenticator-detail", "put", "validate=True&validate=False", True, {}, 200, None),
+    ],
+    ids=[
+        'Good put implicit no validation',
+        'Good put no validation',
+        'Good put validation',
+        'Bad put no validation',
+        'Bad put validation',
+        'Bad post (serializer issue) with validation',
+        'Bad post (db issue) validation',
+        'Bad post (serializer issue) with no validation',
+        'Bad post (db issue) with no validation',
+        'Good post with validation',
+        'Good patch implicit no validation',
+        'Good patch no validation',
+        'Good patch validation',
+        'Bad patch no validation',
+        'Bad patch validation',
+        'Good put multiple validation = True',
+        'Good put multiple validation = False',
+        'Good put multiple validation = True',
+        'Good put multiple validation = False',
+    ],
+)
+def test_validation_mixin_validate(
+    local_authenticator, admin_api_client, reverse_name, method, query_params, same_name, configuration, response_code, response_body
+):
+    if reverse_name == 'authenticator-detail':
+        url = reverse(reverse_name, kwargs={'pk': local_authenticator.pk})
+    else:
+        url = reverse(reverse_name)
+
+    if query_params:
+        url = f'{url}?{query_params}'
+
+    authenticator_data['configuration'] = configuration
+    if same_name:
+        authenticator_data['name'] = local_authenticator.name
+    else:
+        authenticator_data['name'] = 'Not the local authenticator name'
+
+    response = getattr(admin_api_client, method)(url, data=authenticator_data, format='json')
+    assert response.status_code == response_code, f'Expected {response_code} got {response.status_code} {url} {response.json()}'
+    if response_body:
+        assert response.json() == response_body


### PR DESCRIPTION
This add a ValidationSerializerMixin class which will capture the parameter `verify=True` and cause a serializer to return a 202 instead of creating/changing the object. 