### PR TITLE
Using cache in jwt authentication

### DIFF
--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -473,6 +473,19 @@ def test_encryption_public_key():
 
 
 @pytest.fixture
+def random_public_key():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
+    return (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+
+
+@pytest.fixture
 def jwt_token(test_encryption_private_key):
     class Token:
         def __init__(self):

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 import pytest
 import requests
 from django.test.utils import override_settings
+from jwt.exceptions import DecodeError
 from rest_framework.exceptions import AuthenticationFailed
 
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication, JWTCommonAuth, default_mapped_user_fields
@@ -75,7 +76,7 @@ class TestJWTCommonAuth:
     def test_get_decryption_key_absolute_junk(self):
         common_auth = JWTCommonAuth()
         with pytest.raises(AuthenticationFailed, match="Unable to determine how to handle  to get key"):
-            common_auth.get_decryption_key("")
+            common_auth.get_decryption_key("", ignore_cache=True)
 
     def test_get_decryption_key_invalid_scheme(self):
         common_auth = JWTCommonAuth()
@@ -84,7 +85,7 @@ class TestJWTCommonAuth:
             AuthenticationFailed,
             match=f"Unable to determine how to handle {url} to get key",
         ):
-            common_auth.get_decryption_key(url)
+            common_auth.get_decryption_key(url, ignore_cache=True)
 
     @pytest.mark.parametrize(
         "error, exception_class",
@@ -102,45 +103,66 @@ class TestJWTCommonAuth:
         with mock.patch("builtins.open", mock.mock_open()) as mock_file:
             mock_file.side_effect = exception_class
             with pytest.raises(AuthenticationFailed, match=error.format(url_parts.path)):
-                common_auth.get_decryption_key(url)
+                common_auth.get_decryption_key(url, ignore_cache=True)
 
     # This would test any method returning junk instead of an RSA key
     def test_get_decryption_key_invalid_input(self):
         common_auth = JWTCommonAuth()
         with pytest.raises(AuthenticationFailed, match="Returned key does not start and end with BEGIN/END PUBLIC KEY"):
-            common_auth.get_decryption_key("absolute_junk")
+            common_auth.get_decryption_key("absolute_junk", ignore_cache=True)
 
-    def test_get_decryption_key_file_read(self, tmp_path_factory, test_encryption_public_key):
+    @pytest.mark.parametrize(
+        "remove_newlines",
+        [(False), (True)],
+    )
+    def test_get_decryption_key_file_read(self, remove_newlines, tmp_path_factory, test_encryption_public_key):
         common_auth = JWTCommonAuth()
         temp_dir = tmp_path_factory.mktemp("ansible_base.jwt_consumer.common.auth")
         temp_file_name = f"{temp_dir}/test.file"
-        for cert_data in [test_encryption_public_key, test_encryption_public_key.replace("\n", "")]:
-            with open(temp_file_name, "w") as f:
-                f.write(cert_data)
-            response = common_auth.get_decryption_key(f"file:{temp_file_name}")
-            assert response == cert_data
+        if remove_newlines:
+            cert_data = test_encryption_public_key.replace("\n", "")
+        else:
+            cert_data = test_encryption_public_key
+        with open(temp_file_name, "w") as f:
+            f.write(cert_data)
+        key, _ = common_auth.get_decryption_key(f"file:{temp_file_name}", ignore_cache=True)
+        assert key == cert_data
+
+    def test_get_decryption_key_file_read_with_cache(self, tmp_path_factory, test_encryption_public_key):
+        common_auth = JWTCommonAuth()
+        temp_dir = tmp_path_factory.mktemp("ansible_base.jwt_consumer.common.auth")
+        temp_file_name = f"{temp_dir}/test.file"
+        cert_data = test_encryption_public_key
+        with open(temp_file_name, "w") as f:
+            f.write(cert_data)
+        key, cached = common_auth.get_decryption_key(f"file:{temp_file_name}", ignore_cache=True)
+        assert key == cert_data
+        assert cached is False
+        key, cached = common_auth.get_decryption_key(f"file:{temp_file_name}")
+        assert key == cert_data
+        assert cached is True
 
     @mock.patch('requests.get', mock.Mock(side_effect=requests.exceptions.ConnectionError))
     def test_get_decryption_key_connection_error(self):
         common_auth = JWTCommonAuth()
         url = "http://dne.cuz.junk.redhat.com"
         with pytest.raises(AuthenticationFailed, match=rf"Failed to connect to {url}.*"):
-            common_auth.get_decryption_key(url)
+            common_auth.get_decryption_key(url, ignore_cache=True)
 
     @mock.patch('requests.get', mock.Mock(side_effect=requests.exceptions.Timeout))
     def test_get_decryption_key_url_timeout(self):
         common_auth = JWTCommonAuth()
         url = "http://dne.cuz.junk.redhat.com"
-        timeout = 0.1
+        timeout = 1
         with pytest.raises(AuthenticationFailed, match=rf"Timed out after {timeout} secs when connecting to {url}.*"):
-            common_auth.get_decryption_key(url, timeout=timeout)
+            common_auth.get_decryption_key(url, timeout=timeout, ignore_cache=True)
 
     @mock.patch('requests.get', mock.Mock(side_effect=requests.exceptions.RequestException))
     def test_get_decryption_key_url_random_exception(self):
         common_auth = JWTCommonAuth()
         url = "http://dne.cuz.junk.redhat.com"
         with pytest.raises(AuthenticationFailed, match=r"Failed to get JWT decryption key from JWT server: \(RequestException\).*"):
-            common_auth.get_decryption_key(url)
+            common_auth.get_decryption_key(url, ignore_cache=True)
 
     @pytest.mark.parametrize("status_code", ['302', '504'])
     def test_get_decryption_key_url_bad_status_codes(self, status_code, mocked_http):
@@ -148,24 +170,57 @@ class TestJWTCommonAuth:
             requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
             common_auth = JWTCommonAuth()
             with pytest.raises(AuthenticationFailed, match=f"Failed to get 200 response from the issuer: {status_code}"):
-                common_auth.get_decryption_key(f"http://someotherurl.com/{status_code}")
+                common_auth.get_decryption_key(f"http://someotherurl.com/{status_code}", ignore_cache=True)
 
     def test_get_decryption_key_url_bad_200(self, mocked_http):
         common_auth = JWTCommonAuth()
         with mock.patch('requests.get') as requests_get:
             requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
             with pytest.raises(AuthenticationFailed, match="Returned key does not start and end with BEGIN/END PUBLIC KEY"):
-                common_auth.get_decryption_key("http://someotherurl.com/200_junk")
+                common_auth.get_decryption_key("http://someotherurl.com/200_junk", ignore_cache=True)
 
     def test_get_decryption_key_url_good_200(self, mocked_http, test_encryption_public_key):
         common_auth = JWTCommonAuth()
         with mock.patch('requests.get') as requests_get:
             requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
             try:
-                cert = common_auth.get_decryption_key("http://someotherurl.com/200_good")
+                cert, _ = common_auth.get_decryption_key("http://someotherurl.com/200_good", ignore_cache=True)
             except Exception as e:
                 assert False, f"Got unexpected exception {e}"
             assert cert == test_encryption_public_key
+
+    def test_get_decryption_key_url_cache(self, mocked_http, test_encryption_public_key):
+        common_auth = JWTCommonAuth()
+        with mock.patch('requests.get') as requests_get:
+            requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
+            try:
+                cert, cached = common_auth.get_decryption_key("http://someotherurl.com/200_good", ignore_cache=True)
+            except Exception as e:
+                assert False, f"Got unexpected exception {e}"
+            assert cert == test_encryption_public_key
+            assert cached is False
+            cert, cached = common_auth.get_decryption_key("http://someotherurl.com/200_good")
+            assert cert == test_encryption_public_key
+            assert cached is True
+
+    # If other tests are running at the same time there is a chance that they might set the key in the cache.
+    # Since we don't mock the response intentionally we are going to tell this test to use a different cache key
+    @mock.patch('ansible_base.jwt_consumer.common.auth.cache_key', 'expiration_test_jwt_key')
+    def test_cache_expiring(self, mocked_http, test_encryption_public_key):
+        with mock.patch('requests.get') as requests_get:
+            # Setting the cache timeout to 0 effectively says don't cache.
+            with override_settings(ANSIBLE_BASE_JWT_CACHE_TIMEOUT_SECONDS=0):
+                common_auth = JWTCommonAuth()
+                requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
+                try:
+                    cert, cached = common_auth.get_decryption_key("http://someotherurl.com/200_good")
+                except Exception as e:
+                    assert False, f"Got unexpected exception {e}"
+                assert cert == test_encryption_public_key
+                assert cached is False
+                cert, cached = common_auth.get_decryption_key("http://someotherurl.com/200_good")
+                assert cert == test_encryption_public_key
+                assert cached is False
 
     @pytest.mark.parametrize(
         'user_fields,token,should_save',
@@ -244,16 +299,16 @@ class TestJWTCommonAuth:
     @pytest.mark.parametrize(
         "token,key,exception_text",
         [
-            (None, None, "JWT decoding failed: Invalid token type. Token must be a <class 'bytes'>, check your key and generated token"),
-            ("", None, "JWT decoding failed: Not enough segments, check your key and generated token"),
-            (None, "", "JWT decoding failed: Invalid token type. Token must be a <class 'bytes'>, check your key and generated token"),
-            ("junk", "junk", "JWT decoding failed: Not enough segments, check your key and generated token"),
-            ("a.b.c", None, "JWT decoding failed: Invalid header padding, check your key and generated token"),
+            (None, None, "Invalid token type. Token must be a <class 'bytes'>"),
+            ("", None, "Not enough segments"),
+            (None, "", "Invalid token type. Token must be a <class 'bytes'>"),
+            ("junk", "junk", "Not enough segments"),
+            ("a.b.c", None, "Invalid header padding"),
         ],
     )
     def test_validate_token_with_junk_input(self, token, key, exception_text):
         common_auth = JWTCommonAuth()
-        with pytest.raises(AuthenticationFailed, match=exception_text):
+        with pytest.raises(DecodeError, match=exception_text):
             common_auth.validate_token(token, key)
 
     def test_validate_token_random_exception(self):
@@ -289,7 +344,7 @@ class TestJWTAuthentication:
         with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.parse_jwt_token') as mock_parse:
             mock_parse.return_value = (None, {})
             jwt_auth = JWTAuthentication()
-            created_user = jwt_auth.authenticate(mock.MagicMock())
+            created_user, _ = jwt_auth.authenticate(mock.MagicMock())
             assert created_user is None
 
     def test_process_user_data(self):
@@ -303,3 +358,70 @@ class TestJWTAuthentication:
             jwt_auth = JWTAuthentication()
             jwt_auth.process_permissions(None, None, None)
             assert "process_permissions was not overridden for JWTAuthentication" in caplog.text
+
+    def test_raise_an_exception_if_the_key_is_not_cached(self, random_public_key, mocked_http):
+        # We are going to return a key which will not work with jwt_token provided by mocked_http
+        # Because its not cached the call to parse_jwt_token should raise the exception
+        with override_settings(ANSIBLE_BASE_JWT_KEY=random_public_key):
+            with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.get_decryption_key', return_value=(random_public_key, False)):
+                request = mocked_http.mocked_parse_jwt_token_get_request('with_headers')
+                jwt_auth = JWTAuthentication()
+                with pytest.raises(AuthenticationFailed) as af:
+                    jwt_auth.authenticate(request)
+                    assert 'check your key and generated token' in af
+                    assert 'cached key was correct' not in af
+
+    def test_raise_an_exception_if_the_key_is_cached_but_the_new_key_is_the_same(self, random_public_key, mocked_http):
+        # We are going to:
+        #     1. return a key which will not work with jwt_token provided by mocked_http
+        #     2. Cache a key that is invalid
+        #     3. Error when the new token is the same as the cached token
+
+        # Pretend the key is coming from a URL
+        url = 'https://example.com'
+        with override_settings(ANSIBLE_BASE_JWT_KEY=url):
+            # 1. Make the get_decryption_key always return the random key (which is invalid) && 2. pretend the key is cached
+            with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.get_decryption_key', return_value=(random_public_key, True)):
+                # 3. Make the call.
+                # This will attempt to use the cached key, recognize that its invalid, load the key again (which will be the same) and then error out
+                request = mocked_http.mocked_parse_jwt_token_get_request('with_headers')
+                jwt_auth = JWTAuthentication()
+                with pytest.raises(AuthenticationFailed) as af:
+                    jwt_auth.authenticate(request)
+                    assert 'check your key and generated token' in af
+                    assert 'cached key was correct' in af
+
+    def test_correctly_authenticate_if_the_cached_key_is_invalid_but_the_new_key_is_correct(
+        self, random_public_key, mocked_http, test_encryption_public_key, django_user_model, jwt_token
+    ):
+        # Pretend the key is coming from a URL
+        url = 'https://example.com'
+        with override_settings(ANSIBLE_BASE_JWT_KEY=url):
+            return_values = [
+                (random_public_key, True),
+                (test_encryption_public_key, False),
+            ]
+            with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.get_decryption_key', side_effect=return_values):
+                request = mocked_http.mocked_parse_jwt_token_get_request('with_headers')
+                jwt_auth = JWTAuthentication()
+                user = django_user_model.objects.create_user(username=jwt_token.unencrypted_token['sub'], password="password")
+                created_user, _ = jwt_auth.authenticate(request)
+                assert created_user == user
+
+    def test_user_logging_in_and_in_cache_but_deleted_in_db(self, mocked_http, django_user_model, jwt_token, test_encryption_public_key):
+        user = django_user_model.objects.create_user(username=jwt_token.unencrypted_token['sub'], password="password")
+        with override_settings(ANSIBLE_BASE_JWT_KEY=test_encryption_public_key):
+            jwt_auth = JWTAuthentication()
+            request = mocked_http.mocked_parse_jwt_token_get_request('with_headers')
+
+            # Get the user into the cache
+            user_object, created = jwt_auth.authenticate(request)
+            assert user_object == user
+
+            # delete the user from the DB
+            user.delete()
+
+            # Authenticate the user again which will recreate the user so the objects will no longer be the same
+            user_object, _ = jwt_auth.authenticate(request)
+            assert user_object.username == user.username
+            assert user_object.id != user.id


### PR DESCRIPTION
This leverages Djangos cache to store:
* The JWT decryption key
* References to the users that have authenticated 

It will default to reloading the JWT if a decryption fails or doing a user create if the user was cached but unable to be laoded from the DB.