### PR TITLE
Transaction-safe ObjectRole creation

### DIFF
--- a/test_app/tests/rbac/models/test_object_role.py
+++ b/test_app/tests/rbac/models/test_object_role.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+import pytest
+
+from ansible_base.rbac import permission_registry
+from ansible_base.rbac.models import ObjectRole
+from test_app.models import User
+
+
+@pytest.mark.django_db
+def test_existing_object_role_race(inv_rd, inventory):
+    user1 = User.objects.create(username='user1')
+    inv_rd.give_permission(user1, inventory)
+
+    user2 = User.objects.create(username='user2')
+    with mock.patch('django.db.models.query.QuerySet.first', return_value=None):
+        assert ObjectRole.objects.filter(object_id=inventory.pk).first() is None  # sanity
+        inv_rd.give_permission(user2, inventory)
+    assert user2.has_obj_perm(inventory, 'change')

--- a/test_app/tests/rbac/models/test_object_role.py
+++ b/test_app/tests/rbac/models/test_object_role.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import ObjectRole
 from test_app.models import User
 


### PR DESCRIPTION
I got a report from the UI that doing multiple assignments concurrently would give server errors inconsistently. It actually made complete sense that this would be the case, and I developed a reproducer that identifies the obvious suspect.

We can't put this reproducer in a test, because the test works inside of a transaction. Nested transactions (in postgres/django) do not work the same as independent transactions (auto-commit outside the context). Because of that, these are ran in 2 different terminal tabs.

```python
from django.contrib.contenttypes.models import ContentType

# for process 1
org = Organization.objects.create(name='repro')
teams = [Team.objects.create(name=f'repro-{i}', organization=org) for i in range(5)]
inv = Inventory.objects.create(organization=org, name='for-repro')
rd = RoleDefinition.objects.create_from_permissions(name='inv-view', permissions=['view_inventory'], content_type=ContentType.objects.get_for_model(Inventory))

# for other process
org = Organization.objects.get(name='repro')
teams = [Team.objects.get(name=f'repro-{i}', organization=org) for i in range(5)]
inv = Inventory.objects.get(organization=org, name='for-repro')
rd = RoleDefinition.objects.get(name='inv-view')
```

Reproducer, these lines all have to happen sequentially. You're flipping between 2 tabs. shell_plus works best.

```python
# process 1
from django.db import transaction
transaction.atomic().__enter__()
assignment = rd.give_permission(teams[0], inv)

# process 2
from django.db import transaction
with transaction.atomic():
  assignment = rd.give_permission(teams[1], inv)

# back to process 2
# stop here
transaction.atomic().__exit__(None, None, None)
```

Once you run the final command, "process 2" hits this error:

```
Cell In[14], line 2
      1 with transaction.atomic():
----> 2   assignment = rd.give_permission(teams[1], inv)

File ~/repos/awx/testing/django-ansible-base/ansible_base/rbac/models.py:185, in RoleDefinition.give_permission(self, actor, content_object)
    184 def give_permission(self, actor, content_object):
--> 185     return self.give_or_remove_permission(actor, content_object, giving=True)

File ~/repos/awx/testing/django-ansible-base/ansible_base/rbac/models.py:203, in RoleDefinition.give_or_remove_permission(self, actor, content_object, giving, sync_action)
    201     if not giving:
    202         return  # nothing to do
--> 203     object_role = ObjectRole.objects.create(**kwargs)
    204     created = True
    206 from ansible_base.rbac.triggers import needed_updates_on_assignment, update_after_assignment

<snip>

File ~/venvs/awx/lib64/python3.11/site-packages/psycopg/cursor.py:732, in Cursor.execute(self, query, params, prepare, binary)
    728         self._conn.wait(
    729             self._execute_gen(query, params, prepare=prepare, binary=binary)
    730         )
    731 except e._NO_TRACEBACK as ex:
--> 732     raise ex.with_traceback(None)
    733 return self

IntegrityError: duplicate key value violates unique constraint "one_object_role_per_object_and_role"
DETAIL:  Key (object_id, content_type_id, role_definition_id)=(4, 34, 6) already exists.
```

I developed a test that uses mock to approximate this, although I would not trust such a test to fully verify the fix. Like, it's non-obvious that the `.get` after the `IntegrityError` would actually be able to fetch the object. I re-ran the above reproducer and every worked and I'm fairly satisfied with that.

Internal AAP-22518