### PR TITLE
Partially migrate another user editing condition from AWX

### DIFF
--- a/ansible_base/rbac/policies.py
+++ b/ansible_base/rbac/policies.py
@@ -44,6 +44,10 @@ def can_change_user(request_user, target_user) -> bool:
     if not get_setting('MANAGE_ORGANIZATION_AUTH', False):
         return False
 
+    # All users can chang their own password and other details
+    if request_user.pk == target_user.pk:
+        return True
+
     # If the user is not in any organizations, answer can not consider organization permissions
     org_cls = apps.get_model(settings.ANSIBLE_BASE_ORGANIZATION_MODEL)
     target_user_orgs = org_cls.access_qs(target_user, 'member_organization')

--- a/ansible_base/rbac/policies.py
+++ b/ansible_base/rbac/policies.py
@@ -35,6 +35,7 @@ def visible_users(request_user, queryset=None) -> QuerySet:
 
 
 def can_change_user(request_user, target_user) -> bool:
+    """Tells if the request user can modify details of the target user"""
     if request_user.is_superuser:
         return True
     elif target_user.is_superuser:
@@ -43,8 +44,15 @@ def can_change_user(request_user, target_user) -> bool:
     if not get_setting('MANAGE_ORGANIZATION_AUTH', False):
         return False
 
+    # If the user is not in any organizations, answer can not consider organization permissions
     org_cls = apps.get_model(settings.ANSIBLE_BASE_ORGANIZATION_MODEL)
-    return not org_cls.access_qs(target_user, 'member_organization').exclude(pk__in=org_cls.access_ids_qs(request_user, 'change_organization')).exists()
+    target_user_orgs = org_cls.access_qs(target_user, 'member_organization')
+    if not target_user_orgs.exists():
+        return request_user.is_superuser
+
+    # Organization admins can manage users in their organization
+    # this requires change permission to all organizations the target user is a member of
+    return not target_user_orgs.exclude(pk__in=org_cls.access_ids_qs(request_user, 'change_organization')).exists()
 
 
 def check_content_obj_permission(request_user, obj) -> None:

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -20,3 +20,9 @@ def test_unrelated_can_not_change_user():
 
     for first, second in [(alice, bob), (bob, alice)]:
         assert not can_change_user(first, second)
+
+@pytest.mark.django_db
+def test_user_can_manage_themself():
+    alice = User.objects.create(username='alice')
+
+    assert can_change_user(alice, alice)

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -23,6 +23,12 @@ def test_unrelated_can_not_change_user():
 
 
 @pytest.mark.django_db
+def test_superuser_can_change_new_user(admin_user):
+    alice = User.objects.create(username='alice')
+    assert can_change_user(admin_user, alice)
+
+
+@pytest.mark.django_db
 def test_user_can_manage_themself():
     alice = User.objects.create(username='alice')
 

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -21,6 +21,7 @@ def test_unrelated_can_not_change_user():
     for first, second in [(alice, bob), (bob, alice)]:
         assert not can_change_user(first, second)
 
+
 @pytest.mark.django_db
 def test_user_can_manage_themself():
     alice = User.objects.create(username='alice')

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -29,7 +29,6 @@ def test_superuser_can_change_new_user(admin_user):
 
 
 @pytest.mark.django_db
-def test_user_can_manage_themself():
+def test_user_can_manage_themselves():
     alice = User.objects.create(username='alice')
-
     assert can_change_user(alice, alice)

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -11,3 +11,12 @@ def test_org_admin_can_not_change_superuser(org_admin_rd, organization):
 
     admin = User.objects.create(username='new-superuser', is_superuser=True)
     assert not can_change_user(org_admin, admin)
+
+
+@pytest.mark.django_db
+def test_unrelated_can_not_change_user():
+    alice = User.objects.create(username='alice')
+    bob = User.objects.create(username='bob')
+
+    for first, second in [(alice, bob), (bob, alice)]:
+        assert not can_change_user(first, second)


### PR DESCRIPTION
Let me link the legacy code here:

https://github.com/ansible/awx/blob/918d5b3565e5997bdbd57117b92852ba13bb55d6/awx/main/access.py#L713-L726

When you look at that, first note that there is a condition for "orphan" users --> this means users who are not in any organizations.

The need for this is clear from the test. If a user is not in _any_ organization, then we can't allow _any other user_ to manage that user. That's why we need an extra condition in this case. That's not up for debate.

Here, I'm using `is_superuser`, because I'm reluctant to copy over all the rules from AWX to DAB. This one, in particular, seems dubious. The reason why the AWX criteria had extra stuff was so that organization admins could POST to `/api/v2/users/` and then after that add the user as a member of their organization. I would like to punt this over to require an API solution, so that a user can be given an organization on creation @john-westcott-iv @slemrmartin 