### PR TITLE
Require superuser permission to revoke global roles

### DIFF
--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -660,7 +660,9 @@ def admin_rd():
 def external_auditor_constructor():
     data = settings.ANSIBLE_BASE_MANAGED_ROLE_REGISTRY.copy()
     data['ext_aud'] = {'shortname': 'sys_auditor', 'name': 'Ext Auditor'}
-    with override_settings(ANSIBLE_BASE_MANAGED_ROLE_REGISTRY=data):
+    jwt_roles = settings.ANSIBLE_BASE_JWT_MANAGED_ROLES.copy()
+    jwt_roles.append('Ext Auditor')
+    with override_settings(ANSIBLE_BASE_MANAGED_ROLE_REGISTRY=data, ANSIBLE_BASE_JWT_MANAGED_ROLES=jwt_roles):
         # Extra setup needed for external auditor
         permission_registry.register_managed_role_constructors()
         yield permission_registry.get_managed_role_constructor('ext_aud')

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -6,7 +6,6 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
-from django.conf import settings
 from django.test.utils import override_settings
 from jwt.exceptions import DecodeError
 from rest_framework.exceptions import AuthenticationFailed
@@ -38,30 +37,6 @@ def organization_admin_role():
         managed=True,
     )
     return role
-
-
-@pytest.fixture
-def external_auditor_constructor():
-    data = settings.ANSIBLE_BASE_MANAGED_ROLE_REGISTRY.copy()
-    data['ext_aud'] = {'shortname': 'sys_auditor', 'name': 'Ext Auditor'}
-    jwt_roles = settings.ANSIBLE_BASE_JWT_MANAGED_ROLES.copy()
-    jwt_roles.append('Ext Auditor')
-    with override_settings(ANSIBLE_BASE_MANAGED_ROLE_REGISTRY=data, ANSIBLE_BASE_JWT_MANAGED_ROLES=jwt_roles):
-        # Extra setup needed for external auditor
-        permission_registry.register_managed_role_constructors()
-        yield permission_registry.get_managed_role_constructor('ext_aud')
-        permission_registry._managed_roles.pop('ext_aud')
-
-
-@pytest.fixture
-def unmanaged_external_auditor_constructor():
-    data = settings.ANSIBLE_BASE_MANAGED_ROLE_REGISTRY.copy()
-    data['bad_aud'] = {'shortname': 'sys_auditor', 'name': 'Unmanaged Auditor'}
-    with override_settings(ANSIBLE_BASE_MANAGED_ROLE_REGISTRY=data):
-        # Extra setup needed for external auditor
-        permission_registry.register_managed_role_constructors()
-        yield permission_registry.get_managed_role_constructor('bad_aud')
-        permission_registry._managed_roles.pop('bad_aud')
 
 
 class TestJWTCommonAuth:

--- a/test_app/tests/rbac/api/test_assignment_permissions.py
+++ b/test_app/tests/rbac/api/test_assignment_permissions.py
@@ -1,0 +1,132 @@
+import pytest
+from rest_framework.reverse import reverse
+
+from ansible_base.rbac import permission_registry
+from ansible_base.rbac.models import RoleDefinition
+from test_app.models import ImmutableTask
+
+
+@pytest.fixture
+def task_admin_rd():
+    return RoleDefinition.objects.create_from_permissions(
+        permissions=['view_immutabletask', 'delete_immutabletask', 'cancel_immutabletask'],
+        name='Task Admin',
+        content_type=permission_registry.content_type_model.objects.get_for_model(ImmutableTask),
+    )
+
+
+@pytest.fixture
+def task_view_rd():
+    return RoleDefinition.objects.create_from_permissions(
+        permissions=['view_immutabletask'],
+        name='Task View',
+        content_type=permission_registry.content_type_model.objects.get_for_model(ImmutableTask),
+    )
+
+
+@pytest.mark.django_db
+def test_create_user_assignment_immutable(user_api_client, user, rando, task_admin_rd, task_view_rd, org_admin_rd, organization):
+    task = ImmutableTask.objects.create()
+    org_admin_rd.give_permission(user, organization)  # setup so that user can see rando
+    url = reverse('roleuserassignment-list')
+    request_data = {"user": rando.pk, "role_definition": task_admin_rd.pk, "object_id": task.pk}
+
+    response = user_api_client.post(url, data=request_data)
+    assert response.status_code == 400, response.data
+    assert 'object does not exist' in response.data['object_id'][0]
+
+    task_view_rd.give_permission(user, task)
+    response = user_api_client.post(url, data=request_data)
+    assert response.status_code == 403, response.data
+    # Test custom error message
+    assert 'You do not have cancel_immutabletask permission' in str(response.data)
+
+    task_admin_rd.give_permission(user, task)
+    response = user_api_client.post(url, data=request_data)
+    assert response.status_code == 201, response.data
+
+
+@pytest.mark.django_db
+def test_remove_user_assignment_immutable(user_api_client, user, rando, task_admin_rd, task_view_rd):
+    task = ImmutableTask.objects.create()
+    assignment = task_admin_rd.give_permission(rando, task)
+    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+
+    response = user_api_client.delete(url)
+    assert response.status_code == 404, response.data
+
+    task_view_rd.give_permission(user, task)
+    response = user_api_client.delete(url)
+    assert response.status_code == 403, response.data
+    # Test custom error message
+    assert 'You do not have cancel_immutabletask permission' in str(response.data)
+
+    task_admin_rd.give_permission(user, task)
+    response = user_api_client.delete(url)
+    assert response.status_code == 204, response.data
+
+    assert not type(assignment).objects.filter(pk=assignment.pk).exists()
+
+
+@pytest.mark.django_db
+def test_remove_user_assignment_with_global_role(user_api_client, user, inv_rd, global_inv_rd, rando, inventory):
+    assignment = inv_rd.give_permission(rando, inventory)
+    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    response = user_api_client.delete(url)
+    assert response.status_code == 404, response.data
+
+    global_inv_rd.give_global_permission(user)
+    response = user_api_client.delete(url)
+    assert response.status_code == 204, response.data
+
+    assert not type(assignment).objects.filter(pk=assignment.pk).exists()
+
+
+@pytest.mark.django_db
+def test_remove_global_role_assignment(user_api_client, admin_api_client, user, global_inv_rd, rando):
+    assignment = global_inv_rd.give_global_permission(rando)
+    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    response = user_api_client.delete(url)
+    assert response.status_code == 404, response.data
+
+    # Having the role itself does not give permission to remove assignments, but this user can view
+    global_inv_rd.give_global_permission(user)
+    response = user_api_client.delete(url)
+    assert response.status_code == 403, response.data
+
+    # Only superuser can remove global assignments
+    response = admin_api_client.delete(url)
+    assert response.status_code == 204, response.data
+
+    assert not type(assignment).objects.filter(pk=assignment.pk).exists()
+
+
+@pytest.mark.django_db
+def test_remove_global_assignment_yourself(user_api_client, global_inv_rd, user, inventory):
+    assert not user.has_obj_perm(inventory, 'change')
+
+    assignment = global_inv_rd.give_global_permission(user)
+    assert user.has_obj_perm(inventory, 'change')
+
+    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    response = user_api_client.delete(url)
+    # Manually delete cache, because view operates on a User instance loaded anew from DB
+    delattr(user, '_singleton_permissions')
+    assert response.status_code == 204, response.data
+    assert not user.has_obj_perm(inventory, 'change')
+
+
+@pytest.mark.django_db
+def test_remove_object_assignment_yourself(user_api_client, user, inventory):
+    assert not user.has_obj_perm(inventory, 'view')
+
+    rd = RoleDefinition.objects.create_from_permissions(
+        name='inventory viewer role', permissions=['view_inventory'], content_type=permission_registry.content_type_model.objects.get_for_model(inventory)
+    )
+    assignment = rd.give_permission(user, inventory)
+    assert user.has_obj_perm(inventory, 'view')
+
+    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    response = user_api_client.delete(url)
+    assert response.status_code == 204, response.data
+    assert not user.has_obj_perm(inventory, 'change')

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -1,4 +1,5 @@
 import pytest
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -32,6 +33,14 @@ class TestSharedAssignmentsDisabled:
                 'permissions': ['aap.view_organization', 'local.change_organization'],
             },
         )
+        assert response.status_code == 400, response.data
+        assert self.NON_LOCAL_MESSAGE in str(response.data)
+
+    @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
+    def test_auditor_for_external_models(self, admin_api_client, rando, external_auditor_constructor):
+        rd, created = external_auditor_constructor.get_or_create(apps)
+        url = reverse('roleuserassignment-list')
+        response = admin_api_client.post(url, data={'role_definition': rd.id, 'user': rando.id})
         assert response.status_code == 400, response.data
         assert self.NON_LOCAL_MESSAGE in str(response.data)
 


### PR DESCRIPTION
Policy edit to be what AWX prior `is_system_auditor` policy was.

I gave more detail in a followup comment, but here are the key changes:
 - _Require_ superuser permission to revoke a system role assignment
 - _Allow_ removing an assignment if it applies to yourself
 - _Require_ that adding/revoking global role assignments only involve non-shared model permissions

AAP-26308