### PR TITLE
fix: Do not convert jwt_user_id from None to str

### DIFF
--- a/ansible_base/resource_registry/rest_client.py
+++ b/ansible_base/resource_registry/rest_client.py
@@ -56,11 +56,13 @@ class ResourceAPIClient:
         jwt_user_id (UUID): ansible ID of the user to make the request as.
         jwt_expiration (int): number of seconds that the JWT token is valid.
         """
+        if jwt_user_id is not None:
+            jwt_user_id = str(jwt_user_id)
 
         self.base_url = f"{service_url}/{service_path.strip('/')}/"
         self.verify_https = verify_https
         self.raise_if_bad_request = raise_if_bad_request
-        self.jwt_user_id = str(jwt_user_id)
+        self.jwt_user_id = jwt_user_id
         self.jwt_expiration = jwt_expiration
         self._jwt = None
         self._jwt_timeout = None


### PR DESCRIPTION
When jwt_user_id is not informed the default `None` is being converted to `"None"` and ends up being wrong on the JWT `sub`.

Example: https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmN2U5ZDdmZC05MTM1LTRhNzQtODk1Yy1hNDY5OWJmMjA3YjQiLCJzdWIiOiJOb25lIiwiZXhwIjoxNzE3NzAwNzQ4fQ.gv-u5FpSeUVWvS_sS20Y5WnVegrbSRFDSkYpVqmPqKs 

If the sub value is None, the data must be set as `null`