### PR TITLE
[AS] Address incorrect FK refs in summary_fields

### DIFF
--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -49,7 +49,9 @@ class Entry(ImmutableCommonModel):
     def changed_fk_fields(self):
         """
         :return: A dictionary of {field_name: pk} for any ForeignKey fields that have changed.
-            the pk is the new pk value, for changed fields.
+            the pk is the new pk value, for changed fields. In the case of added/removed fields,
+            the pk is the pk of the related object. In the case of a changed field, the pk is the
+            new pk value.
         """
         changed_fks = {}
 

--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -58,30 +58,18 @@ class Entry(ImmutableCommonModel):
 
         for op in ('added_fields', 'changed_fields', 'removed_fields'):
             for field_name, value in self.changes.get(op, {}).items():
-                field = self.content_type.model_class()._meta.get_field(field_name)
+                if (model := self.content_type.model_class()) is None:
+                    continue
+                field = model._meta.get_field(field_name)
                 if isinstance(field, models.ForeignKey):
-                    if op == 'changed_fields':
-                        pk = value[1]
-                    else:
-                        pk = value
-                    changed_fks[field_name] = pk
+                    try:
+                        fk_model = field.related_model
+                    except AttributeError:  # Likely the model was deleted
+                        continue
+                    pk = value[1] if op == 'changed_fields' else value
+                    changed_fks[field_name] = (fk_model, pk)
 
         return changed_fks
-
-    @functools.cached_property
-    def content_object_with_cached_changed_fields(self):
-        """
-        Get the content object with any changed ForeignKey fields cached.
-        This is useful for related and summary_fields in serializers.
-
-        :return: The content object with any changed ForeignKey fields cached.
-        """
-        if self.changes is None:
-            return self.content_object
-
-        changed_fks = self.changed_fk_fields.keys()
-        obj = self.content_type.model_class().objects.select_related(*changed_fks).get(pk=self.object_id)
-        return obj
 
 
 class AuditableModel(models.Model):

--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -68,6 +68,8 @@ class Entry(ImmutableCommonModel):
                         fk_model = field.related_model
                     except AttributeError:  # Likely the model was deleted
                         continue
+                    # For added/removed fields, the value is the pk of the related object
+                    # For changed fields, the value is the *new* pk value
                     pk = value[1] if op == 'changed_fields' else value
                     changed_fks[field_name] = (fk_model, pk)
 

--- a/ansible_base/activitystream/serializers.py
+++ b/ansible_base/activitystream/serializers.py
@@ -70,93 +70,65 @@ class EntrySerializer(ImmutableCommonModelSerializer):
 
     def _get_summary_fields(self, obj) -> dict[str, dict]:
         summary_fields = super()._get_summary_fields(obj)
+        if self.is_list_view:
+            return summary_fields
 
         try:
-            # This will be None if the instance was deleted, but if the *model*
-            # was deleted, it'll raise an AttributeError.
-            content_obj = obj.content_object_with_cached_changed_fields
-        except AttributeError:
-            # The model was deleted
-            content_obj = None
-
-        if content_obj and hasattr(content_obj, 'summary_fields'):
-            summary_fields['content_object'] = content_obj.summary_fields()
+            if obj.content_object is not None and hasattr(obj.content_object, 'summary_fields'):
+                summary_fields['content_object'] = obj.content_object.summary_fields()
+        except AttributeError:  # Likely the model was deleted
+            pass
 
         try:
-            # This will be None if the instance was deleted, but if the *model*
-            # was deleted, it'll raise an AttributeError.
-            related_content_obj = obj.related_content_object
-        except AttributeError:
-            # The model was deleted
-            related_content_obj = None
-
-        if related_content_obj and hasattr(related_content_obj, 'summary_fields'):
-            summary_fields['related_content_object'] = related_content_obj.summary_fields()
+            if obj.related_content_object is not None and hasattr(obj.related_content_object, 'summary_fields'):
+                summary_fields['related_content_object'] = obj.related_content_object.summary_fields()
+        except AttributeError:  # Likely the model was deleted
+            pass
 
         if obj.changes is None:
             return summary_fields
 
-        try:
-            changed_fk_fields = obj.changed_fk_fields
-        except AttributeError:
-            # The model was deleted
-            changed_fk_fields = {}
+        changed_fk_fields = obj.changed_fk_fields
 
-        for field_name, pk in changed_fk_fields.items():
-            related_object = getattr(content_obj, field_name, None)
-            if related_object is None:
-                continue
-
-            if hasattr(related_object, 'summary_fields'):
-                summary_fields[f"changes.{field_name}"] = related_object.summary_fields()
+        for field_name, (related_model, pk) in changed_fk_fields.items():
+            if related_object := related_model.objects.filter(pk=pk).first():
+                if hasattr(related_object, 'summary_fields'):
+                    summary_fields[f"changes.{field_name}"] = related_object.summary_fields()
 
         return summary_fields
 
     def _get_related(self, obj) -> dict[str, str]:
         fields = super()._get_related(obj)
+
+        if self.is_list_view:
+            return fields
+
+        # content_object
         try:
-            content_obj = obj.content_object_with_cached_changed_fields
-        except AttributeError:
-            # The model was deleted
-            return fields
+            if obj.content_object is not None:
+                fields['content_object'] = get_url_for_object(obj.content_object)
+        except AttributeError:  # Likely the model was deleted
+            pass
 
-        if content_obj is None:
-            return fields
-
-        # Add related fields for the content_object and related_content_object
-        fields['content_object'] = get_url_for_object(content_obj)
-
+        # related_content_object
         try:
-            # This will be None if the instance was deleted, but if the *model*
-            # was deleted, it'll raise an AttributeError.
-            related_content_obj = obj.related_content_object
-        except AttributeError:
-            # The model was deleted
-            related_content_obj = None
+            if obj.related_content_object is not None:
+                fields['related_content_object'] = get_url_for_object(obj.related_content_object)
+        except AttributeError:  # Likely the model was deleted
+            pass
 
-        if related_content_obj is not None:
-            fields['related_content_object'] = get_url_for_object(obj.related_content_object)
+        for field_name, (related_model, pk) in obj.changed_fk_fields.items():
+            if related_object := related_model.objects.filter(pk=pk).first():
+                # If the related object inherits CreatableModel, we can check and make sure it's
+                # older than the activity stream entry. If it's not, then we don't want to link to it.
+                if isinstance(related_object, CreatableModel) and related_object.created > obj.created:
+                    model = obj.content_type.model_class()
+                    logger.warning(
+                        f"Refusing to relate {related_object} to activity stream entry for {model} {obj.object_id} because it was created after the entry"
+                    )
+                    continue
 
-        if obj.changes is None:
-            return fields
+                if related_url := get_url_for_object(related_object, pk=pk):
+                    fields[f"changes.{field_name}"] = related_url
 
-        changes_links = {}
-        for field_name, pk in obj.changed_fk_fields.items():
-            related_object = getattr(content_obj, field_name, None)
-            if related_object is None:
-                continue
-
-            # If the related object inherits CreatableModel, we can check and make sure it's
-            # older than the activity stream entry. If it's not, then we don't want to link to it.
-            if isinstance(related_object, CreatableModel) and related_object.created > obj.created:
-                model = obj.content_type.model_class()
-                logger.warning(
-                    f"Refusing to relate {related_object} to activity stream entry for {model} {obj.object_id} because it was created after the entry"
-                )
-                continue
-
-            if related_url := get_url_for_object(related_object, pk=pk):
-                changes_links[f"changes.{field_name}"] = related_url
-
-        fields.update(changes_links)
         return fields

--- a/ansible_base/lib/serializers/common.py
+++ b/ansible_base/lib/serializers/common.py
@@ -36,6 +36,13 @@ class AbstractCommonModelSerializer(ValidationSerializerMixin, serializers.Model
     def get_url(self, obj) -> str:
         return get_url_for_object(obj)
 
+    @property
+    def is_list_view(self) -> bool:
+        view = self.context.get('view')
+        if view is None:
+            raise ValueError("View not found in context")
+        return view.action == 'list'
+
     # Type hints are used by OpenAPI
     def _get_related(self, obj) -> dict[str, str]:
         if obj is None:

--- a/ansible_base/lib/testing/fixtures.py
+++ b/ansible_base/lib/testing/fixtures.py
@@ -64,6 +64,7 @@ def user(db, django_user_model, local_authenticator):
     return django_user_model.objects.create_user(username="user", password="password")
 
 
+@copy_fixture(copies=3)
 @pytest.fixture
 def random_user(db, django_user_model, randname, local_authenticator):
     return django_user_model.objects.create_user(username=randname("user"), password="password")


### PR DESCRIPTION
Followup to #313. Don't use the current FK, use the one that it was
set to when the AS entry was logged.

This ended up triggering a lot more queries because there's really no
way to cache this effectively. So that led to reverting back to not
showing the extra summary_fields and related on list views.

Additionally, clean up a lot of redundant, verbose code, and make
things easier to read.

Signed-off-by: Rick Elrod <rick@elrod.me>