### PR TITLE
Fix server error and prohibit team org member assignment

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -166,6 +166,7 @@ if 'ansible_base.rbac' in INSTALLED_APPS:
     # For assignments
     ANSIBLE_BASE_ALLOW_TEAM_PARENTS = True
     ANSIBLE_BASE_ALLOW_TEAM_ORG_PERMS = True
+    ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER = False
     ANSIBLE_BASE_ALLOW_TEAM_ORG_ADMIN = True
     # For role definitions
     ANSIBLE_BASE_ALLOW_CUSTOM_ROLES = True

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict
-from typing import Type, Union
+from typing import Type, Union, Optional
 
 from django.conf import settings
 from django.db.models import Model
@@ -145,7 +145,7 @@ def validate_codename_for_model(codename: str, model: Union[Model, Type[Model]])
     raise RuntimeError(f'The permission {name} is not valid for model {model._meta.model_name}')
 
 
-def validate_team_assignment_enabled(content_type: Model, has_team_perm: bool = False, has_org_member: bool = False) -> None:
+def validate_team_assignment_enabled(content_type: Optional[Model], has_team_perm: bool = False, has_org_member: bool = False) -> None:
     """Called in role assignment logic, inside RoleDefinition.give_permission
 
     Raises error if a setting disables the kind of permission being given.

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -79,7 +79,7 @@ def validate_role_definition_enabled(permissions, content_type) -> None:
                 raise ValidationError('Creating custom roles that include team permissions is disabled')
 
 
-def validate_permissions_for_model(permissions, content_type: Model, managed: bool = False) -> None:
+def validate_permissions_for_model(permissions, content_type: Optional[Model], managed: bool = False) -> None:
     """Validation for creating a RoleDefinition
 
     This is called by the RoleDefinitionSerializer so clients will get these errors.

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict
-from typing import Type, Union, Optional
+from typing import Optional, Type, Union
 
 from django.conf import settings
 from django.db.models import Model

--- a/test_app/tests/rbac/api/test_rbac_views.py
+++ b/test_app/tests/rbac/api/test_rbac_views.py
@@ -197,6 +197,14 @@ def test_remove_team_assignment(user_api_client, user, inv_rd, team, inventory):
 
 
 @pytest.mark.django_db
+def test_team_assignment_validation_error(admin_api_client, team, organization, org_member_rd):
+    url = reverse('roleteamassignment-list')
+    response = admin_api_client.post(url, data={'team': team.id, 'object_id': organization.id, 'role_definition': org_member_rd.id})
+    assert response.status_code == 400, response.data
+    assert 'Assigning organization member permission to teams is not allowed' in str(response.data)
+
+
+@pytest.mark.django_db
 def test_remove_user_assignment_with_global_role(user_api_client, user, inv_rd, global_inv_rd, rando, inventory):
     assignment = inv_rd.give_permission(rando, inventory)
     url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})


### PR DESCRIPTION
I am reminded that I vaguely remembered that I needed to add this restriction but never got to the point it was imminent. Now it is:

This prohibits (by default, at least) teams from being given the organization member permission. This is a little more gory than the other checks, which are generalized to a fault. But this relies on the existence of the Organization "member" permission, which DAB RBAC was reluctant to give any first-class treatment for up until now. So that's why it didn't happen before, and why the condition sucks a little bit.

The server error is from the "tracked_relationship" thing, which I am trying to delete as soon as I am able to. But for now, it was erroring when it tried to synchronize team role assignments to the organization users list. That's not a thing. Organization members are a collection of only the User type.

fixes:

```
TypeError: attribute name must be string, not 'NoneType'
2024-05-21 19:38:39,061 ERROR    django.request Internal Server Error: /api/v1/role_team_assignments/
Traceback (most recent call last):
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/viewsets.py", line 124, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/api/views.py", line 69, in perform_create
    return super().perform_create(serializer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/mixins.py", line 24, in perform_create
    serializer.save()
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/lib/serializers/validation.py", line 26, in save
    return super().save(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/serializers.py", line 208, in save
    self.instance = self.create(validated_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/api/serializers.py", line 274, in create
    assignment = rd.give_permission(actor, obj)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/models.py", line 187, in give_permission
    return self.give_or_remove_permission(actor, content_object, giving=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/models.py", line 253, in give_or_remove_permission
    tracker.sync_relationship(actor, content_object, giving=giving)
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/triggers.py", line 320, in sync_relationship
    manager = getattr(content_object, self.team_relationship)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: attribute name must be string, not 'NoneType'
```