### PR TITLE
Fix login issue with undefined user

### DIFF
--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -1,10 +1,12 @@
 import logging
 from collections import OrderedDict
 
+from crum import impersonate
 from django.contrib.auth.backends import ModelBackend
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin
 from ansible_base.authentication.models import Authenticator
+from ansible_base.lib.utils.models import get_system_user
 
 logger = logging.getLogger('ansible_base.authentication.backend')
 
@@ -14,6 +16,9 @@ authentication_backends = OrderedDict()
 class AnsibleBaseAuth(ModelBackend):
     def authenticate(self, request, *args, **kwargs):
         logger.debug("Starting AnsibleBaseAuth authentication")
+        system_user = get_system_user()
+        if not system_user:
+            logger.warning("System user is not available, attempting to login but failures could happen")
 
         for database_authenticator in Authenticator.objects.filter(enabled=True):
             # Either get the existing object out of the backends or get a new one for us
@@ -32,7 +37,8 @@ class AnsibleBaseAuth(ModelBackend):
                         continue
             authenticator_object = authentication_backends[database_authenticator.id]
             authenticator_object.update_if_needed(database_authenticator)
-            user = authenticator_object.authenticate(request, *args, **kwargs)
+            with impersonate(system_user):
+                user = authenticator_object.authenticate(request, *args, **kwargs)
             if user:
                 # The local authenticator handles this but we want to check this for other authentication types
                 if not getattr(user, 'is_active', True):

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -87,7 +87,7 @@ class CommonModel(models.Model):
         # Manually perform auto_now_add and auto_now logic.
         now = timezone.now()
         user = get_current_user()
-        if user is None or not user.is_authenticated():
+        if user is None or user.is_anonymous:
             user = get_system_user()
 
         if not self.pk:

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -1,6 +1,13 @@
+import logging
 from itertools import chain
 
+from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
 from inflection import underscore
+
+from ansible_base.lib.utils.settings import get_setting
+
+logger = logging.getLogger('ansible_base.lib.utils.models.py')
 
 
 def get_all_field_names(model):
@@ -49,3 +56,19 @@ def user_summary_fields(user):
     for field_name in ('id', 'username', 'first_name', 'last_name'):
         sf[field_name] = getattr(user, field_name)
     return sf
+
+
+def get_system_user():
+    system_user = None
+    setting_name = 'SYSTEM_USERNAME'
+    system_username = get_setting(setting_name)
+    system_user = get_user_model().objects.filter(username=system_username).first()
+    if system_username is not None and system_user is None:
+        logger.error(
+            _(
+                "{setting_name} is set to {system_username} but no user with that username exists.".format(
+                    setting_name=setting_name, system_username=system_username
+                )
+            )
+        )
+    return system_user

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -7,7 +7,7 @@ from inflection import underscore
 
 from ansible_base.lib.utils.settings import get_setting
 
-logger = logging.getLogger('ansible_base.lib.utils.models.py')
+logger = logging.getLogger('ansible_base.lib.utils.models')
 
 
 def get_all_field_names(model):

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -6,8 +6,6 @@ import pytest
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from django.core.exceptions import ObjectDoesNotExist
-from django.db.utils import IntegrityError
 from django.test.client import RequestFactory
 
 from ansible_base.lib.testing.fixtures import *  # noqa: F403, F401
@@ -455,19 +453,7 @@ def mocked_http(test_encryption_public_key, jwt_token):
 @pytest.fixture
 def system_user(db, settings, no_log_messages):
     with no_log_messages():
-        # Get the _system user from the database
-        try:
-            user_obj = models.User.objects.get(username=settings.SYSTEM_USERNAME)
-        except ObjectDoesNotExist:
-            # Just in case the user object gets trashed we will catch a DNE error and attempt to create it
-            try:
-                # Why don't we use get_or_create? Because we can't pass non_existent_user_fatal=False into get_or_create
-                user_obj = models.User()
-                user_obj.username = settings.SYSTEM_USERNAME
-                user_obj.save(non_existent_user_fatal=False)
-            except IntegrityError as e:
-                # If for some reason we fail again just let it go
-                raise e
+        user_obj, _created = models.User.objects.get_or_create(username=settings.SYSTEM_USERNAME)
     yield user_obj
 
 

--- a/test_app/tests/lib/utils/test_models.py
+++ b/test_app/tests/lib/utils/test_models.py
@@ -1,4 +1,8 @@
+from functools import partial
 from unittest.mock import MagicMock
+
+import pytest
+from django.test.utils import override_settings
 
 from ansible_base.lib.utils import models
 
@@ -8,3 +12,23 @@ def test_get_type_for_model():
     dummy_model._meta.concrete_model._meta.object_name = 'SnakeCaseString'
 
     assert models.get_type_for_model(dummy_model) == 'snake_case_string'
+
+
+@pytest.mark.django_db
+def test_system_user_unset():
+    with override_settings(SYSTEM_USERNAME=None):
+        assert models.get_system_user() is None
+
+
+@pytest.mark.django_db
+def test_system_user_set(system_user):
+    assert models.get_system_user() == system_user
+
+
+@pytest.mark.django_db
+def test_system_user_set_but_no_user(expected_log):
+    system_username = 'LittleTimmy'
+    with override_settings(SYSTEM_USERNAME=system_username):
+        expected_log = partial(expected_log, "ansible_base.lib.utils.models.logger")
+        with expected_log('error', f'is set to {system_username} but no user with that username exists'):
+            assert models.get_system_user() is None


### PR DESCRIPTION
There was an issue where the user already existed in the DB so `not self.pk` was not triggering during a user save. This gets around that by checking the current stack to see we are in a User save from the `authenticate` method.