### PR TITLE
[activitystream] Don't include attnames

### DIFF
--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -15,13 +15,13 @@ from ansible_base.lib.utils.string import make_json_safe
 logger = logging.getLogger('ansible_base.lib.utils.models')
 
 
-def get_all_field_names(model, concrete_only=False):
+def get_all_field_names(model, concrete_only=False, include_attnames=True):
     # Implements compatibility with _meta.get_all_field_names
     # See: https://docs.djangoproject.com/en/1.11/ref/models/meta/#migrating-from-the-old-api
     return list(
         set(
             chain.from_iterable(
-                (field.name, field.attname) if hasattr(field, 'attname') else (field.name,)
+                (field.name, field.attname) if include_attnames and hasattr(field, 'attname') else (field.name,)
                 for field in model._meta.get_fields()
                 # For complete backwards compatibility, you may want to exclude
                 # GenericForeignKey from the results.
@@ -215,7 +215,7 @@ def diff(
         if obj is None:
             continue
 
-        for field in get_all_field_names(obj, concrete_only=True):
+        for field in get_all_field_names(obj, concrete_only=True, include_attnames=False):
             field_obj = obj._meta.get_field(field)
 
             # Skip the field if needed

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -24,14 +24,17 @@ def test_activitystream_create(system_user, animal):
     assert entry.changes['removed_fields'] == {}
     assert entry.changes['added_fields']['name'] == animal.name
     assert entry.changes['added_fields']['owner'] == str(animal.owner.pk)
+    # We don't include the "attnames"
+    assert 'owner_id' not in entry.changes['added_fields']
 
 
-def test_activitystream_update(system_user, animal):
+def test_activitystream_update(system_user, animal, random_user):
     """
     Ensure that an activity stream entry is created when an object is updated.
     """
     original_name = animal.name
     animal.name = 'Rocky'
+    animal.owner = random_user
     animal.save()
 
     entries = animal.activity_stream_entries
@@ -43,8 +46,10 @@ def test_activitystream_update(system_user, animal):
     assert entry.changes['removed_fields'] == {}
     # just name was changed. modified/modified_by doesn't show up because they
     # are set in save, and we're using pre_save, so we won't see the new values yet.
-    assert len(entry.changes['changed_fields']) == 1
+    assert len(entry.changes['changed_fields']) == 2
     assert entry.changes['changed_fields']['name'] == [original_name, 'Rocky']
+    # We don't include the "attnames"
+    assert 'owner_id' not in entry.changes['changed_fields']
 
 
 def test_activitystream_m2m(system_user, animal, user, random_user):

--- a/test_app/tests/lib/utils/test_models.py
+++ b/test_app/tests/lib/utils/test_models.py
@@ -113,7 +113,7 @@ def test_diff_old_none_means_all_fields_are_new(system_user, multiple_fields_mod
     require_type_match should not affect the result.
     """
     delta = models.diff(None, multiple_fields_model, require_type_match=require_type_match, json_safe=False)
-    field_names = models.get_all_field_names(multiple_fields_model)
+    field_names = models.get_all_field_names(multiple_fields_model, concrete_only=True, include_attnames=False)
     assert len(delta.added_fields) == len(field_names)
     assert delta.removed_fields == {}
     assert delta.changed_fields == {}
@@ -131,7 +131,7 @@ def test_diff_new_none_means_all_fields_are_old(system_user, multiple_fields_mod
     require_type_match should not affect the result.
     """
     delta = models.diff(multiple_fields_model, None, require_type_match=require_type_match, json_safe=False)
-    field_names = models.get_all_field_names(multiple_fields_model)
+    field_names = models.get_all_field_names(multiple_fields_model, concrete_only=True, include_attnames=False)
     assert len(delta.removed_fields) == len(field_names)
     assert delta.added_fields == {}
     assert delta.changed_fields == {}
@@ -259,11 +259,13 @@ def test_diff_with_fk(system_user, user, multiple_fields_model_1, multiple_field
 
     delta = models.diff(multiple_fields_model_1, multiple_fields_model_2, json_safe=False)
     assert delta.changed_fields['created_by'] == (multiple_fields_model_1.created_by, multiple_fields_model_2.created_by)
-    assert delta.changed_fields['created_by_id'] == (multiple_fields_model_1.created_by.pk, multiple_fields_model_2.created_by.pk)
+    # We don't include the "attnames"
+    assert 'created_by_id' not in delta.changed_fields
 
     delta = models.diff(multiple_fields_model_1, multiple_fields_model_2, json_safe=True)
     assert delta.changed_fields['created_by'] == (multiple_fields_model_1.created_by.username, multiple_fields_model_2.created_by.username)
-    assert delta.changed_fields['created_by_id'] == (multiple_fields_model_1.created_by.pk, multiple_fields_model_2.created_by.pk)
+    # We don't include the "attnames"
+    assert 'created_by_id' not in delta.changed_fields
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #287, now we only store 'fk_field_name': fk_id

Signed-off-by: Rick Elrod <rick@elrod.me>