### PR TITLE
Change RBAC usage to filter_queryset

### DIFF
--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Iterable
+from typing import Optional
 
 # Django
 from django.conf import settings
@@ -6,6 +8,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection, models
 from django.db.models.functions import Cast
+from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
 
 # Django-rest-framework
@@ -580,7 +583,7 @@ class RoleEvaluationFields(models.Model):
         return (self.codename, self.content_type_id, self.object_id)
 
     @classmethod
-    def accessible_ids(cls, model_cls, actor, codename, content_types=None):
+    def accessible_ids(cls, model_cls, actor, codename: str, content_types: Optional[Iterable[int]] = None) -> QuerySet:
         """
         Corresponds to AWX accessible_pk_qs
 
@@ -600,7 +603,7 @@ class RoleEvaluationFields(models.Model):
         return cls.objects.filter(**filter_kwargs).values_list('object_id').distinct()
 
     @classmethod
-    def accessible_objects(cls, model_cls, user, codename):
+    def accessible_objects(cls, model_cls, user, codename, queryset: Optional[QuerySet] = None) -> QuerySet:
         return model_cls.objects.filter(pk__in=cls.accessible_ids(model_cls, user, codename))
 
     @classmethod

--- a/docs/apps/rbac.md
+++ b/docs/apps/rbac.md
@@ -181,8 +181,8 @@ class MyModelViewSet(viewsets.ModelViewSet):
     permission_classes = [AnsibleBaseObjectPermissions]  # (2)
     serializer_class = MyModelSerializer
 
-    def get_queryset(self):
-        return MyModel.access_qs(self.request.user)  # (3)
+    def filter_queryset(self, queryset):
+        return super().filter_queryset(MyModel.access_qs(self.request.user, queryset=queryset))  # (3)
 ```
 
 This marks 3 different integration points.
@@ -268,6 +268,7 @@ has a certain type of permission to (access control).
 Given a registered model, you can do these things.
 
 - obtain visible objects for a user with `MyModel.access_qs(user, 'view_mymodel')`
+- filter existing `queryset` to objects user can view `MyModel.access_qs(user, queryset)`
 - obtain objects user has permission to delete `MyModel.access_qs(user, 'delete_mymodel')`
 - determine if user can delete one specific object `user.has_obj_perm(obj, 'delete_mymodel')`
 - use only the action name for a queryset shortcut `MyModel.access_qs(user, 'view')`

--- a/test_app/router.py
+++ b/test_app/router.py
@@ -23,13 +23,11 @@ router.register(
     related_views={
         'teams': (views.TeamViewSet, 'teams'),
     },
-    basename='organization',
 )
 
 router.register(
     r'teams',
     views.TeamViewSet,
-    basename='team',
 )
 
 router.register(
@@ -39,9 +37,8 @@ router.register(
         'organizations': (views.OrganizationViewSet, 'organizations'),
         'teams': (views.TeamViewSet, 'teams'),
     },
-    basename='user',
 )
-router.register(r'inventories', views.InventoryViewSet, basename='inventory')
-router.register(r'instance_groups', views.InstanceGroupViewSet, basename='instancegroup')
-router.register(r'cows', views.CowViewSet, basename='cow')
-router.register(r'uuidmodels', views.UUIDModelViewSet, basename='uuidmodel')
+router.register(r'inventories', views.InventoryViewSet)
+router.register(r'instance_groups', views.InstanceGroupViewSet)
+router.register(r'cows', views.CowViewSet)
+router.register(r'uuidmodels', views.UUIDModelViewSet)

--- a/test_app/tests/rbac/api/test_rbac_views.py
+++ b/test_app/tests/rbac/api/test_rbac_views.py
@@ -210,3 +210,15 @@ def test_remove_global_role_assignment(user_api_client, user, inv_rd, global_inv
     assert response.status_code == 204, response.data
 
     assert not type(assignment).objects.filter(pk=assignment.pk).exists()
+
+
+@pytest.mark.django_db
+def test_filter_queryset(user_api_client, user, inventory, inv_rd):
+    "This tests that filter_queryset usage in test_app is effective"
+    url = reverse("inventory-list")
+    response = user_api_client.get(url, format="json")
+    assert response.data['count'] == 0
+
+    inv_rd.give_permission(user, inventory)
+    response = user_api_client.get(url, format="json")
+    assert response.data['count'] == 1


### PR DESCRIPTION
AAP-22130

Before, everything used `get_queryset`. It was always designed so it didn't have to do it this way, but that we could take an existing queryset and filter that. There was just one bug which this fixes in the method that gets attached.

This converts test_app and docs to suggest `filter_queryset`.