### PR TITLE
Supress test standard out unless failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ exclude = [ 'ansible_base/authentication/migrations/*', 'test_app/migrations/*',
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "test_app.settings"
-addopts = "--strict-markers --reuse-db --migrations --typeguard-packages=ansible_base -s -vvv"
+addopts = "--strict-markers --reuse-db --migrations --typeguard-packages=ansible_base -vvv"
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
https://docs.pytest.org/en/7.4.x/how-to/capture-stdout-stderr.html#setting-capturing-methods-or-disabling-capturing

Looking out the docs, honestly the default behavior looks a ton better than what we're getting now which is overwhelmingly loud with DEBUG statements in test runs.

When a test fails it does print the standard out, but if it is successful, nothing gets printed. As the total test count grows... I think we need this.