### PR TITLE
Allow configuring permissions needed to related objects

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -133,6 +133,9 @@ if 'ansible_base.rbac' in INSTALLED_APPS:
 
     # Permissions a user will get when creating a new item
     ANSIBLE_BASE_CREATOR_DEFAULTS = ['add', 'change', 'delete', 'view']
+    # Permissions API will check for related items, think PATCH/PUT
+    # This is a precedence order, so first action related model has will be used
+    ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS = ['use', 'change', 'view']
     # If a role does not already exist that can give those object permissions
     # then the system must create one, this is used for naming the auto-created role
     ANSIBLE_BASE_ROLE_CREATOR_NAME = '{obj._meta.model_name}-creator-permission'

--- a/test_app/migrations/0001_initial.py
+++ b/test_app/migrations/0001_initial.py
@@ -134,11 +134,24 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name='Credential',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=512)),
+                ('organization', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='credentials', to='test_app.organization')),
+            ],
+            options={
+                'ordering': ['id'],
+                'permissions': [('use_credential', 'Apply credential to other models')],
+            },
+        ),
+        migrations.CreateModel(
             name='Inventory',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=512)),
                 ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.ANSIBLE_BASE_ORGANIZATION_MODEL, null=True, related_name='inventories')),
+                ('credential', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='inventories', to='test_app.credential'),)
             ],
             options={
                 'permissions': [('update_inventory', 'Do inventory updates')],

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -123,11 +123,26 @@ class Inventory(models.Model):
     "Simple example of a child object, it has a link to its parent organization"
     name = models.CharField(max_length=512)
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE, null=True, related_name='inventories')
+    credential = models.ForeignKey('test_app.Credential', on_delete=models.SET_NULL, null=True, related_name='inventories')
 
     class Meta:
         app_label = 'test_app'
         ordering = ['id']
         permissions = [('update_inventory', 'Do inventory updates')]
+
+    def summary_fields(self):
+        return {"id": self.id, "name": self.name}
+
+
+class Credential(models.Model):
+    "Example of a model that gets used by other models"
+    name = models.CharField(max_length=512)
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, null=True, related_name='credentials')
+
+    class Meta:
+        app_label = 'test_app'
+        ordering = ['id']
+        permissions = [('use_credential', 'Apply credential to other models')]
 
     def summary_fields(self):
         return {"id": self.id, "name": self.name}
@@ -239,7 +254,7 @@ class Proxy2(Original2):
         proxy = True
 
 
-permission_registry.register(Organization, Inventory, Namespace, Team, Cow, UUIDModel, PositionModel, WeirdPerm)
+permission_registry.register(Organization, Inventory, Credential, Namespace, Team, Cow, UUIDModel, PositionModel, WeirdPerm)
 permission_registry.register(ParentName, parent_field_name='my_organization')
 permission_registry.register(CollectionImport, parent_field_name='namespace')
 permission_registry.register(InstanceGroup, ImmutableTask, parent_field_name=None)

--- a/test_app/tests/rbac/api/test_rbac_permissions.py
+++ b/test_app/tests/rbac/api/test_rbac_permissions.py
@@ -1,10 +1,11 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
 from django.urls import reverse
 
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
-from test_app.models import Cow, Inventory, Organization
+from test_app.models import Cow, Credential, Inventory, Organization
 
 
 @pytest.fixture
@@ -189,3 +190,56 @@ def test_custom_action(user_api_client, user, organization):
     cow_say_url = reverse('cow-cowsay', kwargs={'pk': cow.id})
     r = user_api_client.post(cow_say_url, {})
     assert r.status_code == 200
+
+
+@pytest.fixture
+def cred_view_rd():
+    return RoleDefinition.objects.create_from_permissions(
+        permissions=['view_credential'],
+        name='view-credential',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Credential),
+    )
+
+
+@pytest.mark.django_db
+def test_related_view_permissions(inventory, organization, user, user_api_client, inv_rd, cred_view_rd):
+    credential = Credential.objects.create(name='foo-cred', organization=organization)
+    assert not inventory.credential  # sanity
+    inv_rd.give_permission(user, inventory)
+    cred_view_rd.give_permission(user, credential)
+    url = reverse('inventory-detail', kwargs={'pk': inventory.pk})
+
+    response = user_api_client.patch(url, data={'credential': credential.pk})
+    assert response.status_code == 403
+    assert 'credential' in response.data
+
+    with override_settings(ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS=['view']):
+        response = user_api_client.patch(url, data={'credential': credential.pk})
+        assert response.status_code == 200
+        inventory.refresh_from_db()
+        assert inventory.credential == credential
+
+
+@pytest.mark.django_db
+def test_related_use_permission(inventory, organization, user, user_api_client, inv_rd, cred_view_rd):
+    credential = Credential.objects.create(name='foo-cred', organization=organization)
+    inv_rd.give_permission(user, inventory)
+    cred_view_rd.give_permission(user, credential)
+    url = reverse('inventory-detail', kwargs={'pk': inventory.pk})
+
+    # without needed permissions to the credential, user can not apply this credential
+    response = user_api_client.patch(url, data={'credential': credential.pk})
+    assert response.status_code == 403
+    assert 'credential' in response.data
+
+    # with use permission (by default settings) user can apply this credential
+    cred_use_rd = RoleDefinition.objects.create_from_permissions(
+        permissions=['use_credential', 'view_credential'],
+        name='use-credential',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Credential),
+    )
+    cred_use_rd.give_permission(user, credential)
+    response = user_api_client.patch(url, data={'credential': credential.pk})
+    assert response.status_code == 200
+    inventory.refresh_from_db()
+    assert inventory.credential == credential

--- a/test_app/tests/rbac/api/test_rbac_permissions.py
+++ b/test_app/tests/rbac/api/test_rbac_permissions.py
@@ -221,6 +221,22 @@ def test_related_view_permissions(inventory, organization, user, user_api_client
 
 
 @pytest.mark.django_db
+@override_settings(ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS=[])
+def test_related_no_permissions(inventory, organization, user, user_api_client, inv_rd):
+    "Turn off checking of related permissions"
+    credential = Credential.objects.create(name='foo-cred', organization=organization)
+    assert not inventory.credential  # sanity
+    inv_rd.give_permission(user, inventory)
+    url = reverse('inventory-detail', kwargs={'pk': inventory.pk})
+
+    # No permissions to related credential needed, YOLO
+    response = user_api_client.patch(url, data={'credential': credential.pk})
+    assert response.status_code == 200
+    inventory.refresh_from_db()
+    assert inventory.credential == credential
+
+
+@pytest.mark.django_db
 def test_related_use_permission(inventory, organization, user, user_api_client, inv_rd, cred_view_rd):
     credential = Credential.objects.create(name='foo-cred', organization=organization)
     inv_rd.give_permission(user, inventory)


### PR DESCRIPTION
There was a sentiment that requiring "change" permission to related objects might be too much. I expected this, but was trying to finish development fast earlier.

Normally I would expect an app to rely on "use" permission, like AWX for `use_role` of credentials and other things. But that requires re-configuring permission structure and another permission for each model. I'm not ready to take that step now, and without that your choices are "change" or "view". If required is downgraded to "view", that's perfectly coherent. It's a policy question that I have no specific opinion on.

In short, this will allow apps using the DAB RBAC API utilities to configure what level of related permission they want to check. This comes in a precedence list defined in setting. If nothing in the preference list applies to the target model, then we won't check permissions for that item.

Ping @Dostonbek1 