### PR TITLE
Handle system user login via external source

### DIFF
--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -72,7 +72,7 @@ def determine_username_from_uid(uid: str = None, authenticator: Authenticator = 
         return new_username
 
     # We didn't have an exact match but no other provider is servicing this uid so lets return that for usage
-    logger.info(f"Authenticator {authenticator.name} is is able to authenticate user {uid} as {uid}")
+    logger.info(f"Authenticator {authenticator.name} is able to authenticate user {uid} as {uid}")
     return uid
 
 

--- a/ansible_base/lib/channels/middleware.py
+++ b/ansible_base/lib/channels/middleware.py
@@ -48,4 +48,4 @@ def DrfAuthMiddlewareStack(inner):  # noqa: N802
 
 
 def _http_key(key: str) -> str:
-    return f"HTTP_{key.replace('-','_').upper()}"
+    return f"HTTP_{key.replace('-', '_').upper()}"

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 from social_core.exceptions import AuthException
 
 from ansible_base.authentication.models import AuthenticatorUser
@@ -46,6 +47,26 @@ class TestAuthenticationUtilsAuthentication:
                 assert new_username == random_user.username
             else:
                 assert len(new_username) > len(random_user.username)
+
+    @pytest.mark.parametrize(
+        "auth_fixture",
+        [
+            "local_authenticator",
+            "ldap_authenticator",
+            "keycloak_authenticator",
+            "saml_authenticator",
+            "oidc_authenticator",
+            "tacacs_authenticator",
+            "radius_authenticator",
+        ],
+    )
+    def test_external_system_user_login(self, request, auth_fixture):
+        uid = settings.SYSTEM_USERNAME
+        authenticator = request.getfixturevalue(auth_fixture)
+        with pytest.raises(AuthException):
+            authentication.determine_username_from_uid(uid, authenticator)
+        with pytest.raises(AuthException):
+            authentication.get_or_create_authenticator_user(uid, authenticator, {}, {})
 
     #
     # Tests for get_or_create_authenticator_user (gocau)

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -26,7 +26,7 @@ class TestAuthenticationUtilsAuthentication:
     @pytest.mark.parametrize(
         "related_authenticator,info_message,expected_username",
         [
-            (None, 'is is able to authenticate user', True),
+            (None, 'is able to authenticate user', True),
             ('local', 'already authenticated', True),
             ('ldap', 'username is already in use by another authenticator', False),
             ('multiple', 'already authenticated', True),


### PR DESCRIPTION
Description:

- The `_system` user is not intended to be an interactive user. However, there is a possibility someone might create a `_system` user and attempt to log in via an external authenticator

This PR:
- Raise AuthException and return 403 when System User attempts to login via an external source
- Add unit tests

Steps to test:

1. Enable the testing authenticator in `container-startup.yml`
2. Create a user with username `_system` by adding in the appropriate configuration for _system user in the following files:
   -  LDAP: in `/aap-gateway/tools/ansible/roles/ldap/files/ldap.ldif` (remember to ensure the user pass the allow map policy)
   -  Radius: in `/aap-gateway/tools/ansible/roles/radius/defaults/main.yml`
   -  Keycloak: login to keycloak via port 8443 with credential (usr:`admin`, pw:`admin`), create a new _system user through the Users tab
 3. Login using _system credential
  - LDAP + Radius: login via port 8800 `/api/gateway/v1/login/`
  - Keycloak: navigate to /api/gateway/v1/ui_auth, choose the corresponding `login_url` for SAML/ OIDC
 4. Confirm that response is 403 - Forbidden and there is warning in logger.
 
 To see the 403 Permission Denied Page - need this [AAP-PR#442](https://github.com/ansible/aap-gateway/pull/442)

