### PR TITLE
Avoid import from resource_registry at top of file

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -185,11 +185,11 @@ class JWTCommonAuth:
         If this is the name of a managed role for which we have a corresponding definition in code,
         and that role can not be found in the database, it may be created here
         """
-        from ansible_base.rbac.models import RoleDefinition
+        role_definition_cls = apps.get_model('dab_rbac', 'RoleDefinition')
 
         try:
-            return RoleDefinition.objects.get(name=name)
-        except RoleDefinition.DoesNotExist:
+            return role_definition_cls.objects.get(name=name)
+        except role_definition_cls.DoesNotExist:
             from ansible_base.rbac.permission_registry import permission_registry
 
             constructor = permission_registry.get_managed_role_constructor_by_name(name)
@@ -238,12 +238,14 @@ class JWTCommonAuth:
 
         This can only build or get organizations or teams
         """
+        resource_cls = apps.get_model('dab_resource_registry', 'Resource')
+
         object_ansible_id = data['ansible_id']
         try:
-            resource = Resource.objects.get(ansible_id=object_ansible_id)
+            resource = resource_cls.objects.get(ansible_id=object_ansible_id)
             logger.debug(f"Resource {object_ansible_id} already exists")
             return resource, resource.content_object
-        except Resource.DoesNotExist:
+        except resource_cls.DoesNotExist:
             pass
 
         # The resource was missing so we need to create its stub

--- a/ansible_base/jwt_consumer/hub/auth.py
+++ b/ansible_base/jwt_consumer/hub/auth.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication
@@ -25,9 +26,11 @@ class HubJWTAuth(JWTAuthentication):
                 for object_index in self.common_auth.token['object_roles'][role_name]['objects']:
                     team_data = self.common_auth.token['objects']['team'][object_index]
                     ansible_id = team_data['ansible_id']
+                    resource_cls = apps.get_model('dab_resource_registry', 'Resource')
+
                     try:
-                        resource = Resource.objects.get(ansible_id=ansible_id)
-                    except Resource.DoesNotExist:
+                        resource = resource_cls.objects.get(ansible_id=ansible_id)
+                    except resource_cls.DoesNotExist:
                         try:
                             resource = self.get_or_create_resource('team', team_data)
                         except Exception as e:

--- a/ansible_base/jwt_consumer/hub/auth.py
+++ b/ansible_base/jwt_consumer/hub/auth.py
@@ -25,11 +25,9 @@ class HubJWTAuth(JWTAuthentication):
                 for object_index in self.common_auth.token['object_roles'][role_name]['objects']:
                     team_data = self.common_auth.token['objects']['team'][object_index]
                     ansible_id = team_data['ansible_id']
-                    resource_cls = apps.get_model('dab_resource_registry', 'Resource')
-
                     try:
-                        resource = resource_cls.objects.get(ansible_id=ansible_id)
-                    except resource_cls.DoesNotExist:
+                        resource = self.resource_cls.objects.get(ansible_id=ansible_id)
+                    except self.resource_cls.DoesNotExist:
                         try:
                             resource = self.get_or_create_resource('team', team_data)
                         except Exception as e:

--- a/ansible_base/jwt_consumer/hub/auth.py
+++ b/ansible_base/jwt_consumer/hub/auth.py
@@ -25,9 +25,10 @@ class HubJWTAuth(JWTAuthentication):
                 for object_index in self.common_auth.token['object_roles'][role_name]['objects']:
                     team_data = self.common_auth.token['objects']['team'][object_index]
                     ansible_id = team_data['ansible_id']
+                    resource_cls = apps.get_model('dab_resource_registry', 'Resource')
                     try:
-                        resource = self.resource_cls.objects.get(ansible_id=ansible_id)
-                    except self.resource_cls.DoesNotExist:
+                        resource = resource_cls.objects.get(ansible_id=ansible_id)
+                    except resource_cls.DoesNotExist:
                         try:
                             resource = self.get_or_create_resource('team', team_data)
                         except Exception as e:

--- a/ansible_base/jwt_consumer/hub/auth.py
+++ b/ansible_base/jwt_consumer/hub/auth.py
@@ -5,7 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 from ansible_base.jwt_consumer.common.exceptions import InvalidService
-from ansible_base.resource_registry.models import Resource
 
 logger = logging.getLogger('ansible_base.jwt_consumer.hub.auth')
 


### PR DESCRIPTION
I saw an issue about this, and since I had just done a similar solution for DAB RBAC I wanted to just go in and try to make it look more standard.

For the root problem, I might need some help understanding how galaxy_ng feature flags work.

https://github.com/ansible/galaxy_ng/blob/2f19483e1a7564afece88557833119969e255857/galaxy_ng/app/dynaconf_hooks.py#L67

This linked code sure strongly suggests that, in some cases, the resource_registry app might not be installed. If that's the case, then this would likely be the right kind of fix.