### PR TITLE
Allow null values for ansible_id fields

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -158,6 +158,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
     object_ansible_id = serializers.UUIDField(
         required=False,
         help_text=_('Resource id of the object this role applies to. Alternative to the object_id field.'),
+        allow_null=True,  # for ease of use of the browseable API
     )
 
     def __init__(self, *args, **kwargs):
@@ -289,6 +290,7 @@ class RoleUserAssignmentSerializer(BaseAssignmentSerializer):
     user_ansible_id = serializers.UUIDField(
         required=False,
         help_text=_('Resource id of the user who will receive permissions from this assignment. Alternative to user field.'),
+        allow_null=True,  # for ease of use of the browseable API
     )
 
     class Meta:


### PR DESCRIPTION
These were already non-required, allowing blank/omitting. But that might be difficult for some clients to adhere to. It also makes the DRF browseable API hard to use, giving:

```json
{
    "object_ansible_id": [
        "This field may not be null."
    ],
    "user_ansible_id": [
        "This field may not be null."
    ]
}
```

If you look at the serializer logic, it already assumes we might be getting blank values. This eliminates the error above, and just makes the assignment.