### PR TITLE
Remove unwanted URL registrations from related endpoints

### DIFF
--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from ansible_base.lib.routers import AssociationResourceRouter
 from test_app import views
-from test_app.models import Inventory, User
+from test_app.models import Cow, Inventory, User
 
 
 def validate_expected_url_pattern_names(router, expected_url_pattern_names):
@@ -205,3 +205,30 @@ def test_sublist_filtering(inventory, organization, admin_api_client):
     response = admin_api_client.get(url, data={'name': inventory.name})
     assert response.status_code == 200, response.data
     assert response.data['count'] == 1
+
+
+@pytest.mark.parametrize('method', ['GET', 'PUT', 'POST', 'DELETE'])
+def test_related_detail_actions_get_scrubed(organization, method, admin_api_client):
+    cow = Cow.objects.create(organization=organization)
+    # raise Exception(reverse('organization-cows-list', kwargs={'pk': organization.pk}))
+    url = f'/api/v1/organizations/{organization.pk}/cows/{cow.pk}/'
+    # Can not use the reverse function like this, because post-fix, the view does not exist
+    # url = reverse('organization-cows-detail', kwargs={'pk': organization.pk, 'cows': cow.pk})
+    if method in ('PUT', 'POST'):
+        response = admin_api_client.get(url, data={})
+    else:
+        response = admin_api_client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize('method', ['GET', 'PUT', 'POST', 'DELETE'])
+def test_related_custom_actions_get_scrubed(organization, method, admin_api_client):
+    cow = Cow.objects.create(organization=organization)
+    url = f'/api/v1/organizations/{organization.pk}/cows/{cow.pk}/cowsay/'
+    # Can not use the reverse function like this, because post-fix, the view does not exist
+    # url = reverse('organization-cows-cowsay', kwargs={'pk': organization.pk, 'cows': cow.pk})
+    if method in ('PUT', 'POST'):
+        response = admin_api_client.get(url, data={})
+    else:
+        response = admin_api_client.get(url)
+    assert response.status_code == 404

--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from ansible_base.lib.routers import AssociationResourceRouter
 from test_app import views
-from test_app.models import Cow, Inventory, User
+from test_app.models import Cow, Inventory, RelatedFieldsTestModel, Team, User
 
 
 def validate_expected_url_pattern_names(router, expected_url_pattern_names):
@@ -60,8 +60,6 @@ def test_association_router_associate_viewset_all_mapings():
 
 
 def test_association_router_good_associate(db, admin_api_client, randname, organization):
-    from test_app.models import RelatedFieldsTestModel, Team
-
     related_model = RelatedFieldsTestModel.objects.create()
     assert related_model.more_teams.count() == 0
 
@@ -89,8 +87,6 @@ def test_association_router_good_associate(db, admin_api_client, randname, organ
     ],
 )
 def test_association_router_associate_bad_data(db, admin_api_client, data, response_instances):
-    from test_app.models import RelatedFieldsTestModel
-
     related_model = RelatedFieldsTestModel.objects.create()
     assert related_model.users.count() == 0
 
@@ -101,8 +97,6 @@ def test_association_router_associate_bad_data(db, admin_api_client, data, respo
 
 
 def test_association_router_associate_existing_item(db, admin_api_client, random_user):
-    from test_app.models import RelatedFieldsTestModel
-
     related_model = RelatedFieldsTestModel.objects.create()
     related_model.users.add(random_user)
     assert related_model.users.count() == 1
@@ -117,8 +111,6 @@ def test_association_router_associate_existing_item(db, admin_api_client, random
 
 
 def test_association_router_disassociate(db, admin_api_client, randname, organization):
-    from test_app.models import RelatedFieldsTestModel, Team
-
     team = Team.objects.create(name=randname('team'), organization=organization)
 
     related_model = RelatedFieldsTestModel.objects.create()
@@ -147,8 +139,6 @@ def test_association_router_disassociate(db, admin_api_client, randname, organiz
     ],
 )
 def test_association_router_disassociate_bad_data(db, admin_api_client, data, response_instances):
-    from test_app.models import RelatedFieldsTestModel
-
     related_model = RelatedFieldsTestModel.objects.create()
     assert related_model.more_teams.count() == 0
 
@@ -159,8 +149,6 @@ def test_association_router_disassociate_bad_data(db, admin_api_client, data, re
 
 
 def test_association_router_disassociate_something_not_associated(db, admin_api_client, organization):
-    from test_app.models import RelatedFieldsTestModel, Team
-
     related_model = RelatedFieldsTestModel.objects.create()
     team1 = Team.objects.create(name='Team 1', organization=organization)
     team2 = Team.objects.create(name='Team 2', organization=organization)
@@ -173,7 +161,7 @@ def test_association_router_disassociate_something_not_associated(db, admin_api_
     assert response.json().get('instances') == f'Cannot disassociate these objects because they are not all related to this object: {team2.pk}, {team3.pk}'
 
 
-def test_association_router_related_viewset_all_mapings(db):
+def test_association_router_related_viewset_reverse_mapings(db):
     router = AssociationResourceRouter()
     router.register(
         r'organization',
@@ -186,8 +174,29 @@ def test_association_router_related_viewset_all_mapings(db):
     expected_urls = [
         'my_test_basename-detail',
         'my_test_basename-list',
-        'my_test_basename-teams-detail',
         'my_test_basename-teams-list',
+    ]
+    validate_expected_url_pattern_names(router, expected_urls)
+
+
+def test_association_router_related_viewset_m2m_mapings(db, user):
+    router = AssociationResourceRouter()
+    obj = RelatedFieldsTestModel.objects.create()
+    obj.users.add(user)
+    router.register(
+        r'rel_models',
+        views.RelatedFieldsTestModelViewSet,
+        related_views={
+            'users': (views.UserViewSet, 'users'),
+        },
+        basename='rel_test_basename',
+    )
+    expected_urls = [
+        'rel_test_basename-detail',
+        'rel_test_basename-list',
+        'rel_test_basename-users-list',
+        'rel_test_basename-users-associate',
+        'rel_test_basename-users-disassociate',
     ]
     validate_expected_url_pattern_names(router, expected_urls)
 


### PR DESCRIPTION
Fixes https://github.com/ansible/django-ansible-base/issues/275

I finally hit a wall with this trying to add related `resource` fields to the user/team association endpoints. I went into http://127.0.0.1:8000/api/v1/docs/#/role_team_assignments/role_team_assignments_create and it had _duplicate view names_. This was caused by the same problem as 275. Random views were unintentionally getting registered.

So I had to bite the bullet and fix this. This bug was... kind of bad already. Those custom actions look concerning. It is true that the lookup field probably makes it unusable, but this isn't a good thing to rely on.