### PR TITLE
[oauth2] Add a general /tokens/ to user mixin

### DIFF
--- a/ansible_base/oauth2_provider/fixtures.py
+++ b/ansible_base/oauth2_provider/fixtures.py
@@ -15,6 +15,10 @@ __all__ = [  # noqa: F822, the additional _pat_X are unknown so we need this her
     'oauth2_user_pat_1',
     'oauth2_user_pat_2',
     'oauth2_user_pat_3',
+    'oauth2_user_application_token',
+    'oauth2_user_application_token_1',
+    'oauth2_user_application_token_2',
+    'oauth2_user_application_token_3',
 ]
 
 
@@ -73,4 +77,17 @@ def oauth2_user_pat(user, randname):
         # This has to be timezone aware
         expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
         token=generate_token(),
+    )[0]
+
+
+@copy_fixture(copies=3)
+@pytest.fixture
+def oauth2_user_application_token(user, randname, oauth2_application):
+    return OAuth2AccessToken.objects.get_or_create(
+        user=user,
+        description=randname("Application Access Token for 'user'"),
+        # This has to be timezone aware
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+        token=generate_token(),
+        application=oauth2_application[0],
     )[0]

--- a/test_app/router.py
+++ b/test_app/router.py
@@ -62,7 +62,6 @@ router.register(
     related_views={
         'organizations': (views.OrganizationViewSet, 'organizations'),
         'teams': (views.TeamViewSet, 'teams'),
-        'tokens': (oauth2_provider_views.OAuth2TokenViewSet, 'access_tokens'),
         'applications': (oauth2_provider_views.OAuth2ApplicationViewSet, 'applications'),
     },
     basename='user',

--- a/test_app/tests/oauth2_provider/views/test_token.py
+++ b/test_app/tests/oauth2_provider/views/test_token.py
@@ -406,3 +406,22 @@ def test_oauth2_refresh_token_expiration_is_respected(oauth2_application, oauth2
     assert OAuth2RefreshToken.objects.filter(token=refresh_token).exists()
     assert OAuth2AccessToken.objects.count() == 1
     assert OAuth2RefreshToken.objects.count() == 1
+
+
+def test_oauth2_tokens_list_for_user(
+    oauth2_user_pat,
+    oauth2_user_pat_1,
+    oauth2_user_application_token,
+    oauth2_user_application_token_1,
+    oauth2_user_application_token_2,
+    oauth2_user_application_token_3,
+    user,
+    admin_api_client,
+):
+    """
+    Tests that we can list a user's tokens via user endpoint.
+    """
+    url = reverse('user-tokens-list', kwargs={"pk": user.pk})
+    response = admin_api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data['results']) == 6


### PR DESCRIPTION
This provides a readonly endpoint to list both PATs and authorized tokens in the user mixin (usually /users/PK/tokens/), and an associated test.

Signed-off-by: Rick Elrod <rick@elrod.me>