### PR TITLE
Add handling for jwt enc OIDC user info

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/keycloak.py
+++ b/ansible_base/authentication/authenticator_plugins/keycloak.py
@@ -31,7 +31,7 @@ class KeycloakConfiguration(BaseAuthenticatorConfiguration):
         ui_field_label=_('Keycloak OIDC Key'),
     )
     PUBLIC_KEY = CharField(
-        help_text=_("RS256 public key provided by your Keycloak ream."),
+        help_text=_("RS256 public key provided by your Keycloak realm."),
         allow_null=False,
         ui_field_label=_('Keycloak Public Key'),
     )

--- a/ansible_base/authentication/authenticator_plugins/keycloak.py
+++ b/ansible_base/authentication/authenticator_plugins/keycloak.py
@@ -31,7 +31,7 @@ class KeycloakConfiguration(BaseAuthenticatorConfiguration):
         ui_field_label=_('Keycloak OIDC Key'),
     )
     PUBLIC_KEY = CharField(
-        help_text=_("RS256 public key provided by your Keycloak realm."),
+        help_text=_("RS256 public key provided by your Keycloak ream."),
         allow_null=False,
         ui_field_label=_('Keycloak Public Key'),
     )

--- a/ansible_base/authentication/authenticator_plugins/oidc.py
+++ b/ansible_base/authentication/authenticator_plugins/oidc.py
@@ -253,6 +253,7 @@ class AuthenticatorPlugin(SocialAuthMixin, OpenIdConnectAuth, AbstractAuthentica
         """
         user_data = self.request(self.userinfo_url(), headers={"Authorization": f"Bearer {access_token}"})
         if user_data.headers["Content-Type"] == "application/jwt":
+            # If the content type is application/jwt than we can assume that the token is encrypted. Otherwise it should be application/json
             pubkey = self.public_key()
             if not pubkey:
                 logger.error(_("OIDC client sent encrypted user info response, but no public key found."))

--- a/ansible_base/authentication/authenticator_plugins/oidc.py
+++ b/ansible_base/authentication/authenticator_plugins/oidc.py
@@ -226,13 +226,17 @@ class AuthenticatorPlugin(SocialAuthMixin, OpenIdConnectAuth, AbstractAuthentica
 
     def public_key(self):
         key = self.setting("PUBLIC_KEY")
-        return "\n".join(
-            [
-                "-----BEGIN PUBLIC KEY-----",
-                key,
-                "-----END PUBLIC KEY-----",
-            ]
-        ) if key else None
+        return (
+            "\n".join(
+                [
+                    "-----BEGIN PUBLIC KEY-----",
+                    key,
+                    "-----END PUBLIC KEY-----",
+                ]
+            )
+            if key
+            else None
+        )
 
     def user_data(self, access_token, *args, **kwargs):
         user_data = self.request(self.userinfo_url(), headers={"Authorization": f"Bearer {access_token}"})

--- a/ansible_base/authentication/authenticator_plugins/oidc.py
+++ b/ansible_base/authentication/authenticator_plugins/oidc.py
@@ -1,4 +1,3 @@
-import http
 import logging
 
 import jwt


### PR DESCRIPTION
For blocker bug related to failure to decode jwt encoded OIDC user info response.  This attempts to decode it using JWT specified algorithms and public key.
