### PR TITLE
feat: Add resource manifest endpoint

### DIFF
--- a/ansible_base/lib/utils/hashing.py
+++ b/ansible_base/lib/utils/hashing.py
@@ -1,0 +1,18 @@
+import hashlib
+import json
+from typing import Callable, Optional
+
+from django.db.models import Model
+from rest_framework.serializers import Serializer
+
+
+def hash_serializer_data(instance: Model, serializer: Serializer, field: Optional[str] = None, hasher: Callable = hashlib.sha256):
+    """
+    Takes an instance, serialize it and take the .data or the specified field
+    as input for the hasher function.
+    """
+    serialized_data = serializer(instance).data
+    if field:
+        serialized_data = serialized_data[field]
+    metadata_json = json.dumps(serialized_data, sort_keys=True).encode("utf-8")
+    return hasher(metadata_json).hexdigest()

--- a/ansible_base/lib/utils/response.py
+++ b/ansible_base/lib/utils/response.py
@@ -1,0 +1,33 @@
+import csv
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from django.http import StreamingHttpResponse
+
+
+class CSVBuffer:
+    """An object that implements just the write method of the file-like Protocol
+    # NOTE: cannot use io.StringIO because its write returns length instead of text
+    # we need the text to be immediatelly written to the streaming response.
+    """
+
+    def write(self, value):
+        return value
+
+
+@dataclass
+class CSVStreamResponse:
+    """Streams a CSV from any sequence e.g: queryset, generator"""
+
+    lines: Sequence[Sequence[str]]  # can be a generator that yields tuple[str]
+    filename: Optional[str] = None
+    content_type: str = "text/event-stream"
+    headers: Optional[dict] = None
+
+    def stream(self):
+        writer = csv.writer(CSVBuffer())
+        headers = {"Cache-Control": "no-cache"} if self.headers is None else self.headers
+        if self.filename:  # pragma: no cover
+            headers["Content-Disposition"] = f"attachment; filename={self.filename}"
+
+        return StreamingHttpResponse((writer.writerow(line) for line in self.lines), status=200, content_type=self.content_type, headers=headers)

--- a/test_app/tests/lib/utils/test_hashing.py
+++ b/test_app/tests/lib/utils/test_hashing.py
@@ -1,0 +1,34 @@
+import uuid
+
+from rest_framework.serializers import CharField, IntegerField, Serializer, UUIDField
+
+from ansible_base.lib.utils.hashing import hash_serializer_data
+
+DATA = {"name": "foo", "id": 1234, "uuid": uuid.uuid4()}
+
+
+class DataSerializer(Serializer):
+    name = CharField()
+    id = IntegerField()
+    uuid = UUIDField()
+
+
+def test_hash_serializer_data_idempotency():
+    """Test hashing same data gives same output"""
+    assert hash_serializer_data(DATA, DataSerializer) == hash_serializer_data(DATA, DataSerializer)
+
+
+def test_hash_serializer_data_difference():
+    """Test hashing different data changes the hash"""
+    assert hash_serializer_data(DATA, DataSerializer) != hash_serializer_data({**DATA, **{"id": 4567}}, DataSerializer)
+
+
+def test_hash_serializer_with_nested_field():
+    """Test hashing can be performed on nested data"""
+    NESTED_DATA = {"field": {"name": "foo", "id": 1234}}
+
+    class NestedSerializer(Serializer):
+        def to_representation(self, instance):
+            return instance
+
+    assert hash_serializer_data(NESTED_DATA, NestedSerializer, "field") == hash_serializer_data(NESTED_DATA["field"], NestedSerializer)

--- a/test_app/tests/lib/utils/test_response.py
+++ b/test_app/tests/lib/utils/test_response.py
@@ -1,0 +1,21 @@
+import csv
+from io import StringIO
+
+from ansible_base.lib.utils.response import CSVStreamResponse
+
+
+def test_csv_stream_response():
+    expected = [b'header,other\r\n', b'data0,other0\r\n', b'data1,other1\r\n', b'data2,other2\r\n', b'data3,other3\r\n', b'data4,other4\r\n']
+
+    def data_generator():
+        yield ["header", "other"]
+        for i in range(5):
+            yield [f"data{i}", f"other{i}"]
+
+    stream = CSVStreamResponse(data_generator(), filename="manifest.csv").stream()
+    response = list(stream.streaming_content)
+    assert response == expected
+
+    csv_file = StringIO("".join(item.decode() for item in response))
+    for ix, row in enumerate(csv.DictReader(csv_file)):
+        assert row == {"header": f"data{ix}", "other": f"other{ix}"}

--- a/test_app/tests/resource_registry/test_resource_types_api.py
+++ b/test_app/tests/resource_registry/test_resource_types_api.py
@@ -1,3 +1,6 @@
+import csv
+from io import StringIO
+
 from django.urls import reverse
 
 
@@ -21,3 +24,23 @@ def test_resource_type_detail(admin_api_client):
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert response.data["name"] == "shared.user"
+
+
+def test_resource_type_manifest(admin_api_client):
+    """
+    Test get the csv for resource type manifest
+    """
+    url = reverse("resourcetype-manifest", kwargs={"name": "shared.user"})
+    response = admin_api_client.get(url)
+    assert response.status_code == 200
+    response_data = list(response.streaming_content)
+    data = StringIO("".join(item.decode() for item in response_data))
+    for row in csv.DictReader(data):
+        assert "resource_id" in row
+        assert "resource_hash" in row
+
+
+def test_resource_type_manifest_404(admin_api_client):
+    url = reverse("resourcetype-manifest", kwargs={"name": "doesnt.exist"})
+    response = admin_api_client.get(url)
+    assert response.status_code == 404


### PR DESCRIPTION
Add a /manifest/ to the resource type API that returns a streamed CSV response.

Each service will fetch this CSV at a regular interval and perform the sync of resources

Response is streamed to be able to handle large amount of objects without pagination and the CSV format is more suitable for a streaming response than JSON.

Issue: AAP-20218


```console
$curl  -X GET \
  'https://localhost/api/gateway/v1/service-index/resource-types/shared.user/manifest/' \
  --header 'Accept: */*' \
  --header 'Authorization: Basic YWRtaW46YWRtaW4='
```
```csv
resource_id,resource_hash
863b5744-bc79-49fb-95cb-bb171a372c50,86f06a619dd768393c4969f725bae089a265168fb79f1fdcac2d4442e41ac529
4c9ddcb4-080f-4d8c-a0d2-9dbffee1b3ce,6c78ee32d146a01bc22902a36dbced5af6ec0563c6d190491ad1262ef53dc6ed
```

Replaces #136 