### PR TITLE
Fix bug where org admins could modify superusers

### DIFF
--- a/ansible_base/rbac/policies.py
+++ b/ansible_base/rbac/policies.py
@@ -34,6 +34,8 @@ def visible_users(request_user, queryset=None) -> QuerySet:
 def can_change_user(request_user, target_user) -> bool:
     if request_user.is_superuser:
         return True
+    elif target_user.is_superuser:
+        return False  # target is a superuser and request user is not
 
     if not get_setting('MANAGE_ORGANIZATION_AUTH', False):
         return False

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansible_base.rbac.policies import can_change_user, visible_users
+from ansible_base.rbac.policies import can_change_user
 from test_app.models import User
 
 

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -1,0 +1,13 @@
+import pytest
+
+from ansible_base.rbac.policies import can_change_user, visible_users
+from test_app.models import User
+
+
+@pytest.mark.django_db
+def test_org_admin_can_not_change_superuser(org_admin_rd, organization):
+    org_admin = User.objects.create(username='org-admin')
+    org_admin_rd.give_permission(org_admin, organization)
+
+    admin = User.objects.create(username='new-superuser', is_superuser=True)
+    assert not can_change_user(org_admin, admin)


### PR DESCRIPTION
Sorry I've kind of slow-rolled the work on this a little bit. Let me show the criteria this is borrowing from AWX in `UserAccess.can_admin`.

```python
        if obj.is_superuser or obj.is_system_auditor:
            # must be superuser to admin users with system roles
            return False
```

That's pretty clearly the same as the criteria I am adding here. I missed this because I was trying to _avoid_ this other criteria, which was:

```python
        if data is not None and ('is_superuser' in data or 'is_system_auditor' in data):
            if to_python_boolean(data.get('is_superuser', 'false'), allow_none=True) and not self.user.is_superuser:
                return False
            if to_python_boolean(data.get('is_system_auditor', 'false'), allow_none=True) and not (self.user.is_superuser or self.user == obj):
                return False
```

My reason for avoiding that was because it is re-validation and should be avoided (like `to_python_boolean` can't be fully trusted b/c it is not the proper source-of-truth). It should instead happen in the serializers (which has largely already been done). But that caused me to miss this other criteria. This should take care of it.