### PR TITLE
Always clear ContentType cache to enforce determinism

### DIFF
--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
 from django.db.migrations.recorder import MigrationRecorder
 from django.db.models.signals import post_migrate
 from django.test.client import RequestFactory
@@ -63,6 +64,14 @@ def test_migrations_okay(*args, **kwargs):
 
 
 post_migrate.connect(test_migrations_okay)
+
+
+@pytest.fixture(autouse=True)
+def clear_content_type_cache():
+    """This enforces determinism between tests by deleting cached ContentType items from old tests"""
+    ContentType.objects.clear_cache()
+    yield
+    ContentType.objects.clear_cache()
 
 
 @pytest.fixture

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -277,6 +277,7 @@ class TestJWTCommonAuth:
             request = mocked_http.mocked_parse_jwt_token_get_request('with_headers')
             common_auth.parse_jwt_token(request)
 
+    @pytest.mark.django_db
     def test_cert_fails_decryption_from_cached_key_but_key_is_invalid(self, mocked_http, expected_log, test_encryption_public_key):
         with override_settings(ANSIBLE_BASE_JWT_KEY=test_encryption_public_key):
             # Get the decryption key into the cache
@@ -435,6 +436,7 @@ class TestJWTAuthentication:
                     assert 'check your key and generated token' in af
                     assert 'cached key was correct' not in af
 
+    @pytest.mark.django_db
     def test_raise_an_exception_if_the_key_is_cached_but_the_new_key_is_the_same(self, random_public_key, mocked_http, create_mock_method):
         # We are going to:
         #     1. return a key which will not work with jwt_token provided by mocked_http


### PR DESCRIPTION
I had a check failure on another PR, and I am pretty sure it is not from that patch, so I'm making this for first discover the test bugs we have, and then fix them on a case-by-case basis after identified.