### PR TITLE
Enforce that type hints are not obviously wrong

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -65,7 +65,7 @@ class AbstractAuthenticatorPlugin:
         else:
             self.logger = logger
 
-    def validate_configuration(self, data: dict, instance: object) -> None:
+    def validate_configuration(self, data: dict, instance: object) -> dict:
         if not issubclass(self.configuration_class, BaseAuthenticatorConfiguration):
             raise TypeError("self.configuration_class must subclass BaseAuthenticatorConfiguration.")
 

--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -104,7 +104,7 @@ class LDAPSearchField(ListField):
         self.validators.append(validator)
 
 
-def validate_ldap_filter(value: Any, with_user: bool = False) -> bool:
+def validate_ldap_filter(value: Any, with_user: bool = False) -> None:
     if type(value) is not str:
         raise ValidationError(VALID_STRING)
 

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -94,7 +95,7 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
     }
 
 
-def process_groups(trigger_condition: dict, groups: list, authenticator_id: int) -> bool:
+def process_groups(trigger_condition: dict, groups: list, authenticator_id: int) -> Optional[bool]:
     '''
     Looks at a maps trigger for a group and users groups and determines if the trigger True or False
     '''
@@ -127,7 +128,7 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int)
     return has_access
 
 
-def has_access_with_join(current_access: bool, new_access: bool, condition: str = 'or') -> bool:
+def has_access_with_join(current_access: Optional[bool], new_access: bool, condition: str = 'or') -> Optional[bool]:
     '''
     Handle join of authenticator_maps
     '''
@@ -141,7 +142,7 @@ def has_access_with_join(current_access: bool, new_access: bool, condition: str 
         return current_access and new_access
 
 
-def process_user_attributes(trigger_condition: dict, attributes: dict, authenticator_id: int) -> bool:
+def process_user_attributes(trigger_condition: dict, attributes: dict, authenticator_id: int) -> Optional[bool]:
     '''
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is True, False or None
     '''

--- a/ansible_base/lib/utils/hashing.py
+++ b/ansible_base/lib/utils/hashing.py
@@ -1,12 +1,12 @@
 import hashlib
 import json
-from typing import Callable, Optional
+from typing import Callable, Optional, Type
 
 from django.db.models import Model
 from rest_framework.serializers import Serializer
 
 
-def hash_serializer_data(instance: Model, serializer: Serializer, field: Optional[str] = None, hasher: Callable = hashlib.sha256):
+def hash_serializer_data(instance: Model, serializer: Type[Serializer], field: Optional[str] = None, hasher: Callable = hashlib.sha256):
     """
     Takes an instance, serialize it and take the .data or the specified field
     as input for the hasher function.

--- a/ansible_base/lib/utils/settings.py
+++ b/ansible_base/lib/utils/settings.py
@@ -45,3 +45,9 @@ def get_function_from_setting(setting_name: str) -> Any:
     except Exception:
         logger.exception(_('{setting_name} was set but we were unable to import its reference as a function.').format(setting_name=setting_name))
         return None
+
+
+def get_from_import(module_name, attr):
+    "Thin wrapper around importlib.import_module, mostly exists so that we can safely mock this in tests"
+    module = importlib.import_module(module_name, package=attr)
+    return getattr(module, attr)

--- a/ansible_base/lib/utils/views/django_app_api.py
+++ b/ansible_base/lib/utils/views/django_app_api.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework.filters import SearchFilter
 
+from ansible_base.lib.utils.settings import get_from_import
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 from ansible_base.rest_filters.rest_framework.field_lookup_backend import FieldLookupBackend
 from ansible_base.rest_filters.rest_framework.order_backend import OrderByBackend
@@ -24,8 +25,7 @@ if parent_view:
         if not module_name or not class_name:
             logger.error(_("ANSIBLE_BASE_CUSTOM_VIEW_PARENT must be in the format package.subpackage.view, defaulting to AnsibleBaseView"))
         else:
-            module = importlib.import_module(module_name, package=class_name)
-            parent_view_class = getattr(module, class_name)
+            parent_view_class = get_from_import(module_name, class_name)
     except ModuleNotFoundError:
         logger.error(_("Failed to find parent view class {parent_view}, defaulting to AnsibleBaseView".format(parent_view=parent_view)))
     except ImportError:

--- a/ansible_base/lib/utils/views/django_app_api.py
+++ b/ansible_base/lib/utils/views/django_app_api.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 
 from django.conf import settings

--- a/ansible_base/resource_registry/rest_client.py
+++ b/ansible_base/resource_registry/rest_client.py
@@ -1,5 +1,6 @@
 import logging
 from collections import namedtuple
+from typing import Optional
 
 import requests
 import urllib3
@@ -32,7 +33,7 @@ class ResourceAPIClient:
         self.verify_https = verify_https
         self.raise_if_bad_request = raise_if_bad_request
 
-    def _make_request(self, method: str, path: str, data: dict = None, params: dict = None) -> requests.Response:
+    def _make_request(self, method: str, path: str, data: Optional[dict] = None, params: Optional[dict] = None) -> requests.Response:
         url = self.base_url + path.lstrip("/")
         logger.info(f"Making {method} request to {url}.")
 

--- a/ansible_base/resource_registry/rest_client.py
+++ b/ansible_base/resource_registry/rest_client.py
@@ -83,11 +83,11 @@ class ResourceAPIClient:
     def delete_resource(self, ansible_id):
         return self._make_request("delete", f"resources/{ansible_id}/")
 
-    def list_resources(self, filters: dict = None):
+    def list_resources(self, filters: Optional[dict] = None):
         return self._make_request("get", "resources/", params=filters)
 
     def get_resource_type(self, name):
         return self._make_request("get", f"resource-types/{name}/")
 
-    def list_resource_types(self, filters: dict = None):
+    def list_resource_types(self, filters: Optional[dict] = None):
         return self._make_request("get", "resource-types/", params=filters)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ exclude = [ 'ansible_base/authentication/migrations/*', 'test_app/migrations/*',
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "test_app.settings"
-addopts = "--strict-markers --reuse-db --migrations -s -vvv"
+addopts = "--strict-markers --reuse-db --migrations --typeguard-packages=ansible_base -s -vvv"
 
 [tool.tox]
 legacy_tox_ini = """

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -4,6 +4,7 @@ django-extensions
 django-debug-toolbar
 ipython
 tox
+typeguard
 pytest
 pytest-asyncio
 pytest-xdist

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -390,7 +390,7 @@ def test_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
     """
     invalid_filter = "(&(cn=%(user)s)(objectClass=posixAccount)(invalid))"
     with pytest.raises(ValidationError) as e:
-        validate_ldap_filter(invalid_filter, 'foo')
+        validate_ldap_filter(invalid_filter, True)
     assert e.value.args[0] == 'Invalid filter: (invalid)'
 
 

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -6,6 +6,7 @@ import ldap
 import pytest
 from django.urls import reverse
 from rest_framework.serializers import ValidationError
+from typeguard import suppress_type_checks
 
 from ansible_base.authentication.authenticator_plugins.ldap import AuthenticatorPlugin, LDAPSettings, validate_ldap_filter
 from ansible_base.authentication.models import Authenticator
@@ -288,6 +289,7 @@ def test_ldap_backend_authenticate_empty_username_password(
     assert response.status_code == 401
 
 
+@suppress_type_checks
 @pytest.mark.django_db
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
@@ -317,6 +319,7 @@ def test_ldap_backend_authenticate_valid_user(
     assert response.data['results'][0]['name'] == ldap_authenticator.name
 
 
+@suppress_type_checks
 @pytest.mark.django_db
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -8,7 +8,6 @@ import pytest
 import requests
 from django.test.utils import override_settings
 from rest_framework.exceptions import AuthenticationFailed
-from typeguard import suppress_type_checks
 
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication, JWTCommonAuth, default_mapped_user_fields
 
@@ -151,7 +150,6 @@ class TestJWTCommonAuth:
                 assert False, f"Got unexpected exception {e}"
             assert cert == test_encryption_public_key
 
-    @suppress_type_checks
     @pytest.mark.parametrize(
         'user_fields,token,should_save',
         [

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from django.test.utils import override_settings
 from rest_framework.exceptions import AuthenticationFailed
+from typeguard import suppress_type_checks
 
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication, JWTCommonAuth, default_mapped_user_fields
 
@@ -150,6 +151,7 @@ class TestJWTCommonAuth:
                 assert False, f"Got unexpected exception {e}"
             assert cert == test_encryption_public_key
 
+    @suppress_type_checks
     @pytest.mark.parametrize(
         'user_fields,token,should_save',
         [

--- a/test_app/tests/lib/utils/test_hashing.py
+++ b/test_app/tests/lib/utils/test_hashing.py
@@ -1,6 +1,7 @@
 import uuid
 
 from rest_framework.serializers import CharField, IntegerField, Serializer, UUIDField
+from typeguard import suppress_type_checks
 
 from ansible_base.lib.utils.hashing import hash_serializer_data
 
@@ -13,16 +14,19 @@ class DataSerializer(Serializer):
     uuid = UUIDField()
 
 
+@suppress_type_checks
 def test_hash_serializer_data_idempotency():
     """Test hashing same data gives same output"""
     assert hash_serializer_data(DATA, DataSerializer) == hash_serializer_data(DATA, DataSerializer)
 
 
+@suppress_type_checks
 def test_hash_serializer_data_difference():
     """Test hashing different data changes the hash"""
     assert hash_serializer_data(DATA, DataSerializer) != hash_serializer_data({**DATA, **{"id": 4567}}, DataSerializer)
 
 
+@suppress_type_checks
 def test_hash_serializer_with_nested_field():
     """Test hashing can be performed on nested data"""
     NESTED_DATA = {"field": {"name": "foo", "id": 1234}}

--- a/test_app/tests/lib/utils/test_validation.py
+++ b/test_app/tests/lib/utils/test_validation.py
@@ -1,9 +1,11 @@
 import pytest
 from rest_framework.exceptions import ValidationError
+from typeguard import suppress_type_checks
 
 from ansible_base.lib.utils.validation import to_python_boolean, validate_cert_with_key, validate_image_data, validate_url
 
 
+@suppress_type_checks
 @pytest.mark.parametrize(
     "valid,url,schemes,allow_plain_hostname",
     [

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -1,6 +1,5 @@
 import importlib
 import logging
-import sys
 from unittest import mock
 
 import pytest
@@ -66,7 +65,6 @@ def test_ansible_base_view_parent_view(caplog, setting, log_message, default_par
             assert log_message in caplog.text
 
 
-@pytest.mark.xfail(reason='Type checking calls import_module', condition=lambda: sys.version.startswith('3.11'))
 def test_ansible_base_view_parent_view_exception(caplog):
     with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT='does.not.exist'):
         with caplog.at_level(logging.ERROR):

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import sys
 from unittest import mock
 
 import pytest
@@ -65,6 +66,11 @@ def test_ansible_base_view_parent_view(caplog, setting, log_message, default_par
             assert log_message in caplog.text
 
 
+def is_py_311():
+    return bool(sys.version.startswith('3.11'))
+
+
+@pytest.mark.xfail(reason='Type checking calls import_module', condition=is_py_311)
 def test_ansible_base_view_parent_view_exception(caplog):
     with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT='does.not.exist'):
         with caplog.at_level(logging.ERROR):

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -70,7 +70,8 @@ def test_ansible_base_view_parent_view(caplog, setting, log_message, default_par
 def test_ansible_base_view_parent_view_exception(caplog):
     with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT='does.not.exist'):
         with caplog.at_level(logging.ERROR):
-            with mock.patch('importlib.import_module', side_effect=ImportError("Test Exception")):
+            with mock.patch('ansible_base.lib.utils.settings.get_from_import', side_effect=ImportError("Test Exception")):
+
                 import ansible_base.lib.utils.views.django_app_api
 
                 importlib.reload(ansible_base.lib.utils.views.django_app_api)

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -66,11 +66,7 @@ def test_ansible_base_view_parent_view(caplog, setting, log_message, default_par
             assert log_message in caplog.text
 
 
-def is_py_311():
-    return bool(sys.version.startswith('3.11'))
-
-
-@pytest.mark.xfail(reason='Type checking calls import_module', condition=is_py_311)
+@pytest.mark.xfail(reason='Type checking calls import_module', condition=lambda: sys.version.startswith('3.11'))
 def test_ansible_base_view_parent_view_exception(caplog):
     with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT='does.not.exist'):
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
Outcome of day of learning - I've seen type hints become quite popular, but for all they are worth, they might as well be comments.

Since this is a _library_, it seems like the best place to start doing something better. We already know we have at least decent coverage from SonarCloud work, thanks @john-westcott-iv. Given that relatively decent and meaningful coverage, if tests are still passing, that means that at type hint gives relatively good assurance that the type is genuine.

This seems valuable if apps are interacting with DAB through a python interface. Those interface methods, in particular, can offer hardened type hints.