### PR TITLE
Disable activitystream for access token last_used

### DIFF
--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -33,6 +33,7 @@ if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
 class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activitystream):
     router_basename = 'token'
     ignore_relations = ['refresh_token']
+    activity_stream_excluded_field_names = ['last_used']
 
     class Meta(oauth2_models.AbstractAccessToken.Meta):
         verbose_name = _('access token')


### PR DESCRIPTION
Adds overridden bearer token validator to prevent multiple calls to is_valid, which in turn was causing multiple updates of last_used on the token and multiple activitystream entries reflecting that.