### PR TITLE
Return None indicates auth does not apply

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -281,7 +281,7 @@ class JWTAuthentication(BaseAuthentication):
 
             return user, None
         else:
-            return None, None
+            return None
 
     def process_user_data(self, user, token):
         common_auth = JWTCommonAuth(self.map_fields)

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -342,10 +342,10 @@ class TestJWTAuthentication:
 
     def test_authenticate_no_user(self, user):
         with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.parse_jwt_token') as mock_parse:
-            mock_parse.return_value = (None, {})
+            mock_parse.return_value = (None, None)
             jwt_auth = JWTAuthentication()
-            created_user, _ = jwt_auth.authenticate(mock.MagicMock())
-            assert created_user is None
+            auth_provided = jwt_auth.authenticate(mock.MagicMock())
+            assert auth_provided is None
 
     def test_process_user_data(self):
         with mock.patch("ansible_base.jwt_consumer.common.auth.JWTCommonAuth.map_user_fields") as mock_inspect:


### PR DESCRIPTION
* Returning a tuple indicates the user auth failure. We want "auth does not apply".