### PR TITLE
Add typing necessary to satisfy eda-server OpenAPI issues

### DIFF
--- a/ansible_base/activitystream/serializers.py
+++ b/ansible_base/activitystream/serializers.py
@@ -29,7 +29,7 @@ class EntrySerializer(ImmutableCommonModelSerializer):
         if obj.related_content_type:
             return obj.related_content_type.model
 
-    def _get_summary_fields(self, obj):
+    def _get_summary_fields(self, obj) -> dict[str, dict]:
         summary_fields = super()._get_summary_fields(obj)
 
         content_obj = obj.content_object

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db.models.fields import IntegerField
 from django.utils.translation import gettext as _
 from rest_framework import routers, serializers, status
 from rest_framework.decorators import action
@@ -143,7 +144,12 @@ class AssociationResourceRouter(routers.SimpleRouter):
             if is_reverse_view:
                 modified_related_viewset.http_method_names = ['get', 'head', 'options']
 
+            if isinstance(child_model._meta.pk, IntegerField):
+                url_path = f"{prefix}/(?P<pk>[0-9]+)/{related_name}"
+            else:
+                url_path = f"{prefix}/(?P<pk>[^/.]+)/{related_name}"
+
             # Register the viewset
-            self.registry.append((f"{prefix}/(?P<pk>[^/.]+)/{related_name}", modified_related_viewset, f'{basename}-{fk}'))
+            self.registry.append((url_path, modified_related_viewset, f'{basename}-{fk}'))
 
         super().register(prefix, viewset, basename)

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -81,7 +81,7 @@ class ContentTypeField(ChoiceLikeMixin):
         kwargs['help_text'] = _('The type of resource this applies to')
         super().__init__(**kwargs)
 
-    def get_resource_type_name(self, cls):
+    def get_resource_type_name(self, cls) -> str:
         if registry := self.get_resource_registry():
             # duplicates logic in ansible_base/resource_registry/apps.py
             try:
@@ -257,7 +257,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
 
         return assignment
 
-    def _get_related(self, obj):
+    def _get_related(self, obj) -> dict[str, str]:
         related = super()._get_related(obj)
         content_obj = obj.content_object
         if content_obj:
@@ -265,7 +265,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
                 related['content_object'] = related_url
         return related
 
-    def _get_summary_fields(self, obj):
+    def _get_summary_fields(self, obj) -> dict[str, dict]:
         summary_fields = super()._get_summary_fields(obj)
         content_obj = obj.content_object
         if content_obj and hasattr(content_obj, 'summary_fields'):

--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
@@ -48,10 +49,10 @@ class ResourceSerializer(serializers.ModelSerializer):
             "url",
         ]
 
-    def get_url(self, obj):
+    def get_url(self, obj) -> str:
         return reverse_lazy('resource-detail', kwargs={"ansible_id": obj.ansible_id})
 
-    def get_has_serializer(self, obj):
+    def get_has_serializer(self, obj) -> bool:
         return bool(obj.content_type.resource_type.get_resource_config().managed_serializer)
 
     # update ansible ID
@@ -99,13 +100,13 @@ class ResourceTypeSerializer(serializers.ModelSerializer):
         model = ResourceType
         fields = ["id", "name", "externally_managed", "shared_resource_type", "url"]
 
-    def get_shared_resource_type(self, obj):
+    def get_shared_resource_type(self, obj) -> Optional[str]:
         if serializer := obj.get_resource_config().managed_serializer:
             return serializer.RESOURCE_TYPE
         else:
             return None
 
-    def get_url(self, obj):
+    def get_url(self, obj) -> str:
         return reverse_lazy('resourcetype-detail', kwargs={"name": obj.name})
 
 

--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -1,7 +1,6 @@
 import logging
-from typing import Optional, Union
+from typing import Optional
 
-from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.reverse import reverse_lazy
@@ -50,8 +49,9 @@ class ResourceSerializer(serializers.ModelSerializer):
             "url",
         ]
 
-    def get_url(self, obj) -> Union[str, Promise]:
-        return reverse_lazy('resource-detail', kwargs={"ansible_id": obj.ansible_id})
+    def get_url(self, obj) -> str:
+        # conversion to string is done to satisfy type checking and OpenAPI schema generator
+        return str(reverse_lazy('resource-detail', kwargs={"ansible_id": obj.ansible_id}))
 
     def get_has_serializer(self, obj) -> bool:
         return bool(obj.content_type.resource_type.get_resource_config().managed_serializer)
@@ -107,8 +107,8 @@ class ResourceTypeSerializer(serializers.ModelSerializer):
         else:
             return None
 
-    def get_url(self, obj) -> Union[str, Promise]:
-        return reverse_lazy('resourcetype-detail', kwargs={"name": obj.name})
+    def get_url(self, obj) -> str:
+        return str(reverse_lazy('resourcetype-detail', kwargs={"name": obj.name}))
 
 
 class UserAuthenticationSerializer(serializers.Serializer):

--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -1,6 +1,7 @@
 import logging
-from typing import Optional
+from typing import Optional, Union
 
+from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.reverse import reverse_lazy
@@ -49,7 +50,7 @@ class ResourceSerializer(serializers.ModelSerializer):
             "url",
         ]
 
-    def get_url(self, obj) -> str:
+    def get_url(self, obj) -> Union[str, Promise]:
         return reverse_lazy('resource-detail', kwargs={"ansible_id": obj.ansible_id})
 
     def get_has_serializer(self, obj) -> bool:
@@ -106,7 +107,7 @@ class ResourceTypeSerializer(serializers.ModelSerializer):
         else:
             return None
 
-    def get_url(self, obj) -> str:
+    def get_url(self, obj) -> Union[str, Promise]:
         return reverse_lazy('resourcetype-detail', kwargs={"name": obj.name})
 
 


### PR DESCRIPTION
This fixes problems that I encountered on the eda-server RBAC branch using the OpenAPI generator, when rendering the `openapi.json` endpoint.

For these things, it complains that it doesn't know what type to use. It hasn't stopped complaining. Here are some that still remain, limited to DAB content:

```
/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/lib/routers/association_resource_router.py: Warning [RelatedRoleTeamAssignmentViewSet]: could not derive type of path parameter "team_assignments" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:team_assignments>) or annotating the parameter type with @extend_schema. Defaulting to "string".
/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/lib/routers/association_resource_router.py: Warning [RelatedRoleUserAssignmentViewSet]: could not derive type of path parameter "user_assignments" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:user_assignments>) or annotating the parameter type with @extend_schema. Defaulting to "string".
/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/api/views.py: Warning [RoleTeamAssignmentViewSet]: could not derive type of path parameter "id" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:id>) or annotating the parameter type with @extend_schema. Defaulting to "string".
/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/api/views.py: Warning [RoleUserAssignmentViewSet]: could not derive type of path parameter "id" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:id>) or annotating the parameter type with @extend_schema. Defaulting to "string".
/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/resource_registry/views.py: Error [ServiceIndexRootView]: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'super' object has no attribute 'get_serializer_class')
/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/resource_registry/views.py: Error [ServiceMetadataView]: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'super' object has no attribute 'get_serializer_class')
/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/resource_registry/views.py: Error [ValidateLocalUserView]: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'super' object has no attribute 'get_serializer_class')
2024-04-05 21:20:09,160 django.channels.server INFO     HTTP GET /api/eda/v1/openapi.json 200 [0.17, 127.0.0.1:44884]
```

But the much larger list of issues is knocked down by these changes.

The generated client also somewhat needs this to be right, and this matters most for the related endpoint `pk` parameter which it could not identify as an integer before. So that in specific is likely to fix a bug their QE hasn't gotten far enough to hit yet.

Type hints are quite nice for this, in that it avoids us having to add the dependency and decorate all our views, and I really don't want to do that.