### PR TITLE
Dynamically create api root for test_app

### DIFF
--- a/test_app/views.py
+++ b/test_app/views.py
@@ -40,10 +40,13 @@ class RelatedFieldsTestModelViewSet(TestAppViewSet):
 # create api root view from the router
 @api_view(['GET'])
 def api_root(request, format=None):
-    return Response(
-        {
-            'organizations': reverse('organization-list', request=request, format=format),
-            'teams': reverse('team-list', request=request, format=format),
-            'users': reverse('user-list', request=request, format=format),
-        }
-    )
+    from test_app.router import router
+
+    list_endpoints = {}
+    for url in router.urls:
+        # only want "root" list views, for example:
+        # want '^users/$' [name='user-list']
+        # do not want '^users/(?P<pk>[^/.]+)/organizations/$' [name='user-organizations-list'],
+        if '-list' in url.name and url.pattern._regex.count('/') == 1:
+            list_endpoints[url.name.removesuffix('-list')] = reverse(url.name, request=request, format=format)
+    return Response(list_endpoints)


### PR DESCRIPTION
Instead of hard-coding root api endpoints, automatically add them.

- Loops over router URL patterns and add an entry for the "*-list" views.

- Checks that the entry is a "root" view by checking for a single "/" in the pattern.
![image](https://github.com/ansible/django-ansible-base/assets/8745776/a637ab75-692a-44ea-bec8-07e5ca1309ac)
