### PR TITLE
Introduce caching utility for lazy managed role references

### DIFF
--- a/test_app/management/commands/create_demo_data.py
+++ b/test_app/management/commands/create_demo_data.py
@@ -7,7 +7,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
-from ansible_base.authentication.utils.claims import ReconcileUser
 from ansible_base.oauth2_provider.models import OAuth2Application
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.validators import combine_values, permissions_allowed_for_role
@@ -87,13 +86,14 @@ class Command(BaseCommand):
 
         # NOTE: managed role definitions are turned off, you could turn them on and get rid of these
         org_perms = combine_values(permissions_allowed_for_role(Organization))
+        role_manager = type(RoleDefinition.objects.managed)
         org_admin, _ = RoleDefinition.objects.get_or_create(
-            name=ReconcileUser.ORGANIZATION_ADMIN_ROLE_NAME,
+            name=role_manager.org_admin.role_name,
             permissions=org_perms,
             defaults={'content_type': ContentType.objects.get_for_model(Organization), 'managed': True},
         )
         RoleDefinition.objects.get_or_create(
-            name=ReconcileUser.ORGANIZATION_MEMBER_ROLE_NAME,
+            name=role_manager.org_member.role_name,
             permissions=['member_organization', 'view_organization'],
             defaults={'content_type': ContentType.objects.get_for_model(Organization), 'managed': True},
         )
@@ -104,12 +104,12 @@ class Command(BaseCommand):
         )
         team_perms = combine_values(permissions_allowed_for_role(Team))
         RoleDefinition.objects.get_or_create(
-            name=ReconcileUser.TEAM_ADMIN_ROLE_NAME,
+            name=role_manager.team_admin.role_name,
             permissions=team_perms,
             defaults={'content_type': ContentType.objects.get_for_model(Team), 'managed': True},
         )
         team_member, _ = RoleDefinition.objects.get_or_create(
-            name=ReconcileUser.TEAM_MEMBER_ROLE_NAME,
+            name=role_manager.team_member.role_name,
             permissions=['view_team', 'member_team'],
             defaults={'content_type': ContentType.objects.get_for_model(Team), 'managed': True},
         )

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -615,6 +615,7 @@ role_manager = type(RoleDefinition.objects.managed)
 def org_admin_rd():
     """Give all permissions possible for an organization"""
     perm_list = combine_values(permissions_allowed_for_role(models.Organization))
+    RoleDefinition.objects.managed.clear()
     return RoleDefinition.objects.create_from_permissions(
         permissions=perm_list,
         name=role_manager.org_admin.role_name,
@@ -625,6 +626,7 @@ def org_admin_rd():
 
 @pytest.fixture
 def org_member_rd():
+    RoleDefinition.objects.managed.clear()
     return RoleDefinition.objects.create_from_permissions(
         permissions=['view_organization', 'member_organization'],
         name=role_manager.org_member.role_name,
@@ -636,6 +638,7 @@ def org_member_rd():
 @pytest.fixture
 def member_rd():
     "Member role for a team, place in root conftest because it is needed for the team users tracked relationship"
+    RoleDefinition.objects.managed.clear()
     return RoleDefinition.objects.create_from_permissions(
         permissions=[permission_registry.team_permission, f'view_{permission_registry.team_model._meta.model_name}'],
         name=role_manager.team_member.role_name,
@@ -647,6 +650,7 @@ def member_rd():
 @pytest.fixture
 def admin_rd():
     "Member role for a team, place in root conftest because it is needed for the team users tracked relationship"
+    RoleDefinition.objects.managed.clear()
     return RoleDefinition.objects.create_from_permissions(
         permissions=[
             permission_registry.team_permission,

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -18,7 +18,6 @@ from drf_spectacular.generators import SchemaGenerator
 from rest_framework.request import Request
 from rest_framework.test import force_authenticate
 
-from ansible_base.authentication.utils.claims import ReconcileUser
 from ansible_base.lib.testing.fixtures import *  # noqa: F403, F401
 from ansible_base.lib.testing.util import copy_fixture, delete_authenticator
 from ansible_base.oauth2_provider.fixtures import *  # noqa: F403, F401
@@ -609,13 +608,16 @@ def disable_activity_stream():
         yield
 
 
+role_manager = type(RoleDefinition.objects.managed)
+
+
 @pytest.fixture
 def org_admin_rd():
     """Give all permissions possible for an organization"""
     perm_list = combine_values(permissions_allowed_for_role(models.Organization))
     return RoleDefinition.objects.create_from_permissions(
         permissions=perm_list,
-        name=ReconcileUser.ORGANIZATION_ADMIN_ROLE_NAME,
+        name=role_manager.org_admin.role_name,
         content_type=permission_registry.content_type_model.objects.get_for_model(models.Organization),
         managed=True,
     )
@@ -625,7 +627,7 @@ def org_admin_rd():
 def org_member_rd():
     return RoleDefinition.objects.create_from_permissions(
         permissions=['view_organization', 'member_organization'],
-        name=ReconcileUser.ORGANIZATION_MEMBER_ROLE_NAME,
+        name=role_manager.org_member.role_name,
         content_type=permission_registry.content_type_model.objects.get_for_model(models.Organization),
         managed=True,
     )
@@ -636,7 +638,7 @@ def member_rd():
     "Member role for a team, place in root conftest because it is needed for the team users tracked relationship"
     return RoleDefinition.objects.create_from_permissions(
         permissions=[permission_registry.team_permission, f'view_{permission_registry.team_model._meta.model_name}'],
-        name=ReconcileUser.TEAM_MEMBER_ROLE_NAME,
+        name=role_manager.team_member.role_name,
         content_type=permission_registry.content_type_model.objects.get_for_model(permission_registry.team_model),
         managed=True,
     )
@@ -651,7 +653,7 @@ def admin_rd():
             f'view_{permission_registry.team_model._meta.model_name}',
             f'change_{permission_registry.team_model._meta.model_name}',
         ],
-        name=ReconcileUser.TEAM_ADMIN_ROLE_NAME,
+        name=role_manager.team_admin.role_name,
         content_type=permission_registry.content_type_model.objects.get_for_model(permission_registry.team_model),
         managed=True,
     )

--- a/test_app/tests/rbac/test_validators.py
+++ b/test_app/tests/rbac/test_validators.py
@@ -3,7 +3,6 @@ from django.test.utils import override_settings
 from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
 
-from ansible_base.authentication.utils.claims import ReconcileUser
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
 from test_app.models import Inventory, Organization

--- a/test_app/tests/rbac/test_validators.py
+++ b/test_app/tests/rbac/test_validators.py
@@ -89,7 +89,7 @@ class TestProhibitedRoleDefinitions:
         )
         with pytest.raises(ValidationError) as exc:
             RoleDefinition.objects.create_from_permissions(
-                name=ReconcileUser.TEAM_MEMBER_ROLE_NAME,
+                name=type(RoleDefinition.objects.managed).team_member.role_name,
                 permissions=['member_team', 'view_team'],
                 content_type=permission_registry.content_type_model.objects.get_for_model(permission_registry.team_model),
             )


### PR DESCRIPTION
This is a baby-step in the direction I want to go for defining managed RoleDefinitions (or at least some of them in DAB), but for now, this removes the error seen in test logs:

```
INFO     ansible_base.authentication.utils.claims:claims.py:368 Reconciling user claims
ERROR    ansible_base.authentication.utils.claims:claims.py:275 Failed to reconcile user claims: RoleDefinition matching query does not exist.
Traceback (most recent call last):
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/authentication/utils/claims.py", line 273, in update_user_claims
    reconcile_user_class.reconcile_user_claims(user, authenticator_user)
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/authentication/utils/claims.py", line 371, in reconcile_user_claims
    org_member_rd = RoleDefinition.objects.get(name=cls.ORGANIZATION_MEMBER_ROLE_NAME)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/models/query.py", line 637, in get
    raise self.model.DoesNotExist(
ansible_base.rbac.models.RoleDefinition.DoesNotExist: RoleDefinition matching query does not exist.
```

I really don't want to require that each `RoleDefinition` exists to be able to use basic authentication. If you get a _claim_ for a role definition that doesn't exist, yeah, that'll be a problem. But if there are no claims to a `RoleDefinition` that doesn't exist, I really don't want to do anything about that. The tests via test_app won't have these role definitions loaded, and I don't want to change that.