### PR TITLE
Fix failing AWX checks due to schema issues

### DIFF
--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -143,8 +143,6 @@ class ResourceTypeViewSet(
 class ServiceMetadataView(
     AnsibleBaseDjangoAppApiView,
 ):
-    action = "service-metadata"
-
     permission_classes = [
         HasResourceRegistryPermissions,
     ]
@@ -173,8 +171,6 @@ class ValidateLocalUserView(AnsibleBaseDjangoAppApiView):
     """
     Validate a user's username and password.
     """
-
-    action = "validate-local-user"
     permission_classes = [
         HasResourceRegistryPermissions,
     ]

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -171,6 +171,7 @@ class ValidateLocalUserView(AnsibleBaseDjangoAppApiView):
     """
     Validate a user's username and password.
     """
+
     permission_classes = [
         HasResourceRegistryPermissions,
     ]


### PR DESCRIPTION
The `action` variable is meaningful in terms of DRF viewsets. These views used that on views which are not viewsets. This works fine with what's in DAB api_documentation app, but AWX uses `drf_yasg`, which is a different implementation, and it chokes on this inconsistency. Leads to this:

```
2024-04-08T11:39:41.4533845Z _____________ ERROR at setup of TestSwaggerGeneration.test_sanity ______________
2024-04-08T11:39:41.4535191Z [gw0] linux -- Python 3.11.7 /var/lib/awx/venv/awx/bin/python3.11
2024-04-08T11:39:41.4535986Z Traceback (most recent call last):
2024-04-08T11:39:41.4537210Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/runner.py", line 340, in from_call
2024-04-08T11:39:41.4538611Z     result: Optional[TResult] = func()
2024-04-08T11:39:41.4597180Z                                 ^^^^^^
2024-04-08T11:39:41.4598633Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/runner.py", line 240, in <lambda>
2024-04-08T11:39:41.4600643Z     lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
2024-04-08T11:39:41.4601792Z             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4603060Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_hooks.py", line 501, in __call__
2024-04-08T11:39:41.4604417Z     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
2024-04-08T11:39:41.4605320Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4606896Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_manager.py", line 119, in _hookexec
2024-04-08T11:39:41.4608207Z     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2024-04-08T11:39:41.4609013Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4623383Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 138, in _multicall
2024-04-08T11:39:41.4624708Z     raise exception.with_traceback(exception.__traceback__)
2024-04-08T11:39:41.4626288Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
2024-04-08T11:39:41.4627626Z     teardown.throw(exception)  # type: ignore[union-attr]
2024-04-08T11:39:41.4652173Z     ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4653605Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/unraisableexception.py", line 85, in pytest_runtest_setup
2024-04-08T11:39:41.4654954Z     yield from unraisable_exception_runtest_hook()
2024-04-08T11:39:41.4656576Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/unraisableexception.py", line 65, in unraisable_exception_runtest_hook
2024-04-08T11:39:41.4657902Z     yield
2024-04-08T11:39:41.4660092Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
2024-04-08T11:39:41.4661589Z     teardown.throw(exception)  # type: ignore[union-attr]
2024-04-08T11:39:41.4662287Z     ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4663581Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/logging.py", line 843, in pytest_runtest_setup
2024-04-08T11:39:41.4664819Z     yield from self._runtest_for(item, "setup")
2024-04-08T11:39:41.4666120Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/logging.py", line 832, in _runtest_for
2024-04-08T11:39:41.4667196Z     yield
2024-04-08T11:39:41.4668225Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
2024-04-08T11:39:41.4669518Z     teardown.throw(exception)  # type: ignore[union-attr]
2024-04-08T11:39:41.4670156Z     ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4671370Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/capture.py", line 878, in pytest_runtest_setup
2024-04-08T11:39:41.4672508Z     return (yield)
2024-04-08T11:39:41.4672877Z             ^^^^^
2024-04-08T11:39:41.4673973Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
2024-04-08T11:39:41.4675270Z     teardown.throw(exception)  # type: ignore[union-attr]
2024-04-08T11:39:41.4675900Z     ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4677199Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/threadexception.py", line 82, in pytest_runtest_setup
2024-04-08T11:39:41.4678506Z     yield from thread_exception_runtest_hook()
2024-04-08T11:39:41.4761283Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/threadexception.py", line 63, in thread_exception_runtest_hook
2024-04-08T11:39:41.4762914Z     yield
2024-04-08T11:39:41.4764157Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 102, in _multicall
2024-04-08T11:39:41.4765284Z     res = hook_impl.function(*args)
2024-04-08T11:39:41.4765816Z           ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4767106Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/runner.py", line 158, in pytest_runtest_setup
2024-04-08T11:39:41.4768571Z     item.session._setupstate.setup(item)
2024-04-08T11:39:41.4769972Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/runner.py", line 515, in setup
2024-04-08T11:39:41.4770992Z     raise exc
2024-04-08T11:39:41.4772006Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/runner.py", line 512, in setup
2024-04-08T11:39:41.4773022Z     col.setup()
2024-04-08T11:39:41.4774042Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/python.py", line 1775, in setup
2024-04-08T11:39:41.4775435Z     self._request._fillfixtures()
2024-04-08T11:39:41.4776679Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/fixtures.py", line 687, in _fillfixtures
2024-04-08T11:39:41.4777931Z     item.funcargs[argname] = self.getfixturevalue(argname)
2024-04-08T11:39:41.4783234Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4784698Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/fixtures.py", line 541, in getfixturevalue
2024-04-08T11:39:41.4786007Z     fixturedef = self._get_active_fixturedef(argname)
2024-04-08T11:39:41.4786702Z                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4788135Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/fixtures.py", line 570, in _get_active_fixturedef
2024-04-08T11:39:41.4789414Z     self._compute_fixture_value(fixturedef)
2024-04-08T11:39:41.4790832Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/fixtures.py", line 647, in _compute_fixture_value
2024-04-08T11:39:41.4792103Z     fixturedef.execute(request=subrequest)
2024-04-08T11:39:41.4793392Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/fixtures.py", line 1079, in execute
2024-04-08T11:39:41.4794713Z     result = ihook.pytest_fixture_setup(fixturedef=self, request=request)
2024-04-08T11:39:41.4795573Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4796890Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_hooks.py", line 501, in __call__
2024-04-08T11:39:41.4798264Z     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
2024-04-08T11:39:41.4799170Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4800537Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_manager.py", line 119, in _hookexec
2024-04-08T11:39:41.4801883Z     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2024-04-08T11:39:41.4802736Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4804080Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 181, in _multicall
2024-04-08T11:39:41.4805242Z     return outcome.get_result()
2024-04-08T11:39:41.4805738Z            ^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4806929Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_result.py", line 99, in get_result
2024-04-08T11:39:41.4808101Z     raise exc.with_traceback(exc.__traceback__)
2024-04-08T11:39:41.4809409Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 166, in _multicall
2024-04-08T11:39:41.4810552Z     teardown.throw(outcome._exception)
2024-04-08T11:39:41.4811976Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/setuponly.py", line 36, in pytest_fixture_setup
2024-04-08T11:39:41.4813178Z     return (yield)
2024-04-08T11:39:41.4813579Z             ^^^^^
2024-04-08T11:39:41.4814712Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pluggy/_callers.py", line 102, in _multicall
2024-04-08T11:39:41.4815857Z     res = hook_impl.function(*args)
2024-04-08T11:39:41.4816387Z           ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4817721Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/fixtures.py", line 1132, in pytest_fixture_setup
2024-04-08T11:39:41.4819265Z     result = call_fixture_func(fixturefunc, request, kwargs)
2024-04-08T11:39:41.4820226Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4821635Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/fixtures.py", line 913, in call_fixture_func
2024-04-08T11:39:41.4822867Z     fixture_result = fixturefunc(**kwargs)
2024-04-08T11:39:41.4823450Z                      ^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4824356Z   File "/awx_devel/awx/main/tests/docs/test_swagger_generation.py", line 47, in _prepare
2024-04-08T11:39:41.4825602Z     response = get(url, user=admin)
2024-04-08T11:39:41.4826140Z                ^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4826922Z   File "/awx_devel/awx/main/tests/functional/conftest.py", line 624, in rf
2024-04-08T11:39:41.4827852Z     response = view(request, *view_args, **view_kwargs)
2024-04-08T11:39:41.4828538Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4829988Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
2024-04-08T11:39:41.4831286Z     return view_func(*args, **kwargs)
2024-04-08T11:39:41.4831837Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4833103Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/views/generic/base.py", line 104, in view
2024-04-08T11:39:41.4834340Z     return self.dispatch(request, *args, **kwargs)
2024-04-08T11:39:41.4834992Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4836319Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
2024-04-08T11:39:41.4837523Z     response = self.handle_exception(exc)
2024-04-08T11:39:41.4838108Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4839454Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
2024-04-08T11:39:41.4840685Z     self.raise_uncaught_exception(exc)
2024-04-08T11:39:41.4842139Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
2024-04-08T11:39:41.4843392Z     raise exc
2024-04-08T11:39:41.4844515Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
2024-04-08T11:39:41.4845721Z     response = handler(request, *args, **kwargs)
2024-04-08T11:39:41.4846357Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4847514Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/drf_yasg/views.py", line 96, in get
2024-04-08T11:39:41.4848673Z     schema = generator.get_schema(request, self.public)
2024-04-08T11:39:41.4849373Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4850709Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/drf_yasg/generators.py", line 276, in get_schema
2024-04-08T11:39:41.4852095Z     paths, prefix = self.get_paths(endpoints, components, request, public)
2024-04-08T11:39:41.4852955Z                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4854335Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/drf_yasg/generators.py", line 482, in get_paths
2024-04-08T11:39:41.4855833Z     operation = self.get_operation(view, path, prefix, method, components, request)
2024-04-08T11:39:41.4856800Z                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4858773Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/drf_yasg/generators.py", line 509, in get_operation
2024-04-08T11:39:41.4860436Z     operation_keys = self.get_operation_keys(path[len(prefix):], method, view)
2024-04-08T11:39:41.4861431Z                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-08T11:39:41.4862913Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/drf_yasg/generators.py", line 386, in get_operation_keys
2024-04-08T11:39:41.4864135Z     mapped_methods = {
2024-04-08T11:39:41.4864559Z                      ^
2024-04-08T11:39:41.4865397Z TypeError: 'NoneType' object is not iterable
```

For the AWX schema & swagger checks.

This is the same as when you run the AWX docker-compose server and visit https://localhost:8043/api/swagger/, which fails with that traceback. With this, I was able to verify the fix. I can't easily add regression testing for that unless new dependencies to DAB are added.