### PR TITLE
Turn off create-db by default, add check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ exclude = [ 'ansible_base/authentication/migrations/*', 'test_app/migrations/*',
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "test_app.settings"
-addopts = "--strict-markers --reuse-db --create-db --migrations -s -vvv"
+addopts = "--strict-markers --reuse-db --migrations -s -vvv"
 
 [tool.tox]
 legacy_tox_ini = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ legacy_tox_ini = """
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
     allowlist_externals = sh
-    commands = sh -c 'make postgres && pytest -n auto --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}'
+    commands = sh -c 'make postgres && pytest -n auto --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}'
 
     [testenv:check]
     deps =

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -10,10 +10,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.apps import apps
-from django.core.exceptions import ObjectDoesNotExist
 from django.db.migrations.recorder import MigrationRecorder
 from django.db.models.signals import post_migrate
-from django.db.utils import IntegrityError
 from django.test.client import RequestFactory
 
 from ansible_base.lib.testing.fixtures import *  # noqa: F403, F401


### PR DESCRIPTION
I'm going to be honest, `--create-db` just doesn't work for me. I'm _frequently_ just running 1 test over and over again. The migration takes a long time and dumps pages of logs.

Yes, I have been manually removing this line from my local source tree manually. Today I just got sick enough of it that I thought I would do something. @relrod expressed concern that this introduces _subtle_ bugs in tests (a column doesn't exist) when switching between different database states. Sure. But for the record, this doesn't address the need for `makemigrations`, and we live with _that_.

So, here are reproduction steps for the concern:

 - check out this branch https://github.com/ansible/django-ansible-base/compare/devel...AlanCoding:django-ansible-base:test_migration?expand=1
 - run a test `py.test test_app/tests/resource_registry/ -k test_resource_type_detail --create-db`, the --create-db put in for illustration
 - check out this branch and try to run

The idea there is that you need to add `--create-db` but it is subtle that you do. With this patch, you get:

```
E           AssertionError: Migrations not expected for app test_app, perhaps you need --create-db?
E           assert {'0003_create_system_user', '0001_initial', '0002_set_up_resources_test_data'} == {'0003_create_system_user', '0004_remove_team_encryptioner', '0001_initial', '0002_set_up_resources_test_data'}
E             Extra items in the right set:
E             '0004_remove_team_encryptioner'
E             Full diff:
E               {
E                '0001_initial',
E                '0002_set_up_resources_test_data',
E                '0003_create_system_user',
E             -  '0004_remove_team_encryptioner',
E               }

test_app/tests/conftest.py:45: AssertionError
```