### PR TITLE
Add nice error message for missing app when running test

### DIFF
--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -30,7 +30,10 @@ def test_migrations_okay(*args, **kwargs):
     for app in MigrationRecorder.Migration.objects.values_list('app', flat=True).distinct():
         if app in app_exceptions:
             continue
-        app_config = apps.get_app_config(app)
+        try:
+            app_config = apps.get_app_config(app)
+        except LookupError:
+            raise RuntimeError(f'App {app} is present in the recorded migrations but not installed, perhaps you need --create-db?')
         for path in os.listdir(os.path.join(app_config.path, 'migrations')):
             if re.match(r'^\d{4}_.*.py$', path):
                 disk_steps[app].add(path.rsplit('.')[0])


### PR DESCRIPTION
### Scenario

Successfully run tests in the DAB RBAC branch. Then switch to `devel` and run tests without `--create-db`

### Results

Before, this would return a KeyError at some level.

with this:

```
E               RuntimeError: App dab_rbac is present in the recorded migrations but not installed, perhaps you need --create-db?

test_app/tests/conftest.py:38: RuntimeError
```