### PR TITLE
Be sensitive of application User models without organizations|teams_administered

### DIFF
--- a/ansible_base/resource_registry/shared_types.py
+++ b/ansible_base/resource_registry/shared_types.py
@@ -23,10 +23,22 @@ class UserAdditionalDataSerializer(serializers.Serializer):
     external_auth_uid = serializers.CharField(required=False, allow_blank=True)
 
     organizations = AnsibleResourceManyRelated("shared.organization")
-    organizations_administered = AnsibleResourceManyRelated("shared.organization")
+    organizations_administered = serializers.SerializerMethodField()
 
     teams = AnsibleResourceManyRelated("shared.team")
-    teams_administered = AnsibleResourceManyRelated("shared.team")
+    teams_administered = serializers.SerializerMethodField()
+
+    def get_organizations_administered(self, obj):
+        if not hasattr(obj, "organizations_administered"):
+            return []
+        ansible_resources_serializer = AnsibleResourceManyRelated("shared.organization")
+        return ansible_resources_serializer.to_representation(obj.organizations_administered)
+
+    def get_teams_administered(self, obj):
+        if not hasattr(obj, "teams_administered"):
+            return []
+        ansible_resources_serializer = AnsibleResourceManyRelated("shared.team")
+        return ansible_resources_serializer.to_representation(obj.organizations_administered)
 
 
 class UserType(SharedResourceTypeSerializer):

--- a/ansible_base/resource_registry/shared_types.py
+++ b/ansible_base/resource_registry/shared_types.py
@@ -38,7 +38,7 @@ class UserAdditionalDataSerializer(serializers.Serializer):
         if not hasattr(obj, "teams_administered"):
             return []
         ansible_resources_serializer = AnsibleResourceManyRelated("shared.team")
-        return ansible_resources_serializer.to_representation(obj.organizations_administered)
+        return ansible_resources_serializer.to_representation(obj.teams_administered)
 
 
 class UserType(SharedResourceTypeSerializer):


### PR DESCRIPTION
Galaxy's User model does not have these fields yet ...

```
pulp-1          | Traceback (most recent call last):                                                                                                                                                                                           
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/fields.py", line 446, in get_attribute
pulp-1          |     return get_attribute(instance, self.source_attrs)                                                                                                                                                                        
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                 
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/fields.py", line 96, in get_attribute 
pulp-1          |     instance = getattr(instance, attr)                                                               
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^^^                                                               
pulp-1          | AttributeError: 'User' object has no attribute 'organizations_administered'                                                                                                                                                  
pulp-1          |                                          
pulp-1          | During handling of the above exception, another exception occurred:                                                   
pulp-1          |                                                                                                      
pulp-1          | Traceback (most recent call last):                                                                                    
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
pulp-1          |     response = get_response(request)                                                                 
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^                                                                 
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response              
pulp-1          |     response = wrapped_callback(request, *callback_args, **callback_kwargs)                                                                                                                                                  
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view            
pulp-1          |     return view_func(*args, **kwargs)                                                                                 
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                 
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/viewsets.py", line 125, in view                         
pulp-1          |     return self.dispatch(request, *args, **kwargs)                                                                     
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                          
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch                                             
pulp-1          |     response = self.handle_exception(exc)                                                                                                   
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                   
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception                                     
pulp-1          |     self.raise_uncaught_exception(exc)                                                                                                      
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception                             
pulp-1          |     raise exc                                                
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch                                              
pulp-1          |     response = handler(request, *args, **kwargs)                                                                                             
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                             
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/ansible_base/resource_registry/views.py", line 97, in additional_data                        
pulp-1          |     return Response(data.data)                               
pulp-1          |                     ^^^^^^^^^                                
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 555, in data                                            
pulp-1          |     ret = super().data                                       
pulp-1          |           ^^^^^^^^^^^^                                       
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 253, in data                                            
pulp-1          |     self._data = self.to_representation(self.instance)                                                                                       
pulp-1          |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                       
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 509, in to_representation                               
pulp-1          |     attribute = field.get_attribute(instance)                                                                                                
pulp-1          |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/fields.py", line 479, in get_attribute                                        
pulp-1          |     raise type(exc)(msg)                                     
pulp-1          | AttributeError: Got AttributeError when attempting to get a value for field `organizations_administered` on serializer `UserAdditionalDataSerializer`.
pulp-1          | The serializer field might be named incorrectly and not match any attribute or key on the `User` instance.                                   
pulp-1          | Original exception text was: 'User' object has no attribute 'organizations_administered'.                                                    
pulp-1          | ('pulp [5bde5eec76614a49be2aca1c56699a35]: ::ffff:127.0.0.1 - admin [08/Apr/2024:20:41:01 +0000] "GET /api/galaxy/service-index/resources/d8663e2a-4c21-41ef-b705-c3faa71664cb/additional_data/ HTTP/1.0" 500 154351 "-" "curl/8.0.1"',)
```