### PR TITLE
Use dynamic docstrings for sublists

### DIFF
--- a/test_app/tests/lib/routers/test_association_resoure_router.py
+++ b/test_app/tests/lib/routers/test_association_resoure_router.py
@@ -267,6 +267,22 @@ def test_related_custom_actions_get_scrubed(organization, method, admin_api_clie
     assert response.status_code == 404
 
 
+def test_associated_view_description(admin_api_client, organization):
+    Cow.objects.create(organization=organization)
+    url = reverse('organization-cows-list', kwargs={'pk': organization.id})
+    response = admin_api_client.options(url)
+    assert response.status_code == 200, response.data
+    assert 'GET /:id/cows/ to show cows currently in the relationship' in response.data.get('description', '')
+    assert 'POST' not in response.data.get('description', '')
+
+
+def test_associated_modifications_description(admin_api_client, organization):
+    url = reverse('organization-users-list', kwargs={'pk': organization.id})
+    response = admin_api_client.options(url)
+    assert response.status_code == 200, response.data
+    assert 'POST a list of instances to /:id/users/associate/ to add those users to the relationship' in response.data.get('description', '')
+
+
 def test_autogen_viewset_attributes():
     sublist_viewset = None
     for url, viewset, view_name in router.registry:


### PR DESCRIPTION
Previously the `associate` and `disassociate` docstring was getting rendered in the "description" of OPTIONS and in the browsable API. It wasn't _the worst_ in terms of documentation, but it was a little awkward and out-of-place.

Result of this patch:

![Screenshot from 2024-05-28 15-06-10](https://github.com/ansible/django-ansible-base/assets/1385596/e4277dbb-8c34-400d-8a4b-a0f6ffae487e)

You'll see this in the code, but if it's read-only, and only shows list, the POST options won't be included. This doesn't give specific docstrings for each endpoint, because I think the bigger picture is more important for usability here.