### PR TITLE
Change required logic on plugin configuration

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -21,6 +21,13 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
         ui_field_label=_('Additional Authenticator Fields'),
     )
 
+    def _field_required(self, field):
+        if hasattr(field, 'required'):
+            return getattr(field, 'required')
+        elif hasattr(field, 'allow_null'):
+            return not getattr(field, 'allow_null')
+        return True
+
     def get_configuration_schema(self):
         fields = self.get_fields()
 
@@ -35,7 +42,7 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
             schema_data = {
                 "name": f,
                 "help_text": field.help_text,
-                "required": not field.allow_null,
+                "required": self._field_required(field),
                 "default": default,
                 "type": field.__class__.__name__,
                 "ui_field_label": getattr(field, 'ui_field_label', _('Undefined')),

--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -25,7 +25,7 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
         if hasattr(field, 'required'):
             return field.required
         elif hasattr(field, 'allow_null'):
-            return not getattr(field, 'allow_null')
+            return not field.allow_null
         return True
 
     def get_configuration_schema(self):

--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -12,6 +12,14 @@ from ansible_base.lib.serializers.fields import JSONField
 logger = logging.getLogger('ansible_base.authentication.authenticator_plugins.base')
 
 
+def _field_required(field):
+    if hasattr(field, 'required'):
+        return field.required
+    elif hasattr(field, 'allow_null'):
+        return not field.allow_null
+    return True
+
+
 class BaseAuthenticatorConfiguration(serializers.Serializer):
     documentation_url = None
     ADDITIONAL_UNVERIFIED_ARGS = JSONField(
@@ -20,13 +28,6 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
         allow_null=True,
         ui_field_label=_('Additional Authenticator Fields'),
     )
-
-    def _field_required(self, field):
-        if hasattr(field, 'required'):
-            return field.required
-        elif hasattr(field, 'allow_null'):
-            return not field.allow_null
-        return True
 
     def get_configuration_schema(self):
         fields = self.get_fields()
@@ -42,7 +43,7 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
             schema_data = {
                 "name": f,
                 "help_text": field.help_text,
-                "required": self._field_required(field),
+                "required": _field_required(field),
                 "default": default,
                 "type": field.__class__.__name__,
                 "ui_field_label": getattr(field, 'ui_field_label', _('Undefined')),

--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -23,7 +23,7 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
 
     def _field_required(self, field):
         if hasattr(field, 'required'):
-            return getattr(field, 'required')
+            return field.required
         elif hasattr(field, 'allow_null'):
             return not getattr(field, 'allow_null')
         return True

--- a/test_app/tests/authentication/authenticator_plugins/test_base.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansible_base.authentication.authenticator_plugins.base import BaseAuthenticatorConfiguration
+from ansible_base.authentication.authenticator_plugins.base import _field_required
 
 
 class DummyField:
@@ -27,5 +27,4 @@ class DummyField:
 )
 def test__field_required(required, allow_null, expected_result):
     field = DummyField(required, allow_null)
-    configuration = BaseAuthenticatorConfiguration()
-    assert configuration._field_required(field) is expected_result
+    assert _field_required(field) is expected_result

--- a/test_app/tests/authentication/authenticator_plugins/test_base.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_base.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ansible_base.authentication.authenticator_plugins.base import BaseAuthenticatorConfiguration
+
+
+class DummyField:
+    def __init__(self, required, allow_null):
+        if required is not None:
+            self.required = required
+        if allow_null is not None:
+            self.allow_null = allow_null
+
+
+@pytest.mark.parametrize(
+    "required,allow_null,expected_result",
+    [
+        (None, None, True),
+        (True, None, True),
+        (False, None, False),
+        (None, True, False),
+        (None, False, True),
+        (True, False, True),
+        (False, False, False),
+        (True, True, True),
+        (False, True, False),
+    ],
+)
+def test__field_required(required, allow_null, expected_result):
+    field = DummyField(required, allow_null)
+    configuration = BaseAuthenticatorConfiguration()
+    assert configuration._field_required(field) is expected_result


### PR DESCRIPTION
Before we would simply check "if not allow_null" but this falls short if a field has a default value but does not allow null. In that case the field would be required. This change will now explicity accept the `required` field and then fallback to `not allow_null`. 
