### PR TITLE
Fix tests passing when they should be failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ legacy_tox_ini = """
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
     allowlist_externals = sh
-    commands = sh -c 'make postgres && pytest -n auto --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}; make stop-postgres'
+    commands = sh -c 'make postgres && pytest -n auto --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}'
 
     [testenv:check]
     deps =


### PR DESCRIPTION
Look at some recent checks:

```
---------- coverage: platform linux, python 3.9.18-final-0 -----------
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
Coverage JSON written to file coverage.json

=========================== short test summary info ============================
FAILED test_app/tests/authentication/authenticator_plugins/test_ldap.py::test_ldap_backend_authenticate_valid_user
FAILED test_app/tests/authentication/authenticator_plugins/test_ldap.py::test_ldap_backend_authenticate_unbind_exception
FAILED test_app/tests/resource_registry/test_resource_types_api.py::test_resource_type_manifest
FAILED test_app/tests/lib/utils/test_hashing.py::test_hash_serializer_data_idempotency
FAILED test_app/tests/lib/utils/test_hashing.py::test_hash_serializer_data_difference
FAILED test_app/tests/lib/utils/test_hashing.py::test_hash_serializer_with_nested_field
FAILED test_app/tests/lib/utils/test_response.py::test_csv_stream_response - ...
FAILED test_app/tests/lib/utils/test_validation.py::test_validate_bad_urls[False-4-schemes0-True]
FAILED test_app/tests/lib/utils/test_validation.py::test_validate_bad_urls[False-None-schemes7-True]
= 9 failed, 656 passed, 11 xfailed, 3 xpassed, 36 warnings in 61.15s (0:01:01) =
echo "Killing dab_postgres container"
Killing dab_postgres container
docker kill dab_postgres
dab_postgres
  py39: OK (125.81=setup[55.92]+cmd[69.89] seconds)
  congratulations :) (125.93 seconds)
```

They failed. But OK. This is actually not OK. It looks like it's considered a success because we're running multiple commands and the last command (stop-postgres) was a success. So let's put a _stop_ to that.