### PR TITLE
disallow filtering by encrypted_fields

### DIFF
--- a/ansible_base/rest_filters/utils.py
+++ b/ansible_base/rest_filters/utils.py
@@ -42,8 +42,8 @@ def get_fields_from_path(model, path, treat_jsonfield_as_text=True):
         else:
             new_parts.append(name)
 
-        if name in getattr(model, 'PASSWORD_FIELDS', ()):
-            raise PermissionDenied(_('Filtering on password fields is not allowed.'))
+        if name in getattr(model, 'PASSWORD_FIELDS', ()) or name in getattr(model, 'encrypted_fields', ()):
+            raise PermissionDenied(_('Filtering on field %(name)s is not allowed.') % {'name': name})
         elif name == 'pk':
             field = model._meta.pk
         else:

--- a/test_app/tests/rest_filters/test_utils.py
+++ b/test_app/tests/rest_filters/test_utils.py
@@ -1,11 +1,20 @@
 import pytest
-from rest_framework.exceptions import ParseError
+from rest_framework.exceptions import ParseError, PermissionDenied
 
 from ansible_base.authentication.models import Authenticator
 from ansible_base.rest_filters.utils import get_field_from_path
+from test_app.models import EncryptionModel
 
 
 def test_invalid_field_hop():
     with pytest.raises(ParseError) as excinfo:
         get_field_from_path(Authenticator, 'created_by__last_name__user')
     assert 'No related model for' in str(excinfo)
+
+
+def test_invalid_field_filter():
+    test_field = EncryptionModel.encrypted_fields[0]
+    with pytest.raises(PermissionDenied) as excinfo:
+        get_field_from_path(EncryptionModel, test_field)
+
+    assert f"Filtering on field {test_field} is not allowed." in str(excinfo)


### PR DESCRIPTION
Raise a PermissionDenied exception when attempting to get encrypted fields via ansible_base.rest_filters.utils::get_field_from_path, so such requests get handled in the same way that attempting to filter by a password field does.

No-Issue