### PR TITLE
Fix authenticator/:id/users endpoint

### DIFF
--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django.utils.translation import gettext_lazy as _
+from rest_framework.reverse import reverse
 from rest_framework.serializers import ChoiceField, ValidationError
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin, get_authenticator_plugins
@@ -103,3 +104,12 @@ class AuthenticatorSerializer(NamedCommonModelSerializer):
             return data
         except ImportError as e:
             raise ValidationError({'type': _('Failed to import %(e)s') % {'e': e}})
+
+    def _get_related(self, obj) -> dict[str, str]:
+        related = super()._get_related(obj)
+        from ansible_base.authentication.views.authenticator_users import get_authenticator_user_view
+
+        if get_authenticator_user_view():
+            related['users'] = reverse('authenticator-users-list', kwargs={'pk': obj.pk})
+
+        return related

--- a/ansible_base/authentication/views/authenticator_users.py
+++ b/ansible_base/authentication/views/authenticator_users.py
@@ -19,7 +19,12 @@ def get_authenticator_user_view():
 
         class AuthenticatorPluginRelatedUsersView(user_viewset_view):
             def get_queryset(self, **kwargs):
-                authenticator_id = kwargs.get('authenticator_id', None)
+                # during unit testing we get the pk from kwargs
+                authenticator_id = kwargs.get('pk', None)
+                if hasattr(self, 'kwargs'):
+                    # But at runtime self has kwargs attached and no kwargs associated
+                    authenticator_id = self.kwargs.get('pk', None)
+                # if we didn't get an ID for some reason we will just return None
                 if authenticator_id is None:
                     return get_user_model().objects.none()
                 authenticator_users = get_user_model().objects.filter(authenticator_user__provider__id=authenticator_id)

--- a/test_app/tests/authentication/views/test_authenticator_user.py
+++ b/test_app/tests/authentication/views/test_authenticator_user.py
@@ -54,5 +54,5 @@ def test_authenticator_user_view_authenticator_user_count(local_authenticator, d
 
     view_class = get_authenticator_user_view()
     view = view_class()
-    query_set = view.get_queryset(**{'authenticator_id': local_authenticator.id})
+    query_set = view.get_queryset(**{'pk': local_authenticator.id})
     assert query_set.count() == num_users


### PR DESCRIPTION
This adds the URL back into the related dict on /authenticators/:id and corrects a bug where it always returned 0 users.