### PR TITLE
Fix mysterious schema generating error

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -190,7 +190,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         if request:
             qs = self.get_actor_queryset(request.user)
         else:
-            qs = self.Meta.model.get_field(self.actor_field).model.objects.all()
+            qs = self.Meta.model._meta.get_field(self.actor_field).model.objects.all()
         self.fields[self.actor_field] = serializers.PrimaryKeyRelatedField(queryset=qs, required=False)
 
     def raise_id_fields_error(self, field1, field2):


### PR DESCRIPTION
I feel really bad that I don't have a test for this, but the test_app docs works fine. I was able to replicate the issue with eda-server

http://127.0.0.1:8000/api/eda/v1/openapi.json

And I was able to confirm this fixes it (no 500 error). But I don't know of any way we can test that here. In any case, the bug is obvious.