### PR TITLE
Fix 500 on unintended endpoints and further refactor association router

### DIFF
--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -77,7 +77,7 @@ class AssociationViewSetMethodsMixin:
 class RelatedListMixin:
     """Mixin used for related viewsets which contain a sub-list, like /organizations/N/teams/"""
 
-    def check_parent_object_permissions(self, request, parent_obj: Model) -> bool:
+    def check_parent_object_permissions(self, request, parent_obj: Model) -> None:
         """Check that request user has permission to parent_obj
 
         Associate and disassociate is a POST request, list is GET
@@ -88,8 +88,7 @@ class RelatedListMixin:
         if (request.method not in SAFE_METHODS) and 'ansible_base.rbac' in settings.INSTALLED_APPS and permission_registry.is_registered(parent_obj):
             from ansible_base.rbac.policies import check_content_obj_permission
 
-            return check_content_obj_permission(request.user, parent_obj)
-        return True
+            check_content_obj_permission(request.user, parent_obj)
 
     def get_parent_object(self) -> Model:
         """Modeled mostly after DRF get_object, but for the parent model

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -150,7 +150,8 @@ class AssociateMixin(RelatedListMixin):
         if self.action in ('disassociate', 'associate'):
             qs = self.get_association_queryset()
 
-            cls_name = f'{type(self).__name__}AssociationSerializer'
+            rel_name = self.association_fk.replace('_', ' ').title().replace(' ', '')
+            cls_name = f'{self.parent_viewset.__name__}{rel_name}AssociationSerializer'
 
             if cls_name not in serializer_registry:
                 serializer_registry[cls_name] = type(cls_name, (AssociationSerializerBase,), {'target_queryset': qs})

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -215,8 +215,9 @@ class AssociationResourceRouter(routers.SimpleRouter):
             associated_viewset = self.associated_viewset_cls_factory(related_view)
 
             # Generate the related viewset
+            # Name includes and parent and child viewset, because this defines global uniqueness
             modified_related_viewset = type(
-                f'Related{related_view.__name__}',
+                f'Related{viewset.__name__}{related_view.__name__}',
                 (mixin_class, associated_viewset),
                 {
                     'association_fk': fk,

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -151,7 +151,7 @@ class AssociateMixin(RelatedListMixin):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    def get_parent_serializer_class(self, cls: Model) -> Type[serializers.Serializer]:
+    def get_parent_serializer_class(self, cls: Type[Model]) -> Type[serializers.Serializer]:
         if self.action == 'disassociate':
             return BasicAssociationSerializer
         elif self.action == 'associate':

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -163,7 +163,7 @@ class AssociateMixin(RelatedListMixin):
         cls = self.serializer_class.Meta.model
         return cls.objects.all()
 
-    def get_serializer_class(self) -> serializers.Serializer:
+    def get_serializer_class(self) -> serializers.BaseSerializer:
         if self.action in ('disassociate', 'associate'):
             rel_name = self.association_fk.replace('_', ' ').title().replace(' ', '')
             cls_name = f'{self.parent_viewset.__name__}{rel_name}{self.action.title()}Serializer'

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -141,7 +141,10 @@ class AssociateMixin(RelatedListMixin):
             qs = cls.objects.all()
 
         if self.action == 'associate':
-            return self.filter_queryset(qs)
+            if hasattr(self, 'filter_associate_queryset'):
+                return self.filter_associate_queryset(qs)
+            else:
+                return self.filter_queryset(qs)
         return qs
 
     def get_serializer_class(self):

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -77,7 +77,7 @@ class AssociationViewSetMethodsMixin:
 class RelatedListMixin:
     """Mixin used for related viewsets which contain a sub-list, like /organizations/N/teams/"""
 
-    def check_parent_object_permissions(self, request, parent_obj: Model) -> None:
+    def check_parent_object_permissions(self, request, parent_obj: Model) -> bool:
         """Check that request user has permission to parent_obj
 
         Associate and disassociate is a POST request, list is GET

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -157,7 +157,6 @@ class AssociateMixin(RelatedListMixin):
         """Return queryset for instances field of the serializer used for association"""
         if self.queryset:
             qs = self.queryset
-            cls = self.queryset.model
         else:
             cls = self.serializer_class.Meta.model
             qs = cls.objects.all()

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -4,7 +4,6 @@ from itertools import chain
 from typing import Type
 
 from django.conf import settings
-from django.db.models import Model
 from django.db.models.fields import IntegerField
 from django.db.models.query import QuerySet
 from django.http import QueryDict

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -4,6 +4,7 @@ from itertools import chain
 from typing import Type
 
 from django.conf import settings
+from django.db.models import Model
 from django.db.models.fields import IntegerField
 from django.db.models.query import QuerySet
 from django.http import QueryDict
@@ -21,7 +22,61 @@ from ansible_base.rbac.permission_registry import permission_registry
 logger = logging.getLogger('ansible_base.lib.routers.association_resource_router')
 
 
+class AssociationViewSetMethodsMixin:
+    """Contains methods called by viewset methods for list, associate, disassociate actions
+
+    Importantly, this is placed high up in the inheritance chain.
+    This means that the viewset passed in for the related views can override these methods.
+    General principal is that these should not overlap with DRF methods, because those
+    are likely already defined by the passed-in viewset and will not take effect.
+    """
+
+    def filter_associate_queryset(self, qs: QuerySet) -> QuerySet:
+        """Limits queryset to objects allowed to be associated
+
+        This is allowed to be different from the filter for the list view,
+        which affects what is visible to the user.
+        Compare to this, which defines what objects can be _associated_
+        probably due to permission restrictions... normally based on visibility.
+        """
+        return self.filter_queryset(qs)
+
+    def get_sublist_queryset(self, parent_instance: Model) -> QuerySet:
+        """Queryset to show, given a parent object
+
+        Example would be /organizations/N/teams/
+        This method returns the team queryset, given organization object pk=N
+        """
+        return getattr(parent_instance, self.association_fk).all()
+
+    def perform_associate(self, parent_instance: Model, related_instances: list[Model]) -> None:
+        """Attach related_instances to instance via the relationship this viewset manages"""
+        manager = getattr(parent_instance, self.association_fk)
+        manager.add(*related_instances)
+
+    def perform_disassociate(self, parent_instance: Model, related_instances: list[Model]) -> None:
+        """Remove related_instances from the managed relationship of instance"""
+        manager = getattr(parent_instance, self.association_fk)
+
+        # Ensure each of the given related_instances is actually related to the instance.
+        # If any isn't, then bomb out and tell the user which ones aren't related.
+        given_related_instance_set = set(related_instances)
+        related_instance_set = set(manager.all())
+        non_related_instances = given_related_instance_set - related_instance_set
+        if non_related_instances:
+            raise serializers.ValidationError(
+                {
+                    'instances': _('Cannot disassociate these objects because they are not all related to this object: %(non_related_instances)s')
+                    % {'non_related_instances': ', '.join(str(i.pk) for i in non_related_instances)},
+                }
+            )
+
+        manager.remove(*related_instances)
+
+
 class RelatedListMixin:
+    """Mixin used for related viewsets which contain a sub-list, like /organizations/N/teams/"""
+
     def check_parent_object_permissions(self, request, parent_obj):
         # Associate and disassociate is a POST request, list is GET
         # the normal process of get_object --> check_object_permissions
@@ -54,7 +109,74 @@ class RelatedListMixin:
 
     def get_queryset(self):
         parent_instance = self.get_parent_object()
-        return getattr(parent_instance, self.association_fk).all()
+        return self.get_sublist_queryset(parent_instance)
+
+
+class AssociateMixin(RelatedListMixin):
+    """Mixin used for writable related viewsets, where objects can be associated or disassociated from the relationship"""
+
+    @action(detail=False, methods=['post'])
+    def associate(self, request, **kwargs):
+        """
+        Associate a related object with this object.
+
+        This will be served at /{basename}/{pk}/{related_name}/associate/
+        We will be given a list of primary keys in the request body.
+        """
+        instance = self.get_parent_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        related_instances = serializer.validated_data['instances']
+        if not related_instances:
+            raise serializers.ValidationError({'instances': _('Please pass in one or more instances to associate')})
+
+        self.perform_associate(instance, related_instances)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=False, methods=['post'])
+    def disassociate(self, request, **kwargs):
+        """
+        Disassociate a related object from this object.
+
+        This will be served at /{basename}/{pk}/{related_name}/disassociate/
+        We will be given a list of primary keys in the request body.
+        """
+        instance = self.get_parent_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        related_instances = serializer.validated_data['instances']
+        if not related_instances:
+            raise serializers.ValidationError({'instances': _('Please pass in one or more instances to disassociate')})
+
+        self.perform_disassociate(instance, related_instances)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def get_association_queryset(self) -> QuerySet:
+        """Return queryset for instances field of the serializer used for association"""
+        if self.queryset:
+            qs = self.queryset
+            cls = self.queryset.model
+        else:
+            cls = self.serializer_class.Meta.model
+            qs = cls.objects.all()
+
+        if self.action == 'associate':
+            return self.filter_associate_queryset(qs)
+        return qs
+
+    def get_serializer_class(self):
+        if self.action in ('disassociate', 'associate'):
+            rel_name = self.association_fk.replace('_', ' ').title().replace(' ', '')
+            cls_name = f'{self.parent_viewset.__name__}{rel_name}{self.action.title()}Serializer'
+
+            if cls_name not in serializer_registry:
+                qs = self.get_association_queryset()
+                serializer_registry[cls_name] = type(cls_name, (AssociationSerializerBase,), {'target_queryset': qs})
+            return serializer_registry[cls_name]
+
+        return super().get_serializer_class()
 
 
 class AssociationSerializerBase(serializers.Serializer):
@@ -79,89 +201,16 @@ class AssociationSerializerBase(serializers.Serializer):
 serializer_registry = {}
 
 
-class AssociateMixin(RelatedListMixin):
-    @action(detail=False, methods=['post'])
-    def associate(self, request, **kwargs):
-        """
-        Associate a related object with this object.
-
-        This will be served at /{basename}/{pk}/{related_name}/associate/
-        We will be given a list of primary keys in the request body.
-        """
-        instance = self.get_parent_object()
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        related_instances = serializer.validated_data['instances']
-        if not related_instances:
-            raise serializers.ValidationError({'instances': _('Please pass in one or more instances to associate')})
-        manager = getattr(instance, self.association_fk)
-        manager.add(*related_instances)
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
-    @action(detail=False, methods=['post'])
-    def disassociate(self, request, **kwargs):
-        """
-        Disassociate a related object from this object.
-
-        This will be served at /{basename}/{pk}/{related_name}/disassociate/
-        We will be given a list of primary keys in the request body.
-        """
-        instance = self.get_parent_object()
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        related_instances = serializer.validated_data['instances']
-        if not related_instances:
-            raise serializers.ValidationError({'instances': _('Please pass in one or more instances to disassociate')})
-        manager = getattr(instance, self.association_fk)
-
-        # Ensure each of the given related_instances is actually related to the instance.
-        # If any isn't, then bomb out and tell the user which ones aren't related.
-        given_related_instance_set = set(related_instances)
-        related_instance_set = set(manager.all())
-        non_related_instances = given_related_instance_set - related_instance_set
-        if non_related_instances:
-            raise serializers.ValidationError(
-                {
-                    'instances': _('Cannot disassociate these objects because they are not all related to this object: %(non_related_instances)s')
-                    % {'non_related_instances': ', '.join(str(i.pk) for i in non_related_instances)},
-                }
-            )
-
-        manager.remove(*related_instances)
-
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
-    def get_association_queryset(self) -> QuerySet:
-        if self.queryset:
-            qs = self.queryset
-            cls = self.queryset.model
-        else:
-            cls = self.serializer_class.Meta.model
-            qs = cls.objects.all()
-
-        if self.action == 'associate':
-            if hasattr(self, 'filter_associate_queryset'):
-                return self.filter_associate_queryset(qs)
-            else:
-                return self.filter_queryset(qs)
-        return qs
-
-    def get_serializer_class(self):
-        if self.action in ('disassociate', 'associate'):
-            qs = self.get_association_queryset()
-
-            rel_name = self.association_fk.replace('_', ' ').title().replace(' ', '')
-            cls_name = f'{self.parent_viewset.__name__}{rel_name}AssociationSerializer'
-
-            if cls_name not in serializer_registry:
-                serializer_registry[cls_name] = type(cls_name, (AssociationSerializerBase,), {'target_queryset': qs})
-            return serializer_registry[cls_name]
-
-        return super().get_serializer_class()
-
-
 @property
 def attribute_raiser(cls):
+    """This method is used to exclude methods in subclass of provided viewset
+
+    How it works:
+    SimpleRouter.get_method_map determines what actions are in a viewset with hasattr.
+    raising AttributeError makes that return False, so methods like retrieve
+    will not be included in the returned method map, so it will not build a URL
+    for those, because we do not want them in the association URL set.
+    """
     raise AttributeError
 
 
@@ -190,7 +239,7 @@ class AssociationResourceRouter(routers.SimpleRouter):
         for method in ('retrieve', 'update', 'partial_update', 'destroy') + tuple(custom_methods):
             setattr(AssociatedViewSetType, method, attribute_raiser)
 
-        class AssociatedViewSet(viewset, metaclass=AssociatedViewSetType):
+        class AssociatedViewSet(viewset, AssociationViewSetMethodsMixin, metaclass=AssociatedViewSetType):
             """Adjusted version of given viewset for related endpoint with only list views"""
 
             pass

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -163,7 +163,7 @@ class AssociateMixin(RelatedListMixin):
         cls = self.serializer_class.Meta.model
         return cls.objects.all()
 
-    def get_serializer_class(self) -> serializers.BaseSerializer:
+    def get_serializer_class(self) -> Type[serializers.BaseSerializer]:
         if self.action in ('disassociate', 'associate'):
             rel_name = self.association_fk.replace('_', ' ').title().replace(' ', '')
             cls_name = f'{self.parent_viewset.__name__}{rel_name}{self.action.title()}Serializer'

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -198,7 +198,13 @@ class AssociationSerializerBase(serializers.Serializer):
 
 
 class FilteredAssociationSerializer(AssociationSerializerBase):
-    viewset_instance = None
+    """Serializer that adds filtering on top of AssociationSerializerBase
+
+    This filtering is expected to be used for limiting candidate association objects
+    to only those the requesting user has permission to view.
+    None of that is handled here, that is the sole discression of the view,
+    which can define filter_associate_queryset to their liking.
+    """
 
     def get_queryset_on_init(self) -> QuerySet:
         qs = super().get_queryset_on_init()

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -150,7 +150,8 @@ class AssociateMixin(RelatedListMixin):
     def get_serializer_class(self) -> Type[serializers.BaseSerializer]:
         if self.action in ('disassociate', 'associate'):
             cls = self.get_viewset_model()
-            cls_name = f'{cls._meta.model_name}{self.action.title()}Serializer'
+            pretty_model_name = cls._meta.verbose_name.title().replace(' ', '')
+            cls_name = f'{pretty_model_name}{self.action.title()}Serializer'
 
             default_instances_field = serializers.PrimaryKeyRelatedField(queryset=cls.objects.all(), many=True)
 
@@ -185,7 +186,8 @@ class DisassociationSerializerBase(AssociationSerializerBase):
     def get_queryset_on_init(self, original_qs: QuerySet) -> QuerySet:
         if 'view' in self.context:
             view = self.context['view']
-            return view.get_queryset()
+            if 'pk' in view.kwargs:
+                return view.get_queryset()
         return original_qs
 
     def __init__(self, *args, **kwargs):

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -148,7 +148,7 @@ class AssociateMixin(RelatedListMixin):
         if self.action in ('disassociate', 'associate'):
             qs = self.get_association_queryset()
 
-            cls_name = f'{self.__name__}AssociationSerializer'
+            cls_name = f'{type(self).__name__}AssociationSerializer'
 
             if cls_name not in serializer_registry:
                 serializer_registry[cls_name] = type(cls_name, (AssociationSerializerBase,), {'target_queryset': qs})

--- a/docs/lib/routers.md
+++ b/docs/lib/routers.md
@@ -57,8 +57,7 @@ Several methods defined in the `<ViewSet for relation>` will have an effect on c
 Those are:
 
  - `get_sublist_queryset` - items shown in the listing _before_ filtering, OR candidate items for disassociation
- - `filter_queryset` - filter applied to items shown in sublist, which works the same as the viewset by itself
- - `get_queryset` - candidate items to associate _before_ filtering
+ - `filter_queryset` - filter applied to items shown in sublist, typically RBAC filtering of what the request user can view in addition to filters from query params
  - `filter_associate_queryset` - filter to items user should be able to associate, defers to `filter_queryset` by default
  - `perform_associate` - associate items
  - `perform_disassociate` - disassociate items
@@ -67,8 +66,9 @@ These are intended to be overwritten for customization.
 For heavy customizations, you can either manage this on your existing viewset like `views.TeamViewSet`
 or introduce a new class that subclasses from that.
 
-Standard DAB practice is that `filter_queryset` limits the queryset to what the request user can view.
 If you want a sublist to show all items, then you probably need to create a new class for the related viewset.
+This is because `filter_queryset` is used for the global lists as well (like `/api/v1/teams/`), so you likely
+will need a new class so that sublist-specific behavior is non-conflicting with the global list.
 
 
 ## Many-to-Many

--- a/docs/lib/routers.md
+++ b/docs/lib/routers.md
@@ -50,14 +50,18 @@ NOTE: Often times the `<entry in API related field>` will be the same as `<relat
 Several methods defined in the `<ViewSet for relation>` will have an effect on constructed related endpoints.
 Those are:
 
+ - `get_sublist_queryset` - queryset for items shown in a GET for the listing _before_ filtering
+ - `filter_queryset` - filter applied to items shown in sublist, which works the same as the viewset by itself
  - `filter_associate_queryset` - queryset that can be associated, defers to `filter_queryset` by default
- - `get_sublist_queryset` - queryset for items shown in a GET for the listing
  - `perform_associate` - associate items
  - `perform_disassociate` - disassociate items
 
 These are intended to be overwritten for customization.
 For heavy customizations, you can either manage this on your existing viewset like `views.TeamViewSet`
 or introduce a new class that subclasses from that.
+
+Standard DAB practice is that `filter_queryset` limits the queryset to what the request user can view.
+If you want a sublist to show all items, then you would need to create a new class for the related viewset.
 
 
 ## Many-to-Many

--- a/docs/lib/routers.md
+++ b/docs/lib/routers.md
@@ -1,6 +1,12 @@
 # Associative Resource Router
 
-django-ansible-base provides an `AssociationResourceRouter` which will auto-construct /associate and /disassociate endpoints for related ManyToMany fields for your models.
+django-ansible-base provides an `AssociationResourceRouter` which will auto-construct 3 endpoints for related ManyToMany fields for your models.
+
+1. Read-only listing of items at `/api/v2/parent_objects/:id/relationship/`
+2. An `/associate` write-only endpoint with (1) as URL base
+3. A `/disassociate` write-only endpoint with (1) as URL base
+
+This can also be used for reverse relationships, which will only construct (1).
 
 To use this router simply do the following:
 ```
@@ -20,9 +26,9 @@ urlpatterns = [
 
 This would create an endpoint called `users` in your application with all of the post/patch/put/delete/get endpoints as defined by the UserViewSet.
 
-# Related fields
+## Related fields
 
-The AssociationResourceRouter can also handle many-to-many or reverse foreign key (one-to_many) fields by adding a `related_views` field to the register function. For example, consider this register command:
+The AssociationResourceRouter works by adding a `related_views` field to the register function. For example, consider this register command:
 ```
 router.register(
     r'users',
@@ -50,9 +56,10 @@ NOTE: Often times the `<entry in API related field>` will be the same as `<relat
 Several methods defined in the `<ViewSet for relation>` will have an effect on constructed related endpoints.
 Those are:
 
- - `get_sublist_queryset` - queryset for items shown in a GET for the listing _before_ filtering
+ - `get_sublist_queryset` - items shown in the listing _before_ filtering, OR candidate items for disassociation
  - `filter_queryset` - filter applied to items shown in sublist, which works the same as the viewset by itself
- - `filter_associate_queryset` - queryset that can be associated, defers to `filter_queryset` by default
+ - `get_queryset` - candidate items to associate _before_ filtering
+ - `filter_associate_queryset` - filter to items user should be able to associate, defers to `filter_queryset` by default
  - `perform_associate` - associate items
  - `perform_disassociate` - disassociate items
 
@@ -61,7 +68,7 @@ For heavy customizations, you can either manage this on your existing viewset li
 or introduce a new class that subclasses from that.
 
 Standard DAB practice is that `filter_queryset` limits the queryset to what the request user can view.
-If you want a sublist to show all items, then you would need to create a new class for the related viewset.
+If you want a sublist to show all items, then you probably need to create a new class for the related viewset.
 
 
 ## Many-to-Many

--- a/docs/lib/routers.md
+++ b/docs/lib/routers.md
@@ -34,7 +34,7 @@ router.register(
 )
 ```
 
-The router interrogates model of the queryset from the parent view along with the model of the query set from the related view and determines if the relation is a many-to-many or a reverse foreign key.
+The router interrogates the parent viewset (`views.UserViewSet`) along with the related viewset (ex. `views.TeamViewSet` above) and automatically constructuts a new viewset for the related teams of a user. If the relation is a many-to-many, associate and disassociate endpoints are added, and if it is a reverse foreign key it only provides list.
 
 Related views are expressed in the following format:
 
@@ -43,6 +43,21 @@ Related views are expressed in the following format:
 ```
 
 NOTE: Often times the `<entry in API related field>` will be the same as `<related field name>` but this is not always the case.
+
+
+## Customization
+
+Several methods defined in the `<ViewSet for relation>` will have an effect on constructed related endpoints.
+Those are:
+
+ - `filter_associate_queryset` - queryset that can be associated, defers to `filter_queryset` by default
+ - `get_sublist_queryset` - queryset for items shown in a GET for the listing
+ - `perform_associate` - associate items
+ - `perform_disassociate` - disassociate items
+
+These are intended to be overwritten for customization.
+For heavy customizations, you can either manage this on your existing viewset like `views.TeamViewSet`
+or introduce a new class that subclasses from that.
 
 
 ## Many-to-Many

--- a/test_app/router.py
+++ b/test_app/router.py
@@ -18,9 +18,8 @@ class RelatedUserViewSet(views.UserViewSet):
         "Do not filter users for the related list view, /organizations/42/users/"
         return self.apply_optimizations(qs)
 
-    def get_association_queryset(self):
+    def filter_associate_queryset(self, qs):
         "Use RBAC filter when associating new users, /organizations/42/users/associate/"
-        qs = super.get_assocation_queryset()
         return super().filter_queryset(qs)
 
 

--- a/test_app/router.py
+++ b/test_app/router.py
@@ -13,14 +13,22 @@ router.register(r'encrypted_models', views.EncryptionModelViewSet, basename='enc
 # Here, we demonstrate how to turn on or off filtering of related endpoints
 # viewsets of models with roles filter to what is visable by requesting user
 # in the filter_queryset method, but in some endpoints we show all users
-class RelatedUserViewSet(views.UserViewSet):
+class RelatedCowViewSet(views.CowViewSet):
     def filter_queryset(self, qs):
-        "Do not filter users for the related list view, /organizations/42/users/"
-        return self.apply_optimizations(qs)
+        # AVOID RBAC filtering of cows, for test case test_sublist_override_filtering
+        return super(views.TestAppViewSet, self).filter_queryset(qs)
 
-    def filter_associate_queryset(self, qs):
-        "Use RBAC filter when associating new users, /organizations/42/users/associate/"
-        return super().filter_queryset(qs)
+
+class RelatedUserViewSet(views.UserViewSet):
+    """Class that avoids RBAC filtering on user sublists
+
+    View permission to an organization implies permission to view its users anyway
+    So this is basically an optimization to turn off sublist filtering for organizations
+
+    Teams, on the other hand, need to be able to see their members
+    """
+    def filter_queryset(self, qs):
+        return super(views.TestAppViewSet, self).filter_queryset(qs)
 
 
 router.register(
@@ -42,7 +50,7 @@ router.register(
         'teams': (views.TeamViewSet, 'teams'),
         'inventories': (views.InventoryViewSet, 'inventories'),
         'namespaces': (views.NamespaceViewSet, 'namespaces'),
-        'cows': (views.CowViewSet, 'cows'),
+        'cows': (RelatedCowViewSet, 'cows'),
         'uuidmodels': (views.UUIDModelViewSet, 'uuidmodels'),
         'parentnames': (views.ParentNameViewSet, 'parentnames'),
         'positionmodels': (views.PositionModelViewSet, 'positionmodels'),

--- a/test_app/router.py
+++ b/test_app/router.py
@@ -15,7 +15,13 @@ router.register(r'encrypted_models', views.EncryptionModelViewSet, basename='enc
 # in the filter_queryset method, but in some endpoints we show all users
 class RelatedUserViewSet(views.UserViewSet):
     def filter_queryset(self, qs):
+        "Do not filter users for the related list view, /organizations/42/users/"
         return self.apply_optimizations(qs)
+
+    def get_association_queryset(self):
+        "Use RBAC filter when associating new users, /organizations/42/users/associate/"
+        qs = super.get_assocation_queryset()
+        return super().filter_queryset(qs)
 
 
 router.register(

--- a/test_app/router.py
+++ b/test_app/router.py
@@ -30,6 +30,10 @@ class RelatedUserViewSet(views.UserViewSet):
     def filter_queryset(self, qs):
         return super(views.TestAppViewSet, self).filter_queryset(qs)
 
+    def filter_associate_queryset(self, qs):
+        "Shows special case, although we want an unfiltered list, we require view permission to attach"
+        return super().filter_queryset(qs)
+
 
 router.register(
     r'related_fields_test_models',

--- a/test_app/router.py
+++ b/test_app/router.py
@@ -27,6 +27,7 @@ class RelatedUserViewSet(views.UserViewSet):
 
     Teams, on the other hand, need to be able to see their members
     """
+
     def filter_queryset(self, qs):
         return super(views.TestAppViewSet, self).filter_queryset(qs)
 

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -24,6 +24,7 @@ from ansible_base.lib.testing.util import copy_fixture, delete_authenticator
 from ansible_base.oauth2_provider.fixtures import *  # noqa: F403, F401
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
+from ansible_base.rbac.validators import combine_values, permissions_allowed_for_role
 from test_app import models
 
 
@@ -606,6 +607,28 @@ def disable_activity_stream():
 
     with no_activity_stream():
         yield
+
+
+@pytest.fixture
+def org_admin_rd():
+    """Give all permissions possible for an organization"""
+    perm_list = combine_values(permissions_allowed_for_role(models.Organization))
+    return RoleDefinition.objects.create_from_permissions(
+        permissions=perm_list,
+        name=ReconcileUser.ORGANIZATION_ADMIN_ROLE_NAME,
+        content_type=permission_registry.content_type_model.objects.get_for_model(models.Organization),
+        managed=True,
+    )
+
+
+@pytest.fixture
+def org_member_rd():
+    return RoleDefinition.objects.create_from_permissions(
+        permissions=['view_organization', 'member_organization'],
+        name=ReconcileUser.ORGANIZATION_MEMBER_ROLE_NAME,
+        content_type=permission_registry.content_type_model.objects.get_for_model(models.Organization),
+        managed=True,
+    )
 
 
 @pytest.fixture

--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from ansible_base.lib.routers import AssociationResourceRouter
 from test_app import views
-from test_app.models import Cow, Organization, Inventory, RelatedFieldsTestModel, Team, User
+from test_app.models import Cow, Inventory, Organization, RelatedFieldsTestModel, Team, User
 
 
 def validate_expected_url_pattern_names(router, expected_url_pattern_names):

--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from ansible_base.lib.routers import AssociationResourceRouter
 from test_app import views
-from test_app.models import Inventory, Organization, User
+from test_app.models import Cow, Organization, Inventory, User
 
 
 def validate_expected_url_pattern_names(router, expected_url_pattern_names):
@@ -202,3 +202,30 @@ def test_sublist_filtering(inventory, organization, admin_api_client):
     response = admin_api_client.get(url, data={'name': inventory.name})
     assert response.status_code == 200, response.data
     assert response.data['count'] == 1
+
+
+@pytest.mark.parametrize('method', ['GET', 'PUT', 'POST', 'DELETE'])
+def test_related_detail_actions_get_scrubed(organization, method, admin_api_client):
+    cow = Cow.objects.create(organization=organization)
+    # raise Exception(reverse('organization-cows-list', kwargs={'pk': organization.pk}))
+    url = f'/api/v1/organizations/{organization.pk}/cows/{cow.pk}/'
+    # Can not use the reverse function like this, because post-fix, the view does not exist
+    # url = reverse('organization-cows-detail', kwargs={'pk': organization.pk, 'cows': cow.pk})
+    if method in ('PUT', 'POST'):
+        response = admin_api_client.get(url, data={})
+    else:
+        response = admin_api_client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize('method', ['GET', 'PUT', 'POST', 'DELETE'])
+def test_related_custom_actions_get_scrubed(organization, method, admin_api_client):
+    cow = Cow.objects.create(organization=organization)
+    url = f'/api/v1/organizations/{organization.pk}/cows/{cow.pk}/cowsay/'
+    # Can not use the reverse function like this, because post-fix, the view does not exist
+    # url = reverse('organization-cows-cowsay', kwargs={'pk': organization.pk, 'cows': cow.pk})
+    if method in ('PUT', 'POST'):
+        response = admin_api_client.get(url, data={})
+    else:
+        response = admin_api_client.get(url)
+    assert response.status_code == 404

--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -198,8 +198,9 @@ def test_association_router_related_viewset_m2m_mapings(db, user):
     validate_expected_url_pattern_names(router, expected_urls)
 
 
-def test_sublist_filtering(inventory, organization, admin_api_client):
-    Inventory.objects.create(name='another-inventory', organization=organization)
+def test_sublist_filtering(organization, admin_api_client):
+    obj = Inventory.objects.create(name='first-one', organization=organization)
+    Inventory.objects.create(name='another-one', organization=organization)
     url = reverse('organization-inventories-list', kwargs={'pk': organization.pk})
 
     # sanity, without filtering, we get the 2 inventories
@@ -208,9 +209,33 @@ def test_sublist_filtering(inventory, organization, admin_api_client):
     assert response.data['count'] == 2
 
     # now we can filter by name for only the inventory object
-    response = admin_api_client.get(url, data={'name': inventory.name})
+    response = admin_api_client.get(url, data={'name': obj.name})
     assert response.status_code == 200, response.data
     assert response.data['count'] == 1
+
+
+def test_sublist_override_filtering(organization, inventory, user_api_client, user, org_member_rd):
+    "The organization cow list shows all cows regardless of view permission"
+    cow_url = reverse('organization-cows-list', kwargs={'pk': organization.pk})
+    inventory_url = reverse('organization-inventories-list', kwargs={'pk': organization.pk})
+    Cow.objects.create(organization=organization)
+
+    # User needs view permission to the parent object
+    org_member_rd.give_permission(user, organization)
+
+    # User can not view any inventories because they do not have view permission
+    # The cow sublist is not set up this way in test_app, just for testing
+    response = user_api_client.get(cow_url)
+    assert response.status_code == 200, response.data
+    assert response.data['count'] == 1
+    response = user_api_client.get(inventory_url)
+    assert response.status_code == 200, response.data
+    assert response.data['count'] == 0
+
+    # Assures that rest_filters still works
+    response = user_api_client.get(cow_url, data={'id': 12341234})
+    assert response.status_code == 200, response.data
+    assert response.data['count'] == 0
 
 
 @pytest.mark.parametrize('method', ['GET', 'PUT', 'POST', 'DELETE'])

--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -125,7 +125,7 @@ def test_association_router_disassociate(db, admin_api_client, randname, organiz
 @pytest.mark.parametrize(
     "data,response_instances",
     [
-        ({'instances': [-1]}, ['Invalid pk "-1" - object does not exist.']),
+        ({'instances': [-1]}, ['Invalid pk "-1" - object does not exist or is not associated with parent object.']),
         ({'instances': ['a']}, ['Incorrect type. Expected pk value, received str.']),
         ({'instances': [True]}, ['Incorrect type. Expected pk value, received bool.']),
         ({'instances': {}}, 'Please pass in one or more instances to disassociate'),
@@ -155,7 +155,7 @@ def test_association_router_disassociate_something_not_associated(db, admin_api_
     url = reverse('related_fields_test_model-more_teams-disassociate', kwargs={'pk': related_model.pk})
     response = admin_api_client.post(url, data={'instances': [team1.pk, team2.pk, team3.pk]}, format='json')
     assert response.status_code == 400
-    assert response.json().get('instances') == f'Cannot disassociate these objects because they are not all related to this object: {team2.pk}, {team3.pk}'
+    assert response.json().get('instances') == [f'Invalid pk "{team2.pk}" - object does not exist or is not associated with parent object.']
 
 
 def test_association_router_related_viewset_reverse_mapings(db):

--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from ansible_base.lib.routers import AssociationResourceRouter
 from test_app import views
-from test_app.models import Cow, Inventory, RelatedFieldsTestModel, Team, User
+from test_app.models import Cow, Organization, Inventory, RelatedFieldsTestModel, Team, User
 
 
 def validate_expected_url_pattern_names(router, expected_url_pattern_names):

--- a/test_app/tests/rbac/conftest.py
+++ b/test_app/tests/rbac/conftest.py
@@ -1,10 +1,8 @@
 import pytest
 from django.contrib.auth import get_user_model
 
-from ansible_base.authentication.utils.claims import ReconcileUser
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
-from ansible_base.rbac.validators import combine_values, permissions_allowed_for_role
 from test_app.models import Inventory, Organization
 
 
@@ -46,28 +44,6 @@ def view_inv_rd():
         name='view-inv',
         permissions=['view_inventory'],
         content_type=permission_registry.content_type_model.objects.get_for_model(Inventory),
-    )
-
-
-@pytest.fixture
-def org_admin_rd():
-    """Give all permissions possible for an organization"""
-    perm_list = combine_values(permissions_allowed_for_role(Organization))
-    return RoleDefinition.objects.create_from_permissions(
-        permissions=perm_list,
-        name=ReconcileUser.ORGANIZATION_ADMIN_ROLE_NAME,
-        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
-        managed=True,
-    )
-
-
-@pytest.fixture
-def org_member_rd():
-    return RoleDefinition.objects.create_from_permissions(
-        permissions=['view_organization', 'member_organization'],
-        name=ReconcileUser.ORGANIZATION_MEMBER_ROLE_NAME,
-        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
-        managed=True,
     )
 
 

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -61,7 +61,7 @@ class UserViewSet(DABOAuth2UserViewsetMixin, TestAppViewSet):
     def filter_queryset(self, qs):
         qs = visible_users(self.request.user, queryset=qs)
         qs = self.apply_optimizations(qs)
-        return qs
+        return super().filter_queryset(qs)
 
     @action(detail=False, methods=['get'])
     def me(self, request, pk=None):


### PR DESCRIPTION
Something drove me crazy after testing with my last patch - which is that certain serializers (with the same name) were created twice. This is logical if you think about what's being done. This PR adds a registry to fix the problem.

It also trades a few things in code organization. It gets rid of the "factory" method, and adds a new utility method for getting the parent class, which has to follow a certain format. Then the registry management becomes the main job of `get_serializer_class`

Recapping of major changes being done here:

- Serializers for association & disassociation are refactored so that they don't do "rbac" filtering by their own logic. This change gets rid of the user-specialized association serializer using `visible_users` and the general `access_qs` call in favor of calls to `filter_queryset`.
- As a subpoint of the above point, `get_serializer_class` no longer builds querysets (for `instances`). This changes it to use methods from the view _instance_ inside of the serializer context. This has to happen on the serializer `__init__`.
- Disassociation validation that the object is already attached is deleted, replaced by queryset logic, which now uses the same `get_queryset` as the listing does, which only includes attached objects to begin with.
- New parent class for related model viewsets is added which is inserted and _lower_ precedence than the passed-in class. This means that methods defined here can be overwritten in order to customize behavior. These are listed in docs too.
- When synthesizing the new association viewset class, all methods _other than list_ are disabled by a metaclass. This avoids the duplicate registration I complained above above.
- A serializer registry is added so that we don't create the same-name class multiple times, which confuses OpenAPI.
