### PR TITLE
Split assignment setting from other setting

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -199,7 +199,7 @@ if 'ansible_base.rbac' in INSTALLED_APPS:
     ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS = False
 
     # API clients can assign users and teams roles for shared resources
-    ALLOW_LOCAL_RESOURCE_MANAGEMENT = True
+    ANSIBLE_BASE_ALLOW_LOCAL_RESOURCE_ASSIGNMENTS = True
 
     try:
         MANAGE_ORGANIZATION_AUTH

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -199,7 +199,7 @@ def check_locally_managed(rd: Model) -> None:
     This rule is a bridge solution until the RoleDefinition model declares
     explicitly whether it is managed locally or by a remote system.
     """
-    if settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT is True:
+    if settings.ANSIBLE_BASE_ALLOW_LOCAL_RESOURCE_ASSIGNMENTS is True:
         return
     for perm in rd.permissions.prefetch_related('content_type'):
         model = perm.content_type.model_class()

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -7,13 +7,13 @@ from ansible_base.rbac.models import RoleDefinition
 
 @pytest.mark.django_db
 class TestSharedAssignmentsDisabled:
-    @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
+    @override_settings(ANSIBLE_BASE_ALLOW_LOCAL_RESOURCE_ASSIGNMENTS=False)
     def test_team_member_role_not_assignable(self, member_rd, team, rando, admin_api_client):
         url = reverse('roleuserassignment-list')
         response = admin_api_client.post(url, data={'object_id': team.id, 'role_definition': member_rd.id, 'user': rando.id})
         assert response.status_code == 400, response.data
 
-    @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
+    @override_settings(ANSIBLE_BASE_ALLOW_LOCAL_RESOURCE_ASSIGNMENTS=False)
     def test_resource_roles_still_assignable(self, org_inv_rd, organization, rando, admin_api_client):
         url = reverse('roleuserassignment-list')
         response = admin_api_client.post(url, data={'object_id': organization.id, 'role_definition': org_inv_rd.id, 'user': rando.id})


### PR DESCRIPTION
This will default to `True`, so the near-term plan to fix some problems we're having will be to let it assume the default value.

This will allow clients to assign permissions in the local (following) server so that it _can_ drift from the provider server's role assignments... for lack of a better solution.

AAP-25541