### PR TITLE
Add app links to root API view

### DIFF
--- a/test_app/views.py
+++ b/test_app/views.py
@@ -51,9 +51,11 @@ class RelatedFieldsTestModelViewSet(TestAppViewSet):
 @api_view(['GET'])
 def api_root(request, format=None):
     from test_app.router import router
+    from ansible_base.authentication.urls import router as auth_router
+    from ansible_base.resource_registry.urls import service_router
 
     list_endpoints = {}
-    for url in router.urls:
+    for url in router.urls + auth_router.urls + service_router.urls:
         # only want "root" list views, for example:
         # want '^users/$' [name='user-list']
         # do not want '^users/(?P<pk>[^/.]+)/organizations/$' [name='user-organizations-list'],

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -50,9 +50,9 @@ class RelatedFieldsTestModelViewSet(TestAppViewSet):
 # create api root view from the router
 @api_view(['GET'])
 def api_root(request, format=None):
-    from test_app.router import router
     from ansible_base.authentication.urls import router as auth_router
     from ansible_base.resource_registry.urls import service_router
+    from test_app.router import router
 
     list_endpoints = {}
     for url in router.urls + auth_router.urls + service_router.urls:


### PR DESCRIPTION
After this change:

```json
{
    "encryption_test_model": "http://127.0.0.1:8000/api/v1/encrypted_models/",
    "related_fields_test_model": "http://127.0.0.1:8000/api/v1/related_fields_test_models/",
    "organization": "http://127.0.0.1:8000/api/v1/organizations/",
    "team": "http://127.0.0.1:8000/api/v1/teams/",
    "user": "http://127.0.0.1:8000/api/v1/users/",
    "authenticator": "http://127.0.0.1:8000/api/v1/authenticators/",
    "authenticatormap": "http://127.0.0.1:8000/api/v1/authenticator_maps/",
    "resource": "http://127.0.0.1:8000/api/v1/service-index/resources/",
    "resourcetype": "http://127.0.0.1:8000/api/v1/service-index/resource-types/"
}
```

Links for the apps, like authenticator and resource were missing.