### PR TITLE
Add VSCode launch configuration for test app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,6 @@ venv/
 # Mac OS X
 *.DS_Store
 
-# VSCode
-.vscode/
-
 # Editors
 *.sw[poj]
 *~

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Test App Server",
+            "consoleTitle": "Test App Server",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "env": {
+                "DJANGO_SETTINGS_MODULE": "test_app.sqlite3settings"
+            },
+            "preLaunchTask": "Run vscodebootstrap.sh",
+            "args": [
+                "runserver"
+            ],
+            "django": true,
+            "autoStartBrowser": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run vscodebootstrap.sh",
+      "type": "shell",
+      "command": "sh",
+      "args": [
+        "${workspaceFolder}/.vscode/vscodebootstrap.sh"
+      ],
+    }
+  ]
+}

--- a/.vscode/vscodebootstrap.sh
+++ b/.vscode/vscodebootstrap.sh
@@ -1,0 +1,2 @@
+DJANGO_SETTINGS_MODULE=test_app.sqlite3settings python manage.py migrate
+DJANGO_SETTINGS_MODULE=test_app.sqlite3settings python manage.py create_demo_data

--- a/test_app/sqlite3settings.py
+++ b/test_app/sqlite3settings.py
@@ -1,0 +1,8 @@
+from test_app.settings import *  # noqa
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "db.sqlite3",
+    }
+}


### PR DESCRIPTION
Adds a launch configuration for test app

This will launch the test app server via VSCode so that develops can set debug points and step through code using VSCode.

Additional changes:

bootstrap.sh can be called with args

./bootstrap.sh startpostgres

this allows the launch configuration to start the postgres server separately from runserver.

./bootstrap.sh without args runs exactly as it did before.

![image](https://github.com/ansible/django-ansible-base/assets/8745776/56ba8bb8-cc7b-4a47-b169-70500d734ebf)
