### PR TITLE
Respect admin password env var and remove duplication creation

### DIFF
--- a/test_app/scripts/bootstrap.sh
+++ b/test_app/scripts/bootstrap.sh
@@ -43,11 +43,16 @@ for i in $(seq 1 $MAX_ATTEMPTS); do
     sleep 1
 done
 
+admin_password='admin'
+
 if [ "${migrate_needed}" -ne 0 ]
 then
     echo "Migrating database"
     python3 manage.py migrate
-    DJANGO_SUPERUSER_PASSWORD=password DJANGO_SUPERUSER_USERNAME=admin DJANGO_SUPERUSER_EMAIL=admin@stuff.invalid python3 manage.py createsuperuser --noinput
+    if [ "${DJANGO_SUPERUSER_PASSWORD}" ]; then
+        admin_password=${DJANGO_SUPERUSER_PASSWORD}
+    fi
+    DJANGO_SUPERUSER_PASSWORD=$admin_password DJANGO_SUPERUSER_USERNAME=admin DJANGO_SUPERUSER_EMAIL=admin@stuff.invalid python3 manage.py createsuperuser --noinput
     python3 manage.py authenticators --initialize
     python3 manage.py create_demo_data
 fi

--- a/test_app/tests/test_demo_data.py
+++ b/test_app/tests/test_demo_data.py
@@ -5,7 +5,7 @@ from test_app.models import Organization
 
 
 @pytest.mark.django_db
-def test_demo_data_with_existing_data():
+def test_demo_data_with_existing_data(admin_user):
     Organization.objects.create(name='stub')
     Command().handle()
     assert Organization.objects.filter(name='AWX_community').exists()
@@ -13,13 +13,13 @@ def test_demo_data_with_existing_data():
 
 
 @pytest.mark.django_db
-def test_demo_data_create_data():
+def test_demo_data_create_data(admin_user):
     Command().handle()
     assert Organization.objects.filter(name='AWX_community').exists()
 
 
 @pytest.mark.django_db
-def test_demo_data_idempotent():
+def test_demo_data_idempotent(admin_user):
     Command().handle()
     assert Organization.objects.filter(name='AWX_community').exists()
     Command().handle()


### PR DESCRIPTION
Fixes https://github.com/ansible/django-ansible-base/issues/469

Tested by

```
DJANGO_SUPERUSER_PASSWORD=new_password ./test_app/scripts/bootstrap.sh
```

And I was able to log in as admin/new_password.

