### PR TITLE
Add callback to validate role assignment

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -4,8 +4,6 @@ from django.db import transaction
 from django.db.utils import IntegrityError
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from django.core.exceptions import ValidationError as DjangoValidationError, PermissionDenied as DjangoPermissionDenied
-
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.fields import flatten_choices_dict, to_choices_dict

--- a/docs/apps/rbac/for_app_developers.md
+++ b/docs/apps/rbac/for_app_developers.md
@@ -279,3 +279,10 @@ and `Team.tracked_parents` ManyToMany relationships, respectively.
 So if you have a team object, `team.users.add(user)` will also give that
 user _member permission_ to that team, where those permissions are defined by the
 role definition with the name "team-member".
+
+
+### Role assignment callback
+
+Apps that utilize django-ansible-base may wish to add extra validation when assigning roles to actors (users or teams).
+
+see [Validation callback for role assignment](../../lib/validation.md)

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -23,4 +23,13 @@ The signature of this callback is
 
 `validate_role_assignment(self, actor, role_definition)`
 
-This method is reponsible for raising the appropriate exception if necessary (e.g. DRF ValidationError or DRF PermissionDenied).
+This method is reponsible for raising the appropriate exception if necessary, for example,
+
+```python
+from rest_framework.exceptions import ValidationError
+class MyDjangoModel:
+    def validate_role_assignment(self, actor, role_definition):
+        raise ValidationError({'detail': 'Role assignment not allowed.'})
+```
+
+Note, if you want the exception to result in a HTTP 400 or 403 response, you can raise django rest framework exceptions instead of django exceptions.

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -10,4 +10,17 @@ Must be a valid string
 
 `ansible_base.lib.utils.validation.validate_url` this is similar to the validate_url in django but has a parameter for `allow_plain_hostname: bool = False` which means you can have a url like `https://something:443/testing`.
 
-`ansible_base.lib.utils.validation.validate_url_list` this is a convince method which takes an array of urls and validates each of them using its own validate_url method. 
+`ansible_base.lib.utils.validation.validate_url_list` this is a convince method which takes an array of urls and validates each of them using its own validate_url method.
+
+
+# Validation callback for role assignment
+
+Apps that utilize django-ansible-base may wish to add extra validation when assigning roles to actors (users or teams).
+
+For this, django-ansible-base will call out to `validate_role_assignment` method that defined on the object that being assigned.
+
+The signature of this callback is
+
+`validate_role_assignment(self, actor, role_definition)`
+
+This method is reponsible for raising the appropriate exception if necessary (e.g. DRF ValidationError or DRF PermissionDenied).

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -5,6 +5,8 @@ from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.db.models import JSONField
 
+from rest_framework.exceptions import ValidationError as DRFValidationError, PermissionDenied as DRFPermissionDenied
+
 from ansible_base.activitystream.models import AuditableModel
 from ansible_base.lib.abstract_models import AbstractOrganization, AbstractTeam, CommonModel, ImmutableCommonModel, ImmutableModel, NamedCommonModel
 from ansible_base.lib.utils.models import prevent_search, user_summary_fields
@@ -148,6 +150,16 @@ class Inventory(models.Model):
 
     def summary_fields(self):
         return {"id": self.id, "name": self.name}
+
+    def validate_role_assignment(self, actor, role_definition):
+        if isinstance(actor, User):
+            name = actor.username
+        if isinstance(actor, Team):
+            name = actor.name
+        if name == 'test-400':
+            raise DRFValidationError({'detail': 'Role assignment not allowed 400'})
+        if name == 'test-403':
+            raise DRFPermissionDenied('Role assignment not allowed 403')
 
 
 class Credential(models.Model):

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -4,8 +4,8 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.db.models import JSONField
-
-from rest_framework.exceptions import ValidationError as DRFValidationError, PermissionDenied as DRFPermissionDenied
+from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from ansible_base.activitystream.models import AuditableModel
 from ansible_base.lib.abstract_models import AbstractOrganization, AbstractTeam, CommonModel, ImmutableCommonModel, ImmutableModel, NamedCommonModel


### PR DESCRIPTION
Some dab-based apps like AWX may wish to add exceptions to the user and team role assignments.

This PR adds logic to the serializer `.create` method to execute a callback method that is optionally defined on the model.

This callback signature looks like:

`validate_role_assignment(self, actor, role_definition)`

and should return either
- None
- a string describing the validation error

If a string is returned, the string will be wrapped up in a `PermissionDenied` error (HTTP 403)

**Open questions:**

- [x] should validate_role_assignment signature take any other params? maybe `**kwargs`?
- [x] should validate_role_assignment return a string? We could have it raise a django ValidationError, but then the create serializer method would need to try/catch the exception and raise a 403. Simplest design is to just return a string in my opinion