### PR TITLE
Cut an automatic create-only serializer for eda-server consistency

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -26,6 +26,14 @@ except NameError:
     REST_FRAMEWORK = {}
 
 
+# Tells the base serializer to auto-create a creation-only serializer
+# with the read-only fields excluded, for OpenAPI / openapi-generator / generated client
+try:
+    ANSIBLE_BASE_AUTO_CREATE_SERIALIZER
+except NameError:
+    ANSIBLE_BASE_AUTO_CREATE_SERIALIZER = False
+
+
 if 'ansible_base.api_documentation' in INSTALLED_APPS:
     if 'drf_spectacular' not in INSTALLED_APPS:
         INSTALLED_APPS.append('drf_spectacular')

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -26,8 +26,7 @@ except NameError:
     REST_FRAMEWORK = {}
 
 
-# Tells the base serializer to auto-create a creation-only serializer
-# with the read-only fields excluded, for OpenAPI / openapi-generator / generated client
+# See docs/lib/views.md
 try:
     ANSIBLE_BASE_AUTO_CREATE_SERIALIZER
 except NameError:

--- a/docs/lib/views.md
+++ b/docs/lib/views.md
@@ -48,3 +48,58 @@ class DefaultAPIView(AnsibleBaseView):
     all my good stuff
     ...
 ```
+
+## Automatic Create-only Serializer
+
+For a specific niche case, using this setting will tell the base view
+to auto-create a creation-only serializer with read-only fields excluded.
+
+```
+ANSIBLE_BASE_AUTO_CREATE_SERIALIZER = True
+```
+
+This affects the OpenAPI spec generated in the following way.
+The POST actions for list views will map to a dynamically generated "ModelCreate" serializer
+which will omit the fields which are not editable.
+
+```
+"RoleDefinitionCreate": {
+  "type": "object",
+  "properties": {
+    "permissions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/PermissionsEnum"
+      }
+    },
+    "content_type": {
+      "nullable": true,
+      "description": "The type of resource this applies to\n\n* ...",
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/ContentTypeEnum"
+        },
+        {
+          "$ref": "#/components/schemas/NullEnum"
+        }
+      ]
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "permissions"
+  ]
+}
+```
+
+This is specifically offered for using with the openapi-generator
+automatically generated client.
+The "required" listing only shows the writable fields, whereas
+other methods like GET return these every time, making them "required"
+according to jsonschema standards.

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -135,3 +135,6 @@ SYSTEM_USERNAME = '_system'
 ANSIBLE_BASE_ROLE_PRECREATE = {}  # tested in individual tests
 ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
+
+# Feature to use custom "create" serializer for create actions for OpenAPI stuff
+ANSIBLE_BASE_AUTO_CREATE_SERIALIZER = True

--- a/test_app/tests/lib/serializers/test_common.py
+++ b/test_app/tests/lib/serializers/test_common.py
@@ -136,3 +136,26 @@ def test_common_serializer_schema(openapi_schema):
 
     assert rd_schema['properties']['id']['type'] == 'integer'
     assert rd_schema['properties']['id']['readOnly'] is True
+
+
+@pytest.mark.django_db
+def test_common_create_serializer(openapi_schema):
+    post_schema = openapi_schema['paths']['/api/v1/role_definitions/']['post']
+    serializer_ref = post_schema['requestBody']['content']['application/json']['schema']['$ref']
+    serializer_name = serializer_ref.rsplit('/', 1)[-1]
+    assert serializer_name == 'RoleDefinitionCreate'
+
+    rd_schema = openapi_schema['components']['schemas']['RoleDefinitionCreate']
+
+    assert 'summary_fields' not in rd_schema['required']
+
+    # Repeat for assignment models
+    for endpoint in ('role_user_assignments', 'role_team_assignments'):
+        post_schema = openapi_schema['paths'][f'/api/v1/{endpoint}/']['post']
+        serializer_ref = post_schema['requestBody']['content']['application/json']['schema']['$ref']
+        serializer_name = serializer_ref.rsplit('/', 1)[-1]
+        assert serializer_name.endswith('Create')
+
+        rd_schema = openapi_schema['components']['schemas'][serializer_name]
+
+        assert 'summary_fields' not in rd_schema['required']

--- a/test_app/tests/rbac/api/test_rbac_views.py
+++ b/test_app/tests/rbac/api/test_rbac_views.py
@@ -74,7 +74,11 @@ def test_make_user_assignment(admin_api_client, inv_rd, rando, inventory):
     data = dict(role_definition=inv_rd.id, user=rando.id, object_id=inventory.id)
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data
-    assert response.data['created_by']
+    assert response.data['user'] == rando.pk
+    assert int(response.data['object_id']) == inventory.pk
+    assert response.data['role_definition'] == inv_rd.pk
+
+    assert rando.has_obj_perm(inventory, 'change')
 
 
 @pytest.mark.django_db
@@ -97,7 +101,11 @@ def test_make_global_user_assignment(admin_api_client, rando, inventory):
     data = dict(role_definition=rd.id, user=rando.id, object_id=None)
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data
-    assert response.data['created_by']
+    assert response.data['user'] == rando.pk
+    assert response.data['object_id'] == None
+    assert response.data['role_definition'] == rd.pk
+
+    assert rando.has_obj_perm(inventory, 'change')
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/api/test_rbac_views.py
+++ b/test_app/tests/rbac/api/test_rbac_views.py
@@ -102,7 +102,7 @@ def test_make_global_user_assignment(admin_api_client, rando, inventory):
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data
     assert response.data['user'] == rando.pk
-    assert response.data['object_id'] == None
+    assert response.data['object_id'] is None
     assert response.data['role_definition'] == rd.pk
 
     assert rando.has_obj_perm(inventory, 'change')


### PR DESCRIPTION
Ping for review on the expected usability side of things:
 - @ttuffin
 - @dhaustein
 - Doston (in reviewers)