### PR TITLE
Social Auth reflects Authentication maps

### DIFF
--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -27,6 +27,7 @@ def get_authentication_backends(last_updated):
 
 class AnsibleBaseAuth(ModelBackend):
     def authenticate(self, request, *args, **kwargs):
+        from ansible_base.authentication.social_auth import SOCIAL_AUTH_PIPELINE_FAILED_STATUS
         logger.debug("Starting AnsibleBaseAuth authentication")
 
         # Query the database for the most recently last modified timestamp.
@@ -36,6 +37,11 @@ class AnsibleBaseAuth(ModelBackend):
 
         for authenticator_id, authenticator_object in get_authentication_backends(last_modified).items():
             user = authenticator_object.authenticate(request, *args, **kwargs)
+
+            # Social Auth pipeline can return False when update_user_claims fails (authentication maps deny access)
+            if user == SOCIAL_AUTH_PIPELINE_FAILED_STATUS:
+                continue
+
             if user:
                 # The local authenticator handles this but we want to check this for other authentication types
                 if not getattr(user, 'is_active', True):
@@ -46,5 +52,4 @@ class AnsibleBaseAuth(ModelBackend):
 
                 logger.info(f'User {user.username} logged in from authenticator with ID "{authenticator_id}"')
                 return user
-
         return None

--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -28,6 +28,7 @@ def get_authentication_backends(last_updated):
 class AnsibleBaseAuth(ModelBackend):
     def authenticate(self, request, *args, **kwargs):
         from ansible_base.authentication.social_auth import SOCIAL_AUTH_PIPELINE_FAILED_STATUS
+
         logger.debug("Starting AnsibleBaseAuth authentication")
 
         # Query the database for the most recently last modified timestamp.
@@ -38,7 +39,7 @@ class AnsibleBaseAuth(ModelBackend):
         for authenticator_id, authenticator_object in get_authentication_backends(last_modified).items():
             user = authenticator_object.authenticate(request, *args, **kwargs)
 
-            # Social Auth pipeline can return False when update_user_claims fails (authentication maps deny access)
+            # Social Auth pipeline can return status string when update_user_claims fails (authentication maps deny access)
             if user == SOCIAL_AUTH_PIPELINE_FAILED_STATUS:
                 continue
 

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -15,7 +15,11 @@ from social_django.strategy import DjangoStrategy
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_class, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 
+
 logger = logging.getLogger('ansible_base.authentication.social_auth')
+
+
+SOCIAL_AUTH_PIPELINE_FAILED_STATUS = "pipeline-failed"
 
 
 class AuthenticatorStorage(BaseDjangoStorage):
@@ -188,4 +192,6 @@ def create_user_claims_pipeline(*args, backend, response, **kwargs):
     from ansible_base.authentication.utils.claims import update_user_claims
 
     extra_groups = response["Group"] if "Group" in response else None
-    update_user_claims(kwargs["user"], backend.database_instance, backend.get_user_groups(extra_groups))
+    user = update_user_claims(kwargs["user"], backend.database_instance, backend.get_user_groups(extra_groups))
+    if user is None:
+        return SOCIAL_AUTH_PIPELINE_FAILED_STATUS

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -15,7 +15,6 @@ from social_django.strategy import DjangoStrategy
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_class, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 
-
 logger = logging.getLogger('ansible_base.authentication.social_auth')
 
 


### PR DESCRIPTION
Social Auth (i.e. github-enterprise) calls `update_user_claims` which parses Authentication Maps in the pipeline specified by `SOCIAL_AUTH_PIPELINE` in settings.

To reflect that the auth map refuses to authenticate, the pipeline must return something other than `dict`,  `False` or `None`