### PR TITLE
Custom permission class for oauth token scope adherence

### DIFF
--- a/ansible_base/oauth2_provider/permissions.py
+++ b/ansible_base/oauth2_provider/permissions.py
@@ -1,0 +1,29 @@
+import oauth2_provider.models as oauth2_models
+from oauth2_provider.contrib.rest_framework import TokenHasReadWriteScope
+from rest_framework.permissions import BasePermission, IsAuthenticated
+
+# This is not in views/permissions.py because we import that in other oauth2_provider files
+# and when we try to specify this OAuth2ScopePermission in an app's settings.py, we get a
+# cyclic dependency.
+
+
+class OAuth2ScopePermission(BasePermission):
+    """
+    A DRF Permission class to be used by apps that functions in the following way:
+
+    - If an OAuth 2 token is used to authenticate, then its scope must contain the required scope
+      (i.e. "read" cannot use "unsafe" methods)
+    - Otherwise, fall back.
+    """
+
+    def has_permission(self, request, view):
+        is_authenticated = IsAuthenticated().has_permission(request, view)
+        is_oauth = False
+        if is_authenticated and request.auth and isinstance(request.auth, oauth2_models.AbstractAccessToken):
+            is_oauth = True
+            scopes = request.auth.scope.split()
+            if 'write' in scopes and 'read' not in scopes:
+                request.auth.scope += ' read'  # write implies read
+            token_permission = TokenHasReadWriteScope()
+            has_oauth_permission = token_permission.has_permission(request, view)
+        return is_authenticated and (not is_oauth or has_oauth_permission)

--- a/ansible_base/oauth2_provider/permissions.py
+++ b/ansible_base/oauth2_provider/permissions.py
@@ -19,6 +19,7 @@ class OAuth2ScopePermission(BasePermission):
     def has_permission(self, request, view):
         is_authenticated = IsAuthenticated().has_permission(request, view)
         is_oauth = False
+        has_oauth_permission = False
         if is_authenticated and request.auth and isinstance(request.auth, oauth2_models.AbstractAccessToken):
             is_oauth = True
             scopes = request.auth.scope.split()

--- a/ansible_base/oauth2_provider/views/permissions.py
+++ b/ansible_base/oauth2_provider/views/permissions.py
@@ -1,4 +1,6 @@
+import oauth2_provider.models as oauth2_models
 from django.conf import settings
+from oauth2_provider.contrib.rest_framework import TokenHasReadWriteScope
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 
@@ -35,3 +37,22 @@ class OAuth2TokenPermission(BasePermission):
             if obj.application and obj.application.organization.access_qs(request.user, "change").exists():
                 return True
         return request.user == obj.user
+
+
+class OAuth2ScopePermission(BasePermission):
+    """
+    A DRF Permission class to be used by apps that functions in the following way:
+
+    - If an OAuth 2 token is used to authenticate, then its scope must contain the required scope
+      (i.e. read cannot use "unsafe" methods)
+    - Otherwise, fall back.
+    """
+
+    def has_permission(self, request, view):
+        if request.auth and isinstance(request.auth, oauth2_models.AbstractAccessToken):
+            scopes = request.auth.scope.split()
+            if 'write' in scopes and 'read' not in scopes:
+                request.auth.scope += ' read'  # write implies read
+            token_permission = TokenHasReadWriteScope()
+            return token_permission.has_permission(request, view)
+        return True

--- a/ansible_base/oauth2_provider/views/permissions.py
+++ b/ansible_base/oauth2_provider/views/permissions.py
@@ -1,24 +1,24 @@
-import oauth2_provider.models as oauth2_models
 from django.conf import settings
-from oauth2_provider.contrib.rest_framework import TokenHasReadWriteScope
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 
 class OAuth2TokenPermission(BasePermission):
-    # An app token is a token that has an application attached to it
-    # A personal access token (PAT) is a token with no application attached to it
-    # With that in mind:
-    # - An app token can be read, changed, or deleted if:
-    #   - I am the superuser
-    #   - I am the admin of the organization of the application of the token
-    #   - I am the user of the token
-    # - An app token can be created if:
-    #   - I have read access to the application (currently this means: I am the superuser)
-    # - A PAT can be read, changed, or deleted if:
-    #   - I am the superuser
-    #   - I am the user of the token
-    # - A PAT can be created if:
-    #   - I am a user
+    """
+    An app token is a token that has an application attached to it
+    A personal access token (PAT) is a token with no application attached to it
+    With that in mind:
+    - An app token can be read, changed, or deleted if:
+      - I am the superuser
+      - I am the admin of the organization of the application of the token
+      - I am the user of the token
+    - An app token can be created if:
+      - I have read access to the application (currently this means: I am the superuser)
+    - A PAT can be read, changed, or deleted if:
+      - I am the superuser
+      - I am the user of the token
+    - A PAT can be created if:
+      - I am a user
+    """
 
     def has_permission(self, request, view):
         # Handle PAT and app token creation separately
@@ -37,22 +37,3 @@ class OAuth2TokenPermission(BasePermission):
             if obj.application and obj.application.organization.access_qs(request.user, "change").exists():
                 return True
         return request.user == obj.user
-
-
-class OAuth2ScopePermission(BasePermission):
-    """
-    A DRF Permission class to be used by apps that functions in the following way:
-
-    - If an OAuth 2 token is used to authenticate, then its scope must contain the required scope
-      (i.e. read cannot use "unsafe" methods)
-    - Otherwise, fall back.
-    """
-
-    def has_permission(self, request, view):
-        if request.auth and isinstance(request.auth, oauth2_models.AbstractAccessToken):
-            scopes = request.auth.scope.split()
-            if 'write' in scopes and 'read' not in scopes:
-                request.auth.scope += ' read'  # write implies read
-            token_permission = TokenHasReadWriteScope()
-            return token_permission.has_permission(request, view)
-        return True

--- a/ansible_base/oauth2_provider/views/token.py
+++ b/ansible_base/oauth2_provider/views/token.py
@@ -12,7 +12,7 @@ from ansible_base.oauth2_provider.serializers import OAuth2TokenSerializer
 from ansible_base.oauth2_provider.views.permissions import OAuth2TokenPermission
 
 
-class TokenView(oauth_views.TokenView, AnsibleBaseDjangoAppApiView):
+class TokenView(oauth_views.TokenView):
     # There is a big flow of logic that happens around this (create_token_response) behind the scenes.
     #
     # oauth2_provider.views.TokenView inherits from oauth2_provider.views.mixins.OAuthLibMixin

--- a/docs/apps/oauth2_provider.md
+++ b/docs/apps/oauth2_provider.md
@@ -1,3 +1,32 @@
+# Security (Permissions)
+
+Token "scopes" are meaningless, until and unless they are checked. The upstream
+Django OAuth Toolit provides DRF permissions classes for checking them. In fact,
+they have some that get close to what we want, but none that exactly seem to do
+what we need. We really want a mix of their `IsAuthenticatedOrTokenHasScope` and
+their `TokenHasReadWriteScope`.
+
+Since this doesn't exist upstream, the DAB `oauth2_provider` app provides its
+own implementation,
+`ansible_base.oauth2_provider.permissions.OAuth2ScopePermission`.
+
+**You should set this as a default permission class in your app's settings.py**
+because for any view that doesn't include it, token scopes have no meaning, and
+every token is given full access.
+
+For example:
+
+```python
+REST_FRAMEWORK = {
+    # ...
+    'DEFAULT_PERMISSION_CLASSES': [
+        'ansible_base.oauth2_provider.permissions.OAuth2ScopePermission',
+        'ansible_base.rbac.api.permissions.AnsibleBaseObjectPermissions',
+    ],
+    # ...
+}
+```
+
 # Differences from AWX
 
 * Because of how DAB's router works, we don't allow for POSTing to (for example)

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -93,7 +93,10 @@ REST_FRAMEWORK = {
         'test_app.authentication.logged_basic_auth.LoggedBasicAuthentication',
         'test_app.authentication.service_token_auth.ServiceTokenAuthentication',
     ],
-    'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'ansible_base.oauth2_provider.permissions.OAuth2ScopePermission',
+        'ansible_base.rbac.api.permissions.AnsibleBaseObjectPermissions',
+    ],
 }
 
 DATABASES = {

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -149,31 +149,22 @@ def test_oauth2_bearer_no_activitystream(unauthenticated_api_client, oauth2_admi
     ],
 )
 @pytest.mark.django_db
-def test_oauth2_pat_scope(request, org_member_rd, org_admin_rd, user, user_api_client, scope, status):
+def test_oauth2_pat_scope(request, org_member_rd, org_admin_rd, admin_user, oauth2_admin_access_token, unauthenticated_api_client, scope, status):
     """
     Ensure that scopes are adhered to for PATs
     """
 
-    url = reverse("token-list")
+    oauth2_admin_access_token.scope = scope
+    oauth2_admin_access_token.save()
 
-    # Create PAT, read only
-    data = {
-        'description': 'new PAT',
-        'scope': scope,
-    }
-    response = user_api_client.post(url, data=data)
-    assert response.status_code == 201
-    token = response.data['token']
-
-    # Ensure read only PAT can't create
     url = reverse("animal-list")
     data = {
         "name": "Fido",
-        "owner": user.pk,
+        "owner": admin_user.pk,
     }
-    response = user_api_client.post(
+    response = unauthenticated_api_client.post(
         url,
         data=data,
-        headers={'Authorization': f'Bearer {token}'},
+        headers={'Authorization': f'Bearer {oauth2_admin_access_token.token}'},
     )
     assert response.status_code == status, response.status_code

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -191,6 +191,7 @@ class PublicDataViewSet(TestAppViewSet):
 class AnimalViewSet(TestAppViewSet):
     serializer_class = serializers.AnimalSerializer
     queryset = models.Animal.objects.all()
+    permission_classes = []
 
 
 class CityViewSet(TestAppViewSet):

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -11,6 +11,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 from ansible_base.oauth2_provider.views import DABOAuth2UserViewsetMixin
+from ansible_base.oauth2_provider.views.permissions import OAuth2ScopePermission
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.api.permissions import AnsibleBaseObjectPermissions, AnsibleBaseUserPermissions
 from ansible_base.rbac.policies import visible_users
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestAppViewSet(ModelViewSet, AnsibleBaseView):
-    permission_classes = [AnsibleBaseObjectPermissions]
+    permission_classes = [OAuth2ScopePermission, AnsibleBaseObjectPermissions]
     prefetch_related = ()
     select_related = ()
 
@@ -191,7 +192,6 @@ class PublicDataViewSet(TestAppViewSet):
 class AnimalViewSet(TestAppViewSet):
     serializer_class = serializers.AnimalSerializer
     queryset = models.Animal.objects.all()
-    permission_classes = []
 
 
 class CityViewSet(TestAppViewSet):

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -11,9 +11,8 @@ from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 from ansible_base.oauth2_provider.views import DABOAuth2UserViewsetMixin
-from ansible_base.oauth2_provider.views.permissions import OAuth2ScopePermission
 from ansible_base.rbac import permission_registry
-from ansible_base.rbac.api.permissions import AnsibleBaseObjectPermissions, AnsibleBaseUserPermissions
+from ansible_base.rbac.api.permissions import AnsibleBaseUserPermissions
 from ansible_base.rbac.policies import visible_users
 from test_app import models, serializers
 
@@ -21,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 class TestAppViewSet(ModelViewSet, AnsibleBaseView):
-    permission_classes = [OAuth2ScopePermission, AnsibleBaseObjectPermissions]
     prefetch_related = ()
     select_related = ()
 


### PR DESCRIPTION
Provide a DRF permission class for ensuring that token scopes are adhered to, based on the upstream DOT permission classes.