### PR TITLE
Replace X-TRUSTED-HEADER with pub/priv encrypted message

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -1,16 +1,12 @@
 import logging
-from typing import Optional, Tuple
-from urllib.parse import urljoin, urlparse
 
 import jwt
-import requests
-from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.cache import caches
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
-from ansible_base.lib.utils.settings import get_setting
+from ansible_base.jwt_consumer.common.cache import JWTCache
+from ansible_base.jwt_consumer.common.cert import JWTCert, JWTCertException
 from ansible_base.lib.utils.translations import translatableConditionally as _
 
 logger = logging.getLogger("ansible_base.jwt_consumer.common.auth")
@@ -24,21 +20,12 @@ default_mapped_user_fields = [
     "is_superuser",
     "is_system_auditor",
 ]
-# This setting allows a service to override which django cache we want to use
-jwt_cache_name = getattr(settings, 'ANSIBLE_BASE_JWT_CACHE_NAME', 'default')
-cache = caches[jwt_cache_name]
-# This is the cache name we will use for the JWT key
-cache_key = 'ansible_base_jwt_public_key'
 
 
 class JWTCommonAuth:
     def __init__(self, user_fields=default_mapped_user_fields) -> None:
         self.mapped_user_fields = user_fields
-
-    def get_cache_timeout(self):
-        # If unspecified the cache will expire in 7 days
-        cache_timeout = get_setting('ANSIBLE_BASE_JWT_CACHE_TIMEOUT_SECONDS', 604800)
-        return cache_timeout
+        self.cache = JWTCache()
 
     def parse_jwt_token(self, request):
         logger.debug("Starting JWT Authentication")
@@ -48,40 +35,39 @@ class JWTCommonAuth:
             return None, None
         logger.debug(f"Received JWT auth token: {token}")
 
-        jwt_key_setting = get_setting("ANSIBLE_BASE_JWT_KEY")
-        if not jwt_key_setting:
-            logger.info("Failed to get the setting ANSIBLE_BASE_JWT_KEY")
+        cert_object = JWTCert()
+        try:
+            cert_object.get_decryption_key()
+        except JWTCertException as jce:
+            logger.error(jce)
+            raise AuthenticationFailed(jce)
+
+        if cert_object.key is None:
             return None, None
 
-        decryption_key, jwt_key_was_cached = self.get_decryption_key(
-            jwt_key_setting,
-            validate_certs=get_setting("ANSIBLE_BASE_JWT_VALIDATE_CERT", True),
-            timeout=get_setting("ANSIBLE_BASE_JWT_URL_TIMEOUT", 30),
-        )
         try:
-            validated_body = self.validate_token(token, decryption_key)
+            validated_body = self.validate_token(token, cert_object.key)
         except jwt.exceptions.DecodeError as de:
             # This exception means the decryption key failed... maybe it was because the cache is bad.
-            if not jwt_key_was_cached:
+            if not cert_object.cached:
                 # It wasn't cached anyway so we an just raise our exception
                 self.log_and_raise(_("JWT decoding failed: %(e)s, check your key and generated token"), {"e": de})
 
             # We had a cached key so lets get the key again ignoring the cache
-            new_decryption_key, _junk = self.get_decryption_key(
-                jwt_key_setting,
-                validate_certs=get_setting("ANSIBLE_BASE_JWT_VALIDATE_CERT", True),
-                timeout=get_setting("ANSIBLE_BASE_JWT_URL_TIMEOUT", 30),
-                ignore_cache=True,
-            )
-            if new_decryption_key == decryption_key:
+            old_key = cert_object.key
+            try:
+                cert_object.get_decryption_key(ignore_cache=True)
+            except JWTCertException as jce:
+                self.log_and_raise(_("Failed to get JWT token on the second try: %(e)s"), {"e": jce})
+            if old_key == cert_object.key:
                 # The new key matched the old key so don't even try and decrypt again, the key just doesn't match
                 self.log_and_raise(_("JWT decoding failed: %(e)s, cached key was correct; check your key and generated token"), {"e": de})
             # Since we got a new key, lets go ahead and try to validate the token again.
             # If it fails this time we can just raise whatever
-            validated_body = self.validate_token(token, new_decryption_key)
+            validated_body = self.validate_token(token, cert_object.key)
 
         # Let's see if we have the same user info in the cache already
-        is_cached, user_defaults = self.check_user_in_cache(validated_body)
+        is_cached, user_defaults = self.cache.check_user_in_cache(validated_body)
 
         user_model = get_user_model()
         user = None
@@ -110,111 +96,6 @@ class JWTCommonAuth:
     def log_and_raise(self, conditional_translate_object, expand_values={}):
         logger.error(conditional_translate_object.not_translated() % expand_values)
         raise AuthenticationFailed(conditional_translate_object.translated() % expand_values)
-
-    def check_user_in_cache(self, validated_body: dict) -> Tuple[bool, dict]:
-        # These are the defaults which will get passed to the user creation and what we expect in the cache
-        expected_cache_value = {
-            "first_name": validated_body["first_name"],
-            "last_name": validated_body["last_name"],
-            "email": validated_body["email"],
-            "is_superuser": validated_body["is_superuser"],
-        }
-        cached_user = cache.get(validated_body["sub"], None)
-        # If the user was in the cache and the values of the cache match the expected values we had it in cache
-        if cached_user is not None and cached_user == expected_cache_value:
-            return True, expected_cache_value
-        # The user was not previously in the cache, set the user in the cache so it is found on future requests
-        cache.set(validated_body["sub"], expected_cache_value, timeout=self.get_cache_timeout())
-        return False, expected_cache_value
-
-    def get_key_from_cache(self, ignore_cache: bool = False) -> Optional[str]:
-        # If we are not ignoring the cache (forcing a reload of the key), check it
-        logger.debug(f"Ignore cache is {ignore_cache}")
-        if not ignore_cache:
-            key = cache.get(cache_key, None)
-            logger.debug(f"Cached key is {key}")
-            # We had a key in the cache so we can return that
-            if key:
-                return key
-        return None
-
-    def get_decryption_key_from_url(self, url: str, timeout: int = 30, validate_certs: bool = True, ignore_cache: bool = False) -> Tuple[str, bool]:
-        cached_key = self.get_key_from_cache(ignore_cache)
-        if cached_key:
-            logger.debug(f"Loading decryption key from cache instead of from url {url}")
-            return cached_key, True
-
-        # If the URL does not end with / the urljoin will wipe out the existing path
-        if not url.endswith('/'):
-            url = f"{url}/"
-        jwt_key_url = urljoin(url, "api/gateway/v1/jwt_key/")
-
-        logger.debug(f"Loading decryption key from url {jwt_key_url}")
-
-        try:
-            response = requests.get(
-                jwt_key_url,
-                verify=validate_certs,
-                timeout=timeout,
-            )
-            if response.status_code != 200:
-                self.log_and_raise(_("Failed to get 200 response from the issuer: %(status_code)s"), {"status_code": response.status_code})
-            return response.text, False
-        except requests.exceptions.ConnectionError as e:
-            self.log_and_raise(_("Failed to connect to %(jwt_key_url)s: %(e)s"), {"jwt_key_url": jwt_key_url, "e": e})
-        except requests.exceptions.Timeout:
-            self.log_and_raise(_("Timed out after %(timeout)s secs when connecting to %(jwt_key_url)s"), {"timeout": timeout, "jwt_key_url": jwt_key_url})
-        except requests.exceptions.RequestException as e:
-            self.log_and_raise(_("Failed to get JWT decryption key from JWT server: (%(e_class_name)s) %(e)s"), {"e_class_name": e.__class__.__name__, "e": e})
-
-    def get_decryption_key_from_file(self, file_path: str, ignore_cache: bool = False) -> Tuple[str, bool]:
-        cached_key = self.get_key_from_cache(ignore_cache)
-        if cached_key:
-            logger.debug(f"Loading decryption key from cache instead of from file {file_path}")
-            return cached_key, True
-
-        logger.debug(f"Loading decryption key from file {file_path}")
-
-        try:
-            with open(file_path, "r") as f:
-                cert = f.read()
-            return cert, False
-        except FileNotFoundError:
-            self.log_and_raise(_("The specified file %(file_path)s does not exist"), {"file_path": file_path})
-        except IsADirectoryError:
-            self.log_and_raise(_("The specified file %(file_path)s is not a file"), {"file_path": file_path})
-        except PermissionError:
-            self.log_and_raise(_("Permission error when reading %(file_path)s"), {"file_path": file_path})
-        except Exception as e:
-            self.log_and_raise(_("Failed reading %(file_path)s: %(e)s"), {"file_path": file_path, "e": e})
-
-    def get_decryption_key(self, url_or_string: str, ignore_cache: bool = False, validate_certs: bool = True, timeout: Optional[int] = 30) -> Tuple[str, bool]:
-        # We don't check the cache right away here because we only want to check the cache if its a file or URL.
-        # A hard coded key would be less efficient if we were attempting to load the cache every time.
-        cached = False
-        url_info = urlparse(url_or_string)
-        key = None
-        logger.info(f"Loading decryption key from {url_or_string} scheme {url_info.scheme}")
-        if url_info.scheme in ["http", "https"]:
-            key, cached = self.get_decryption_key_from_url(url_or_string, timeout, validate_certs, ignore_cache)
-        elif url_info.scheme == "file":
-            file_path = url_info.path
-            key, cached = self.get_decryption_key_from_file(file_path, ignore_cache)
-        elif url_info.scheme == "" and url_info.path != "":
-            logger.debug("Assuming decryption key is the actual cert")
-            key = url_or_string
-
-        if key is None:
-            self.log_and_raise(_("Unable to determine how to handle %(url_or_string)s to get key"), {"url_or_string": url_or_string})
-        elif not key.startswith('-----BEGIN PUBLIC KEY-----') and not key.endswith('-----END PUBLIC KEY-----'):
-            logger.debug(key)
-            self.log_and_raise(_("Returned key does not start and end with BEGIN/END PUBLIC KEY"))
-        logger.info("Decryption key appears valid")
-        logger.debug(f"{key}")
-
-        # Here we cache whatever key we were able to load
-        cache.set(cache_key, key, timeout=self.get_cache_timeout())
-        return key, cached
 
     def map_user_fields(self, user, token):
         user_needs_save = False

--- a/ansible_base/jwt_consumer/common/cache.py
+++ b/ansible_base/jwt_consumer/common/cache.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Optional, Tuple
+
+from django.conf import settings
+from django.core.cache import caches
+
+from ansible_base.lib.utils.settings import get_setting
+
+logger = logging.getLogger('ansible_base.jwt_consumer.common.cache')
+
+
+# This setting allows a service to override which django cache we want to use
+jwt_cache_name = getattr(settings, 'ANSIBLE_BASE_JWT_CACHE_NAME', 'default')
+cache = caches[jwt_cache_name]
+# This is the cache name we will use for the JWT key
+cache_key = 'ansible_base_jwt_public_key'
+
+
+class JWTCache:
+    def get_cache_timeout(self):
+        # If unspecified the cache will expire in 7 days
+        cache_timeout = get_setting('ANSIBLE_BASE_JWT_CACHE_TIMEOUT_SECONDS', 604800)
+        return cache_timeout
+
+    def check_user_in_cache(self, validated_body: dict) -> Tuple[bool, dict]:
+        # These are the defaults which will get passed to the user creation and what we expect in the cache
+        expected_cache_value = {
+            "first_name": validated_body["first_name"],
+            "last_name": validated_body["last_name"],
+            "email": validated_body["email"],
+            "is_superuser": validated_body["is_superuser"],
+        }
+        cached_user = cache.get(validated_body["sub"], None)
+        # If the user was in the cache and the values of the cache match the expected values we had it in cache
+        if cached_user is not None and cached_user == expected_cache_value:
+            return True, expected_cache_value
+        # The user was not previously in the cache, set the user in the cache so it is found on future requests
+        cache.set(validated_body["sub"], expected_cache_value, timeout=self.get_cache_timeout())
+        return False, expected_cache_value
+
+    def get_key_from_cache(self) -> Optional[str]:
+        # If we are not ignoring the cache (forcing a reload of the key), check it
+        key = cache.get(cache_key, None)
+        logger.debug(f"Cached key is {key}")
+        return key
+
+    def set_key_in_cache(self, key: str) -> None:
+        cache.set(cache_key, key, timeout=self.get_cache_timeout())

--- a/ansible_base/jwt_consumer/common/cert.py
+++ b/ansible_base/jwt_consumer/common/cert.py
@@ -1,0 +1,112 @@
+import logging
+from urllib.parse import urljoin, urlparse
+
+import requests
+from django.utils.translation import gettext as _
+
+from ansible_base.jwt_consumer.common.cache import JWTCache
+from ansible_base.lib.utils.settings import get_setting
+
+logger = logging.getLogger('ansible_base.jwt_consumer.common.cert')
+
+
+class JWTCertException(Exception):
+    '''
+    Raised if we can't get the cert for any reason.
+    The message will already be translated.
+    '''
+
+    pass
+
+
+class JWTCert:
+    key_name = 'ANSIBLE_BASE_JWT_KEY'
+
+    def __init__(self):
+        self.cached = None
+        self.key = None
+        self.jwt_key_setting = get_setting(self.key_name, None)
+        self.cache = JWTCache()
+
+    def _get_decryption_key_from_url(self) -> None:
+        url = self.jwt_key_setting
+        validate_certs = get_setting("ANSIBLE_BASE_JWT_VALIDATE_CERT", True)
+        timeout = get_setting("ANSIBLE_BASE_JWT_URL_TIMEOUT", 30)
+
+        # If the URL does not end with / the urljoin will wipe out the existing path
+        if not url.endswith('/'):
+            url = f"{url}/"
+        jwt_key_url = urljoin(url, "api/gateway/v1/jwt_key/")
+
+        logger.debug(f"Loading decryption key from url {jwt_key_url}")
+
+        try:
+            response = requests.get(
+                jwt_key_url,
+                verify=validate_certs,
+                timeout=timeout,
+            )
+            if response.status_code != 200:
+                raise JWTCertException(_("Failed to get 200 response from the issuer: {0}").format(response.status_code))
+            self.key = response.text
+        except requests.exceptions.ConnectionError as e:
+            raise JWTCertException(_("Failed to connect to {0}: {1}").format(jwt_key_url, e))
+        except requests.exceptions.Timeout:
+            raise JWTCertException(_("Timed out after {0} secs when connecting to {1}").format(timeout, jwt_key_url))
+        except requests.exceptions.RequestException as e:
+            raise JWTCertException(_("Failed to get JWT decryption key from JWT server: ({0}) {1}").format(e.__class__.__name__, e))
+
+    def _get_decryption_key_from_file(self, file_path: str) -> None:
+        logger.debug(f"Loading decryption key from file {file_path}")
+
+        try:
+            with open(file_path, "r") as f:
+                self.key = f.read()
+        except FileNotFoundError:
+            raise JWTCertException(_("The specified file {0} does not exist").format(file_path))
+        except IsADirectoryError:
+            raise JWTCertException(_("The specified file {0} is not a file").format(file_path))
+        except PermissionError:
+            raise JWTCertException(_("Permission error when reading {0}").format(file_path))
+        except Exception as e:
+            raise JWTCertException(_("Failed reading {0}: {1}").format(file_path, e))
+
+    def get_decryption_key(self, ignore_cache: bool = False) -> None:
+        # Set key and cached to None
+        self.key = None
+        self.cached = None
+
+        if self.jwt_key_setting is None:
+            logger.info(f"Failed to get the setting {self.key_name}")
+            return
+
+        cached_key = self.cache.get_key_from_cache()
+        if cached_key and not ignore_cache:
+            logger.debug(f"Loading decryption key from cache instead of from url {self.jwt_key_setting}")
+            self.cached = True
+            self.key = cached_key
+            return
+
+        # We don't check the cache right away here because we only want to check the cache if its a file or URL.
+        # A hard coded key would be less efficient if we were attempting to load the cache every time.
+        url_or_string = self.jwt_key_setting
+        url_info = urlparse(url_or_string)
+        logger.info(f"Loading decryption key from {url_or_string} scheme {url_info.scheme}")
+        if url_info.scheme in ["http", "https"]:
+            self._get_decryption_key_from_url()
+        elif url_info.scheme == "file":
+            file_path = url_info.path
+            self._get_decryption_key_from_file(file_path)
+        elif url_info.scheme == "" and url_info.path != "":
+            logger.debug("Assuming decryption key is the actual cert")
+            self.key = url_or_string
+
+        if self.key is None:
+            raise JWTCertException(_("Unable to determine how to handle {0} to get key").format(url_or_string))
+        elif not self.key.startswith('-----BEGIN PUBLIC KEY-----') and not self.key.endswith('-----END PUBLIC KEY-----'):
+            logger.debug(self.key)
+            raise JWTCertException(_("Returned key does not start and end with BEGIN/END PUBLIC KEY"))
+        logger.info("Decryption key appears valid")
+        logger.debug(f"{self.key}")
+        self.cache.set_key_in_cache(self.key)
+        self.cached = False

--- a/ansible_base/jwt_consumer/common/util.py
+++ b/ansible_base/jwt_consumer/common/util.py
@@ -1,0 +1,52 @@
+import logging
+import time
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+from ansible_base.jwt_consumer.common.cert import JWTCert, JWTCertException
+
+logger = logging.getLogger('ansible_base.jwt_consumer.common.util')
+
+_SHARED_SECRET = 'trusted_proxy'
+
+
+def generate_x_trusted_proxy_header(key: str) -> str:
+    private_key = serialization.load_pem_private_key(bytes(key, 'utf-8'), password=None)
+    timestamp = time.time_ns()
+    message = f'{_SHARED_SECRET}-{timestamp}'
+    signature = private_key.sign(bytes(message, 'utf-8'), padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())
+    return f"{timestamp}-{signature.hex()}"
+
+
+def validate_x_trusted_proxy_header(header_value: str, ignore_cache=False) -> bool:
+    try:
+        cert = JWTCert()
+        cert.get_decryption_key(ignore_cache=ignore_cache)
+        if cert.key is None:
+            raise JWTCertException(f"Failed to load cert from setting {cert.key_name}")
+    except JWTCertException as e:
+        logger.error(f"Failed to validate x-trusted-proxy-header, unable to load cert {e}")
+        return False
+
+    try:
+        public_key = serialization.load_pem_public_key(cert.key.encode('utf-8'))
+    except Exception:
+        logger.exception("Failed to load public key")
+        return False
+
+    timestamp, signature = header_value.split('-')
+
+    try:
+        public_key.verify(
+            bytes.fromhex(signature),
+            bytes(f'{_SHARED_SECRET}-{timestamp}', 'utf-8'),
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        return True
+    except InvalidSignature:
+        if ignore_cache or not cert.cached:
+            return False
+        return validate_x_trusted_proxy_header(header_value, ignore_cache=True)

--- a/ansible_base/lib/testing/fixtures.py
+++ b/ansible_base/lib/testing/fixtures.py
@@ -264,3 +264,28 @@ def ldap_authenticator(ldap_configuration):
     )
     yield authenticator
     delete_authenticator(authenticator)
+
+
+@pytest.fixture
+def create_mock_method():
+    # Creates a function that when called, generates a function that can be used to patch
+    # a method. Useful for when you want to mock an object method that modifies an object's state.
+    # Accepts arguments:
+    #   field_dicts: iterable of dictionaries containing key-value pairs to modify for parent object
+    def mock_method_generator(field_dicts: list[dict]):
+        def create_generator():
+            for field_dict in field_dicts:
+                yield field_dict
+
+        generator = create_generator()
+
+        def mock_method(self, ignore_cache=False):
+            # Get dictionary of fields to modify
+            fields = next(generator)
+            # Modify JWTCert object with each field defined in the fields dictionary
+            for field, value in fields.items():
+                setattr(self, field, value)
+
+        return mock_method
+
+    return mock_method_generator

--- a/docs/lib/requests.md
+++ b/docs/lib/requests.md
@@ -7,6 +7,6 @@ If you are running behind a proxy or load balancer the value in this header coul
 DAB offers two functions called `get_remote_host` and `get_remote_hosts` to help deal with this.
 
 `get_remote_hosts` will attempt to look at the setting `REMOTE_HOST_HEADERS` (defaulted to `['REMOTE_ADDR', 'REMOTE_HOST']`). For any named header in that array the code will split the header (if present) on `,` and then return an array of all the addresses found (in order with duplicates).
-Additionally if the header `HTTP_X_TRUSTED_PROXY` and is present and is properly signed with a pre-shared key (set in the setting `ANSIBLE_BASE_SHARED_SECRET`), the method will automatically prepend the following to `REMOTE_HOST_HEADERS`: `['HTTP_X_FORWARDED_FOR', 'HTTP_X_ENVOY_EXTERNAL_ADDRESS']`.
+Additionally if the header `HTTP_X_TRUSTED_PROXY` and is present and is properly signed with with a private key (the public key will pull from ansible_base.jwt_consumer.common.auth.get_decryption_key), the method will automatically prepend the following to `REMOTE_HOST_HEADERS`: `['HTTP_X_FORWARDED_FOR', 'HTTP_X_ENVOY_EXTERNAL_ADDRESS']`.
 
 `get_remote_host` will return the first entry found by `get_remote_hosts` or None. 

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -169,8 +169,6 @@ ANSIBLE_BASE_USER_VIEWSET = 'test_app.views.UserViewSet'
 
 LOGIN_URL = "/login/login"
 
-ANSIBLE_BASE_SHARED_SECRET = 'testing'
-
 RESOURCE_SERVER = {
     "URL": "http://localhost",
     "SECRET_KEY": "my secret key",

--- a/test_app/tests/fixtures/test_fixtures.py
+++ b/test_app/tests/fixtures/test_fixtures.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 
@@ -5,3 +7,25 @@ import pytest
 def test_clients_do_not_conflict(unauthenticated_api_client, user_api_client, admin_api_client):
     assert dict(user_api_client.cookies) != dict(admin_api_client.cookies)
     assert dict(unauthenticated_api_client.cookies) == {}
+
+
+class ThrowawayObject:
+    def method_that_should_be_patched(self):
+        raise Exception("object was not patched properly")
+
+
+def test_mock_method(create_mock_method):
+    with pytest.raises(StopIteration):
+        fields_list = [
+            {"field": "hi"},
+        ]
+
+        with mock.patch("test_app.tests.fixtures.test_fixtures.ThrowawayObject.method_that_should_be_patched", create_mock_method(fields_list)):
+            test_object = ThrowawayObject()
+            # Test good path: assert that calling object fields are overwritten
+            for fields in fields_list:
+                test_object.method_that_should_be_patched()
+                for field, value in fields.items():
+                    assert getattr(test_object, field, None) == value
+            # Test bad path: ie assert that the mock method throws an exception when it is called more than expected
+            test_object.method_that_should_be_patched()

--- a/test_app/tests/jwt_consumer/common/test_cache.py
+++ b/test_app/tests/jwt_consumer/common/test_cache.py
@@ -1,0 +1,1 @@
+# The cache is tested by test_auth and test_cert

--- a/test_app/tests/jwt_consumer/common/test_cert.py
+++ b/test_app/tests/jwt_consumer/common/test_cert.py
@@ -1,0 +1,177 @@
+from unittest import mock
+from urllib.parse import urlparse
+
+import pytest
+import requests
+from django.conf import settings
+from django.test import override_settings
+
+from ansible_base.jwt_consumer.common.cert import JWTCert, JWTCertException
+
+
+class TestJWTCert:
+    def test_get_decryption_key_no_setting(self):
+        cert = JWTCert()
+        cert.get_decryption_key()
+        assert cert.key is None and cert.cached is None
+
+    @pytest.mark.parametrize(
+        "setting,string",
+        [
+            ('', 'Unable to determine how to handle  to get key'),
+            ("ftp://www.ansible.com", 'Unable to determine how to handle ftp://www.ansible.com to get key'),
+            ('absolute_junk', 'Returned key does not start and end with BEGIN/END PUBLIC KEY'),
+        ],
+    )
+    def test_get_decryption_key_random_settings(self, setting, string):
+        with override_settings(ANSIBLE_BASE_JWT_KEY=setting):
+            cert = JWTCert()
+            with pytest.raises(JWTCertException, match=string):
+                cert.get_decryption_key(ignore_cache=True)
+                assert cert.key is None and cert.cached is None
+
+    @pytest.mark.parametrize(
+        "error, exception_class",
+        [
+            ("The specified file {0} does not exist", FileNotFoundError()),
+            ("The specified file {0} is not a file", IsADirectoryError()),
+            ("Permission error when reading {0}", PermissionError()),
+            ("Failed reading {0}: argh", IOError('argh')),
+        ],
+    )
+    @override_settings(ANSIBLE_BASE_JWT_KEY='file:///gibberish')
+    def test_get_decryption_key_file_exceptions(self, error, exception_class, tmp_path_factory):
+        cert = JWTCert()
+        url_parts = urlparse(settings.ANSIBLE_BASE_JWT_KEY)
+        with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+            mock_file.side_effect = exception_class
+            with pytest.raises(JWTCertException, match=error.format(url_parts.path)):
+                cert.get_decryption_key(ignore_cache=True)
+                assert cert.key is None and cert.cached is None
+
+    @pytest.mark.parametrize(
+        "remove_newlines",
+        [(False), (True)],
+    )
+    def test_get_decryption_key_file_read(self, remove_newlines, tmp_path_factory, test_encryption_public_key):
+        temp_dir = tmp_path_factory.mktemp("ansible_base.jwt_consumer.common.auth")
+        temp_file_name = f"{temp_dir}/test.file"
+        if remove_newlines:
+            cert_data = test_encryption_public_key.replace("\n", "")
+        else:
+            cert_data = test_encryption_public_key
+        with open(temp_file_name, "w") as f:
+            f.write(cert_data)
+        with override_settings(ANSIBLE_BASE_JWT_KEY=f'file:{temp_file_name}'):
+            cert = JWTCert()
+            cert.get_decryption_key(ignore_cache=True)
+            assert cert.key == cert_data
+            assert cert.cached is False
+
+    def test_get_decryption_key_file_read_with_cache(self, tmp_path_factory, test_encryption_public_key):
+        temp_dir = tmp_path_factory.mktemp("ansible_base.jwt_consumer.common.auth")
+        temp_file_name = f"{temp_dir}/test.file"
+        cert_data = test_encryption_public_key
+        with open(temp_file_name, "w") as f:
+            f.write(cert_data)
+
+        with override_settings(ANSIBLE_BASE_JWT_KEY=f'file:{temp_file_name}'):
+            cert = JWTCert()
+            cert.get_decryption_key(ignore_cache=True)
+            assert cert.key == cert_data
+            assert cert.cached is False, "First key read should not have been cached"
+            cert.get_decryption_key()
+            assert cert.key == cert_data
+            assert cert.cached is True, "Second key read should have been cached"
+
+    @mock.patch('requests.get', mock.Mock(side_effect=requests.exceptions.ConnectionError))
+    @override_settings(ANSIBLE_BASE_JWT_KEY="http://dne.cuz.junk.redhat.com")
+    def test_get_decryption_key_connection_error(self):
+        cert = JWTCert()
+        with pytest.raises(JWTCertException, match=rf"Failed to connect to {settings.ANSIBLE_BASE_JWT_KEY}.*"):
+            cert.get_decryption_key(ignore_cache=True)
+            assert cert.key is None and cert.cached is None
+
+    @mock.patch('requests.get', mock.Mock(side_effect=requests.exceptions.Timeout))
+    @override_settings(ANSIBLE_BASE_JWT_KEY="http://dne.cuz.junk.redhat.com", ANSIBLE_BASE_JWT_URL_TIMEOUT=1)
+    def test_get_decryption_key_url_timeout(self):
+        cert = JWTCert()
+        with pytest.raises(
+            JWTCertException, match=rf"Timed out after {settings.ANSIBLE_BASE_JWT_URL_TIMEOUT} secs when connecting to {settings.ANSIBLE_BASE_JWT_KEY}.*"
+        ):
+            cert.get_decryption_key(ignore_cache=True)
+            assert cert.key is None and cert.cached is None
+
+    @mock.patch('requests.get', mock.Mock(side_effect=requests.exceptions.RequestException))
+    @override_settings(ANSIBLE_BASE_JWT_KEY="http://dne.cuz.junk.redhat.com")
+    def test_get_decryption_key_url_random_exception(self):
+        cert = JWTCert()
+        with pytest.raises(JWTCertException, match=r"Failed to get JWT decryption key from JWT server: \(RequestException\).*"):
+            cert.get_decryption_key(ignore_cache=True)
+            assert cert.key is None and cert.cached is None
+
+    @pytest.mark.parametrize("status_code", ['302', '504'])
+    def test_get_decryption_key_url_bad_status_codes(self, status_code, mocked_http):
+        with mock.patch('requests.get') as requests_get:
+            requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
+            with override_settings(ANSIBLE_BASE_JWT_KEY=f"http://someotherurl.com/{status_code}"):
+                cert = JWTCert()
+                with pytest.raises(JWTCertException, match=f"Failed to get 200 response from the issuer: {status_code}"):
+                    cert.get_decryption_key(ignore_cache=True)
+                    assert cert.key is None and cert.cached is None
+
+    @override_settings(ANSIBLE_BASE_JWT_KEY="http://someotherurl.com/200_junk/")
+    def test_get_decryption_key_url_bad_200(self, mocked_http):
+        cert = JWTCert()
+        with mock.patch('requests.get') as requests_get:
+            requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
+            with pytest.raises(JWTCertException, match="Returned key does not start and end with BEGIN/END PUBLIC KEY"):
+                cert.get_decryption_key(ignore_cache=True)
+                assert cert.key is None and cert.cached is None
+
+    @override_settings(ANSIBLE_BASE_JWT_KEY="http://someotherurl.com/200_good")
+    def test_get_decryption_key_url_good_200(self, mocked_http, test_encryption_public_key):
+        cert = JWTCert()
+        with mock.patch('requests.get') as requests_get:
+            requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
+            try:
+                cert.get_decryption_key(ignore_cache=True)
+            except Exception as e:
+                assert False, f"Got unexpected exception {e}"
+            assert cert.key == test_encryption_public_key
+            assert cert.cached is False
+
+    @override_settings(ANSIBLE_BASE_JWT_KEY="http://someotherurl.com/200_good")
+    def test_get_decryption_key_url_cache(self, mocked_http, test_encryption_public_key):
+        cert = JWTCert()
+        with mock.patch('requests.get') as requests_get:
+            requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
+            try:
+                cert.get_decryption_key(ignore_cache=True)
+            except Exception as e:
+                assert False, f"Got unexpected exception {e}"
+            assert cert.key == test_encryption_public_key
+            assert cert.cached is False, "First key read should not have been cached"
+            cert.get_decryption_key()
+            assert cert.key == test_encryption_public_key
+            assert cert.cached is True, "Second key read should have been cached"
+
+    # If other tests are running at the same time there is a chance that they might set the key in the cache.
+    # Since we don't mock the response intentionally we are going to tell this test to use a different cache key
+    @mock.patch('ansible_base.jwt_consumer.common.cache.cache_key', 'expiration_test_jwt_key')
+    @override_settings(ANSIBLE_BASE_JWT_KEY="http://someotherurl.com/200_good")
+    def test_cache_expiring(self, mocked_http, test_encryption_public_key):
+        with mock.patch('requests.get') as requests_get:
+            # Setting the cache timeout to 0 effectively says don't cache.
+            with override_settings(ANSIBLE_BASE_JWT_CACHE_TIMEOUT_SECONDS=0):
+                cert = JWTCert()
+                requests_get.side_effect = mocked_http.mocked_get_decryption_key_get_request
+                try:
+                    cert.get_decryption_key()
+                except Exception as e:
+                    assert False, f"Got unexpected exception {e}"
+                assert cert.key == test_encryption_public_key
+                assert cert.cached is False, "The first cert load should not have been cached"
+                cert.get_decryption_key()
+                assert cert.key == test_encryption_public_key
+                assert cert.cached is False

--- a/test_app/tests/jwt_consumer/common/test_util.py
+++ b/test_app/tests/jwt_consumer/common/test_util.py
@@ -1,0 +1,32 @@
+from unittest import mock
+
+from django.test.utils import override_settings
+
+from ansible_base.jwt_consumer.common.util import generate_x_trusted_proxy_header, validate_x_trusted_proxy_header
+
+
+class TestValidateTrustedProxy:
+
+    def test_validate_trusted_proxy_header_bad_cached_key_but_correct_setting(self, rsa_keypair, random_public_key, create_mock_method):
+        field_dicts = [
+            {"key": random_public_key, "cached": True},
+            {"key": rsa_keypair.public, "cached": False},
+        ]
+        with override_settings(ANSIBLE_BASE_JWT_KEY=rsa_keypair.public):
+            with mock.patch("ansible_base.jwt_consumer.common.util.JWTCert.get_decryption_key", create_mock_method(field_dicts)):
+                assert validate_x_trusted_proxy_header(generate_x_trusted_proxy_header(rsa_keypair.private))
+
+    def test_validate_trusted_proxy_header_no_key(self, caplog):
+        with override_settings(ANSIBLE_BASE_JWT_KEY=None):
+            assert not validate_x_trusted_proxy_header("any input")
+            assert "Failed to validate x-trusted-proxy-header, unable to load cert" in caplog.text
+
+    @mock.patch("cryptography.hazmat.primitives.serialization.load_pem_public_key", side_effect=Exception())
+    def test_validate_trusted_proxy_header_fail_load_public_key(self, mock_load_pem_public_key, caplog, random_public_key):
+        with override_settings(ANSIBLE_BASE_JWT_KEY=random_public_key):
+            assert not validate_x_trusted_proxy_header("any input")
+            assert "Failed to load public key" in caplog.text
+
+    def test_validate_trusted_proxy_header_bad_public_key(self, random_public_key):
+        with override_settings(ANSIBLE_BASE_JWT_KEY=random_public_key):
+            assert not validate_x_trusted_proxy_header("0-12345123451234512345")

--- a/test_app/tests/lib/utils/test_encryption.py
+++ b/test_app/tests/lib/utils/test_encryption.py
@@ -1,13 +1,6 @@
 import pytest
-from django.test import override_settings
 
-from ansible_base.lib.utils.encryption import (
-    ENCRYPTION_METHOD,
-    Fernet256,
-    SharedSecretNotFound,
-    generate_hmac_sha256_shared_secret,
-    validate_hmac_sha256_shared_secret,
-)
+from ansible_base.lib.utils.encryption import ENCRYPTION_METHOD, Fernet256
 
 logger = 'ansible_base.lib.utils.encryption.logger'
 
@@ -50,69 +43,3 @@ def test_fernet256_unsupported_algorithm():
     with pytest.raises(ValueError) as e:
         fernet.decrypt_string(encrypted_string)
     assert str(e.value) == "Unsupported algorithm: monkey"
-
-
-def test_generate_hmac_field_setting_set(expected_log):
-    """
-    Ensure a log is generated if the variable is unset
-    """
-    hmac_message = 'The setting ANSIBLE_BASE_SHARED_SECRET was not set, some functionality may be disabled.'
-    with expected_log(logger, 'error', hmac_message, assert_not_called=True):
-        generate_hmac_sha256_shared_secret()
-
-
-def test_generate_hmac_field_setting_unset(expected_log):
-    """
-    Ensure a log is generated if the variable is unset
-    """
-    with override_settings(ANSIBLE_BASE_SHARED_SECRET=None):
-        with pytest.raises(SharedSecretNotFound):
-            generate_hmac_sha256_shared_secret()
-
-
-def test_generate_hmac_no_nonce_is_ok():
-    """
-    Validate that if we don't set an nonce it will pick one and do the encryption with it
-    """
-    secret = generate_hmac_sha256_shared_secret()
-    nonce, _ = secret.split(':')
-    assert secret == generate_hmac_sha256_shared_secret(nonce=nonce)
-
-
-@pytest.mark.parametrize(
-    "pre_shared_secret,causes_failure",
-    [
-        ("some_string", False),
-        (1, False),
-        (None, True),
-        ('', True),
-        (True, False),
-        ({}, True),
-        ([], True),
-    ],
-)
-def test_generate_hmac_different_types_of_pre_shared_secret(pre_shared_secret, causes_failure):
-    with override_settings(ANSIBLE_BASE_SHARED_SECRET=pre_shared_secret):
-        try:
-            generate_hmac_sha256_shared_secret()
-        except SharedSecretNotFound:
-            if not causes_failure:
-                assert False, f"Should not have gotten a SharedSecretNotFound exception for {pre_shared_secret}"
-
-
-@pytest.mark.parametrize(
-    "nonce,secret,valid",
-    [
-        (None, None, True),
-        (7, None, False),
-        (None, 'gibberish', False),
-        ('12', 'junk', False),
-    ],
-)
-def test_generate_hmac_validation(nonce, secret, valid):
-    generated_nonce, generated_secret = generate_hmac_sha256_shared_secret().split(':')
-    if nonce:
-        generated_nonce = nonce
-    if secret:
-        generated_secret = secret
-    assert validate_hmac_sha256_shared_secret(f'{generated_nonce}:{generated_secret}') is valid

--- a/test_app/tests/lib/utils/test_requests.py
+++ b/test_app/tests/lib/utils/test_requests.py
@@ -4,7 +4,7 @@ import pytest
 from django.test import override_settings
 from django.test.client import RequestFactory
 
-from ansible_base.lib.utils.encryption import generate_hmac_sha256_shared_secret
+from ansible_base.jwt_consumer.common.util import generate_x_trusted_proxy_header
 from ansible_base.lib.utils.requests import get_remote_host, get_remote_hosts
 
 
@@ -39,14 +39,14 @@ def test_get_remote_hosts_no_headers():
         ({'X_FORWARDED_FOR': '1.2.3.4'}, {}, True, ['127.0.0.1']),
         ({'X_ENVOY_EXTERNAL_ADDRESS': '1.2.3.4'}, {}, True, ['127.0.0.1']),
         # Validate that given the value the trusted header the headers supersede the REMOTE_ADD
-        ({'X_TRUSTED_PROXY': generate_hmac_sha256_shared_secret(), 'X_FORWARDED_FOR': '1.2.3.4'}, {}, True, ['1.2.3.4']),
-        ({'X_TRUSTED_PROXY': generate_hmac_sha256_shared_secret(), 'X_ENVOY_EXTERNAL_ADDRESS': '1.2.3.4'}, {}, True, ['1.2.3.4']),
-        ({'X_TRUSTED_PROXY': generate_hmac_sha256_shared_secret(), 'X_FORWARDED_FOR': '1.2.3.4'}, {}, False, ['1.2.3.4', '127.0.0.1']),
-        ({'X_TRUSTED_PROXY': generate_hmac_sha256_shared_secret(), 'X_ENVOY_EXTERNAL_ADDRESS': '1.2.3.4'}, {}, False, ['1.2.3.4', '127.0.0.1']),
+        ({'X_TRUSTED_PROXY': '', 'X_FORWARDED_FOR': '1.2.3.4'}, {}, True, ['1.2.3.4']),
+        ({'X_TRUSTED_PROXY': '', 'X_ENVOY_EXTERNAL_ADDRESS': '1.2.3.4'}, {}, True, ['1.2.3.4']),
+        ({'X_TRUSTED_PROXY': '', 'X_FORWARDED_FOR': '1.2.3.4'}, {}, False, ['1.2.3.4', '127.0.0.1']),
+        ({'X_TRUSTED_PROXY': '', 'X_ENVOY_EXTERNAL_ADDRESS': '1.2.3.4'}, {}, False, ['1.2.3.4', '127.0.0.1']),
         # Assert the anticipated load order whit multiple headers
         (
             {
-                'X_TRUSTED_PROXY': generate_hmac_sha256_shared_secret(),
+                'X_TRUSTED_PROXY': '',
                 'X_FORWARDED_FOR': '1.2.3.4, 5.6.7.8',
                 'X_ENVOY_EXTERNAL_ADDRESS': '5.6.7.8, 9.10.11.12',
             },
@@ -66,10 +66,13 @@ def test_get_remote_hosts_no_headers():
         ),
     ],
 )
-def test_get_remote_hosts(headers, extra, get_first_only, expected_result):
-    request = RequestFactory().get('/hello', headers=headers, **extra)
-    remote_hosts = get_remote_hosts(request, get_first_only=get_first_only)
-    assert remote_hosts == expected_result
+def test_get_remote_hosts(headers, extra, get_first_only, expected_result, rsa_keypair):
+    with override_settings(ANSIBLE_BASE_JWT_KEY=rsa_keypair.public):
+        if 'X_TRUSTED_PROXY' in headers:
+            headers['X_TRUSTED_PROXY'] = generate_x_trusted_proxy_header(rsa_keypair.private)
+        request = RequestFactory().get('/hello', headers=headers, **extra)
+        remote_hosts = get_remote_hosts(request, get_first_only=get_first_only)
+        assert remote_hosts == expected_result
 
 
 def test_get_remote_hosts_alternate_headers():
@@ -83,17 +86,47 @@ def test_get_remote_hosts_alternate_headers():
         assert remote_hosts == ['a.b.c.d']
 
 
-def test_get_remote_hosts_alternate_headers_behind_trusted_proxy():
+def test_get_remote_hosts_alternate_headers_behind_trusted_proxy(rsa_keypair):
     """
     Same as last test but we are behind a trusted proxy so we will add in those headers regardless of the list
     """
-    headers = {
-        'X_JOHNS_HEADER': 'a.b.c.d',
-        'X_TRUSTED_PROXY': generate_hmac_sha256_shared_secret(),
-        'X_FORWARDED_FOR': '1.2.3.4, 5.6.7.8',
-        'X_ENVOY_EXTERNAL_ADDRESS': '5.6.7.8, 9.10.11.12',
-    }
-    request = RequestFactory().get('/hello', headers=headers)
-    with override_settings(REMOTE_HOST_HEADERS=['HTTP_X_JOHNS_HEADER']):
+    with override_settings(ANSIBLE_BASE_JWT_KEY=rsa_keypair.public):
+        headers = {
+            'X_JOHNS_HEADER': 'a.b.c.d',
+            'X_TRUSTED_PROXY': generate_x_trusted_proxy_header(rsa_keypair.private),
+            'X_FORWARDED_FOR': '1.2.3.4, 5.6.7.8',
+            'X_ENVOY_EXTERNAL_ADDRESS': '5.6.7.8, 9.10.11.12',
+        }
+        request = RequestFactory().get('/hello', headers=headers)
+        with override_settings(REMOTE_HOST_HEADERS=['HTTP_X_JOHNS_HEADER']):
+            remote_hosts = get_remote_hosts(request, get_first_only=False)
+            assert remote_hosts == ['5.6.7.8', '9.10.11.12', '1.2.3.4', '5.6.7.8', 'a.b.c.d']
+
+
+@mock.patch("ansible_base.lib.utils.requests.validate_x_trusted_proxy_header", side_effect=Exception)
+def test_get_remote_hosts_validate_trusted_proxy_header_exception(mock_validate: mock.MagicMock, rsa_keypair, caplog):
+    with override_settings(ANSIBLE_BASE_JWT_KEY=rsa_keypair.public):
+        headers = {
+            'X_TRUSTED_PROXY': generate_x_trusted_proxy_header(rsa_keypair.private),
+            'X_FORWARDED_FOR': '1.2.3.4, 5.6.7.8',
+            'X_ENVOY_EXTERNAL_ADDRESS': '5.6.7.8, 9.10.11.12',
+        }
+        request = RequestFactory().get('/hello', headers=headers)
         remote_hosts = get_remote_hosts(request, get_first_only=False)
-        assert remote_hosts == ['5.6.7.8', '9.10.11.12', '1.2.3.4', '5.6.7.8', 'a.b.c.d']
+        mock_validate.assert_called_once()
+        assert "Failed to validate HTTP_X_TRUSTED_PROXY" in caplog.text
+        assert remote_hosts == ['127.0.0.1']
+
+
+def test_get_remote_hosts_validate_trusted_proxy_header_failure(random_public_key, rsa_keypair, caplog):
+    with override_settings(ANSIBLE_BASE_JWT_KEY=random_public_key):
+        headers = {
+            'X_TRUSTED_PROXY': generate_x_trusted_proxy_header(rsa_keypair.private),
+            'X_FORWARDED_FOR': '1.2.3.4, 5.6.7.8',
+            'X_ENVOY_EXTERNAL_ADDRESS': '5.6.7.8, 9.10.11.12',
+        }
+        request = RequestFactory().get('/hello', headers=headers)
+        remote_hosts = get_remote_hosts(request, get_first_only=False)
+
+        assert "Unable to use headers from trusted proxy because shared secret was invalid!" in caplog.text
+        assert remote_hosts == ['127.0.0.1']


### PR DESCRIPTION
In simple testing this method appears to be fast but significantly slower than the shared secret method.

Fixes: [AAP-24036](https://issues.redhat.com/browse/AAP-24036)