### PR TITLE
Fix flaky test failure

### DIFF
--- a/test_app/tests/lib/utils/test_models.py
+++ b/test_app/tests/lib/utils/test_models.py
@@ -372,12 +372,13 @@ def test_get_system_user_create_raises_exception(resource_registry_in_installed_
     from ansible_base.resource_registry.models import ResourceType
 
     rr_app_name = 'ansible_base.resource_registry'
+    installed_apps = settings.INSTALLED_APPS.copy()
     if resource_registry_in_installed_apps and rr_app_name not in settings.INSTALLED_APPS:
-        settings.INSTALLED_APPS.append(rr_app_name)
+        installed_apps.append(rr_app_name)
     elif not resource_registry_in_installed_apps and rr_app_name in settings.INSTALLED_APPS:
-        settings.INSTALLED_APPS.remove(rr_app_name)
+        installed_apps.remove(rr_app_name)
 
-    with override_settings(SYSTEM_USERNAME='not_system'):
+    with override_settings(SYSTEM_USERNAME='not_system', INSTALLED_APPS=installed_apps):
         with mock.patch('ansible_base.lib.utils.models.create_system_user', side_effect=ResourceType.DoesNotExist("Failing on purpose")):
             try:
                 assert models.get_system_user() is None


### PR DESCRIPTION
Reproducer:

```
py.test test_app/tests/ -k "test_get_system_user_create_raises_exception or test_get_role_definition"
```

Without this patch, it fails with:

```
=========================================== short test summary info ===========================================
FAILED test_app/tests/rbac/api/test_rbac_views.py::test_get_role_definition - AssertionError: assert {'local.view_inventory', 'local.change_inventory'} == {'aap.view_inventory', 'aap.change_inventory'}
  
  Extra items in the left set:
  'local.change_inventory'
  'local.view_inventory'
  Extra items in the right set:
  'aap.view_inventory'
  'aap.change_inventory'
  
  Full diff:
    {
  -     'aap.change_inventory',
  ?       ^^
  +     'local.change_inventory',
  ?      +++ ^
  -     'aap.view_inventory',
  ?       ^^
  +     'local.view_inventory',
  ?      +++ ^
    }
```

With this patch, it passes. The test `test_get_system_user_create_raises_exception` was leaving around a modified `INSTALLED_APPS` for the rest of the test run.

Introduced in https://github.com/ansible/django-ansible-base/pull/433