### PR TITLE
Remove test_app local_authenticator fixture from test utils

### DIFF
--- a/ansible_base/lib/testing/fixtures.py
+++ b/ansible_base/lib/testing/fixtures.py
@@ -29,7 +29,7 @@ def unauthenticated_api_client(db):
 
 
 @pytest.fixture
-def admin_api_client(db, admin_user, unauthenticated_api_client, local_authenticator):
+def admin_api_client(db, admin_user, unauthenticated_api_client):
     client = unauthenticated_api_client
     client.login(username="admin", password="password")
     yield client
@@ -41,21 +41,21 @@ def admin_api_client(db, admin_user, unauthenticated_api_client, local_authentic
 
 
 @pytest.fixture
-def user(db, django_user_model, local_authenticator):
+def user(db, django_user_model):
     user = django_user_model.objects.create_user(username="user", password="password")
     yield user
     user.delete()
 
 
 @pytest.fixture
-def random_user(db, django_user_model, randname, local_authenticator):
+def random_user(db, django_user_model, randname):
     user = django_user_model.objects.create_user(username=randname("user"), password="password")
     yield user
     user.delete()
 
 
 @pytest.fixture
-def user_api_client(db, user, unauthenticated_api_client, local_authenticator):
+def user_api_client(db, user, unauthenticated_api_client):
     client = unauthenticated_api_client
     client.login(username="user", password="password")
     yield client

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -255,7 +255,7 @@ def saml_authenticator(saml_configuration):
     authenticator.delete()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def local_authenticator(db):
     from ansible_base.authentication.models import Authenticator
 


### PR DESCRIPTION
Either we need to do this, or we need to move that fixture into this module.

Otherwise other apps can't legitimately use these fixtures.