### PR TITLE
Move the rest_filters reserved names to a setting

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -59,6 +59,21 @@ ANSIBLE_BASE_ALL_REST_FILTERS = (
 
 if 'ansible_base.rest_filters' in INSTALLED_APPS:
     REST_FRAMEWORK.update({'DEFAULT_FILTER_BACKENDS': ANSIBLE_BASE_ALL_REST_FILTERS})
+
+    ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES = (
+        'page',
+        'page_size',
+        'format',
+        'order',
+        'order_by',
+        'search',
+        'type',
+        'host_filter',
+        'count_disabled',
+        'no_truncate',
+        'limit',
+        'validate',
+    )
 else:
     # Explanation - these are the filters for views provided by DAB like /authenticators/
     # we want them to be enabled by default _even if_ the rest_filters app is not used

--- a/docs/apps/rest_filters.md
+++ b/docs/apps/rest_filters.md
@@ -31,6 +31,34 @@ REST_FRAMEWORK = {
 }
 ```
 
+## Letting Extra Query Params Through
+
+Sometimes you may have a view that needs to use a query param for a reason unrelated to filtering.
+If the rest_filters filtering is enabled, then this will not work, resulting in a 400 response code
+due to the model not having an expected field.
+
+To deal with this, after including the dynamic settings, you can add your field to the "reserved" list:
+
+```python
+from ansible_base.lib import dynamic_config
+dab_settings = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_settings.py')
+include(dab_settings)
+
+ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES += ('extra_querystring',)
+```
+
+This will prevent 400 errors for requests like `/api/v1/organizations/?extra_querystring=foo`.
+No filtering would be done in this case, the query string would simply be ignored.
+
+If you want to do this on a view level, not for the whole app, then add `rest_filters_reserved_names` to the view.
+
+```python
+class CowViewSet(ModelViewSet, AnsibleBaseView):
+    serializer_class = MySerializer
+    queryset = MyModel.objects.all()
+    rest_filters_reserved_names = ('extra_querystring',)
+```
+
 ## Preventing Field Searching
 
 ### prevent_search function

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -119,6 +119,9 @@ class CowViewSet(TestAppViewSet):
     serializer_class = serializers.CowSerializer
     queryset = models.Cow.objects.all()
     rbac_action = None
+    # Reserved names corresponds to
+    # test_app/tests/rest_filters/rest_framework/test_field_lookup_backend.py::test_view_level_ignore_field
+    rest_filters_reserved_names = ['cud']
 
     @action(detail=True, rbac_action='say', methods=['post'])
     def cowsay(self, request, pk=None):


### PR DESCRIPTION
My 2 cents here - this code was really just copied over from AWX. There is a process that code needs to go through in order to generalize it so that it's just abstract, for use via a library. This never happened for at least this part of rest_filters. Since it came up, I wanted to go ahead and get it done.