### PR TITLE
Revert superuser claims

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -436,9 +436,6 @@ class ReconcileUser:
 
         self.apply_permissions()
 
-        # Superuser "role"
-        self.apply_superuser_permission()
-
     def _compute_system_permissions(self) -> None:
         for role_name, has_permission in self.claims['rbac_roles'].get('system', {}).get('roles', {}).items():
             self.permissions_cache.add_or_remove(role_name, has_permission, organization=None, team=None)
@@ -473,15 +470,6 @@ class ReconcileUser:
 
             for role_name, has_permission in team_details['roles'].items():
                 self.permissions_cache.add_or_remove(role_name, has_permission, team=team)
-
-    def apply_superuser_permission(self) -> None:
-        is_superuser = self.claims.get('is_superuser')
-        if is_superuser is not None and is_superuser != self.user.is_superuser:
-            self.user.is_superuser = is_superuser
-            self.user.save()
-        elif is_superuser is None and self.rebuild_user_permissions and self.user.is_superuser:
-            self.user.is_superuser = False
-            self.user.save()
 
     def apply_permissions(self) -> None:
         """See RoleUserAssignmentsCache for more details."""

--- a/test_app/tests/authentication/utils/test_claims_reconcile_user.py
+++ b/test_app/tests/authentication/utils/test_claims_reconcile_user.py
@@ -37,39 +37,6 @@ def test_create_organizations_and_teams():
 
 
 @pytest.mark.django_db
-def test_add_superuser(user, default_rbac_roles_claims):
-    assert user.is_superuser is False
-
-    authenticator_user = mock.Mock()
-    authenticator_user.claims = {'rbac_roles': default_rbac_roles_claims, 'is_superuser': True}
-
-    authenticator_user.provider.remove_users = False
-    ReconcileUser.reconcile_user_claims(user, authenticator_user)
-    assert user.is_superuser is True
-
-
-@pytest.mark.parametrize("remove_users", [True, False])
-@pytest.mark.django_db
-def test_remove_superuser(remove_users, default_rbac_roles_claims):
-    admin1 = User.objects.create(username='test-admin-1', is_superuser=True)
-    admin2 = User.objects.create(username='test-admin-2', is_superuser=True)
-
-    authenticator_user1 = mock.Mock()
-    authenticator_user2 = mock.Mock()
-    authenticator_user1.provider.remove_users = remove_users
-    authenticator_user2.provider.remove_users = remove_users
-
-    authenticator_user1.claims = {'rbac_roles': default_rbac_roles_claims, 'is_superuser': False}
-    authenticator_user2.claims = {'rbac_roles': default_rbac_roles_claims, 'is_superuser': None}
-
-    ReconcileUser.reconcile_user_claims(admin1, authenticator_user1)
-    ReconcileUser.reconcile_user_claims(admin2, authenticator_user2)
-
-    assert admin1.is_superuser is False
-    assert admin2.is_superuser is not remove_users
-
-
-@pytest.mark.django_db
 def test_add_user_to_org(org_member_rd, org_admin_rd, default_rbac_roles_claims):
     org = Organization.objects.create(name='test-org-01')
     org2 = Organization.objects.create(name='test-org-02')


### PR DESCRIPTION
Reverts this commit: https://github.com/ansible/django-ansible-base/pull/431/commits/903519bc54038ff6b18193c9f3e03d7214205920

Because `is_superuser` is handled by [update_user_claims()](https://github.com/ansible/django-ansible-base/blob/6a54df11c05ed58d20b3dd847fd2c0efbd6b04bf/ansible_base/authentication/utils/claims.py#L300)