### PR TITLE
fix: make RESOURCE_JWT_USER_ID and RESOURCE_SERVICE_PATH optional.

### DIFF
--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -65,11 +65,12 @@ class SyncResult:
 
 def create_api_client() -> ResourceAPIClient:
     """Factory for pre-configured ResourceAPIClient."""
-    client = get_resource_server_client(
-        jwt_user_id=settings.RESOURCE_JWT_USER_ID,
-        service_path=settings.RESOURCE_SERVICE_PATH,
-        raise_if_bad_request=False,
-    )
+    params = {"raise_if_bad_request": False, "service_path": "/api/gateway/v1/service-index/"}
+    if jwt_user_id := getattr(settings, "RESOURCE_JWT_USER_ID", None):
+        params["jwt_user_id"] = jwt_user_id
+    if service_path := getattr(settings, "RESOURCE_SERVICE_PATH", None):
+        params["service_path"] = service_path
+    client = get_resource_server_client(**params)
     return client
 
 

--- a/docs/apps/resource_registry.md
+++ b/docs/apps/resource_registry.md
@@ -346,11 +346,14 @@ to `SyncExecutor` or automatically created based on the configuration from
 the `django.conf.settings` that looks like.
 
 ```python
+# Required
 RESOURCE_SERVER = {
     "URL": "https://localhost",
     "SECRET_KEY": "<VERY-SECRET-KEY-HERE>",
     "VALIDATE_HTTPS": False,
 }
+
+# Optional
 RESOURCE_JWT_USER_ID = "97447387-8596-404f-b0d0-6429b04c8d22"
 RESOURCE_SERVICE_PATH = "/api/server/v1/service-index/"
 ```

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -32,12 +32,6 @@ def stdout():
     return Stdout()
 
 
-def test_config_is_required():
-    with pytest.raises(AttributeError) as exc:
-        SyncExecutor()
-    assert "'Settings' object has no attribute 'RESOURCE_JWT_USER_ID'" in str(exc)
-
-
 def test_manifest_not_found(static_api_client, stdout):
     executor = SyncExecutor(api_client=static_api_client, resource_type_names=["shared.team"], stdout=stdout)
     executor.run()


### PR DESCRIPTION
When running the sync command user_id can be omited to assume _system user.