### PR TITLE
Allow for customizing the automatic creator role

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -140,6 +140,9 @@ if 'ansible_base.rbac' in INSTALLED_APPS:
 
     # Permissions a user will get when creating a new item
     ANSIBLE_BASE_CREATOR_DEFAULTS = ['add', 'change', 'delete', 'view']
+    # If a role does not already exist that can give those object permissions
+    # then the system must create one, this is used for naming the auto-created role
+    ANSIBLE_BASE_ROLE_CREATOR_NAME = '{obj._meta.model_name}-creator-permission'
 
     # Specific feature enablement bits
     # For assignments

--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -70,7 +70,7 @@ class RoleDefinitionManager(models.Manager):
         has_permissions = set(RoleEvaluation.get_permissions(user, obj))
         has_permissions.update(user.singleton_permissions())
         if set(needed_perms) - set(has_permissions):
-            kwargs = {'permissions': needed_perms, 'name': f'{obj._meta.model_name}-creator-permission'}
+            kwargs = {'permissions': needed_perms, 'name': settings.ANSIBLE_BASE_ROLE_CREATOR_NAME.format(obj=obj, cls=type(obj))}
             defaults = {'content_type': ContentType.objects.get_for_model(obj)}
             try:
                 rd, _ = self.get_or_create(defaults=defaults, **kwargs)


### PR DESCRIPTION
This is a supporting change for https://github.com/ansible/awx/pull/15087

Naming schemes have changed, so we can't have it hard-coded and opinionated. Once you have a particular look & feel you want for your roles, even the auto-created role needs to have that same feel.