### PR TITLE
Add social auth exception handler middleware

### DIFF
--- a/ansible_base/authentication/middleware.py
+++ b/ansible_base/authentication/middleware.py
@@ -50,8 +50,5 @@ class SocialExceptionHandlerMiddleware(SocialAuthExceptionMiddleware):
         error_url = strategy.setting("LOGIN_ERROR_URL")
         backend = getattr(request, "backend", None)
         backend_name = getattr(backend, "name", "unknown-backend")
-        logger.error(f"Auth failure for backend {backend_name} - {repr(exception)}")
-        # UI expects auth_failed flag
-        url = urljoin(error_url, "/?auth_failed")
-        logger.info(f"Redirecting user to {url}")
-        return url
+        logger.error(f"Auth failure for backend {backend_name} - {repr(exception)}, redirecting to {error_url}")
+        return error_url

--- a/ansible_base/authentication/middleware.py
+++ b/ansible_base/authentication/middleware.py
@@ -1,5 +1,4 @@
 import logging
-from urllib.parse import urljoin
 
 from django.contrib.auth import BACKEND_SESSION_KEY
 from django.core.exceptions import ImproperlyConfigured

--- a/ansible_base/authentication/middleware.py
+++ b/ansible_base/authentication/middleware.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urljoin
 
 from django.contrib.auth import BACKEND_SESSION_KEY
 from django.core.exceptions import ImproperlyConfigured
@@ -46,11 +47,11 @@ class AuthenticatorBackendMiddleware(MiddlewareMixin):
 class SocialExceptionHandlerMiddleware(SocialAuthExceptionMiddleware):
     def get_redirect_uri(self, request, exception):
         strategy = getattr(request, "social_strategy", None)
-        url = strategy.setting("LOGIN_ERROR_URL")
+        error_url = strategy.setting("LOGIN_ERROR_URL")
         backend = getattr(request, "backend", None)
         backend_name = getattr(backend, "name", "unknown-backend")
         logger.error(f"Auth failure for backend {backend_name} - {exception}")
-        # The redirect URL can be customized as necessary for consumption by UI
-        # to display message or send user to an error page
+        # UI expects auth_failed flag
+        url = urljoin(error_url, "/?auth_failed")
         logger.info(f"Redirecting user to {url}")
         return url

--- a/ansible_base/authentication/middleware.py
+++ b/ansible_base/authentication/middleware.py
@@ -50,7 +50,7 @@ class SocialExceptionHandlerMiddleware(SocialAuthExceptionMiddleware):
         error_url = strategy.setting("LOGIN_ERROR_URL")
         backend = getattr(request, "backend", None)
         backend_name = getattr(backend, "name", "unknown-backend")
-        logger.error(f"Auth failure for backend {backend_name} - {exception}")
+        logger.error(f"Auth failure for backend {backend_name} - {repr(exception)}")
         # UI expects auth_failed flag
         url = urljoin(error_url, "/?auth_failed")
         logger.info(f"Redirecting user to {url}")

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -100,17 +100,18 @@ if 'ansible_base.authentication' in INSTALLED_APPS:
     if "ansible_base.authentication.backend.AnsibleBaseAuth" not in AUTHENTICATION_BACKENDS:
         AUTHENTICATION_BACKENDS.append("ansible_base.authentication.backend.AnsibleBaseAuth")
 
-    middleware_class = 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware'
-    try:
-        MIDDLEWARE  # noqa: F821
-        if middleware_class not in MIDDLEWARE:  # noqa: F821
-            try:
-                index = MIDDLEWARE.index('django.contrib.auth.middleware.AuthenticationMiddleware')  # noqa: F821
-                MIDDLEWARE.insert(index, middleware_class)  # noqa: F821
-            except ValueError:
-                MIDDLEWARE.append(middleware_class)  # noqa: F821
-    except NameError:
-        MIDDLEWARE = [middleware_class]
+    middleware_classes = ['social_django.middleware.SocialAuthExceptionMiddleware', 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware']
+    for mw in middleware_classes:
+        try:
+            MIDDLEWARE  # noqa: F821
+            if mw not in MIDDLEWARE:  # noqa: F821
+                try:
+                    index = MIDDLEWARE.index('django.contrib.auth.middleware.AuthenticationMiddleware')  # noqa: F821
+                    MIDDLEWARE.insert(index, mw)  # noqa: F821
+                except ValueError:
+                    MIDDLEWARE.append(mw)  # noqa: F821
+        except NameError:
+            MIDDLEWARE = [mw]
 
     drf_authentication_class = 'ansible_base.authentication.session.SessionAuthentication'
     if 'DEFAULT_AUTHENTICATION_CLASSES' not in REST_FRAMEWORK:  # noqa: F821
@@ -141,6 +142,8 @@ if 'ansible_base.authentication' in INSTALLED_APPS:
 
     ANSIBLE_BASE_SOCIAL_AUDITOR_FLAG = "is_system_auditor"
 
+    # URL to send users when social auth login fails
+    LOGIN_ERROR_URL = "/"
 
 if 'ansible_base.rest_pagination' in INSTALLED_APPS:
     REST_FRAMEWORK['DEFAULT_PAGINATION_CLASS'] = 'ansible_base.rest_pagination.DefaultPaginator'

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -146,7 +146,7 @@ if 'ansible_base.authentication' in INSTALLED_APPS:
     ANSIBLE_BASE_SOCIAL_AUDITOR_FLAG = "is_system_auditor"
 
     # URL to send users when social auth login fails
-    LOGIN_ERROR_URL = "/"
+    LOGIN_ERROR_URL = "/?auth_failed"
 
 if 'ansible_base.rest_pagination' in INSTALLED_APPS:
     REST_FRAMEWORK['DEFAULT_PAGINATION_CLASS'] = 'ansible_base.rest_pagination.DefaultPaginator'

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -100,7 +100,10 @@ if 'ansible_base.authentication' in INSTALLED_APPS:
     if "ansible_base.authentication.backend.AnsibleBaseAuth" not in AUTHENTICATION_BACKENDS:
         AUTHENTICATION_BACKENDS.append("ansible_base.authentication.backend.AnsibleBaseAuth")
 
-    middleware_classes = ['social_django.middleware.SocialAuthExceptionMiddleware', 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware']
+    middleware_classes = [
+        'ansible_base.authentication.middleware.SocialExceptionHandlerMiddleware',
+        'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware',
+    ]
     for mw in middleware_classes:
         try:
             MIDDLEWARE  # noqa: F821

--- a/test_app/tests/authentication/test_middleware.py
+++ b/test_app/tests/authentication/test_middleware.py
@@ -1,0 +1,21 @@
+from social_core.exceptions import AuthException
+
+from ansible_base.authentication.middleware import SocialExceptionHandlerMiddleware
+
+
+def test_social_exception_handler_mw():
+    class Strategy():
+        def setting(self, name):
+            return "/"
+
+    class Backend():
+        def __init__(self):
+            self.name = "test"
+
+    class Request():
+        def __init__(self):
+            self.social_strategy = Strategy()
+            self.backend = Backend()
+    mw = SocialExceptionHandlerMiddleware(None)
+    url = mw.get_redirect_uri(Request(), AuthException("test"))
+    assert url == "/"

--- a/test_app/tests/authentication/test_middleware.py
+++ b/test_app/tests/authentication/test_middleware.py
@@ -4,18 +4,19 @@ from ansible_base.authentication.middleware import SocialExceptionHandlerMiddlew
 
 
 def test_social_exception_handler_mw():
-    class Strategy():
+    class Strategy:
         def setting(self, name):
             return "/"
 
-    class Backend():
+    class Backend:
         def __init__(self):
             self.name = "test"
 
-    class Request():
+    class Request:
         def __init__(self):
             self.social_strategy = Strategy()
             self.backend = Backend()
+
     mw = SocialExceptionHandlerMiddleware(None)
     url = mw.get_redirect_uri(Request(), AuthException("test"))
     assert url == "/"

--- a/test_app/tests/authentication/test_middleware.py
+++ b/test_app/tests/authentication/test_middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from social_core.exceptions import AuthException
 
 from ansible_base.authentication.middleware import SocialExceptionHandlerMiddleware
@@ -6,7 +7,7 @@ from ansible_base.authentication.middleware import SocialExceptionHandlerMiddlew
 def test_social_exception_handler_mw():
     class Strategy:
         def setting(self, name):
-            return "/"
+            return settings.LOGIN_ERROR_URL
 
     class Backend:
         def __init__(self):

--- a/test_app/tests/authentication/test_middleware.py
+++ b/test_app/tests/authentication/test_middleware.py
@@ -19,4 +19,4 @@ def test_social_exception_handler_mw():
 
     mw = SocialExceptionHandlerMiddleware(None)
     url = mw.get_redirect_uri(Request(), AuthException("test"))
-    assert url == "/"
+    assert url == "/?auth_failed"

--- a/test_app/tests/lib/dynamic_config/test_dynamic_settings.py
+++ b/test_app/tests/lib/dynamic_config/test_dynamic_settings.py
@@ -87,7 +87,7 @@ def test_insert_middleware():
     '''
     )
     updated_settings = get_updated_settings(additional_config)
-    assert 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware' == updated_settings['MIDDLEWARE'][1]
+    assert 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware' == updated_settings['MIDDLEWARE'][2]
 
 
 def test_dont_update_class_prefixes():


### PR DESCRIPTION
This middleware catches any exception from python social auth (failed authentication) and redirects the user to LOGIN_ERROR_URL.  The UI will receive something (query param, path var, slug, whatever) from this URL and display a login error of some sort.  So this PR should be updated when the UI knows how it will be handled.