### PR TITLE
Fix Authenticator Maps

### DIFF
--- a/ansible_base/authentication/models/authenticator_map.py
+++ b/ansible_base/authentication/models/authenticator_map.py
@@ -6,7 +6,7 @@ from .authenticator import Authenticator
 
 
 class AuthenticatorMap(NamedCommonModel):
-    router_basename = 'authenticator_map'
+    router_basename = 'authenticatormap'
 
     class Meta:
         # If the map type is a team then we must have an org/team

--- a/test_app/tests/authentication/views/test_authenticator_map.py
+++ b/test_app/tests/authentication/views/test_authenticator_map.py
@@ -145,10 +145,10 @@ def test_authenticator_map_invalid_map_type(admin_api_client, local_authenticato
         ),
         pytest.param(
             'is_superuser',
-            {'name': 'Rule 1', 'map_type': 'is_superuser', 'triggers': {'always': {}}},
+            {'name': 'Rule 1', 'map_type': 'is_superuser', 'order': -20, 'triggers': {'always': {}}},
             'order',
-            "Must be a valid integer",
-            id="map_type=is_superuser, missing order param",
+            "Ensure this value is greater than or equal to 0.",
+            id="map_type=is_superuser, invalid order param",
         ),
     ],
 )


### PR DESCRIPTION
Fixes URL and validations for AuthenticatorMap.option

`order` validation doesn't need to be present if there is default value (that is not compatible with the way how ansible collection can work)
`triggers` validation also doesn't need to be present in PATCH request