### PR TITLE
Handle no authenticator scenario when looking for latest timestamps

### DIFF
--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -28,7 +28,11 @@ def get_authentication_backends(last_updated):
 class AnsibleBaseAuth(ModelBackend):
     def authenticate(self, request, *args, **kwargs):
         logger.debug("Starting AnsibleBaseAuth authentication")
-        last_modified = Authenticator.objects.values("modified_on").order_by("-modified_on").first()["modified_on"]
+
+        # Query the database for the most recently last modified timestamp.
+        # This will be used as a cache key for the cached function get_authentication_backends below
+        last_modified_item = Authenticator.objects.values("modified_on").order_by("-modified_on").first()
+        last_modified = None if last_modified_item is None else last_modified_item.get('modified_on')
 
         for authenticator_id, authenticator_object in get_authentication_backends(last_modified).items():
             user = authenticator_object.authenticate(request, *args, **kwargs)


### PR DESCRIPTION
If we had no authenticators (which is valid for some tests) and attempted to call the authenticate method we would get a stack when looking for the latest timestamp of all authenticators. This change will pass the timestamp or None (if there are no authenticators) as the cache parameter value. 