### PR TITLE
Tidying up system user and other functions

### DIFF
--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -2,8 +2,6 @@ import logging
 import threading
 from contextlib import contextmanager
 
-from ansible_base.lib.utils.models import current_user_or_system_user, diff
-
 logger = logging.getLogger('ansible_base.activitystream.signals')
 
 
@@ -33,6 +31,7 @@ def _store_activitystream_entry(old, new, operation):
         return
 
     from ansible_base.activitystream.models import Entry
+    from ansible_base.lib.utils.models import diff
 
     if operation not in ('create', 'update', 'delete'):
         raise ValueError("Invalid operation: {}".format(operation))
@@ -64,6 +63,7 @@ def _store_activitystream_m2m(given_instance, model, operation, pk_set, reverse,
         return
 
     from ansible_base.activitystream.models import Entry
+    from ansible_base.lib.utils.models import current_user_or_system_user
 
     if operation not in ('associate', 'disassociate'):
         raise ValueError("Invalid operation: {}".format(operation))

--- a/ansible_base/authentication/utils/user.py
+++ b/ansible_base/authentication/utils/user.py
@@ -12,11 +12,11 @@ def can_user_change_password(user: Optional[AbstractUser]) -> bool:
     See if the given user is allowed to change their password.
     True if they are authenticated from the `local` authenticator
     False otherwise.
-    SYSTEM_USER can never change their password
+    The system user can never change their password
     """
     if user is None or is_system_user(user):
-        # The system user can not change their password ever
-        # Or if we didn't actually get a user we can't say they can change their password
+        # If we didn't actually get a user we can't say they can change their password
+        # Or if we are the system user, we can not change our password ever
         return False
 
     auth_users = AuthenticatorUser.objects.filter(user=user)

--- a/ansible_base/lib/serializers/common.py
+++ b/ansible_base/lib/serializers/common.py
@@ -106,8 +106,7 @@ class ImmutableCommonModelSerializer(AbstractCommonModelSerializer):
 
 class CommonUserSerializer(CommonModelSerializer):
     """
-    Disallows editing of system user (settings.SYSTEM_USERNAME) and enforces
-    superuser requirement.
+    Disallows editing of system user and enforces superuser requirement.
     """
 
     def validate(self, data):

--- a/ansible_base/lib/testing/util.py
+++ b/ansible_base/lib/testing/util.py
@@ -22,17 +22,16 @@ def copy_fixture(copies=1):
 
 
 def delete_authenticator(authenticator):
-    from django.conf import settings
-
     from ansible_base.authentication.models import AuthenticatorUser
+    from ansible_base.lib.utils.models import get_system_username
 
     for au in AuthenticatorUser.objects.filter(provider=authenticator):
         try:
-            # The tests are very sensitive to the SYSTEM_USER being removed so we won't delete that user
-            if au.username != settings.SYSTEM_USERNAME:
+            # The tests are very sensitive to the system user being removed so we won't delete that user
+            if au.username != get_system_username[0]:
                 au.user.delete()
         except Exception:
-            # Its possible that something else already delete the user if a user was multi linked somehow
+            # Its possible that something else already deleted the user if a user was multi linked somehow
             pass
         au.delete()
     authenticator.delete()

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -13,6 +13,7 @@ from ansible_base.lib.utils.settings import get_setting
 from ansible_base.lib.utils.string import make_json_safe
 
 logger = logging.getLogger('ansible_base.lib.utils.models')
+_WARNED_ABOUT_SYSTEM_USER = False
 
 
 def get_all_field_names(model, concrete_only=False, include_attnames=True):
@@ -88,11 +89,13 @@ def is_system_user(user):
 
 
 def get_system_user():
+    global _WARNED_ABOUT_SYSTEM_USER
     system_user = None
     setting_name = 'SYSTEM_USERNAME'
     system_username = get_setting(setting_name)
     system_user = get_user_model().objects.filter(username=system_username).first()
-    if system_username is not None and system_user is None:
+    # We are using a global variable to try and track if this thread has already spit out the message, if so ignore
+    if system_username is not None and system_user is None and not _WARNED_ABOUT_SYSTEM_USER:
         logger.error(
             _(
                 "{setting_name} is set to {system_username} but no user with that username exists.".format(
@@ -100,6 +103,7 @@ def get_system_user():
                 )
             )
         )
+        _WARNED_ABOUT_SYSTEM_USER = True
     return system_user
 
 

--- a/test_app/authentication/service_token_auth.py
+++ b/test_app/authentication/service_token_auth.py
@@ -1,8 +1,8 @@
 import jwt
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
 
+from ansible_base.lib.utils.models import get_system_user
 from ansible_base.resource_registry.resource_server import get_resource_server_config
 
 User = get_user_model()
@@ -32,7 +32,7 @@ class ServiceTokenAuthentication(BaseAuthentication):
             if "sub" in data:
                 return (User.objects.get(resource__ansible_id=data["sub"]), None)
             else:
-                return (User.objects.get(username=settings.SYSTEM_USERNAME), None)
+                return (get_system_user(), None)
 
         except jwt.exceptions.PyJWTError as e:
             print(e)

--- a/test_app/migrations/0001_initial.py
+++ b/test_app/migrations/0001_initial.py
@@ -10,23 +10,6 @@ import django.db.models.deletion
 import django.utils.timezone
 
 
-def create_system_user(apps, schema_editor):
-    """
-    Create the system user using the username in settings.
-
-    The user is self-referential in its created_by and modified_by fields.
-    It is inactive, only used for attributing internal changes to the system.
-    """
-    User = apps.get_model(settings.AUTH_USER_MODEL)
-
-    system_username = settings.SYSTEM_USERNAME
-    if not User.objects.filter(username=system_username).exists():
-        system_user = User.objects.create(username=system_username, is_active=False)
-        system_user.created_by = system_user
-        system_user.modified_by = system_user
-        system_user.save()
-
-
 class Migration(migrations.Migration):
 
     initial = True
@@ -301,5 +284,4 @@ class Migration(migrations.Migration):
             },
             bases=('test_app.original2',),
         ),
-        migrations.RunPython(create_system_user),
     ]

--- a/test_app/tests/authentication/management/test_authenticators.py
+++ b/test_app/tests/authentication/management/test_authenticators.py
@@ -86,7 +86,7 @@ def test_authenticators_cli_initialize(django_user_model):
     err = StringIO()
 
     # Sanity check:
-    assert django_user_model.objects.count() == 1
+    assert django_user_model.objects.count() == 0
 
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         call_command('authenticators', "--initialize", stdout=out, stderr=err)

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -555,9 +555,11 @@ def mocked_http(test_encryption_public_key, jwt_token):
 
 
 @pytest.fixture
-def system_user(db, settings, no_log_messages):
+def system_user(db, no_log_messages):
     with no_log_messages():
-        user_obj, _created = models.User.objects.get_or_create(username=settings.SYSTEM_USERNAME)
+        from ansible_base.lib.utils.models import get_system_user
+
+        user_obj = get_system_user()
     yield user_obj
 
 

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -53,11 +53,11 @@ def test_save_attribution_with_system_username_set_but_nonexistent_as_false(syst
         organization.save()
 
     assert organization.created_by == system_user
-    assert organization.modified_by is None
+    assert organization.modified_by is None, "org modified by should have been none"
 
     organization.refresh_from_db()
     assert organization.created_by == system_user
-    assert organization.modified_by is None
+    assert organization.modified_by is None, "org modified by should have been none"
 
 
 @pytest.mark.django_db

--- a/test_app/tests/lib/utils/test_models.py
+++ b/test_app/tests/lib/utils/test_models.py
@@ -62,6 +62,8 @@ def test_system_user_set(system_user):
 def test_system_user_set_but_no_user(expected_log):
     system_username = 'LittleTimmy'
     with override_settings(SYSTEM_USERNAME=system_username):
+        global _WARNED_ABOUT_SYSTEM_USER
+        _WARNED_ABOUT_SYSTEM_USER = False
         expected_log = partial(expected_log, "ansible_base.lib.utils.models.logger")
         with expected_log('error', f'is set to {system_username} but no user with that username exists'):
             assert models.get_system_user() is None

--- a/test_app/tests/lib/utils/test_models.py
+++ b/test_app/tests/lib/utils/test_models.py
@@ -62,11 +62,10 @@ def test_system_user_set(system_user):
 def test_system_user_set_but_no_user(expected_log):
     system_username = 'LittleTimmy'
     with override_settings(SYSTEM_USERNAME=system_username):
-        global _WARNED_ABOUT_SYSTEM_USER
-        _WARNED_ABOUT_SYSTEM_USER = False
         expected_log = partial(expected_log, "ansible_base.lib.utils.models.logger")
         with expected_log('error', f'is set to {system_username} but no user with that username exists'):
-            assert models.get_system_user() is None
+            with expected_log('info', 'Created system user'):
+                assert models.get_system_user() is not None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Modify create_dab_permissions to return a boolean
Create a _WARNED_ABOUT_SYSTEM_USER and only show the SYSTEM_USERNAME is defined but no user matches once per thread based on the variable.
Alter `get_system_user` to create the `system_user` if its missing.
Refactor the system user functions.
Make sure the system_user functions are used globally instead of people referencing the SYSTEM_USER setting or getting the system user directly. 