### PR TITLE
[translations] common/auth update

### DIFF
--- a/ansible_base/lib/utils/translations.py
+++ b/ansible_base/lib/utils/translations.py
@@ -1,0 +1,17 @@
+from django.utils.translation import gettext
+
+'''
+Simple helper class that can be used to translate messages or not translate messages.
+Ex: Function that calls a raise ValidationError and logger.error one after the other.
+'''
+
+
+class translatableConditionally:
+    def __init__(self, message):
+        self.message = message
+
+    def not_translated(self):
+        return self.message
+
+    def translated(self):
+        return gettext(self.message)


### PR DESCRIPTION
First PR of many to update translations. 

Had to do things a little differently here since there was a lot of use around a function that both logged an error and raised an exception all in the same call. Rather than rip that out and just do individual calls each time they were needed and translate there, I worked with @chrismeyersfsu to come up with a helper class that has been added to lib/utils/ called translations.py that can be used to not translate messages immediately (so that they can be logged) and then translate them for exceptions/other potential user facing errors. 

During testing/messing around with ways to not rip out the existing code, some research showed that the command to go look for strings marked for translation (django-admin makemessages) explicitly looks for `_("` so importing this class as `_` follows the same pattern that most all projects that needs translations use. 

Testing steps:
1. pull down PR branch and start dev virtual env
2. install django in virtenv if it is not already present (I believe it is but just in case)
`pip freeze | grep Django` `pip install Django`
4. make a locale directory (makemessages looks for one and we don't have one configured yet so just create your own) `mkdir locale` 
5. run the makemessages command check the output to see if strings were extracted correctly. 
`django-admin makemessages -l es` 
`vim locale/es/LC_MESSAGES/django.po`