### PR TITLE
fix podman-compose on selinux enforcing systems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     working_dir: /src
     command: 'test_app/scripts/container_startup.sh'
     volumes:
-      - '.:/src'
+      - '.:/src:z'
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
using podman-compose to run the test application fails on selinux enforcing systems since podman does not perform file relabeling by default, resulting in access denial when attempting to use files mounted from the host machine, so this change enables the option to relabel mounted files in docker_compose.yml

The change has been tested on a machine using docker-ce, and does not appear to affect setups using it.