### PR TITLE
Add organization field to teams shared serializer.

### DIFF
--- a/ansible_base/resource_registry/shared_types.py
+++ b/ansible_base/resource_registry/shared_types.py
@@ -58,4 +58,4 @@ class TeamType(serializers.Serializer):
     RESOURCE_TYPE = "team"
 
     name = serializers.CharField()
-    organization = AnsibleResourceForeignKeyField("shared.organization", required=False)
+    organization = AnsibleResourceForeignKeyField("shared.organization", required=False, allow_null=True)

--- a/ansible_base/resource_registry/shared_types.py
+++ b/ansible_base/resource_registry/shared_types.py
@@ -26,9 +26,12 @@ class AnsibleResourceForeignKeyField(serializers.UUIDField):
         return resource.content_object
 
     def get_attribute(self, instance):
-        self.field_name
-        obj_pk = getattr(instance, self.field_name).pk
-        resource = Resource.objects.get(content_type__resource_type__name=self.resource_type, object_id=obj_pk)
+        # If the model doesn't have an attribute with the given field name, return None. This is
+        # mostly here to keep Hub from breaking, which doesn't have organizations yet.
+        obj = getattr(instance, self.field_name, None)
+        if obj is None:
+            return None
+        resource = Resource.objects.get(content_type__resource_type__name=self.resource_type, object_id=obj.pk)
 
         return resource.ansible_id
 
@@ -55,4 +58,4 @@ class TeamType(serializers.Serializer):
     RESOURCE_TYPE = "team"
 
     name = serializers.CharField()
-    organization = AnsibleResourceForeignKeyField("shared.organization")
+    organization = AnsibleResourceForeignKeyField("shared.organization", required=False)

--- a/ansible_base/resource_registry/shared_types.py
+++ b/ansible_base/resource_registry/shared_types.py
@@ -1,4 +1,36 @@
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+
+from ansible_base.resource_registry.models import Resource
+
+
+class AnsibleResourceForeignKeyField(serializers.UUIDField):
+    default_error_messages = {
+        'invalid': _('Must be a valid UUID.'),
+        'does_not_exist': _('Invalid ansible id "{ansible_id}" - resource does not exist.'),
+    }
+
+    def __init__(self, resource_type, **kwargs):
+        self.resource_type = resource_type
+        super().__init__(**kwargs)
+
+    # Convert ansible ID to internal object ID
+    def to_internal_value(self, data):
+        ansible_id = super().to_internal_value(data)
+
+        try:
+            resource = Resource.objects.get(content_type__resource_type__name=self.resource_type, ansible_id=ansible_id)
+        except Resource.DoesNotExist:
+            self.fail('does_not_exist', ansible_id=data)
+
+        return resource.content_object
+
+    def get_attribute(self, instance):
+        self.field_name
+        obj_pk = getattr(instance, self.field_name).pk
+        resource = Resource.objects.get(content_type__resource_type__name=self.resource_type, object_id=obj_pk)
+
+        return resource.ansible_id
 
 
 class UserType(serializers.Serializer):
@@ -23,3 +55,4 @@ class TeamType(serializers.Serializer):
     RESOURCE_TYPE = "team"
 
     name = serializers.CharField()
+    organization = AnsibleResourceForeignKeyField("shared.organization")

--- a/test_app/resource_api.py
+++ b/test_app/resource_api.py
@@ -12,11 +12,9 @@ class APIConfig(ServiceAPIConfig):
 
 RESOURCE_LIST = (
     ResourceConfig(get_user_model(), shared_resource=SharedResource(serializer=UserType, is_provider=False), name_field="username"),
-    # Setting is_provider=True so that we can test that editing is disabled when the service is the resource
-    # source of truth.
     ResourceConfig(
         Team,
-        shared_resource=SharedResource(serializer=TeamType, is_provider=True),
+        shared_resource=SharedResource(serializer=TeamType, is_provider=False),
     ),
     ResourceConfig(
         Organization,

--- a/test_app/tests/resource_registry/test_resources_api.py
+++ b/test_app/tests/resource_registry/test_resources_api.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
 from ansible_base.resource_registry.models import Resource
-from test_app.models import EncryptionModel, Organization, Team
+from test_app.models import EncryptionModel
 
 
 def test_service_index_root(user_api_client):
@@ -61,16 +61,11 @@ def test_resources_delete_api(admin_api_client, django_user_model):
     assert not django_user_model.objects.filter(pk=user.pk).exists()
 
 
-def test_resources_api_invalid_delete(admin_api_client):
+def test_resources_api_invalid_delete(admin_api_client, local_authenticator):
     """Test that resources can be correctly deleted via the API."""
 
-    # Since groups are not set to be managed externally, we can't delete them with this API
-    org = Organization.objects.create(name="my org")
-    group = Team.objects.create(name="super group", organization=org)
-    c_type = ContentType.objects.get_for_model(group)
-    assert Resource.objects.filter(object_id=group.pk, content_type=c_type.pk).exists()
-
-    ansible_id = Resource.objects.get(object_id=group.pk, content_type=c_type.pk).ansible_id
+    # Authenticator is not allowed to be managed by the resources api
+    ansible_id = Resource.get_resource_for_object(local_authenticator).ansible_id
     resp = admin_api_client.delete(reverse("resource-detail", kwargs={"ansible_id": ansible_id}))
 
     assert resp.status_code == 400
@@ -261,7 +256,6 @@ def test_resources_api_crd(admin_api_client, resource):
             "data": {"ansible_id": "a0057c59033e68d91", "resource_type": "shared.team", "resource_data": {"name": "foo"}},
             "field_name": "ansible_id",
         },
-        {"data": {"resource_type": "shared.team", "resource_data": {"name": "foo"}}, "field_name": "resource_type"},
         {"data": {"resource_type": "shared.user", "resource_data": {}}, "field_name": "username"},
         {"data": {"resource_type": "aap.authenticator", "resource_data": {}}, "field_name": "resource_type"},
         {"data": {"resource_type": "fake.fake", "resource_data": {}}, "field_name": "resource_type"},
@@ -295,3 +289,32 @@ def test_resource_summary_fields(
     assert "resource" in data["summary_fields"]
     assert data["summary_fields"]["resource"]["ansible_id"] == resource.ansible_id
     assert data["summary_fields"]["resource"]["resource_type"] == "shared.organization"
+
+
+def test_team_organization_field(admin_api_client, organization, organization_1, team):
+    team_id = str(team.resource.ansible_id)
+    org0_id = str(organization.resource.ansible_id)
+    org1_id = str(organization_1.resource.ansible_id)
+
+    url = reverse("resource-detail", kwargs={"ansible_id": team_id})
+
+    # Test that organization field exists
+    resp = admin_api_client.get(url)
+    assert resp.status_code == 200
+    assert resp.data["resource_data"]["organization"] == org0_id
+
+    # Test updating the organization field
+    data = {"resource_data": {"organization": org1_id}}
+    resp = admin_api_client.patch(url, data, format="json")
+    assert resp.status_code == 200
+    assert resp.data["resource_data"]["organization"] == org1_id
+
+    team.refresh_from_db()
+    assert team.organization == organization_1
+
+    # Test invalid organization ID
+    bad_id = str(uuid.uuid4())
+    data = {"resource_data": {"organization": bad_id}}
+    resp = admin_api_client.patch(url, data, format="json")
+    assert resp.status_code == 400
+    assert bad_id in resp.data["organization"][0]

--- a/test_app/tests/resource_registry/test_resources_api.py
+++ b/test_app/tests/resource_registry/test_resources_api.py
@@ -312,8 +312,14 @@ def test_team_organization_field(admin_api_client, organization, organization_1,
     team.refresh_from_db()
     assert team.organization == organization_1
 
+
+def test_team_organization_field_does_not_exist(admin_api_client, team):
     # Test invalid organization ID
     bad_id = str(uuid.uuid4())
+    team_id = str(team.resource.ansible_id)
+
+    url = reverse("resource-detail", kwargs={"ansible_id": team_id})
+
     data = {"resource_data": {"organization": bad_id}}
     resp = admin_api_client.patch(url, data, format="json")
     assert resp.status_code == 400


### PR DESCRIPTION
```

{
    "object_id": "1",
    "name": "test",
    "ansible_id": "791b8558-001b-487e-a4ea-e7efc718c57f",
    "service_id": "9f1c372d-ed8c-4561-856e-31b888942daf",
    "resource_type": "shared.team",
    "has_serializer": true,
    "resource_data": {
        "name": "test",
        "organization": "37f44a39-2045-4e9b-a1dd-34a560218254"
    },
    "detail_url": "/api/gateway/v1/teams/1/",
    "url": "/api/gateway/v1/service-index/resources/791b8558-001b-487e-a4ea-e7efc718c57f/"
}
```

The organization field takes the ansible id for an organization object and can be used to update a Team's organization.

Right now the "organization" field is nullable in order to keep hub from breaking until we can get proper teams.