### PR TITLE
[activitystream] EntryReadOnlyViewSet permissions

### DIFF
--- a/ansible_base/activitystream/views.py
+++ b/ansible_base/activitystream/views.py
@@ -1,10 +1,22 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
-from rest_framework import permissions
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from ansible_base.activitystream.models import Entry
 from ansible_base.activitystream.serializers import EntrySerializer
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
+
+
+def _permission_classes():
+    entry_permission_classes = []
+    for cls in settings.ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES:
+        try:
+            entry_permission_classes.append(import_string(cls))
+        except ImportError as e:
+            raise ImproperlyConfigured(f"[ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES] Could not find permission class '{cls}'.") from e
+    return entry_permission_classes
 
 
 class EntryReadOnlyViewSet(ReadOnlyModelViewSet, AnsibleBaseDjangoAppApiView):
@@ -14,7 +26,7 @@ class EntryReadOnlyViewSet(ReadOnlyModelViewSet, AnsibleBaseDjangoAppApiView):
 
     queryset = Entry.objects.all()
     serializer_class = EntrySerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = _permission_classes()
 
     def get_view_name(self):
         return _('Activity Stream Entries')

--- a/ansible_base/activitystream/views.py
+++ b/ansible_base/activitystream/views.py
@@ -1,22 +1,12 @@
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
+from rest_framework import permissions
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from ansible_base.activitystream.models import Entry
 from ansible_base.activitystream.serializers import EntrySerializer
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
-
-
-def _permission_classes():
-    entry_permission_classes = []
-    for cls in settings.ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES:
-        try:
-            entry_permission_classes.append(import_string(cls))
-        except ImportError as e:
-            raise ImproperlyConfigured(f"[ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES] Could not find permission class '{cls}'.") from e
-    return entry_permission_classes
+from ansible_base.lib.utils.views.permissions import IsSuperuser
 
 
 class EntryReadOnlyViewSet(ReadOnlyModelViewSet, AnsibleBaseDjangoAppApiView):
@@ -26,7 +16,17 @@ class EntryReadOnlyViewSet(ReadOnlyModelViewSet, AnsibleBaseDjangoAppApiView):
 
     queryset = Entry.objects.all()
     serializer_class = EntrySerializer
-    permission_classes = _permission_classes()
+
+    def get_permissions(self):
+        """
+        If the RBAC app is enabled, then we delegate to it to manage permissions.
+        Otherwise, we require superuser status.
+        """
+        if 'ansible_base.rbac' in settings.INSTALLED_APPS:
+            permission_classes = [permissions.IsAuthenticated]
+        else:
+            permission_classes = [IsSuperuser]
+        return [permission() for permission in permission_classes]
 
     def get_view_name(self):
         return _('Activity Stream Entries')

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -159,8 +159,3 @@ if 'ansible_base.rbac' in INSTALLED_APPS:
     ANSIBLE_BASE_BYPASS_ACTION_FLAGS = {}
 
     ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS = False
-
-
-if 'ansible_base.activitystream':
-    # We can't user rest_framework.permissions.IsAdminUser, because it checks for is_staff, not is_superuser
-    ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES = ['ansible_base.lib.utils.views.permissions.IsSuperuser']

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -159,3 +159,8 @@ if 'ansible_base.rbac' in INSTALLED_APPS:
     ANSIBLE_BASE_BYPASS_ACTION_FLAGS = {}
 
     ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS = False
+
+
+if 'ansible_base.activitystream':
+    # We can't user rest_framework.permissions.IsAdminUser, because it checks for is_staff, not is_superuser
+    ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES = ['ansible_base.lib.utils.views.permissions.IsSuperuser']

--- a/ansible_base/lib/utils/views/permissions.py
+++ b/ansible_base/lib/utils/views/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsSuperuser(BasePermission):
+    """
+    Allows access only to superusers.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_superuser)

--- a/docs/apps/activitystream.md
+++ b/docs/apps/activitystream.md
@@ -82,6 +82,25 @@ urlpatterns = [
 ]
 ```
 
+
+### Permissions
+
+The setting `ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES` can be used to
+specify who can access the viewset exposed by the activity stream app.
+
+The values in this list should be **strings** that are **dotted references to
+classes** and those classes must be subclasses of
+`rest_framework.permissions.BasePermission`. Django REST Framework bundles some
+of these already in `rest_framework.permissions`. View the
+[API Reference](https://www.django-rest-framework.org/api-guide/permissions/#api-reference)
+for the full list. Additionally, django-ansible-base provides
+`ansible_base.lib.utils.views.permissions.IsSuperuser`, and **this is the single
+default entry** in the `ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES`
+list.
+
+NOTE: This setting cannot be changed at runtime, since it is used to define the
+`permission_classes` class variable for the viewset.
+
 ## Dev Docs
 
 The way this works is by making use of Django signals. At a high level, when

--- a/docs/apps/activitystream.md
+++ b/docs/apps/activitystream.md
@@ -85,21 +85,12 @@ urlpatterns = [
 
 ### Permissions
 
-The setting `ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES` can be used to
-specify who can access the viewset exposed by the activity stream app.
+The activity stream can rely on the RBAC app to control permissions pertaining
+to who can see activity stream entries via the API.
 
-The values in this list should be **strings** that are **dotted references to
-classes** and those classes must be subclasses of
-`rest_framework.permissions.BasePermission`. Django REST Framework bundles some
-of these already in `rest_framework.permissions`. View the
-[API Reference](https://www.django-rest-framework.org/api-guide/permissions/#api-reference)
-for the full list. Additionally, django-ansible-base provides
-`ansible_base.lib.utils.views.permissions.IsSuperuser`, and **this is the single
-default entry** in the `ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES`
-list.
+If the RBAC app is **not** being used, then only superusers can access the
+stream.
 
-NOTE: This setting cannot be changed at runtime, since it is used to define the
-`permission_classes` class variable for the viewset.
 
 ## Dev Docs
 

--- a/test_app/tests/activitystream/test_api.py
+++ b/test_app/tests/activitystream/test_api.py
@@ -1,12 +1,5 @@
-from unittest import mock
-
 import pytest
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-from django.test import override_settings
 from django.urls import reverse
-
-from ansible_base.activitystream.views import _permission_classes
 
 
 def test_activitystream_api_read(admin_api_client, user):
@@ -44,44 +37,36 @@ def test_activitystream_api_read_only(admin_api_client, user):
 
 
 @pytest.mark.parametrize(
-    "permission_classes,who",
+    "has_rbac_app,who",
     [
-        (["rest_framework.permissions.IsAuthenticated"], "user"),
-        (["ansible_base.lib.utils.views.permissions.IsSuperuser"], "admin"),
-        (settings.ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES, "admin"),
+        (True, "user"),
+        (False, "admin"),
     ],
 )
-def test_activitystream_api_permission_classes(admin_api_client, user_api_client, permission_classes, who):
+def test_activitystream_api_permission_classes(admin_api_client, user_api_client, has_rbac_app, who, settings):
     """
-    Test that access to the activity stream can be configured with
-    settings.ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES.
+    Test that access to the activity stream is dynamically determined based on
+    whether or not RBAC is enabled.
 
-    :param permission_classes: List of permission classes to use.
-    :param who: "admin" or "user" specifying who should have access. (admin always has access)
+    If RBAC is enabled, then it locks down permissions on its own, so we allow IsAuthenticated.
+    If RBAC is not enabled, then we require IsSuperuser.
     """
     url = reverse("activitystream-list")
 
-    # This is kind of an ugly way to test this, but we want to cover _permission_classes().
-    # We _could_ override has_permission() and compute the permission every time, but that's slower (due to importing).
-    with override_settings(ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES=permission_classes):
-        with mock.patch("ansible_base.activitystream.views.EntryReadOnlyViewSet.permission_classes", _permission_classes()):
-            # Admin can always access
-            response = admin_api_client.get(url)
-            assert response.status_code == 200
+    if 'ansible_base.rbac' in settings.INSTALLED_APPS:
+        if not has_rbac_app:
+            settings.INSTALLED_APPS.remove('ansible_base.rbac')
+    else:
+        if has_rbac_app:
+            settings.INSTALLED_APPS.append('ansible_base.rbac')
 
-            # User can access if the permission class allows it
-            response = user_api_client.get(url)
-            if who == "user":
-                assert response.status_code == 200
-            else:
-                assert response.status_code == 403
+    # Admin can always access
+    response = admin_api_client.get(url)
+    assert response.status_code == 200
 
-
-def test_activitystream_api_permission_classes_invalid():
-    """
-    Test that providing invalid permission classes in settings provides a reasonable error.
-    """
-    with override_settings(ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES=["foo.bar.Baz"]):
-        with pytest.raises(ImproperlyConfigured) as excinfo:
-            _permission_classes()
-    assert "Could not find permission class 'foo.bar.Baz'" in str(excinfo.value)
+    # User can access if the permission class allows it
+    response = user_api_client.get(url)
+    if who == "user":
+        assert response.status_code == 200
+    else:
+        assert response.status_code == 403

--- a/test_app/tests/activitystream/test_api.py
+++ b/test_app/tests/activitystream/test_api.py
@@ -1,4 +1,12 @@
+from unittest import mock
+
+import pytest
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from django.urls import reverse
+
+from ansible_base.activitystream.views import _permission_classes
 
 
 def test_activitystream_api_read(admin_api_client, user):
@@ -33,3 +41,47 @@ def test_activitystream_api_read_only(admin_api_client, user):
     assert response.status_code == 405
     response = admin_api_client.delete(url)
     assert response.status_code == 405
+
+
+@pytest.mark.parametrize(
+    "permission_classes,who",
+    [
+        (["rest_framework.permissions.IsAuthenticated"], "user"),
+        (["ansible_base.lib.utils.views.permissions.IsSuperuser"], "admin"),
+        (settings.ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES, "admin"),
+    ],
+)
+def test_activitystream_api_permission_classes(admin_api_client, user_api_client, permission_classes, who):
+    """
+    Test that access to the activity stream can be configured with
+    settings.ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES.
+
+    :param permission_classes: List of permission classes to use.
+    :param who: "admin" or "user" specifying who should have access. (admin always has access)
+    """
+    url = reverse("activitystream-list")
+
+    # This is kind of an ugly way to test this, but we want to cover _permission_classes().
+    # We _could_ override has_permission() and compute the permission every time, but that's slower (due to importing).
+    with override_settings(ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES=permission_classes):
+        with mock.patch("ansible_base.activitystream.views.EntryReadOnlyViewSet.permission_classes", _permission_classes()):
+            # Admin can always access
+            response = admin_api_client.get(url)
+            assert response.status_code == 200
+
+            # User can access if the permission class allows it
+            response = user_api_client.get(url)
+            if who == "user":
+                assert response.status_code == 200
+            else:
+                assert response.status_code == 403
+
+
+def test_activitystream_api_permission_classes_invalid():
+    """
+    Test that providing invalid permission classes in settings provides a reasonable error.
+    """
+    with override_settings(ANSIBLE_BASE_ACTIVITYSTREAM_VIEW_PERMISSION_CLASSES=["foo.bar.Baz"]):
+        with pytest.raises(ImproperlyConfigured) as excinfo:
+            _permission_classes()
+    assert "Could not find permission class 'foo.bar.Baz'" in str(excinfo.value)


### PR DESCRIPTION
Allow for settings-changeable permissions for EntryReadOnlyViewSet.

This is necessary because some apps might not be using RBAC and in that case might need to be able to limit access to the activity stream to superusers (or some other permission class).