### PR TITLE
Continuing internationalization of strings

### DIFF
--- a/ansible_base/authentication/management/commands/authenticators.py
+++ b/ansible_base/authentication/management/commands/authenticators.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
+
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 

--- a/ansible_base/authentication/management/commands/authenticators.py
+++ b/ansible_base/authentication/management/commands/authenticators.py
@@ -9,8 +9,6 @@ except ImportError:
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
-
-from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser

--- a/ansible_base/authentication/management/commands/authenticators.py
+++ b/ansible_base/authentication/management/commands/authenticators.py
@@ -9,6 +9,8 @@ except ImportError:
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
+from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 
@@ -34,7 +36,7 @@ class Command(BaseCommand):
                 try:
                     authenticator = Authenticator.objects.get(id=id)
                 except Authenticator.DoesNotExist:
-                    raise CommandError(f"Authenticator {id} does not exist")
+                    raise CommandError(_("Authenticator %(id) does not exist") % {"id": id})
                 if authenticator.enabled is not state:
                     authenticator.enabled = state
                     authenticator.save()

--- a/ansible_base/authentication/management/commands/authenticators.py
+++ b/ansible_base/authentication/management/commands/authenticators.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
                 try:
                     authenticator = Authenticator.objects.get(id=id)
                 except Authenticator.DoesNotExist:
-                    raise CommandError(_("Authenticator %(id) does not exist") % {"id": id})
+                    raise CommandError(_("Authenticator %(id)s does not exist") % {"id": id})
                 if authenticator.enabled is not state:
                     authenticator.enabled = state
                     authenticator.save()

--- a/ansible_base/authentication/models/authenticator_map.py
+++ b/ansible_base/authentication/models/authenticator_map.py
@@ -2,6 +2,8 @@ from django.db import models
 
 from ansible_base.lib.abstract_models.common import NamedCommonModel
 
+from django.utils.translation import gettext_lazy as _
+
 from .authenticator import Authenticator
 
 
@@ -26,13 +28,13 @@ class AuthenticatorMap(NamedCommonModel):
         Authenticator,
         null=False,
         on_delete=models.CASCADE,
-        help_text="The authenticator this mapping belongs to",
+        help_text=(_("The authenticator this mapping belongs to")),
         related_name="authenticator_maps",
     )
     revoke = models.BooleanField(
         null=False,
         default=False,
-        help_text="If a user does not meet this rule should we revoke the permission",
+        help_text=(_("If a user does not meet this rule should we revoke the permission")),
     )
     map_type = models.CharField(
         max_length=17,
@@ -45,7 +47,7 @@ class AuthenticatorMap(NamedCommonModel):
             ('allow', 'allow'),
             ('organization', 'organization'),
         ],
-        help_text='What does the map work on, a team, a user flag or is this an allow rule',
+        help_text=(_('What does the map work on, a team, a user flag or is this an allow rule')),
     )
     team = models.CharField(
         max_length=512,
@@ -70,8 +72,8 @@ class AuthenticatorMap(NamedCommonModel):
     order = models.PositiveIntegerField(
         null=False,
         default=0,
-        help_text=(
+        help_text=(_(
             "The order in which this rule should be processed, smaller numbers are of higher precedence. "
             "Items with the same order will be executed in random order"
-        ),
+        )),
     )

--- a/ansible_base/authentication/models/authenticator_map.py
+++ b/ansible_base/authentication/models/authenticator_map.py
@@ -1,8 +1,7 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.abstract_models.common import NamedCommonModel
-
-from django.utils.translation import gettext_lazy as _
 
 from .authenticator import Authenticator
 
@@ -72,8 +71,10 @@ class AuthenticatorMap(NamedCommonModel):
     order = models.PositiveIntegerField(
         null=False,
         default=0,
-        help_text=(_(
-            "The order in which this rule should be processed, smaller numbers are of higher precedence. "
-            "Items with the same order will be executed in random order"
-        )),
+        help_text=(
+            _(
+                "The order in which this rule should be processed, smaller numbers are of higher precedence. "
+                "Items with the same order will be executed in random order"
+            )
+        ),
     )

--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -96,10 +96,10 @@ class AuthenticatorSerializer(NamedCommonModelSerializer):
             if configuration or configuration == {}:
                 for key in authenticator.configuration_encrypted_fields:
                     if not self.instance and configuration.get(key, None) == ENCRYPTED_STRING:
-                        invalid_encrypted_keys[key] = _("Can not be set to %(ENCRYPTED_STRING)") % {"ENCRYPTED_STRING": ENCRYPTED_STRING}
+                        invalid_encrypted_keys[key] = _("Can not be set to %(ENCRYPTED_STRING)s") % {"ENCRYPTED_STRING": ENCRYPTED_STRING}
                 if invalid_encrypted_keys:
                     raise ValidationError(invalid_encrypted_keys)
                 data['configuration'] = authenticator.validate_configuration(configuration, self.instance)
             return data
         except ImportError as e:
-            raise ValidationError({'type': _('Failed to import %(e)') % {'e': e}})
+            raise ValidationError({'type': _('Failed to import %(e)s') % {'e': e}})

--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from django.utils.translation import gettext_lazy as _
 from rest_framework.serializers import ChoiceField, ValidationError
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin, get_authenticator_plugins
@@ -13,7 +14,7 @@ class AuthenticatorSerializer(NamedCommonModelSerializer):
 
     def validate_type(self, value):
         if self.instance and self.instance.type != value:
-            raise ValidationError("Cannot change authenticator type after it has been created.")
+            raise ValidationError(_("Cannot change authenticator type after it has been created."))
         return value
 
     class Meta:
@@ -46,7 +47,7 @@ class AuthenticatorSerializer(NamedCommonModelSerializer):
         except ImportError:
             # A log message will already be displayed if we can't load this
             ret['configuration'] = {}
-            ret['error'] = 'Failed to load the plugin behind this authenticator, configuration hidden to protect secrets'
+            ret['error'] = _('Failed to load the plugin behind this authenticator, configuration hidden to protect secrets')
             return ret
 
         # Generate a sso login URL if this is an sso category
@@ -85,7 +86,7 @@ class AuthenticatorSerializer(NamedCommonModelSerializer):
         # Not having configuration is only valid for a PATCH
         request = self.context.get('request', None)
         if not request or (request.method != 'PATCH' and configuration is None):
-            raise ValidationError("You must specify configuration for the authenticator")
+            raise ValidationError(_("You must specify configuration for the authenticator"))
 
         try:
             invalid_encrypted_keys = {}
@@ -95,10 +96,10 @@ class AuthenticatorSerializer(NamedCommonModelSerializer):
             if configuration or configuration == {}:
                 for key in authenticator.configuration_encrypted_fields:
                     if not self.instance and configuration.get(key, None) == ENCRYPTED_STRING:
-                        invalid_encrypted_keys[key] = f"Can not be set to {ENCRYPTED_STRING}"
+                        invalid_encrypted_keys[key] = _("Can not be set to %(ENCRYPTED_STRING)") % {"ENCRYPTED_STRING": ENCRYPTED_STRING}
                 if invalid_encrypted_keys:
                     raise ValidationError(invalid_encrypted_keys)
                 data['configuration'] = authenticator.validate_configuration(configuration, self.instance)
             return data
         except ImportError as e:
-            raise ValidationError({'type': f'Failed to import {e}'})
+            raise ValidationError({'type': _('Failed to import %(e)') % {'e': e}})

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -1,9 +1,7 @@
 import logging
 
-
-from django.utils.translation import gettext_lazy as _
 from django.conf import settings
-
+from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
@@ -69,7 +70,7 @@ def generate_ui_auth_data():
         response['custom_login_info'] = custom_login_info
     else:
         logger.error("custom_login_info was not a string")
-        raise ValidationError("custom_login_info was set but was not a valid string, ignoring")
+        raise ValidationError(_("custom_login_info was set but was not a valid string, ignoring"))
 
     try:
         custom_logo = get_setting('custom_logo', '')


### PR DESCRIPTION
Tested that the correct strings were pulled in to the .po file.

Testing steps

Clone dir and active python virt env.
install django in virtenv if it is not present via pip
make a locale directory in the project
run django-admin makemessages -l es
navigate to the generated .po file, it will be in the locale directory under the specified language (here it is spanish so es) and then under LC_MESSAGES or something like that, you are looking for the django.po file.
confirm changed strings are present
(you can also just run the command then grep for the strings if preferred)
** These steps are from @thedoubl3j. I referred to his PR https://github.com/ansible/aap-gateway/pull/255.

Reviewed the following files:
ansible_base/authentication/management
ansible_base/authentication/management/__pycache__
ansible_base/authentication/management/commands
ansible_base/authentication/management/commands/__pycache__
ansible_base/authentication/management/commands/authenticators.py
ansible_base/authentication/migrations
ansible_base/authentication/models
ansible_base/authentication/serializers/authenticator_map.py
ansible_base/authentication/serializers/authenticator.py
ansible_base/authentication/utils/claims.py
ansible_base/authentication/views/ui_auth.py

