### PR TITLE
Pin django-oauth-toolkit to 2.3.0

### DIFF
--- a/requirements/requirements_oauth2_provider.in
+++ b/requirements/requirements_oauth2_provider.in
@@ -1,1 +1,1 @@
-django-oauth-toolkit
+django-oauth-toolkit<2.4.0


### PR DESCRIPTION
django-oauth-toolkit released v2.4.0 on May 20th and introduced new db columns 

- `allowed_origins`
- `hash_client_secret`

which causes invalid SQL queries. 
For now let's set version to 2.3.0 (<2.4.0)