### PR TITLE
Add check for system user does not exist

### DIFF
--- a/ansible_base/lib/serializers/common.py
+++ b/ansible_base/lib/serializers/common.py
@@ -111,6 +111,8 @@ class CommonUserSerializer(CommonModelSerializer):
     """
 
     def validate(self, data):
+        if models.get_system_user() is None:
+            return data
         if hasattr(self, 'instance') and hasattr(self.instance, 'id') and self.instance.id == models.get_system_user().id:
             raise ValidationError(_('System users cannot be modified'))
         return data

--- a/test_app/tests/lib/serializers/test_common.py
+++ b/test_app/tests/lib/serializers/test_common.py
@@ -1,5 +1,6 @@
 import pytest
 from crum import impersonate
+from django.test import override_settings
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.models import AuthenticatorMap
@@ -67,6 +68,10 @@ def test_no_modify_system_user():
     update["email"] = "noworky@gmail.com"
     serializer = CommonUserSerializer(sysuser)
     with pytest.raises(ValidationError):
+        serializer.validate(update)
+
+    # Verify lack of system user does not break validation
+    with override_settings(SYSTEM_USERNAME=None):
         serializer.validate(update)
 
 


### PR DESCRIPTION
Seems like the unit tests for aap-gateway sometimes lose the system user, which exposed this issue.  Add check to ensure system user even exists before running validation..