### PR TITLE
Update EDA auth class to not use old Roles

### DIFF
--- a/ansible_base/jwt_consumer/eda/auth.py
+++ b/ansible_base/jwt_consumer/eda/auth.py
@@ -1,31 +1,15 @@
 import logging
 
-from ansible_base.jwt_consumer.common.auth import JWTAuthentication
-from ansible_base.jwt_consumer.common.exceptions import InvalidService
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
-try:
-    from aap_eda.core import models
-    from drf_spectacular.extensions import OpenApiAuthenticationExtension
-except ImportError:
-    raise InvalidService("eda")
+from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 
 logger = logging.getLogger("ansible_base.jwt_consumer.eda.auth")
 
 
 class EDAJWTAuthentication(JWTAuthentication):
     def process_permissions(self, user, claims, token):
-        logger.info("Processing permissions")
-
-        if token.get("is_superuser", False):
-            self._add_roles(user, "Admin", "is_superuser")
-
-        if token.get("is_system_auditor", False):
-            self._add_roles(user, "Auditor", "is_system_auditor")
-
-    def _add_roles(self, user, role_name, user_type):
-        logger.info(f"{user.username} is {user_type}. Adding role {role_name} to user {user.username}")
-        role_id = models.Role.objects.filter(name=role_name).first().id
-        user.roles.add(role_id)
+        logger.info("Processing permissions for {}".format(user.username))
 
 
 class EDAJWTAuthScheme(OpenApiAuthenticationExtension):

--- a/test_app/tests/jwt_consumer/eda/test_auth.py
+++ b/test_app/tests/jwt_consumer/eda/test_auth.py
@@ -2,14 +2,16 @@ import logging
 import sys
 from unittest.mock import MagicMock
 
-import pytest
+from ansible_base.jwt_consumer.eda.auth import EDAJWTAuthentication
 
 
-def test_eda_import_error():
-    from ansible_base.jwt_consumer.common.exceptions import InvalidService
-
-    with pytest.raises(InvalidService):
-        import ansible_base.jwt_consumer.eda.auth  # noqa: 401
+def test_eda_process_permissions(user, caplog):
+    authentication = EDAJWTAuthentication()
+    claims = {}
+    token = {}
+    with caplog.at_level(logging.INFO):
+        authentication.process_permissions(user, claims, token)
+        assert f"Processing permissions for {user.username}" in caplog.text
 
 
 def test_eda_jwt_auth_scheme():
@@ -19,48 +21,3 @@ def test_eda_jwt_auth_scheme():
     scheme = EDAJWTAuthScheme(None)
     response = scheme.get_security_definition(None)
     assert 'name' in response and response['name'] == 'X-DAB-JW-TOKEN'
-
-
-def filter_function(name):
-    role = None
-    if name == 'Admin':
-        role = MagicMock(id=1)
-    elif name == 'Auditor':
-        role = MagicMock(id=2)
-    return MagicMock(**{'first.return_value': role})
-
-
-@pytest.fixture
-def mocked_authenticator():
-    sys.modules['aap_eda.core'] = MagicMock()
-    from ansible_base.jwt_consumer.eda.auth import EDAJWTAuthentication  # noqa: E402
-    from ansible_base.jwt_consumer.eda.auth import models
-
-    models.Role.objects.filter = filter_function
-
-    authenticator = EDAJWTAuthentication()
-    # patch.object(authenticator.models.Role.objects, 'filter', alan_filter)
-    # authenticator.models = MagicMock(**{"Role.objects.filter": filter_function})
-    return authenticator
-
-
-def test_eda_jwt_auth_add_roles(mocked_authenticator, caplog):
-    with caplog.at_level(logging.INFO):
-        user = MagicMock(username='timmy', roles=set())
-        user_type = 'super_user'
-        role_name = 'Auditor'
-        mocked_authenticator._add_roles(user, role_name, user_type)
-        assert f"{user.username} is {user_type}. Adding role {role_name} to user {user.username}" in caplog.text
-
-
-@pytest.mark.parametrize(
-    'is_superuser,is_system_auditor,results', ((False, False, set()), (True, False, set([1])), (False, True, set([2])), (True, True, set([1, 2])))
-)
-def test_eda_jwt_auth_process_permissions(mocked_authenticator, is_superuser, is_system_auditor, results):
-    user = MagicMock(username='timmy', roles=set())
-    token = {
-        'is_superuser': is_superuser,
-        'is_system_auditor': is_system_auditor,
-    }
-    mocked_authenticator.process_permissions(user, {}, token)
-    assert user.roles == results


### PR DESCRIPTION
The old Roles model is removed in favor of DAB RBAC implementation in EDA so this PR aims to remove its use in EDA Auth class and authorize the user as is.

We need this merged before https://github.com/ansible/eda-server/pull/710 is merged. 