### PR TITLE
Handle authenticator slug collision

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/utils.py
+++ b/ansible_base/authentication/authenticator_plugins/utils.py
@@ -2,6 +2,7 @@ import logging
 from functools import lru_cache
 from glob import glob
 from os.path import basename, isfile, join
+from typing import Optional
 
 from django.conf import settings
 from django.utils.text import slugify
@@ -52,5 +53,7 @@ def get_authenticator_urls(authenticator_type: str) -> list:
     return []
 
 
-def generate_authenticator_slug(type: str, name: str) -> str:
-    return slugify(f"{type.replace('.', ' ')}__{name}")
+def generate_authenticator_slug(type: str, name: str, suffix: Optional[str] = None) -> str:
+    clean_type = f"{type.replace('.', ' ')}"
+    slug_template = f"{clean_type}__{name}" if not suffix else f"{clean_type}__{name}__{suffix}"
+    return slugify(slug_template)

--- a/ansible_base/authentication/models/authenticator.py
+++ b/ansible_base/authentication/models/authenticator.py
@@ -1,3 +1,5 @@
+import secrets
+
 from django.db.models import SET_NULL, ForeignKey, JSONField, fields
 
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_plugin
@@ -61,6 +63,8 @@ class Authenticator(UniqueNamedCommonModel):
 
         if not self.slug:
             self.slug = generate_authenticator_slug(self.type, self.name)
+            if Authenticator.objects.filter(slug=self.slug).count():
+                self.slug = generate_authenticator_slug(self.type, self.name, secrets.token_hex(4))
             # TODO: What happens if computed slug is not unique?
             # You would have to create an adapter with a name, rename it and then create a new one with the same name
         super().save(*args, **kwargs)

--- a/ansible_base/authentication/models/authenticator.py
+++ b/ansible_base/authentication/models/authenticator.py
@@ -65,8 +65,6 @@ class Authenticator(UniqueNamedCommonModel):
             self.slug = generate_authenticator_slug(self.type, self.name)
             if Authenticator.objects.filter(slug=self.slug).count():
                 self.slug = generate_authenticator_slug(self.type, self.name, secrets.token_hex(4))
-            # TODO: What happens if computed slug is not unique?
-            # You would have to create an adapter with a name, rename it and then create a new one with the same name
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/test_app/tests/authentication/models/test_authenticator.py
+++ b/test_app/tests/authentication/models/test_authenticator.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+import re
 
 from ansible_base.authentication.models import Authenticator
 
@@ -32,3 +33,19 @@ def test_authenticator_order_on_create_update():
 
     auth3 = Authenticator.objects.create(name='Authenticator 3', type=auth_type)
     assert auth3.order == 12
+
+@pytest.mark.django_db
+def test_dupe_slug(ldap_authenticator):
+    ldap_auth = Authenticator.objects.first()
+    ldap_slug = ldap_auth.slug
+
+    dupe = Authenticator()
+    dupe.name = ldap_auth.name
+    dupe.type = ldap_auth.type
+
+    ldap_auth.name = "changed"
+    ldap_auth.save()
+
+    dupe.save()
+    pattern = ldap_slug + '[a-z0-9_]{8}'
+    assert re.match(pattern, dupe.slug) is not None

--- a/test_app/tests/authentication/models/test_authenticator.py
+++ b/test_app/tests/authentication/models/test_authenticator.py
@@ -1,7 +1,7 @@
+import re
 from unittest import mock
 
 import pytest
-import re
 
 from ansible_base.authentication.models import Authenticator
 
@@ -33,6 +33,7 @@ def test_authenticator_order_on_create_update():
 
     auth3 = Authenticator.objects.create(name='Authenticator 3', type=auth_type)
     assert auth3.order == 12
+
 
 @pytest.mark.django_db
 def test_dupe_slug(ldap_authenticator):


### PR DESCRIPTION
Adds random hex suffix to generated slug if it collides with an existing one (normally due to authenticator name change).