### PR TITLE
Avoid references to User.resource which may not be there

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -96,7 +96,7 @@ class JWTCommonAuth:
         self.user = None
         if is_cached:
             try:
-                self.user = get_user_by_ansible_id()
+                self.user = get_user_by_ansible_id(self.token['sub'])
             except ObjectDoesNotExist:
                 # ooofff... I'm sorry, you user was in the cache but deleted from the database?
                 # but now you have to pay the price to continue logging in

--- a/ansible_base/lib/utils/auth.py
+++ b/ansible_base/lib/utils/auth.py
@@ -1,8 +1,13 @@
-from typing import Any, Type
+from typing import Any, Type, Union
+from uuid import UUID
 
 from django.apps import apps as django_apps
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models import CharField, Model, OuterRef
+from django.db.models.functions import Cast
+from django.db.models.query import QuerySet
 
 from ansible_base.lib.abstract_models.organization import AbstractOrganization
 from ansible_base.lib.abstract_models.team import AbstractTeam
@@ -30,3 +35,18 @@ def get_team_model() -> Type[AbstractTeam]:
 
 def get_organization_model() -> Type[AbstractOrganization]:
     return get_model_from_settings('ANSIBLE_BASE_ORGANIZATION_MODEL')
+
+
+def get_object_by_ansible_id(qs: QuerySet, ansible_id: Union[str, UUID]) -> Model:
+    resource_cls = django_apps.get_model('dab_resource_registry', 'Resource')
+    content_type_cls = django_apps.get_model('contenttypes', 'ContentType')
+    cls = qs.model
+    ct = content_type_cls.objects.get_for_model(cls)
+    pk_field_name = cls._meta.pk.name
+    pk_reference = Cast(OuterRef(pk_field_name), output_field=CharField())
+    resource_qs = resource_cls.objects.filter(object_id=pk_reference, content_type=ct).values('ansible_id')
+    return qs.annotate(ansible_id_for_filter=resource_qs).get(ansible_id_for_filter=ansible_id)
+
+
+def get_user_by_ansible_id(ansible_id: Union[str, UUID]) -> Model:
+    return get_object_by_ansible_id(get_user_model().objects.all(), ansible_id)

--- a/ansible_base/lib/utils/auth.py
+++ b/ansible_base/lib/utils/auth.py
@@ -37,7 +37,7 @@ def get_organization_model() -> Type[AbstractOrganization]:
     return get_model_from_settings('ANSIBLE_BASE_ORGANIZATION_MODEL')
 
 
-def get_object_by_ansible_id(qs: QuerySet, ansible_id: Union[str, UUID]) -> Model:
+def get_object_by_ansible_id(qs: QuerySet, ansible_id: Union[str, UUID], annotate_as: str='ansible_id_for_filter') -> Model:
     resource_cls = django_apps.get_model('dab_resource_registry', 'Resource')
     content_type_cls = django_apps.get_model('contenttypes', 'ContentType')
     cls = qs.model
@@ -45,8 +45,8 @@ def get_object_by_ansible_id(qs: QuerySet, ansible_id: Union[str, UUID]) -> Mode
     pk_field_name = cls._meta.pk.name
     pk_reference = Cast(OuterRef(pk_field_name), output_field=CharField())
     resource_qs = resource_cls.objects.filter(object_id=pk_reference, content_type=ct).values('ansible_id')
-    return qs.annotate(ansible_id_for_filter=resource_qs).get(ansible_id_for_filter=ansible_id)
+    return qs.annotate(**{annotate_as: resource_qs}).get(**{annotate_as: ansible_id})
 
 
-def get_user_by_ansible_id(ansible_id: Union[str, UUID]) -> Model:
-    return get_object_by_ansible_id(get_user_model().objects.all(), ansible_id)
+def get_user_by_ansible_id(ansible_id: Union[str, UUID], annotate_as: str='ansible_id_for_filter') -> Model:
+    return get_object_by_ansible_id(get_user_model().objects.all(), ansible_id, annotate_as=annotate_as)

--- a/ansible_base/lib/utils/auth.py
+++ b/ansible_base/lib/utils/auth.py
@@ -37,7 +37,7 @@ def get_organization_model() -> Type[AbstractOrganization]:
     return get_model_from_settings('ANSIBLE_BASE_ORGANIZATION_MODEL')
 
 
-def get_object_by_ansible_id(qs: QuerySet, ansible_id: Union[str, UUID], annotate_as: str='ansible_id_for_filter') -> Model:
+def get_object_by_ansible_id(qs: QuerySet, ansible_id: Union[str, UUID], annotate_as: str = 'ansible_id_for_filter') -> Model:
     resource_cls = django_apps.get_model('dab_resource_registry', 'Resource')
     content_type_cls = django_apps.get_model('contenttypes', 'ContentType')
     cls = qs.model
@@ -48,5 +48,5 @@ def get_object_by_ansible_id(qs: QuerySet, ansible_id: Union[str, UUID], annotat
     return qs.annotate(**{annotate_as: resource_qs}).get(**{annotate_as: ansible_id})
 
 
-def get_user_by_ansible_id(ansible_id: Union[str, UUID], annotate_as: str='ansible_id_for_filter') -> Model:
+def get_user_by_ansible_id(ansible_id: Union[str, UUID], annotate_as: str = 'ansible_id_for_filter') -> Model:
     return get_object_by_ansible_id(get_user_model().objects.all(), ansible_id, annotate_as=annotate_as)

--- a/test_app/authentication/service_token_auth.py
+++ b/test_app/authentication/service_token_auth.py
@@ -2,6 +2,7 @@ import jwt
 from django.contrib.auth import get_user_model
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
 
+from ansible_base.lib.utils.auth import get_user_by_ansible_id
 from ansible_base.lib.utils.models import get_system_user
 from ansible_base.resource_registry.resource_server import get_resource_server_config
 
@@ -30,7 +31,7 @@ class ServiceTokenAuthentication(BaseAuthentication):
             )
 
             if "sub" in data:
-                return (User.objects.get(resource__ansible_id=data["sub"]), None)
+                return (get_user_by_ansible_id(data["sub"]), None)
             else:
                 return (get_system_user(), None)
 

--- a/test_app/tests/lib/utils/test_auth.py
+++ b/test_app/tests/lib/utils/test_auth.py
@@ -51,6 +51,8 @@ def test_get_user_by_ansible_id_deleted_resource():
     # Even though user 4 can no longer be referenced by ansible_id, the others still work
     for i in range(3):
         assert get_user_by_ansible_id(users[i].resource.ansible_id) == users[i]
+        found_user = get_user_by_ansible_id(users[i].resource.ansible_id, annotate_as='a_id')
+        assert found_user.a_id == users[i].resource.ansible_id
 
 
 @pytest.mark.django_db

--- a/test_app/tests/lib/utils/test_auth.py
+++ b/test_app/tests/lib/utils/test_auth.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
+from uuid import UUID
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
-from ansible_base.lib.utils.auth import get_model_from_settings
+from ansible_base.lib.utils.auth import get_model_from_settings, get_object_by_ansible_id, get_user_by_ansible_id
+from test_app.models import Organization, User
 
 
 def test_get_model_from_settings_invalid_setting_name():
@@ -23,3 +25,42 @@ def test_get_model_from_settings_value_error(mock_settings):
     mock_settings.FOOBAR = 'User'
     with pytest.raises(ImproperlyConfigured):
         get_model_from_settings('FOOBAR')
+
+
+@pytest.mark.django_db
+def test_get_user_by_ansible_id():
+    users = [User.objects.create(username=f'bob-{i}') for i in range(5)]
+    for i in range(5):
+        assert get_user_by_ansible_id(users[i].resource.ansible_id) == users[i]
+
+
+@pytest.mark.django_db
+def test_get_user_by_ansible_id_not_found():
+    with pytest.raises(User.DoesNotExist):
+        get_user_by_ansible_id('0a4a242a-a79b-420c-8584-7809eaa9cbcb')
+
+
+@pytest.mark.django_db
+def test_get_user_by_ansible_id_deleted_resource():
+    users = [User.objects.create(username=f'bob-{i}') for i in range(5)]
+    user_4_id = users[4].id
+    resource = users[4].resource
+    resource.delete()
+    assert User.objects.filter(id=user_4_id).exists()  # sanity, user still exists
+
+    # Even though user 4 can no longer be referenced by ansible_id, the others still work
+    for i in range(3):
+        assert get_user_by_ansible_id(users[i].resource.ansible_id) == users[i]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('arg_type', [str, UUID])
+def test_get_by_ansible_id(organization, arg_type):
+    resource = organization.resource
+    assert type(resource.ansible_id) is UUID  # sanity, set expectation
+    if isinstance(resource.ansible_id, arg_type):
+        uuid_obj = resource.ansible_id
+    else:
+        uuid_obj = arg_type(resource.ansible_id)
+    assert isinstance(uuid_obj, arg_type)
+    assert get_object_by_ansible_id(Organization.objects.all(), organization.resource.ansible_id) == organization


### PR DESCRIPTION
Explanation:

test_app adds the `resource` property to the `User` model as a handy short-hand for referencing its related resource.

https://github.com/ansible/django-ansible-base/blob/cff4a1106b58bd75587eb5e18e131939a2d8fa5d/test_app/models.py#L37-L42

But again, this is test_app, and it should be up to the discretion of the maintainers of test_app (mentally substitute some other real app there) whether or not this is added. Additionally, some apps get their user model from `auth.User`... and while [you can add a related resource](https://github.com/ansible/awx/blob/d94f766fcbe5cf68370830430d980b67d6cfd164/awx/main/models/__init__.py#L109) to that, I don't want to require such a thing. So this does the basic work involved to write a new alternative from scratch.

The SQL for this method:

```sql
SELECT "test_app_user"."id",
       "test_app_user"."password",
       "test_app_user"."last_login",
       "test_app_user"."is_superuser",
       "test_app_user"."username",
       "test_app_user"."first_name",
       "test_app_user"."last_name",
       "test_app_user"."email",
       "test_app_user"."is_staff",
       "test_app_user"."is_active",
       "test_app_user"."date_joined",
       "test_app_user"."modified",
       "test_app_user"."modified_by_id",
       "test_app_user"."created",
       "test_app_user"."created_by_id",
       (
        SELECT U0."ansible_id"
          FROM "dab_resource_registry_resource" U0
         WHERE (U0."content_type_id" = 17 AND U0."object_id" = ("test_app_user"."id")::varchar)
       ) AS "ansible_id_for_filter"
  FROM "test_app_user"
 WHERE (
        SELECT U0."ansible_id"
          FROM "dab_resource_registry_resource" U0
         WHERE (U0."content_type_id" = 17 AND U0."object_id" = ("test_app_user"."id")::varchar)
       ) = '0a4a242aa79b420c85847809eaa9cbcb'::uuid
 LIMIT 21
```

Some things to note:
- This is used in a `.get()`, so while it says LIMIT 21, anything other than 1 user returned will result in an error
- The code for obtaining the ansible_id is redundantly put in here twice, this is because we want the returned item to have `ansible_id_for_filter`, which can be referenced by the caller later. So this might not be the cleanest SQL, but there is a coherent reason for why it is the way it is.