### PR TITLE
Only check redis file settings if tls is enabled

### DIFF
--- a/ansible_base/lib/redis/client.py
+++ b/ansible_base/lib/redis/client.py
@@ -64,10 +64,11 @@ class RedisClient(DefaultClient):
         except (IndexError, ValueError):
             pass
 
-        for file_setting in ['ssl_certfile', 'ssl_keyfile', 'ssl_ca_certs']:
-            file = kwargs.get(file_setting, None)
-            if file and not os.access(file, os.R_OK):
-                raise ImproperlyConfigured(_('Unable to read file {} from setting {}').format(file, file_setting))
+        if kwargs.get('ssl', None):
+            for file_setting in ['ssl_certfile', 'ssl_keyfile', 'ssl_ca_certs']:
+                file = kwargs.get(file_setting, None)
+                if file and not os.access(file, os.R_OK):
+                    raise ImproperlyConfigured(_('Unable to read file {} from setting {}').format(file, file_setting))
 
         # Connect to either a cluster or a standalone redis
         if self.clustered:

--- a/docs/lib/redis.md
+++ b/docs/lib/redis.md
@@ -8,19 +8,19 @@ To leverage this client you can setup your Django cache like:
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
             # Note, the location is not really used but we parse it in the client to get settings like host/port/username/etc.
-            "LOCATION": f"redis://{os.environ.get('REDIS_USER')}:{os.environ.get('REDIS_PASS')}@{os.environ.get('REDIS_HOST')}:{os.environ.get('REDIS_PORT')}",
+            "LOCATION": f"<redis, rediss, file or unix schemed URL>",
             "KEY_PREFIX": '<service name>',
             "OPTIONS": {
                 "CLIENT_CLASS": "ansible_base.lib.redis.RedisClient",
                 "CLIENT_CLASS_KWARGS": {
-                    "clustered": to_python_boolean(os.environ.get('REDIS_IS_CLUSTERED', False)),
+                    "clustered": <true or false>
                     'clustered_hosts': "<host 1>:<port>,<host 2>:<port>,[...],<host N>:<port>",
-                    'ssl': to_python_boolean(os.environ.get('REDIS_TLS', True)),
-                    'ssl_keyfile': '/etc/path/redis.key',
-                    'ssl_certfile': '/etc/path/redis.cert',
-                    'ssl_cert_reqs': 'required',
-                    'ssl_ca_certs': '/etc/path/redis_ca.cert',
-                    'ssl_check_hostname': False,
+                    'ssl': <true or false>,
+                    'ssl_keyfile': '<file path>',
+                    'ssl_certfile': '<file path>',
+                    'ssl_cert_reqs': '<required or none>',
+                    'ssl_ca_certs': '<file path>',
+                    'ssl_check_hostname': <true or false>,
                 },
             },
         }

--- a/test_app/tests/lib/redis/test_client.py
+++ b/test_app/tests/lib/redis/test_client.py
@@ -177,9 +177,16 @@ def test_redis_client_cluster_hosts_parsing(clustered_hosts, raises, expected_le
 
 
 def test_redis_client_read_files():
-    args = {'OPTIONS': {'CLIENT_CLASS_KWARGS': {'ssl_certfile': '/tmp/junk.does.not.exist'}}}
+    args = {'OPTIONS': {'CLIENT_CLASS_KWARGS': {'ssl_certfile': '/tmp/junk.does.not.exist', 'ssl': True}}}
     redis_cache = RedisCache('localhost', args)
     client = RedisClient('localhost', args, redis_cache)
     with pytest.raises(ImproperlyConfigured) as ic:
         client.connect()
         assert 'Unable to read file' in ic
+
+
+def test_redis_client_read_files_no_tls():
+    args = {'OPTIONS': {'CLIENT_CLASS_KWARGS': {'ssl_certfile': '/tmp/junk.does.not.exist'}}}
+    redis_cache = RedisCache('localhost', args)
+    client = RedisClient('localhost', args, redis_cache)
+    client.connect()


### PR DESCRIPTION
When we merged #391 we broke installations where `tls` was disabled but the related file settings for specifying cert/key/ca were still present.  These installations started failing with exceptions that the files were unreadable (which is technically accurate but not needed because tls isn't enabled).