### PR TITLE
Get rid of yield pattern in test fixtures

### DIFF
--- a/ansible_base/lib/testing/fixtures.py
+++ b/ansible_base/lib/testing/fixtures.py
@@ -34,9 +34,7 @@ def local_authenticator(db):
         type="ansible_base.authentication.authenticator_plugins.local",
         configuration={},
     )
-    yield authenticator
-    authenticator.authenticator_user.all().delete()
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -65,16 +63,12 @@ def admin_api_client(db, admin_user, unauthenticated_api_client, local_authentic
 
 @pytest.fixture
 def user(db, django_user_model, local_authenticator):
-    user = django_user_model.objects.create_user(username="user", password="password")
-    yield user
-    user.delete()
+    return django_user_model.objects.create_user(username="user", password="password")
 
 
 @pytest.fixture
 def random_user(db, django_user_model, randname, local_authenticator):
-    user = django_user_model.objects.create_user(username=randname("user"), password="password")
-    yield user
-    user.delete()
+    return django_user_model.objects.create_user(username=randname("user"), password="password")
 
 
 @pytest.fixture

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -91,8 +91,7 @@ def github_authenticator(github_configuration):
         type="ansible_base.authentication.authenticator_plugins.github",
         configuration=github_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -108,8 +107,7 @@ def github_organization_authenticator(github_organization_configuration):
         type="ansible_base.authentication.authenticator_plugins.github_org",
         configuration=github_organization_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -125,8 +123,7 @@ def github_team_authenticator(github_team_configuration):
         type="ansible_base.authentication.authenticator_plugins.github_team",
         configuration=github_team_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -142,8 +139,7 @@ def github_enterprise_authenticator(github_enterprise_configuration):
         type="ansible_base.authentication.authenticator_plugins.github_enterprise",
         configuration=github_enterprise_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -159,8 +155,7 @@ def github_enterprise_organization_authenticator(github_enterprise_organization_
         type="ansible_base.authentication.authenticator_plugins.github_enterprise_org",
         configuration=github_enterprise_organization_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -176,8 +171,7 @@ def github_enterprise_team_authenticator(github_enterprise_team_configuration):
         type="ansible_base.authentication.authenticator_plugins.github_enterprise_team",
         configuration=github_enterprise_team_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -238,8 +232,7 @@ def ldap_authenticator(ldap_configuration):
         type="ansible_base.authentication.authenticator_plugins.ldap",
         configuration=ldap_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -310,8 +303,7 @@ def saml_authenticator(saml_configuration):
         type="ansible_base.authentication.authenticator_plugins.saml",
         configuration=saml_configuration,
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -327,9 +319,7 @@ def custom_authenticator(db):
         type="test_app.tests.fixtures.authenticator_plugins.custom",
         configuration={},
     )
-    yield authenticator
-    authenticator.authenticator_user.all().delete()
-    authenticator.delete()
+    return authenticator
 
 
 @pytest.fixture
@@ -351,8 +341,7 @@ def keycloak_authenticator(db):
             "SECRET": "asdf",
         },
     )
-    yield authenticator
-    authenticator.delete()
+    return authenticator
 
 
 @copy_fixture(copies=3)  # noqa: F405
@@ -368,8 +357,7 @@ def local_authenticator_map(db, local_authenticator, user, randname):
         organization="testorg",
         team="testteam",
     )
-    yield authenticator_map
-    authenticator_map.delete()
+    return authenticator_map
 
 
 # Generate public and private keys for testing
@@ -484,9 +472,7 @@ def system_user(db, settings, no_log_messages):
 
 @pytest.fixture
 def organization(db, randname):
-    organization = models.Organization.objects.create(name=randname("Test Organization"))
-    yield organization
-    organization.delete()
+    return models.Organization.objects.create(name=randname("Test Organization"))
 
 
 @pytest.fixture


### PR DESCRIPTION
When I first saw this I thought it looked weird but not harmful.

But after understanding a bit more about the user deletion issue from https://github.com/ansible/django-ansible-base/pull/160, I now believe it is likely papering over a real issue with cascade deletions. Maybe it made the tests pass at some point, but it's possible it made a test pass that _should_ have been failing.

Also, I need to write tests that do `user.delete()` and with the current fixtures that gives an error on teardown because the user is already deleted.