### PR TITLE
jwt_consumer: remove unauthorized permissions

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -155,6 +155,7 @@ if 'ansible_base.rest_pagination' in INSTALLED_APPS:
 if 'ansible_base.jwt_consumer' in INSTALLED_APPS:
     if 'ansible_base.rbac' not in INSTALLED_APPS:
         INSTALLED_APPS.append('ansible_base.rbac')
+    ANSIBLE_BASE_JWT_MANAGED_ROLES = ["Platform Auditor", "Organization Admin", "Organization Member", "Team Admin", "Team Member"]
 
 if 'ansible_base.rbac' in INSTALLED_APPS:
     # The settings-based specification of managed roles from DAB RBAC vendored ones

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -165,6 +165,7 @@ ANSIBLE_BASE_RESOURCE_CONFIG_MODULE = "test_app.resource_api"
 SYSTEM_USERNAME = '_system'
 
 ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
+    'sys_auditor': {'name': "Platform Auditor"},
     'team_member': {},
     'team_admin': {},
     'org_admin': {},
@@ -172,6 +173,7 @@ ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
     'cow_admin': {'shortname': 'admin_base', 'model_name': 'test_app.cow', 'name': 'Cow Admin'},
     'cow_moo': {'shortname': 'action_base', 'model_name': 'test_app.cow', 'name': 'Cow Mooer', 'action': 'say_cow'},
 }
+ANSIBLE_BASE_JWT_MANAGED_ROLES.append("System Auditor")  # noqa: F821 this is set by dynamic settings for jwt_consumer
 ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
 


### PR DESCRIPTION
Every time a user authenticates with JWT, all user role assignments
unlisted in the decrypted JWT are removed from the database.

AAP-25531
