### PR TITLE
oauth2_provider: support adding, removing, clearing tokens

### DIFF
--- a/ansible_base/oauth2_provider/management/commands/cleanup_tokens.py
+++ b/ansible_base/oauth2_provider/management/commands/cleanup_tokens.py
@@ -1,0 +1,27 @@
+import logging
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2RefreshToken
+
+
+class Command(BaseCommand):
+    def init_logging(self):
+        log_levels = dict(enumerate([logging.ERROR, logging.INFO, logging.DEBUG, 0]))
+        self.logger = logging.getLogger('ansible_base.oauth2_provider.commands.cleanup_tokens')
+        self.logger.setLevel(log_levels.get(self.verbosity, 0))
+        handler = logging.StreamHandler(stream=self.stream)
+        handler.setFormatter(logging.Formatter('%(message)s'))
+        self.logger.addHandler(handler)
+        self.logger.propagate = False
+
+    def execute(self, *args, **options):
+        self.verbosity = int(options.get('verbosity', 1))
+        self.stream = options.get('stderr')
+        self.init_logging()
+        total_accesstokens = OAuth2AccessToken.objects.all().count()
+        total_refreshtokens = OAuth2RefreshToken.objects.all().count()
+        call_command("cleartokens")
+        self.logger.info("Expired OAuth 2 Access Tokens deleted: {}".format(total_accesstokens - OAuth2AccessToken.objects.all().count()))
+        self.logger.info("Expired OAuth 2 Refresh Tokens deleted: {}".format(total_refreshtokens - OAuth2RefreshToken.objects.all().count()))

--- a/ansible_base/oauth2_provider/management/commands/create_oauth2_token.py
+++ b/ansible_base/oauth2_provider/management/commands/create_oauth2_token.py
@@ -1,0 +1,35 @@
+# Django
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand, CommandError
+
+from ansible_base.oauth2_provider.serializers import OAuth2TokenSerializer
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """Command that creates an OAuth2 token for a certain user. Returns the value of created token."""
+
+    help = 'Creates an OAuth2 token for a user.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--user', dest='user', type=str)
+
+    def handle(self, *args, **options):
+        if not options['user']:
+            raise CommandError('Username not supplied. Usage: create_oauth2_token --user=username.')
+        try:
+            user = User.objects.get(username=options['user'])
+        except ObjectDoesNotExist:
+            raise CommandError('The user does not exist.')
+        config = {'user': user, 'scope': 'write'}
+        serializer_obj = OAuth2TokenSerializer()
+
+        class FakeRequest(object):
+            def __init__(self):
+                self.user = user
+
+        serializer_obj.context['request'] = FakeRequest()
+        token_record = serializer_obj.create(config)
+        self.stdout.write(token_record.token)

--- a/ansible_base/oauth2_provider/management/commands/revoke_oauth2_tokens.py
+++ b/ansible_base/oauth2_provider/management/commands/revoke_oauth2_tokens.py
@@ -1,0 +1,38 @@
+# Django
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand, CommandError
+
+from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2RefreshToken
+
+User = get_user_model()
+
+
+def revoke_tokens(token_list):
+    for token in token_list:
+        token.revoke()
+        print('revoked {} {}'.format(token.__class__.__name__, token.token))
+
+
+class Command(BaseCommand):
+    """Command that revokes OAuth2 access tokens."""
+
+    help = 'Revokes OAuth2 access tokens.  Use --all to revoke access and refresh tokens.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--user', dest='user', type=str, help='revoke OAuth2 tokens for a specific username')
+        parser.add_argument('--all', dest='all', action='store_true', help='revoke OAuth2 access tokens and refresh tokens')
+
+    def handle(self, *args, **options):
+        if not options['user']:
+            if options['all']:
+                revoke_tokens(OAuth2RefreshToken.objects.filter(revoked=None))
+            revoke_tokens(OAuth2AccessToken.objects.all())
+        else:
+            try:
+                user = User.objects.get(username=options['user'])
+            except ObjectDoesNotExist:
+                raise CommandError('A user with that username does not exist.')
+            if options['all']:
+                revoke_tokens(OAuth2RefreshToken.objects.filter(revoked=None).filter(user=user))
+            revoke_tokens(OAuth2AccessToken.objects.filter(user=user))

--- a/test_app/tests/oauth2_provider/management/commands/test_cleanup_tokens.py
+++ b/test_app/tests/oauth2_provider/management/commands/test_cleanup_tokens.py
@@ -1,0 +1,41 @@
+# Python
+import datetime
+from io import StringIO
+
+import pytest
+
+# Django
+from django.core.management import call_command
+
+from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2RefreshToken
+
+
+def attempt_cleanup(expected_access_tokens_deleted, expected_refresh_tokens_deleted):
+    with StringIO() as out, StringIO() as err:
+        current_access_tokens = OAuth2AccessToken.objects.count()
+        current_refresh_tokens = OAuth2RefreshToken.objects.count()
+
+        call_command("cleanup_tokens", verbosity=1, stdout=out, stderr=err)
+
+        err_lines = err.getvalue().split("\n")
+
+        assert f"Expired OAuth 2 Access Tokens deleted: {expected_access_tokens_deleted}" in err_lines
+        assert f"Expired OAuth 2 Refresh Tokens deleted: {expected_refresh_tokens_deleted}" in err_lines
+
+        assert OAuth2AccessToken.objects.count() == current_access_tokens - expected_access_tokens_deleted
+        assert OAuth2RefreshToken.objects.count() == current_refresh_tokens - expected_refresh_tokens_deleted
+
+
+@pytest.mark.django_db
+class TestCleanupTokensCommand:
+    def test_cleanup_expired_tokens(self, oauth2_admin_access_token):
+        assert OAuth2AccessToken.objects.count() == 1
+        assert OAuth2RefreshToken.objects.count() == 1
+
+        attempt_cleanup(0, 0)
+
+        # Manually expire admin token
+        oauth2_admin_access_token.expires = datetime.datetime.fromtimestamp(0)
+        oauth2_admin_access_token.save()
+
+        attempt_cleanup(1, 1)

--- a/test_app/tests/oauth2_provider/management/commands/test_create_oauth2_token.py
+++ b/test_app/tests/oauth2_provider/management/commands/test_create_oauth2_token.py
@@ -1,0 +1,44 @@
+# Python
+import random
+import string
+from io import StringIO
+
+import pytest
+
+# Django
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from ansible_base.oauth2_provider.models import OAuth2AccessToken
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestOAuth2CreateCommand:
+    def test_no_user_option(self):
+        with StringIO() as out:
+            out = StringIO()
+            with pytest.raises(CommandError) as excinfo:
+                call_command('create_oauth2_token', stdout=out)
+            assert 'Username not supplied.' in str(excinfo.value)
+
+    def test_non_existing_user(self):
+        with StringIO() as out:
+            fake_username = ''
+            while fake_username == '' or User.objects.filter(username=fake_username).exists():
+                fake_username = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))
+            arg = '--user=' + fake_username
+            with pytest.raises(CommandError) as excinfo:
+                call_command('create_oauth2_token', arg, stdout=out)
+            assert 'The user does not exist.' in str(excinfo.value)
+
+    def test_correct_user(self, random_user):
+        user_username = random_user.username
+        with StringIO() as out:
+            arg = '--user=' + user_username
+            call_command('create_oauth2_token', arg, stdout=out)
+            generated_token = out.getvalue().strip()
+            assert OAuth2AccessToken.objects.filter(user=random_user, token=generated_token).count() == 1
+            assert OAuth2AccessToken.objects.get(user=random_user, token=generated_token).scope == 'write'

--- a/test_app/tests/oauth2_provider/management/commands/test_revoke_oauth2_tokens.py
+++ b/test_app/tests/oauth2_provider/management/commands/test_revoke_oauth2_tokens.py
@@ -1,0 +1,69 @@
+# Python
+import datetime
+from io import StringIO
+
+import pytest
+
+# Django
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2RefreshToken
+
+
+@pytest.mark.django_db
+class TestOAuth2RevokeCommand:
+    def test_non_existing_user(self, randname):
+        with StringIO() as out:
+            fake_username = randname("user")
+            arg = '--user=' + fake_username
+            with pytest.raises(CommandError) as excinfo:
+                call_command('revoke_oauth2_tokens', arg, stdout=out)
+            assert 'A user with that username does not exist' in str(excinfo.value)
+
+    def test_revoke_all_access_tokens(self, oauth2_admin_access_token, oauth2_user_application_token):
+        with StringIO() as out:
+            assert OAuth2AccessToken.objects.count() == 2
+            call_command('revoke_oauth2_tokens', stdout=out)
+            assert OAuth2AccessToken.objects.count() == 0
+
+    def test_revoke_access_token_for_user(self, oauth2_admin_access_token, oauth2_user_application_token):
+        with StringIO() as out:
+            admin_username = oauth2_admin_access_token.user.username
+            user_username = oauth2_user_application_token.user.username
+
+            assert OAuth2AccessToken.objects.count() == 2
+            assert OAuth2RefreshToken.objects.count() == 1
+            for r in OAuth2RefreshToken.objects.all():
+                assert r.revoked is None
+
+            call_command('revoke_oauth2_tokens', f'--user={admin_username}', stdout=out)
+            assert OAuth2AccessToken.objects.count() == 1
+            for r in OAuth2RefreshToken.objects.all():
+                assert r.revoked is None
+
+            call_command('revoke_oauth2_tokens', f'--user={admin_username}', "--all", stdout=out)
+            assert OAuth2AccessToken.objects.count() == 1
+            for r in OAuth2RefreshToken.objects.all():
+                assert r.revoked is not None
+                assert isinstance(r.revoked, datetime.datetime)
+
+            call_command('revoke_oauth2_tokens', f'--user={user_username}', stdout=out)
+            assert OAuth2AccessToken.objects.count() == 0
+
+    def test_revoke_all_refresh_tokens(self, oauth2_admin_access_token):
+        with StringIO() as out:
+            assert OAuth2AccessToken.objects.count() == 1
+            assert OAuth2RefreshToken.objects.count() == 1
+
+            call_command('revoke_oauth2_tokens', stdout=out)
+            assert OAuth2AccessToken.objects.count() == 0
+            assert OAuth2RefreshToken.objects.count() == 1
+            for r in OAuth2RefreshToken.objects.all():
+                assert r.revoked is None
+
+            call_command('revoke_oauth2_tokens', '--all', stdout=out)
+            assert OAuth2RefreshToken.objects.count() == 1
+            for r in OAuth2RefreshToken.objects.all():
+                assert r.revoked is not None
+                assert isinstance(r.revoked, datetime.datetime)


### PR DESCRIPTION
Add support for the django-admin commands: create_oauth2_token, revoke_oauth2_tokens, cleanup_tokens.

Fixes: [AAP-18812](https://issues.redhat.com/browse/AAP-18812)