### PR TITLE
Allow managing org roles with view permission locally

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -145,6 +145,7 @@ class RoleDefinitionSerializer(CommonModelSerializer):
         else:
             content_type = self.instance.content_type
         validate_permissions_for_model(permissions, content_type)
+        check_locally_managed(permissions)
         return super().validate(validated_data)
 
 
@@ -255,7 +256,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
                 raise ValidationError({'object_id': _('Object must be specified for this role assignment')})
 
             check_content_obj_permission(requesting_user, obj)
-            check_locally_managed(rd)
+            check_locally_managed(rd.permissions.prefetch_related('content_type'))
 
             try:
                 with transaction.atomic():

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -136,7 +136,7 @@ class BaseAssignmentViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
         obj = instance.content_object
         if obj:
             check_content_obj_permission(self.request.user, obj)
-            check_locally_managed(instance.role_definition)
+            check_locally_managed(instance.role_definition.permissions.prefetch_related('content_type'))
             with transaction.atomic():
                 instance.role_definition.remove_permission(instance.actor, obj)
         else:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -1,5 +1,6 @@
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from typing import Optional, Type, Union
 
 from django.conf import settings
@@ -191,7 +192,7 @@ def validate_assignment(rd, actor, obj) -> None:
         raise ValidationError(f'Role type {rd_model} does not match object {obj_ct.model}')
 
 
-def check_locally_managed(rd: Model) -> None:
+def check_locally_managed(permissions_qs: Iterable[Model]) -> None:
     """Can the given role definition be managed here, or is it externally managed
 
     If the role definition manages permissions on any shared resources, then
@@ -201,7 +202,7 @@ def check_locally_managed(rd: Model) -> None:
     """
     if settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT is True:
         return
-    for perm in rd.permissions.prefetch_related('content_type'):
+    for perm in permissions_qs:
         # View permission for shared resources is interpreted as permission to view
         # the resource locally, which is needed to be able to view parent objects
         if perm.codename.startswith('view'):

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -202,6 +202,10 @@ def check_locally_managed(rd: Model) -> None:
     if settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT is True:
         return
     for perm in rd.permissions.prefetch_related('content_type'):
+        # View permission for shared resources is interpreted as permission to view
+        # the resource locally, which is needed to be able to view parent objects
+        if perm.codname.startswith('view'):
+            continue
         model = perm.content_type.model_class()
         if permission_registry.get_resource_prefix(model) == 'shared':
             raise ValidationError('Not managed locally, use the resource server instead')

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -204,7 +204,7 @@ def check_locally_managed(rd: Model) -> None:
     for perm in rd.permissions.prefetch_related('content_type'):
         # View permission for shared resources is interpreted as permission to view
         # the resource locally, which is needed to be able to view parent objects
-        if perm.codname.startswith('view'):
+        if perm.codename.startswith('view'):
             continue
         model = perm.content_type.model_class()
         if permission_registry.get_resource_prefix(model) == 'shared':

--- a/test_app/tests/rbac/conftest.py
+++ b/test_app/tests/rbac/conftest.py
@@ -23,7 +23,7 @@ def global_inv_rd():
 @pytest.fixture
 def org_inv_rd():
     return RoleDefinition.objects.create_from_permissions(
-        permissions=['change_organization', 'view_organization', 'change_inventory', 'view_inventory'],
+        permissions=['view_organization', 'change_inventory', 'view_inventory'],
         name='org-inv-rd',
         content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
     )

--- a/test_app/tests/rbac/conftest.py
+++ b/test_app/tests/rbac/conftest.py
@@ -21,10 +21,21 @@ def global_inv_rd():
 
 
 @pytest.fixture
-def org_inv_rd():
+def org_inv_change_rd():
+    """Strange custom role, kept around because older tests used it"""
     return RoleDefinition.objects.create_from_permissions(
-        permissions=['view_organization', 'change_inventory', 'view_inventory'],
-        name='org-inv-rd',
+        permissions=['view_organization', 'change_organization', 'change_inventory', 'view_inventory'],
+        name='org-inv-change-and-view-rd',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+
+
+@pytest.fixture
+def org_inv_rd():
+    """Typical example of an organization-level role that gives admin permissions to a child object"""
+    return RoleDefinition.objects.create_from_permissions(
+        permissions=['view_organization', 'add_inventory', 'change_inventory', 'delete_inventory', 'view_inventory'],
+        name='org-inv-admin-rd',
         content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
     )
 

--- a/test_app/tests/rbac/test_permission_assignment.py
+++ b/test_app/tests/rbac/test_permission_assignment.py
@@ -15,14 +15,14 @@ def test_invalid_actor(inventory, org_inv_rd):
 
 
 @pytest.mark.django_db
-def test_child_object_permission(rando, organization, inventory, org_inv_rd, admin_user):
+def test_child_object_permission(rando, organization, inventory, org_inv_change_rd, admin_user):
     assert inventory.organization == organization
 
     assert set(RoleEvaluation.accessible_objects(Organization, rando, 'change')) == set()
     assert set(RoleEvaluation.accessible_objects(Inventory, rando, 'change')) == set()
 
     with impersonate(admin_user):
-        assignment = org_inv_rd.give_permission(rando, organization)
+        assignment = org_inv_change_rd.give_permission(rando, organization)
 
     assert set(RoleEvaluation.accessible_objects(Organization, rando, 'change_organization')) == set([organization])
     assert set(RoleEvaluation.accessible_objects(Inventory, rando, 'change_inventory')) == set([inventory])
@@ -60,16 +60,16 @@ def test_organization_permission_change(org_inv_rd):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('order', ['role_first', 'obj_first'])
-def test_later_created_child_object_permission(rando, organization, order, org_inv_rd):
+def test_later_created_child_object_permission(rando, organization, order, org_inv_change_rd):
     assert set(RoleEvaluation.accessible_objects(Organization, rando, 'change')) == set()
     assert set(RoleEvaluation.accessible_objects(Inventory, rando, 'change')) == set()
 
     if order == 'role_first':
-        org_inv_rd.give_permission(rando, organization)
+        org_inv_change_rd.give_permission(rando, organization)
         inventory = Inventory.objects.create(name='for-test', organization=organization)
     else:
         inventory = Inventory.objects.create(name='for-test', organization=organization)
-        org_inv_rd.give_permission(rando, organization)
+        org_inv_change_rd.give_permission(rando, organization)
 
     assert set(RoleEvaluation.accessible_objects(Organization, rando, 'change_organization')) == set([organization])
     assert set(RoleEvaluation.accessible_objects(Inventory, rando, 'change_inventory')) == set([inventory])

--- a/test_app/tests/rbac/test_permission_evaluation.py
+++ b/test_app/tests/rbac/test_permission_evaluation.py
@@ -8,12 +8,12 @@ from test_app.models import Inventory, Organization
 
 
 @pytest.mark.django_db
-def test_org_inv_permissions_user(rando, inventory, org_inv_rd):
+def test_org_inv_permissions_user(rando, inventory, org_inv_change_rd):
     assert not rando.has_obj_perm(inventory, 'view_inventory')
     assert not rando.has_obj_perm(inventory, 'change_inventory')
     assert list(Inventory.access_qs(rando)) == []
 
-    org_inv_rd.give_permission(rando, inventory.organization)
+    org_inv_change_rd.give_permission(rando, inventory.organization)
 
     assert rando.has_obj_perm(inventory, 'view_inventory')
     assert rando.has_obj_perm(inventory, 'change_inventory')
@@ -29,12 +29,12 @@ def test_org_inv_permissions_user(rando, inventory, org_inv_rd):
 
 
 @pytest.mark.django_db
-def test_org_inv_permissions_team(team, inventory, org_inv_rd):
+def test_org_inv_permissions_team(team, inventory, org_inv_change_rd):
     "We support using team as actor in model methods like MyModel.access_qs(team) but do not attach has_obj_perm"
     assert list(Inventory.access_qs(team)) == []
     assert list(Inventory.access_ids_qs(team)) == []
 
-    org_inv_rd.give_permission(team, inventory.organization)
+    org_inv_change_rd.give_permission(team, inventory.organization)
 
     assert set(Organization.access_qs(team, 'change_organization')) == set([inventory.organization])
     assert set(Inventory.access_qs(team, 'view')) == set([inventory])

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -84,13 +84,13 @@ def test_delete_signals_object(organization, inventory, rando, inv_rd, what_to_d
 @pytest.mark.django_db
 @pytest.mark.parametrize('what_to_delete', ['user', 'org', 'object'])
 @pytest.mark.parametrize('cache_org', [True, False])
-def test_delete_signals_organization(organization, inventory, rando, inv_rd, org_inv_rd, what_to_delete, cache_org):
+def test_delete_signals_organization(organization, inventory, rando, org_inv_change_rd, what_to_delete, cache_org):
     user_id = rando.id
     inv_gfk = gfk_filter(inventory)
     org_gfk = gfk_filter(organization)
 
     with override_settings(ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS=cache_org):
-        assignment = org_inv_rd.give_permission(rando, organization)
+        assignment = org_inv_change_rd.give_permission(rando, organization)
         assert RoleEvaluation.objects.filter(**org_gfk).count() == (4 if cache_org else 2)
         assert RoleEvaluation.objects.filter(**inv_gfk).count() == 2
 


### PR DESCRIPTION
Modifies work in https://github.com/ansible/django-ansible-base/pull/430

This replaces https://github.com/ansible/django-ansible-base/pull/484, which I put up because I did not have the full details of what was happening.

We are getting unintended errors because organization-level roles contain the "shared.view_organization" permission. So this change will wave those through.

This means that some access evaluations will give a different answer on different servers in some cases (can I view this organization?). If that is restricted to viewing permission of parent objects, that appears manageable.

AAP-25541