### PR TITLE
Add API root view to test_app

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,5 +1,6 @@
 ansible  # Used in build process to generate some configs
 build
+django-extensions
 ipython
 tox
 pytest
@@ -9,3 +10,4 @@ pytest-cov
 pytest-django
 setuptools-scm
 psycopg[binary]
+sdb

--- a/test_app/README.md
+++ b/test_app/README.md
@@ -11,6 +11,7 @@ If you are attempting to start test_app for the first time in a fresh environmen
 
 ```
 pip install -r requirements/requirements_all.txt
+pip install -r requirements/requirements_dev.txt
 ```
 
 # Initialize the test app

--- a/test_app/management/commands/create_demo_data.py
+++ b/test_app/management/commands/create_demo_data.py
@@ -22,7 +22,8 @@ class Command(BaseCommand):
         admin_password = environ.get('DJANGO_SUPERUSER_PASSWORD', 'admin')
         admin.set_password(admin_password)
         admin.save()
-
+        spud.set_password('password')
+        spud.save()
         with impersonate(spud):
             Team.objects.get_or_create(name='awx_docs', defaults={'organization': awx})
             Team.objects.get_or_create(name='awx_devs', defaults={'organization': awx})

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'ansible_base.jwt_consumer',
     'ansible_base.resource_registry',
     'test_app',
+    'django_extensions',
 ]
 
 MIDDLEWARE = [

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path, re_path
 
 from ansible_base.lib.dynamic_config.dynamic_urls import api_urls, api_version_urls, root_urls
 from ansible_base.resource_registry.urls import urlpatterns as resource_api_urls
+from test_app import views
 from test_app.router import router as test_app_router
 
 urlpatterns = [
@@ -14,4 +15,6 @@ urlpatterns = [
     # Admin application
     re_path(r"^admin/", admin.site.urls, name="admin"),
     path('api/v1/', include(resource_api_urls)),
+    path('api/v1/', views.api_root),
+    path('login/', include('rest_framework.urls')),
 ]

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,4 +1,7 @@
 from rest_framework import permissions
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
 from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
@@ -32,3 +35,15 @@ class EncryptionModelViewSet(TestAppViewSet):
 class RelatedFieldsTestModelViewSet(TestAppViewSet):
     queryset = RelatedFieldsTestModel.objects.all()  # needed for automatic basename from router
     serializer_class = serializers.RelatedFieldsTestModelSerializer
+
+
+# create api root view from the router
+@api_view(['GET'])
+def api_root(request, format=None):
+    return Response(
+        {
+            'organizations': reverse('organization-list', request=request, format=format),
+            'teams': reverse('team-list', request=request, format=format),
+            'users': reverse('user-list', request=request, format=format),
+        }
+    )


### PR DESCRIPTION
lists endpoints at api/v1/

Also:

- adds a login button on the DRF pages

- enables django-extensions for shell_plus

![Screenshot from 2024-02-29 16-14-27](https://github.com/ansible/django-ansible-base/assets/8745776/3d8e343a-3791-4750-aa6f-38413a0b6f70)
