### PR TITLE
Fix enablement problem with typeguard

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/utils.py
+++ b/ansible_base/authentication/authenticator_plugins/utils.py
@@ -1,8 +1,8 @@
 import logging
-from types import ModuleType
 from functools import lru_cache
 from glob import glob
 from os.path import basename, isfile, join
+from types import ModuleType
 from typing import Optional
 
 from django.conf import settings

--- a/ansible_base/authentication/authenticator_plugins/utils.py
+++ b/ansible_base/authentication/authenticator_plugins/utils.py
@@ -49,7 +49,7 @@ def get_authenticator_urls(authenticator_type: str) -> list:
         return getattr(urls_module, 'urls', [])
     except Exception as e:
         logger.error(f"Failed to load urls from {authenticator_type} {e}")
-    return None
+    return []
 
 
 def generate_authenticator_slug(type: str, name: str) -> str:

--- a/ansible_base/authentication/authenticator_plugins/utils.py
+++ b/ansible_base/authentication/authenticator_plugins/utils.py
@@ -1,4 +1,5 @@
 import logging
+from types import ModuleType
 from functools import lru_cache
 from glob import glob
 from os.path import basename, isfile, join
@@ -44,7 +45,7 @@ def get_authenticator_plugin(authenticator_type: str):
     return AuthClass()
 
 
-def get_authenticator_urls(authenticator_type: str) -> Optional[list]:
+def get_authenticator_urls(authenticator_type: str) -> Optional[ModuleType]:
     try:
         urls = __import__(authenticator_type, globals(), locals(), ['urls'], 0)
         return urls

--- a/ansible_base/authentication/authenticator_plugins/utils.py
+++ b/ansible_base/authentication/authenticator_plugins/utils.py
@@ -2,6 +2,7 @@ import logging
 from functools import lru_cache
 from glob import glob
 from os.path import basename, isfile, join
+from typing import Optional
 
 from django.conf import settings
 from django.utils.text import slugify
@@ -43,7 +44,7 @@ def get_authenticator_plugin(authenticator_type: str):
     return AuthClass()
 
 
-def get_authenticator_urls(authenticator_type: str) -> list:
+def get_authenticator_urls(authenticator_type: str) -> Optional[list]:
     try:
         urls = __import__(authenticator_type, globals(), locals(), ['urls'], 0)
         return urls

--- a/ansible_base/authentication/authenticator_plugins/utils.py
+++ b/ansible_base/authentication/authenticator_plugins/utils.py
@@ -2,8 +2,6 @@ import logging
 from functools import lru_cache
 from glob import glob
 from os.path import basename, isfile, join
-from types import ModuleType
-from typing import Optional
 
 from django.conf import settings
 from django.utils.text import slugify
@@ -45,10 +43,10 @@ def get_authenticator_plugin(authenticator_type: str):
     return AuthClass()
 
 
-def get_authenticator_urls(authenticator_type: str) -> Optional[ModuleType]:
+def get_authenticator_urls(authenticator_type: str) -> list:
     try:
-        urls = __import__(authenticator_type, globals(), locals(), ['urls'], 0)
-        return urls
+        urls_module = __import__(authenticator_type, globals(), locals(), ['urls'], 0)
+        return getattr(urls_module, 'urls', [])
     except Exception as e:
         logger.error(f"Failed to load urls from {authenticator_type} {e}")
     return None

--- a/ansible_base/authentication/urls.py
+++ b/ansible_base/authentication/urls.py
@@ -22,7 +22,7 @@ api_version_urls = []
 
 # Load urls from authenticator plugins
 for plugin_name in get_authenticator_plugins():
-    plugin_urls = getattr(get_authenticator_urls(plugin_name), 'urls', None)
+    plugin_urls = get_authenticator_urls(plugin_name)
     if plugin_urls:
         api_version_urls.extend(plugin_urls)
         logger.debug(f"Loaded URLS from {plugin_name}")

--- a/ansible_base/lib/utils/encryption.py
+++ b/ansible_base/lib/utils/encryption.py
@@ -65,9 +65,8 @@ class Fernet256(Fernet):
 
         # Finally decode the value
         encrypted = base64.b64decode(b64data)
-        value = self.decrypt(encrypted)
 
-        return smart_str(value)
+        return smart_str(self.decrypt(encrypted))
 
 
 ansible_encryption = SimpleLazyObject(func=lambda: Fernet256())

--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -625,10 +625,8 @@ class RoleEvaluationFields(models.Model):
     @classmethod
     def accessible_objects(cls, model_cls, user, codename, queryset: Optional[QuerySet] = None) -> QuerySet:
         if queryset is None:
-            base_queryset = model_cls.objects
-        else:
-            base_queryset = queryset
-        return base_queryset.filter(pk__in=cls.accessible_ids(model_cls, user, codename))
+            queryset = model_cls.objects.all()
+        return queryset.filter(pk__in=cls.accessible_ids(model_cls, user, codename))
 
     @classmethod
     def get_permissions(cls, user, obj):

--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -625,8 +625,10 @@ class RoleEvaluationFields(models.Model):
     @classmethod
     def accessible_objects(cls, model_cls, user, codename, queryset: Optional[QuerySet] = None) -> QuerySet:
         if queryset is None:
-            queryset = model_cls.objects
-        return queryset.filter(pk__in=cls.accessible_ids(model_cls, user, codename))
+            base_queryset = model_cls.objects
+        else:
+            base_queryset = queryset
+        return base_queryset.filter(pk__in=cls.accessible_ids(model_cls, user, codename))
 
     @classmethod
     def get_permissions(cls, user, obj):

--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Model
+from django.db.models.base import ModelBase  # post_migrate may call with phony objects
 from django.db.models.signals import post_delete, post_migrate
 from django.utils.functional import cached_property
 
@@ -46,7 +47,7 @@ class PermissionRegistry:
     def track_relationship(self, cls, relationship, role_name):
         self._tracked_relationships.add((cls, relationship, role_name))
 
-    def get_parent_model(self, model) -> Optional[Model]:
+    def get_parent_model(self, model) -> Union[type, None]:
         model = self._name_to_model[model._meta.model_name]
         parent_field_name = self.get_parent_fd_name(model)
         if parent_field_name is None:
@@ -159,7 +160,8 @@ class PermissionRegistry:
     def all_registered_models(self):
         return [cls for cls in self._registry]
 
-    def is_registered(self, obj: Model) -> bool:
+    def is_registered(self, obj: Union[ModelBase, Model]) -> bool:
+        """Tells if the given object or class is a type tracked by DAB RBAC"""
         return any(obj._meta.model_name == cls._meta.model_name for cls in self._registry)
 
 

--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -47,7 +47,7 @@ class PermissionRegistry:
     def track_relationship(self, cls, relationship, role_name):
         self._tracked_relationships.add((cls, relationship, role_name))
 
-    def get_parent_model(self, model) -> Union[type, None]:
+    def get_parent_model(self, model) -> Optional[type]:
         model = self._name_to_model[model._meta.model_name]
         parent_field_name = self.get_parent_fd_name(model)
         if parent_field_name is None:

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 from django.apps import apps
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Model, Q
 from django.db.models.signals import m2m_changed, post_delete, post_init, post_save, pre_delete, pre_save
 from django.db.utils import ProgrammingError
 
@@ -131,7 +131,7 @@ def rbac_post_init_set_original_parent(sender, instance, **kwargs):
     instance.__rbac_original_parent_id = getattr(instance, parent_id_name)
 
 
-def get_parent_ids(instance) -> list[tuple[int, int]]:
+def get_parent_ids(instance) -> list[tuple[Model, int]]:
     parent_field_name = permission_registry.get_parent_fd_name(instance)
     if not parent_field_name:
         return []

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -32,7 +32,7 @@ def permissions_allowed_for_system_role() -> dict[Model, set[str]]:
     return permissions_by_model
 
 
-def permissions_allowed_for_role(cls) -> dict[Model, set[str]]:
+def permissions_allowed_for_role(cls) -> dict[type, set[str]]:
     "Permission codenames valid for a RoleDefinition of given class, organized by permission class"
     if cls is None:
         return permissions_allowed_for_system_role()
@@ -51,7 +51,7 @@ def permissions_allowed_for_role(cls) -> dict[Model, set[str]]:
     return permissions_by_model
 
 
-def combine_values(data: dict[Model, str]) -> set[str]:
+def combine_values(data: dict[type, set[str]]) -> set[str]:
     "Utility method to merge everything in .values() into a single set"
     ret = set()
     for this_set in data.values():

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -2,7 +2,6 @@ import re
 from collections import defaultdict
 
 from django.conf import settings
-from django.db.models import Model
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from ansible_base.lib.utils.models import is_add_perm
@@ -21,7 +20,7 @@ def codenames_for_cls(cls) -> set[str]:
     return {t[0] for t in cls._meta.permissions} | {f'{act}_{cls._meta.model_name}' for act in cls._meta.default_permissions}
 
 
-def permissions_allowed_for_system_role() -> dict[Model, set[str]]:
+def permissions_allowed_for_system_role() -> dict[type, set[str]]:
     "Permission codenames useable in system-wide roles, which have content_type set to None"
     permissions_by_model = defaultdict(set)
     for cls in permission_registry.all_registered_models:

--- a/ansible_base/resource_registry/models/resource.py
+++ b/ansible_base/resource_registry/models/resource.py
@@ -1,5 +1,6 @@
 import uuid
 from functools import lru_cache
+from typing import Union
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -95,7 +96,7 @@ class Resource(models.Model):
             self.delete()
 
     @classmethod
-    def create_resource(cls, resource_type: ResourceType, resource_data: dict, ansible_id: str = None, service_id: str = None):
+    def create_resource(cls, resource_type: ResourceType, resource_data: dict, ansible_id: Union[str, uuid.UUID, None] = None, service_id: str = None):
         c_type = resource_type.content_type
         serializer = resource_type.serializer_class(data=resource_data)
         serializer.is_valid(raise_exception=True)
@@ -115,7 +116,7 @@ class Resource(models.Model):
 
             return resource
 
-    def update_resource(self, resource_data: dict, ansible_id=None, partial=False, service_id: str = None):
+    def update_resource(self, resource_data: dict, ansible_id=None, partial=False, service_id: Union[str, uuid.UUID, None] = None):
         resource_type = self.content_type.resource_type
 
         serializer = resource_type.serializer_class(data=resource_data, partial=partial)

--- a/ansible_base/resource_registry/models/resource.py
+++ b/ansible_base/resource_registry/models/resource.py
@@ -96,7 +96,9 @@ class Resource(models.Model):
             self.delete()
 
     @classmethod
-    def create_resource(cls, resource_type: ResourceType, resource_data: dict, ansible_id: Union[str, uuid.UUID, None] = None, service_id: str = None):
+    def create_resource(
+        cls, resource_type: ResourceType, resource_data: dict, ansible_id: Union[str, uuid.UUID, None] = None, service_id: Union[str, uuid.UUID, None] = None
+    ):
         c_type = resource_type.content_type
         serializer = resource_type.serializer_class(data=resource_data)
         serializer.is_valid(raise_exception=True)

--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import List
+from typing import List, Optional
 
 from django.contrib.auth import authenticate
 
@@ -61,7 +61,9 @@ class ResourceConfig:
     actions = None
     name_field = None
 
-    def __init__(self, model, shared_resource: SharedResource = None, parent_resources: List[ParentResource] = None, name_field: str = None):
+    def __init__(
+        self, model, shared_resource: Optional[SharedResource] = None, parent_resources: Optional[List[ParentResource]] = None, name_field: Optional[str] = None
+    ):
         model = get_concrete_model(model)
         self.model_label = model._meta.label
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ exclude = [ 'ansible_base/*/migrations/*', 'test_app/migrations/*', '.tox', 'bui
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "test_app.settings"
-addopts = "--strict-markers --reuse-db --migrations --typeguard-packages=ansible_base -vvv"
+addopts = "--strict-markers --reuse-db --migrations -vvv"
 
 [tool.tox]
 legacy_tox_ini = """

--- a/test_app/resource_api.py
+++ b/test_app/resource_api.py
@@ -23,7 +23,7 @@ class APIConfig(ServiceAPIConfig):
     service_type = "aap"
 
 
-RESOURCE_LIST = (
+RESOURCE_LIST = [
     ResourceConfig(
         get_user_model(),
         shared_resource=SharedResource(serializer=UserType, is_provider=False),
@@ -42,4 +42,4 @@ RESOURCE_LIST = (
     ResourceConfig(ResourceMigrationTestModel),
     ResourceConfig(Original1),
     ResourceConfig(Proxy2),
-)
+]

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -1,8 +1,19 @@
 import os
+import sys
 
 from split_settings.tools import include
 
 DEBUG = True
+
+if "pytest" in sys.modules:
+    # https://github.com/agronholm/typeguard/issues/260
+    # Enable runtime type checking only for running tests
+    # must be done here because python hooks will not reliably call the
+    # typguard plugin setup before other plugins which setup Django, which loads settings.
+    # Lower in this settings file, the dynamic config imports ansible_base
+    from typeguard import install_import_hook
+
+    install_import_hook(packages=["ansible_base"])
 
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
I'll put more details in the upstream issue https://github.com/agronholm/typeguard/issues/260

At some point, the typeguard python plugin was working, but it broke and who knows when.

I expect there will be more failures as the checks run. This validates that I, personally, needed this. Since I've added globs of code with incorrect type hints since I first tried to add enforcement.