### PR TITLE
Add a RootView in order for service-index to be listed on /v1/

### DIFF
--- a/ansible_base/resource_registry/urls.py
+++ b/ansible_base/resource_registry/urls.py
@@ -12,7 +12,11 @@ service_router = routers.SimpleRouter()
 service_router.register(r'resources', views.ResourceViewSet)
 service_router.register(r'resource-types', views.ResourceTypeViewSet)
 
-service = [path('metadata/', views.ServiceMetadataView.as_view(), name="service-metadata"), path('', include(service_router.urls))]
+service = [
+    path('', views.ServiceRootView.as_view(), name="service-index-view"),
+    path('metadata/', views.ServiceMetadataView.as_view(), name="service-metadata"),
+    path('', include(service_router.urls)),
+]
 
 urlpatterns = [
     path('service-index/', include(service)),


### PR DESCRIPTION
To be listed on /api/gateway/v1/ the applications must provide a root view named -view or -list responding with a list of nested endpoint

Gateway RootView expects registered applications to provide a rootview named -view/-list as implemented on https://github.com/ansible/aap-gateway/blob/devel/aap_gateway_api/views/api/v1/__init__.py

![2024-02-24_13-28](https://github.com/ansible/django-ansible-base/assets/458654/aa190de7-a941-4cd2-9df1-7d71d0801ed0)

App can use EndpointEnumerator to filter out detail views
![2024-02-24_13-28_1](https://github.com/ansible/django-ansible-base/assets/458654/74ef0fc2-a0fb-497a-9bd9-a7a6aaf52564)

Extra Actions are shown at the top button for detail and list views.
![2024-02-24_13-29](https://github.com/ansible/django-ansible-base/assets/458654/52ec08e5-ffeb-4301-8dee-898354c5a461)

