### PR TITLE
[RBAC] Fix missing condition for queryset in access_qs

### DIFF
--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -604,7 +604,9 @@ class RoleEvaluationFields(models.Model):
 
     @classmethod
     def accessible_objects(cls, model_cls, user, codename, queryset: Optional[QuerySet] = None) -> QuerySet:
-        return model_cls.objects.filter(pk__in=cls.accessible_ids(model_cls, user, codename))
+        if queryset is None:
+            queryset = model_cls.objects
+        return queryset.filter(pk__in=cls.accessible_ids(model_cls, user, codename))
 
     @classmethod
     def get_permissions(cls, user, obj):

--- a/test_app/tests/rbac/test_permission_evaluation.py
+++ b/test_app/tests/rbac/test_permission_evaluation.py
@@ -45,6 +45,15 @@ def test_org_inv_permissions_team(team, inventory, org_inv_rd):
 
 
 @pytest.mark.django_db
+def test_access_qs_with_parent_qs(inventory, rando, inv_rd):
+    assert list(Inventory.access_qs(rando)) == []
+    inv_rd.give_permission(rando, inventory)
+    assert list(Inventory.access_qs(rando)) == [inventory]
+    assert list(Inventory.access_qs(rando, queryset=Inventory.objects.all())) == [inventory]
+    assert list(Inventory.access_qs(rando, queryset=Inventory.objects.none())) == []
+
+
+@pytest.mark.django_db
 def test_resource_add_permission(rando, inventory):
     rd, _ = RoleDefinition.objects.get_or_create(
         permissions=['add_inventory', 'view_organization'],


### PR DESCRIPTION
This is a bug in my very last merge https://github.com/ansible/django-ansible-base/pull/243

I didn't see it, because all the base view querysets are all objects so it didn't matter for what was being tested.