### PR TITLE
[ModifiableModel] Pass update_fields back to super

### DIFF
--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -62,7 +62,7 @@ class ModifiableModel(models.Model):
         '''
         update_fields = list(kwargs.get('update_fields', []))
 
-        if self.pk and 'modified_by' not in update_fields:
+        if 'modified_by' not in update_fields:
             self.modified_by = current_user_or_system_user()
             update_fields.append('modified_by')
 

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -62,9 +62,12 @@ class ModifiableModel(models.Model):
         '''
         update_fields = list(kwargs.get('update_fields', []))
 
-        if 'modified_by' not in update_fields:
+        if self.pk and 'modified_by' not in update_fields:
             self.modified_by = current_user_or_system_user()
             update_fields.append('modified_by')
+
+        if kwargs.get('update_fields') is not None:
+            kwargs['update_fields'] = update_fields
 
         return super().save(*args, **kwargs)
 
@@ -93,12 +96,10 @@ class CreatableModel(models.Model):
         This save function will provide the following features automatically.
           * It will automatically add a created_by fields for new items
         '''
-        update_fields = list(kwargs.get('update_fields', []))
 
         if not self.pk:
             if self.created_by is None:
                 self.created_by = current_user_or_system_user()
-                update_fields.append('created_by')
 
         return super().save(*args, **kwargs)
 

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -164,3 +164,14 @@ def test_modified_by_respects_given_value(system_user, random_user, user, animal
         animal.save(update_fields=['modified_by'])
     animal.refresh_from_db()
     assert animal.modified_by == random_user
+
+
+def test_modified_by_gets_saved_even_if_not_in_update_fields(system_user, random_user, user, animal):
+    animal.save()
+    assert animal.modified_by == system_user
+    animal.name = 'Bob The Fish'
+    animal.kind = 'fish'
+    with impersonate(user):
+        animal.save(update_fields=['name', 'kind'])
+    animal.refresh_from_db()
+    assert animal.modified_by == user

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -166,7 +166,7 @@ def test_modified_by_respects_given_value(system_user, random_user, user, animal
     assert animal.modified_by == random_user
 
 
-def test_modified_by_gets_saved_even_if_not_in_update_fields(system_user, random_user, user, animal):
+def test_modified_by_gets_saved_even_if_not_in_update_fields(system_user, user, animal):
     animal.save()
     assert animal.modified_by == system_user
     animal.name = 'Bob The Fish'


### PR DESCRIPTION
This came up when debugging #286 which was supposed to be an easy fix
but led me down quite a rabbit hole.

For as long as modified_by has existed (from what I can tell in the
git history), we never obeyed update_fields in save(). When we split
it out into ModifiableModel, the bug was kept in tact.

What ends up happening here is that on login, we'd act as if we're
going to update the modified_by field, and we'd get that in
update_fields, but then we'd just eat update_fields and never pass it
back into the supermethod.

This led to weird things like activity stream thinking that the value
was getting updated when a user logged in (because contractually, it
was *supposed* to be getting updated), but since we forgot
update_fields, it didn't *actually* get updated.

So you'd see an activity stream entry with the change, but check in
the database and see that modified_by never actually updated on login.

This ensures we pass back in update_fields if we were given it in the
first place, and that we only update it when it makes sense (if it's
actually an update, i.e. self.pk exists).

I also add a test showing that if you update modified_by and set
update_fields to include it, the forced value you set it to gets saved
as expected.

Finally, this does *not* fix #286. So I added an XFAIL test for
that. This was found while *working* on #286, but it's a different
bug.

Signed-off-by: Rick Elrod <rick@elrod.me>