### PR TITLE
Only register signals for models in registry

### DIFF
--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -68,7 +68,7 @@ def initialize_resources(sender, **kwargs):
 
 
 def proxies_of_model(cls):
-    "Return models that are a proxy of cls"
+    """Return models that are a proxy of cls"""
     for sub_cls in cls.__subclasses__():
         if sub_cls._meta.concrete_model is cls:
             yield sub_cls
@@ -80,6 +80,8 @@ def connect_resource_signals(sender, **kwargs):
     for model in handlers.get_resource_models():
         signals.post_save.connect(handlers.update_resource, sender=model)
         signals.post_delete.connect(handlers.remove_resource, sender=model)
+        # On registration, resource registry registers the concrete model
+        # so we connect signals for proxies of that model, and not the other way around
         for sub_cls in proxies_of_model(model):
             signals.post_save.connect(handlers.update_resource, sender=sub_cls)
             signals.post_delete.connect(handlers.remove_resource, sender=sub_cls)

--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -70,15 +70,17 @@ def initialize_resources(sender, **kwargs):
 def connect_resource_signals(sender, **kwargs):
     from ansible_base.resource_registry.signals import handlers
 
-    signals.post_save.connect(handlers.update_resource)
-    signals.post_delete.connect(handlers.remove_resource)
+    for model in handlers.get_resource_models():
+        signals.post_save.connect(handlers.update_resource, sender=model)
+        signals.post_delete.connect(handlers.remove_resource, sender=model)
 
 
 def disconnect_resource_signals(sender, **kwargs):
     from ansible_base.resource_registry.signals import handlers
 
-    signals.post_save.disconnect(handlers.update_resource)
-    signals.post_delete.disconnect(handlers.remove_resource)
+    for model in handlers.get_resource_models():
+        signals.post_save.disconnect(handlers.update_resource, sender=model)
+        signals.post_delete.disconnect(handlers.remove_resource, sender=model)
 
 
 class ResourceRegistryConfig(AppConfig):

--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -78,24 +78,20 @@ def connect_resource_signals(sender, **kwargs):
     from ansible_base.resource_registry.signals import handlers
 
     for model in handlers.get_resource_models():
-        signals.post_save.connect(handlers.update_resource, sender=model)
-        signals.post_delete.connect(handlers.remove_resource, sender=model)
-        # On registration, resource registry registers the concrete model
-        # so we connect signals for proxies of that model, and not the other way around
-        for sub_cls in proxies_of_model(model):
-            signals.post_save.connect(handlers.update_resource, sender=sub_cls)
-            signals.post_delete.connect(handlers.remove_resource, sender=sub_cls)
+        for cls in [model] + list(proxies_of_model(model)):
+            # On registration, resource registry registers the concrete model
+            # so we connect signals for proxies of that model, and not the other way around
+            signals.post_save.connect(handlers.update_resource, sender=cls)
+            signals.post_delete.connect(handlers.remove_resource, sender=cls)
 
 
 def disconnect_resource_signals(sender, **kwargs):
     from ansible_base.resource_registry.signals import handlers
 
     for model in handlers.get_resource_models():
-        signals.post_save.disconnect(handlers.update_resource, sender=model)
-        signals.post_delete.disconnect(handlers.remove_resource, sender=model)
-        for sub_cls in proxies_of_model(model):
-            signals.post_save.disconnect(handlers.update_resource, sender=sub_cls)
-            signals.post_delete.disconnect(handlers.remove_resource, sender=sub_cls)
+        for cls in [model] + list(proxies_of_model(model)):
+            signals.post_save.disconnect(handlers.update_resource, sender=cls)
+            signals.post_delete.disconnect(handlers.remove_resource, sender=cls)
 
 
 class ResourceRegistryConfig(AppConfig):

--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -78,7 +78,7 @@ def connect_resource_signals(sender, **kwargs):
     from ansible_base.resource_registry.signals import handlers
 
     for model in handlers.get_resource_models():
-        for cls in [model] + list(proxies_of_model(model)):
+        for cls in [model, *proxies_of_model(model)]:
             # On registration, resource registry registers the concrete model
             # so we connect signals for proxies of that model, and not the other way around
             signals.post_save.connect(handlers.update_resource, sender=cls)
@@ -89,7 +89,7 @@ def disconnect_resource_signals(sender, **kwargs):
     from ansible_base.resource_registry.signals import handlers
 
     for model in handlers.get_resource_models():
-        for cls in [model] + list(proxies_of_model(model)):
+        for cls in [model, *proxies_of_model(model)]:
             signals.post_save.disconnect(handlers.update_resource, sender=cls)
             signals.post_delete.disconnect(handlers.remove_resource, sender=cls)
 

--- a/ansible_base/resource_registry/signals/handlers.py
+++ b/ansible_base/resource_registry/signals/handlers.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 
 from ansible_base.resource_registry.models import Resource, init_resource_from_object
-from ansible_base.resource_registry.registry import get_concrete_model, get_registry
+from ansible_base.resource_registry.registry import get_registry
 
 
 @lru_cache(maxsize=1)
@@ -16,21 +16,17 @@ def get_resource_models():
 
 
 def remove_resource(sender, instance, **kwargs):
-    model = get_concrete_model(sender)
-    if model in get_resource_models():
-        try:
-            resource = Resource.get_resource_for_object(instance)
-            resource.delete()
-        except Resource.DoesNotExist:
-            return
+    try:
+        resource = Resource.get_resource_for_object(instance)
+        resource.delete()
+    except Resource.DoesNotExist:
+        return
 
 
 def update_resource(sender, instance, created, **kwargs):
-    model = get_concrete_model(sender)
-    if model in get_resource_models():
-        if created:
-            resource = init_resource_from_object(instance)
-            resource.save()
-        else:
-            resource = Resource.get_resource_for_object(instance)
-            resource.update_from_content_object()
+    if created:
+        resource = init_resource_from_object(instance)
+        resource.save()
+    else:
+        resource = Resource.get_resource_for_object(instance)
+        resource.update_from_content_object()

--- a/test_app/migrations/0001_initial.py
+++ b/test_app/migrations/0001_initial.py
@@ -195,20 +195,13 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, to='test_app.encryptionmodel'),
         ),
         migrations.CreateModel(
-            name='PositionModel',
-            fields=[
-                ('position', models.BigIntegerField(primary_key=True, serialize=False)),
-                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='test_app.organization')),
-            ],
-        ),
-        migrations.CreateModel(
-            name='WeirdPerm',
+            name='ImmutableTask',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='test_app.organization')),
             ],
             options={
-                'permissions': [("I'm a lovely coconut", 'You can be a lovely coconut with this object'), ('crack', 'Can crack open this coconut')],
+                'permissions': [('cancel_immutabletask', 'Stop this task from running')],
+                'default_permissions': ('add', 'view', 'delete'),
             },
         ),
         migrations.CreateModel(
@@ -224,6 +217,23 @@ class Migration(migrations.Migration):
             bases=('test_app.inventory',),
         ),
         migrations.CreateModel(
+            name='WeirdPerm',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='test_app.organization')),
+            ],
+            options={
+                'permissions': [("I'm a lovely coconut", 'You can be a lovely coconut with this object'), ('crack', 'Can crack open this coconut')],
+            },
+        ),
+        migrations.CreateModel(
+            name='PositionModel',
+            fields=[
+                ('position', models.BigIntegerField(primary_key=True, serialize=False)),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='test_app.organization')),
+            ],
+        ),
+        migrations.CreateModel(
             name='ParentName',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
@@ -231,14 +241,54 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='ImmutableTask',
+            name='Original2',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', models.DateTimeField(auto_now_add=True, help_text='The date/time this resource was created')),
+                ('modified', models.DateTimeField(auto_now=True, help_text='The date/time this resource was created')),
+                ('name', models.CharField(help_text='The name of this resource', max_length=512)),
+                ('created_by', models.ForeignKey(default=None, editable=False, help_text='The user who created this resource', null=True, on_delete=django.db.models.deletion.DO_NOTHING, related_name='%(app_label)s_%(class)s_created+', to=settings.AUTH_USER_MODEL)),
+                ('modified_by', models.ForeignKey(default=None, editable=False, help_text='The user who last modified this resource', null=True, on_delete=django.db.models.deletion.DO_NOTHING, related_name='%(app_label)s_%(class)s_modified+', to=settings.AUTH_USER_MODEL)),
             ],
             options={
-                'permissions': [('cancel_immutabletask', 'Stop this task from running')],
-                'default_permissions': ('add', 'view', 'delete'),
+                'abstract': False,
             },
+        ),
+        migrations.CreateModel(
+            name='Original1',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', models.DateTimeField(auto_now_add=True, help_text='The date/time this resource was created')),
+                ('modified', models.DateTimeField(auto_now=True, help_text='The date/time this resource was created')),
+                ('name', models.CharField(help_text='The name of this resource', max_length=512)),
+                ('created_by', models.ForeignKey(default=None, editable=False, help_text='The user who created this resource', null=True, on_delete=django.db.models.deletion.DO_NOTHING, related_name='%(app_label)s_%(class)s_created+', to=settings.AUTH_USER_MODEL)),
+                ('modified_by', models.ForeignKey(default=None, editable=False, help_text='The user who last modified this resource', null=True, on_delete=django.db.models.deletion.DO_NOTHING, related_name='%(app_label)s_%(class)s_modified+', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='Proxy1',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+                'indexes': [],
+                'constraints': [],
+            },
+            bases=('test_app.original1',),
+        ),
+        migrations.CreateModel(
+            name='Proxy2',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+                'indexes': [],
+                'constraints': [],
+            },
+            bases=('test_app.original2',),
         ),
         migrations.RunPython(create_system_user),
     ]

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -169,6 +169,30 @@ class ProxyInventory(Inventory):
         ]
 
 
+class Original1(NamedCommonModel):
+    "Registered with the Resource Registry"
+    pass
+
+
+class Proxy1(Original1):
+    "Not registered"
+
+    class Meta:
+        proxy = True
+
+
+class Original2(NamedCommonModel):
+    "Not registered"
+    pass
+
+
+class Proxy2(Original2):
+    "Registered with the Resource Registry"
+
+    class Meta:
+        proxy = True
+
+
 permission_registry.register(Organization, Inventory, Namespace, Team, Cow, UUIDModel, PositionModel, WeirdPerm)
 permission_registry.register(ParentName, parent_field_name='my_organization')
 permission_registry.register(CollectionImport, parent_field_name='namespace')

--- a/test_app/resource_api.py
+++ b/test_app/resource_api.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from ansible_base.authentication.models import Authenticator
 from ansible_base.resource_registry.registry import ResourceConfig, ServiceAPIConfig, SharedResource
 from ansible_base.resource_registry.shared_types import OrganizationType, TeamType, UserType
-from test_app.models import Organization, ResourceMigrationTestModel, Team
+from test_app.models import Organization, Original1, Proxy2, ResourceMigrationTestModel, Team
 
 
 class APIConfig(ServiceAPIConfig):
@@ -23,4 +23,6 @@ RESOURCE_LIST = (
     # Authenticators won't be a shared resource in production, but it's a convenient model to use for testing.
     ResourceConfig(Authenticator),
     ResourceConfig(ResourceMigrationTestModel),
+    ResourceConfig(Original1),
+    ResourceConfig(Proxy2),
 )

--- a/test_app/tests/resource_registry/test_resource_types_api.py
+++ b/test_app/tests/resource_registry/test_resource_types_api.py
@@ -12,7 +12,7 @@ def test_resource_type_list(admin_api_client):
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert set([x["name"] for x in response.data['results']]) == set(
-        ["shared.user", "shared.team", "aap.authenticator", "shared.organization", "aap.resourcemigrationtestmodel"]
+        ["shared.user", "shared.team", "aap.authenticator", "aap.original1", "aap.original2", "shared.organization", "aap.resourcemigrationtestmodel"]
     )
 
 

--- a/test_app/tests/resource_registry/test_signals.py
+++ b/test_app/tests/resource_registry/test_signals.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+import pytest
+
+from test_app.models import EncryptionModel, Organization
+
+
+@pytest.mark.django_db
+def test_unregistered_model_triggers_no_save_signals():
+    obj = EncryptionModel.objects.create()
+    with mock.patch('ansible_base.resource_registry.models.Resource.update_from_content_object') as mck:
+        obj.a = 'foobar'
+        obj.save()
+    mck.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_unregistered_model_triggers_no_delete_signals():
+    obj = EncryptionModel.objects.create()
+    with mock.patch('ansible_base.resource_registry.models.Resource.delete') as mck:
+        obj.delete()
+    mck.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_registered_model_triggers_save_signals():
+    obj = Organization.objects.create(name='foo')
+    with mock.patch('ansible_base.resource_registry.models.Resource.update_from_content_object') as mck:
+        obj.description = 'foobar'
+        obj.save()
+    mck.assert_called_once_with()
+
+
+@pytest.mark.django_db
+def test_registered_model_triggers_delete_signals():
+    obj = Organization.objects.create(name='foo')
+    with mock.patch('ansible_base.resource_registry.models.Resource.delete') as mck:
+        obj.delete()
+    mck.assert_called_once_with()

--- a/test_app/tests/resource_registry/test_signals.py
+++ b/test_app/tests/resource_registry/test_signals.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from ansible_base.resource_registry.models import Resource
 from ansible_base.resource_registry.signals import handlers
 from test_app.models import EncryptionModel, Organization, Original1, Original2, Proxy1, Proxy2
 


### PR DESCRIPTION
I saw https://github.com/ansible/django-ansible-base/pull/173 and it reminded me of something I wanted to do.

Right now, `update_resource` will be called every time any object in the system is saved for all objects. I know it uses cached data to do a no-op, but I don't see the necessity of this, and it makes me nervous to call it for say, an AWX `JobEvent` save.

So this is putting my my preference to only register `post_save` type signals on a per-model basis. This is what I see most commonly in other places, and I do this in the RBAC branch.

Also, we can't directly mock the `update_resource` method, because the way Django registers the signals it will still maintain a reference to the method from before the mock.