### PR TITLE
Fix bug detecting running container that needs migration

### DIFF
--- a/test_app/scripts/bootstrap.sh
+++ b/test_app/scripts/bootstrap.sh
@@ -25,7 +25,7 @@ then
     make postgres
 else
     echo "dab_postgres container is already running, will use that container"
-    python manage.py migrate --check; migrate_needed=$?
+    migrate_needed=$(echo $(python manage.py migrate --check > /dev/null 2> /dev/null; echo $?))
 fi
 
 MAX_ATTEMPTS=10
@@ -43,6 +43,7 @@ done
 
 if [ "${migrate_needed}" -ne 0 ]
 then
+    echo "Migrating database"
     python3 manage.py migrate
     DJANGO_SUPERUSER_PASSWORD=password DJANGO_SUPERUSER_USERNAME=admin DJANGO_SUPERUSER_EMAIL=admin@stuff.invalid python3 manage.py createsuperuser --noinput
     python3 manage.py authenticators --initialize

--- a/test_app/scripts/bootstrap.sh
+++ b/test_app/scripts/bootstrap.sh
@@ -28,6 +28,8 @@ else
     set +e
     python manage.py migrate --check; migrate_needed=$?
     set -e
+    python manage.py migrate --check; migrate_needed=$?
+    set -e
 fi
 
 MAX_ATTEMPTS=10

--- a/test_app/scripts/bootstrap.sh
+++ b/test_app/scripts/bootstrap.sh
@@ -25,7 +25,9 @@ then
     make postgres
 else
     echo "dab_postgres container is already running, will use that container"
-    migrate_needed=$(echo $(python manage.py migrate --check > /dev/null 2> /dev/null; echo $?))
+    set +e
+    python manage.py migrate --check; migrate_needed=$?
+    set -e
 fi
 
 MAX_ATTEMPTS=10

--- a/test_app/scripts/bootstrap.sh
+++ b/test_app/scripts/bootstrap.sh
@@ -28,8 +28,6 @@ else
     set +e
     python manage.py migrate --check; migrate_needed=$?
     set -e
-    python manage.py migrate --check; migrate_needed=$?
-    set -e
 fi
 
 MAX_ATTEMPTS=10


### PR DESCRIPTION
I've been hitting this a lot lately, and the prior solution just wasn't working --> it went to error state when given a perfectly good running (but un-migrated) database.

```
python manage.py migrate --check; migrate_needed=$?
```

This was supposed to capture the exit code, but it didn't. In the first command, it just went straight to the trap. This seems to fix it... as devious and ugly as it is.