### PR TITLE
Fix bug from referencing manager on instance

### DIFF
--- a/ansible_base/resource_registry/models/service_id.py
+++ b/ansible_base/resource_registry/models/service_id.py
@@ -11,7 +11,7 @@ class ServiceID(models.Model):
     id = models.UUIDField(default=uuid.uuid4, primary_key=True, null=False, editable=False)
 
     def save(self, *args, **kwargs):
-        if self.objects.exists():
+        if ServiceID.objects.exists():
             raise RuntimeError("This service already has a ServiceID")
 
         return super().save()

--- a/test_app/tests/resource_registry/models/test_service_id.py
+++ b/test_app/tests/resource_registry/models/test_service_id.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ansible_base.resource_registry.models.service_id import ServiceID
+
+
+@pytest.mark.django_db
+def test_service_id_already_exists():
+    "The resource registry already creates this, so we expect an error here"
+    with pytest.raises(RuntimeError) as exc:
+        ServiceID.objects.create()
+    assert 'This service already has a ServiceID' in str(exc)
+
+
+@pytest.mark.django_db
+def test_service_id_does_not_yet_exist():
+    ServiceID.objects.first().delete()  # clear out what migration created
+    ServiceID.objects.create()  # expect no error


### PR DESCRIPTION
You can't reference `.objects` on an initialized instance. See:

https://stackoverflow.com/questions/3874187/manager-isnt-accessible-via-model-instances

Why did we not see this before? Because the migrations don't run the custom `.save` method.

Why would I ever hit this? Because AWX doesn't run migration in CI checks, see https://github.com/ansible/awx/pull/14896 so I added the post_migrate signal in the tests themselves and it hit this.

Notify @jessicamack @Spredzy 