### PR TITLE
Fix authenticator-related users view with permission handling

### DIFF
--- a/ansible_base/authentication/views/authenticator_users.py
+++ b/ansible_base/authentication/views/authenticator_users.py
@@ -33,7 +33,6 @@ def get_authenticator_user_view():
                 # if we didn't get an ID for some reason we will just return None
                 if authenticator_id is None or not Authenticator.objects.filter(pk=authenticator_id).exists():
                     raise Http404()
-                    # return get_user_model().objects.none()
                 authenticator_users = get_user_model().objects.filter(authenticator_users__provider__id=authenticator_id)
                 return authenticator_users
 

--- a/ansible_base/authentication/views/authenticator_users.py
+++ b/ansible_base/authentication/views/authenticator_users.py
@@ -4,6 +4,10 @@ from types import ModuleType
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.http import Http404
+
+from ansible_base.authentication.models import Authenticator
+from ansible_base.lib.utils.views.permissions import IsSuperuserOrAuditor
 
 logger = logging.getLogger('ansible_base.authentication.views.authenticator_users')
 
@@ -18,6 +22,8 @@ def get_authenticator_user_view():
             raise ModuleNotFoundError()
 
         class AuthenticatorPluginRelatedUsersView(user_viewset_view):
+            permission_classes = [IsSuperuserOrAuditor]
+
             def get_queryset(self, **kwargs):
                 # during unit testing we get the pk from kwargs
                 authenticator_id = kwargs.get('pk', None)
@@ -25,8 +31,9 @@ def get_authenticator_user_view():
                     # But at runtime self has kwargs attached and no kwargs associated
                     authenticator_id = self.kwargs.get('pk', None)
                 # if we didn't get an ID for some reason we will just return None
-                if authenticator_id is None:
-                    return get_user_model().objects.none()
+                if authenticator_id is None or not Authenticator.objects.filter(pk=authenticator_id).exists():
+                    raise Http404()
+                    # return get_user_model().objects.none()
                 authenticator_users = get_user_model().objects.filter(authenticator_users__provider__id=authenticator_id)
                 return authenticator_users
 
@@ -35,5 +42,7 @@ def get_authenticator_user_view():
         logger.error("ANSIBLE_BASE_USER_VIEWSET was not an APIView")
     except AttributeError:
         logger.debug("ANSIBLE_BASE_USER_VIEWSET was not specified")
+    except Http404:
+        logger.error("Authenticator not available")
 
     return None


### PR DESCRIPTION
- Implement view to handle authenticator-related users with correct permission class, returning 200 for `superuser`, 403 for `normal user` and 401 for `unauthenticated user`
- If given a bad authenticator pk, return 404
- Include checks for authenticator existence and return 404 if not found
- Add unit tests for authenticator-related users list and authenticator with bad pk
=> This PR resolves [APP-25719](https://issues.redhat.com/browse/AAP-25719)