### PR TITLE
[dynamic_urls] Avoid masking import errors

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_urls.py
+++ b/ansible_base/lib/dynamic_config/dynamic_urls.py
@@ -17,4 +17,4 @@ for app in getattr(settings, 'INSTALLED_APPS', []):
             for url_type in ['api_version_urls', 'root_urls', 'api_urls']:
                 globals()[url_type].extend(getattr(url_module, url_type, []))
         except ImportError:
-            logger.debug(f'Module {app} does not specify urls.py')
+            logger.exception(f'Module {app} does not specify urls.py')

--- a/ansible_base/lib/dynamic_config/dynamic_urls.py
+++ b/ansible_base/lib/dynamic_config/dynamic_urls.py
@@ -1,3 +1,4 @@
+import importlib.util
 import logging
 
 from django.conf import settings
@@ -11,10 +12,10 @@ for url_type in url_types:
 
 for app in getattr(settings, 'INSTALLED_APPS', []):
     if app.startswith('ansible_base.'):
-        try:
-            url_module = __import__(f'{app}.urls', fromlist=url_types)
-            logger.debug(f'Including URLS from {app}.urls')
-            for url_type in ['api_version_urls', 'root_urls', 'api_urls']:
-                globals()[url_type].extend(getattr(url_module, url_type, []))
-        except ImportError:
-            logger.exception(f'Module {app} does not specify urls.py')
+        if not importlib.util.find_spec(f'{app}.urls'):
+            logger.debug(f'Module {app} does not specify urls.py')
+            continue
+        url_module = __import__(f'{app}.urls', fromlist=url_types)
+        logger.debug(f'Including URLS from {app}.urls')
+        for url_type in ['api_version_urls', 'root_urls', 'api_urls']:
+            globals()[url_type].extend(getattr(url_module, url_type, []))

--- a/ansible_base/rest_filters/apps.py
+++ b/ansible_base/rest_filters/apps.py
@@ -3,7 +3,7 @@ from django.apps import AppConfig
 import ansible_base.lib.checks  # noqa: F401 - register checks
 
 
-class AuthenticationConfig(AppConfig):
+class RestFiltersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'ansible_base.rest_filters'
     label = 'dab_rest_filters'

--- a/ansible_base/rest_filters/urls.py
+++ b/ansible_base/rest_filters/urls.py
@@ -1,7 +1,0 @@
-from ansible_base.rest_filters.apps import RestFiltersConfig
-
-app_name = RestFiltersConfig.label
-
-api_version_urls = []
-root_urls = []
-api_urls = []

--- a/ansible_base/rest_pagination/urls.py
+++ b/ansible_base/rest_pagination/urls.py
@@ -1,7 +1,0 @@
-from ansible_base.rest_pagination.apps import RestPaginationConfig
-
-app_name = RestPaginationConfig.label
-
-api_version_urls = []
-root_urls = []
-api_urls = []


### PR DESCRIPTION
Also fix rest_filters whose urls.py could never get imported because
it referenced a name that wasn't defined.

Signed-off-by: Rick Elrod <rick@elrod.me>