### PR TITLE
[WIP] Fix missing check in sync triggers

### DIFF
--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -350,14 +350,14 @@ class TrackedRelationship:
     def sync_team_to_role(self, instance: Model, action: str, model: type, pk_set: Optional[set[int]], reverse: bool, **kwargs):
         if not reverse:
             self._sync_actor_to_role(permission_registry.team_model, instance, action, pk_set)
-        else:
+        elif pk_set:
             for pk in pk_set:
                 self._sync_actor_to_role(permission_registry.team_model, model(pk=pk), action, {instance.pk})
 
     def sync_user_to_role(self, instance: Model, action: str, model: type, pk_set: Optional[set[int]], reverse: bool, **kwargs):
         if not reverse:
             self._sync_actor_to_role(permission_registry.user_model, instance, action, pk_set)
-        else:
+        elif pk_set:
             for pk in pk_set:
                 self._sync_actor_to_role(permission_registry.user_model, model(pk=pk), action, {instance.pk})
 

--- a/test_app/tests/rbac/conftest.py
+++ b/test_app/tests/rbac/conftest.py
@@ -7,6 +7,7 @@ from ansible_base.rbac.validators import combine_values, permissions_allowed_for
 from test_app.models import Inventory, Organization
 
 
+# REVIEW(cutwater): Fixture name is obscure and non-descriptive.
 @pytest.fixture
 def rando():
     return get_user_model().objects.create(username='rando')

--- a/test_app/tests/rbac/features/test_role_tracking.py
+++ b/test_app/tests/rbac/features/test_role_tracking.py
@@ -71,3 +71,13 @@ def test_add_organization_member_to_relationship(rando, organization, org_member
     object_role = org_member_rd.object_roles.first()
     assert rando in object_role.users.all()
     assert rando.has_obj_perm(organization, 'member')
+
+
+@pytest.mark.django_db
+def test_user_teams_clear(rando):
+    rando.teams.clear()
+
+
+@pytest.mark.django_db
+def test_user_orgs_clear(rando):
+    rando.member_of_organizations.clear()


### PR DESCRIPTION
Check if `pk_set` is a True-like (e.g. non-empty set) object.

The `pk_set` parameter may be `None` in cases when user teams list is cleared (e.g. calling `user.teams.clear()`).

This code will fail with the following exception:

```
TypeError: 'NoneType' object is not iterable
```

due to attempt to iterate over `None` value.