### PR TITLE
Adding get_relative_url and get_fully_qualified_url

### DIFF
--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -3,11 +3,11 @@ import functools
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.abstract_models import ImmutableCommonModel
+from ansible_base.lib.utils.response import get_relative_url
 
 
 class Entry(ImmutableCommonModel):
@@ -107,7 +107,7 @@ class AuditableModel(models.Model):
             'content_type': content_type.pk,
             'object_id': self.pk,
         }
-        activity_stream_url = reverse('activitystream-list') + '?' + urlencode(query_kwargs)
+        activity_stream_url = get_relative_url('activitystream-list') + '?' + urlencode(query_kwargs)
         return {
             'activity_stream': activity_stream_url,
         }

--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -3,11 +3,11 @@ import logging
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.fields import empty
-from rest_framework.reverse import reverse
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.serializers.fields import JSONField
+from ansible_base.lib.utils.response import get_relative_url
 
 logger = logging.getLogger('ansible_base.authentication.authenticator_plugins.base')
 
@@ -127,7 +127,7 @@ class AbstractAuthenticatorPlugin:
 
     def get_login_url(self, authenticator):
         if authenticator.category == 'sso':
-            return reverse('social:begin', kwargs={'backend': authenticator.slug})
+            return get_relative_url('social:begin', kwargs={'backend': authenticator.slug})
 
     def add_related_fields(self, request, authenticator):
         return {}

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -5,7 +5,6 @@ from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 from onelogin.saml2.errors import OneLogin_Saml2_Error
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
-from rest_framework.reverse import reverse
 from rest_framework.serializers import ValidationError
 from rest_framework.views import View
 from social_core.backends.saml import SAMLAuth, SAMLIdentityProvider
@@ -22,6 +21,7 @@ from ansible_base.authentication.social_auth import (
 )
 from ansible_base.lib.serializers.fields import CharField, JSONField, ListField, PrivateKey, PublicCert, URLField
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.lib.utils.validation import validate_cert_with_key
 
@@ -243,11 +243,11 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
     configuration_encrypted_fields = ['SP_PRIVATE_KEY']
 
     def get_login_url(self, authenticator):
-        url = reverse('social:begin', kwargs={'backend': authenticator.slug})
+        url = get_relative_url('social:begin', kwargs={'backend': authenticator.slug})
         return f'{url}?idp={idp_string}'
 
     def add_related_fields(self, request, authenticator):
-        return {"metadata": reverse('authenticator-metadata', kwargs={'pk': authenticator.id})}
+        return {"metadata": get_relative_url('authenticator-metadata', kwargs={'pk': authenticator.id})}
 
     def extra_data(self, user, backend, response, *args, **kwargs):
         attrs = response["attributes"] if "attributes" in response else {}

--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -1,13 +1,13 @@
 from collections import OrderedDict
 
 from django.utils.translation import gettext_lazy as _
-from rest_framework.reverse import reverse
 from rest_framework.serializers import ChoiceField, ValidationError
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
+from ansible_base.lib.utils.response import get_relative_url
 
 
 class AuthenticatorSerializer(NamedCommonModelSerializer):
@@ -115,6 +115,6 @@ class AuthenticatorSerializer(NamedCommonModelSerializer):
         from ansible_base.authentication.views.authenticator_users import get_authenticator_user_view
 
         if get_authenticator_user_view():
-            related['users'] = reverse('authenticator-users-list', kwargs={'pk': obj.pk})
+            related['users'] = get_relative_url('authenticator-users-list', kwargs={'pk': obj.pk})
 
         return related

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -6,7 +6,6 @@ from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.utils import IntegrityError
 from django.http import HttpResponseNotFound
-from rest_framework.reverse import reverse
 from social_core.utils import setting_name
 from social_django.models import Association, Code, Nonce, Partial
 from social_django.storage import BaseDjangoStorage
@@ -14,6 +13,7 @@ from social_django.strategy import DjangoStrategy
 
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_class, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
+from ansible_base.lib.utils.response import get_fully_qualified_url
 
 logger = logging.getLogger('ansible_base.authentication.social_auth')
 
@@ -182,7 +182,7 @@ class SocialAuthValidateCallbackMixin:
             else:
                 slug = serializer.instance.slug
 
-            configuration['CALLBACK_URL'] = reverse('social:complete', request=serializer.context['request'], kwargs={'backend': slug})
+            configuration['CALLBACK_URL'] = get_fully_qualified_url('social:complete', kwargs={'backend': slug})
 
         return data
 

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -7,11 +7,11 @@ from django.db import models
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import gettext_lazy as _
 from inflection import underscore
-from rest_framework.reverse import reverse
 
 from ansible_base.lib.abstract_models.immutable import ImmutableModel
 from ansible_base.lib.utils.encryption import ansible_encryption
 from ansible_base.lib.utils.models import current_user_or_system_user, is_system_user
+from ansible_base.lib.utils.response import get_relative_url
 
 logger = logging.getLogger('ansible_base.lib.abstract_models.common')
 
@@ -31,7 +31,7 @@ def get_url_for_object(obj, request=None, pk=None):
     basename = get_cls_view_basename(obj.__class__)
 
     try:
-        return reverse(f'{basename}-detail', kwargs={'pk': pk or obj.pk})
+        return get_relative_url(f'{basename}-detail', kwargs={'pk': pk or obj.pk})
     except NoReverseMatch:
         logger.debug(f"Tried to reverse {basename}-detail for model {obj.__class__.__name__} but said view is not defined")
         return ''
@@ -201,7 +201,7 @@ class AbstractCommonModel(models.Model):
                 continue
             reverse_view = f"{basename}-{field_name}-list"
             try:
-                response[field_name] = reverse(reverse_view, kwargs={'pk': self.pk})
+                response[field_name] = get_relative_url(reverse_view, kwargs={'pk': self.pk})
             except NoReverseMatch:
                 missing_relations.append(reverse_view)
 

--- a/ansible_base/oauth2_provider/fixtures.py
+++ b/ansible_base/oauth2_provider/fixtures.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timezone
 
 import pytest
-from django.urls import reverse
 from oauthlib.common import generate_token
 
 from ansible_base.lib.testing.fixtures import copy_fixture
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2Application
 
 __all__ = [  # noqa: F822, the additional _pat_X are unknown so we need this here
@@ -62,7 +62,7 @@ def oauth2_application_password(randname):
 
 @pytest.fixture
 def oauth2_admin_access_token(oauth2_application, admin_api_client, admin_user):
-    url = reverse('token-list')
+    url = get_relative_url('token-list')
     response = admin_api_client.post(url, {'application': oauth2_application[0].pk})
     assert response.status_code == 201
     return OAuth2AccessToken.objects.get(token=response.data['token'])

--- a/ansible_base/oauth2_provider/models/application.py
+++ b/ansible_base/oauth2_provider/models/application.py
@@ -1,12 +1,12 @@
 import oauth2_provider.models as oauth2_models
 from django.conf import settings
 from django.db import models
-from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from oauth2_provider.generators import generate_client_secret
 
 from ansible_base.lib.abstract_models.common import NamedCommonModel
 from ansible_base.lib.utils.models import prevent_search
+from ansible_base.lib.utils.response import get_relative_url
 
 activitystream = object
 if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
@@ -87,4 +87,4 @@ class OAuth2Application(NamedCommonModel, oauth2_models.AbstractApplication, act
     def get_absolute_url(self):
         # This is kind of annoying. This method lives on the superclass and we check for it in CommonModel.
         # But better would be to not have this method and let the CommonModel logic fall back to the "right" way of finding this.
-        return reverse(f'{self.router_basename}-detail', kwargs={'pk': self.pk})
+        return get_relative_url(f'{self.router_basename}-detail', kwargs={'pk': self.pk})

--- a/ansible_base/oauth2_provider/views/authorization_root.py
+++ b/ansible_base/oauth2_provider/views/authorization_root.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 from django.utils.translation import gettext_lazy as _
 from rest_framework import permissions
 from rest_framework.response import Response
-from rest_framework.reverse import _reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 
@@ -16,7 +16,7 @@ class ApiOAuthAuthorizationRootView(AnsibleBaseDjangoAppApiView):
 
     def get(self, request, format=None):
         data = OrderedDict()
-        data['authorize'] = _reverse('authorize')
-        data['revoke_token'] = _reverse('revoke-token')
-        data['token'] = _reverse('token')
+        data['authorize'] = get_relative_url('authorize')
+        data['revoke_token'] = get_relative_url('revoke-token')
+        data['token'] = get_relative_url('token')
         return Response(data)

--- a/ansible_base/oauth2_provider/views/user_mixin.py
+++ b/ansible_base/oauth2_provider/views/user_mixin.py
@@ -1,9 +1,9 @@
 from django.contrib.auth import get_user_model
-from django.urls import reverse
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from ansible_base.lib.abstract_models.common import get_cls_view_basename
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2AccessToken
 from ansible_base.oauth2_provider.serializers import OAuth2TokenSerializer
 
@@ -16,9 +16,9 @@ class DABOAuth2UserViewsetMixin:
     def extra_related_fields(self, obj) -> dict[str, str]:
         fields = super().extra_related_fields(obj)
         user_basename = get_cls_view_basename(get_user_model())
-        fields['personal_tokens'] = reverse(f'{user_basename}-personal-tokens-list', kwargs={"pk": obj.pk})
-        fields['authorized_tokens'] = reverse(f'{user_basename}-authorized-tokens-list', kwargs={"pk": obj.pk})
-        fields['tokens'] = reverse(f'{user_basename}-tokens-list', kwargs={"pk": obj.pk})
+        fields['personal_tokens'] = get_relative_url(f'{user_basename}-personal-tokens-list', kwargs={"pk": obj.pk})
+        fields['authorized_tokens'] = get_relative_url(f'{user_basename}-authorized-tokens-list', kwargs={"pk": obj.pk})
+        fields['tokens'] = get_relative_url(f'{user_basename}-tokens-list', kwargs={"pk": obj.pk})
         return fields
 
     def _user_token_response(self, request, filters, pk):

--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
-from rest_framework.reverse import reverse_lazy
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.resource_registry.models import Resource, ResourceType
 
 logger = logging.getLogger('ansible_base.serializers')
@@ -51,7 +51,7 @@ class ResourceSerializer(serializers.ModelSerializer):
 
     def get_url(self, obj) -> str:
         # conversion to string is done to satisfy type checking and OpenAPI schema generator
-        return str(reverse_lazy('resource-detail', kwargs={"ansible_id": obj.ansible_id}))
+        return get_relative_url('resource-detail', kwargs={"ansible_id": obj.ansible_id})
 
     def get_has_serializer(self, obj) -> bool:
         return bool(obj.content_type.resource_type.get_resource_config().managed_serializer)
@@ -108,7 +108,7 @@ class ResourceTypeSerializer(serializers.ModelSerializer):
             return None
 
     def get_url(self, obj) -> str:
-        return str(reverse_lazy('resourcetype-detail', kwargs={"name": obj.name}))
+        return get_relative_url('resourcetype-detail', kwargs={"name": obj.name})
 
 
 class UserAuthenticationSerializer(serializers.Serializer):

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -8,10 +8,9 @@ from rest_framework import permissions
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 from rest_framework.viewsets import GenericViewSet, mixins
 
-from ansible_base.lib.utils.response import CSVStreamResponse
+from ansible_base.lib.utils.response import CSVStreamResponse, get_relative_url
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 from ansible_base.resource_registry.models import Resource, ResourceType, service_id
 from ansible_base.resource_registry.models.resource import resource_type_cache
@@ -174,9 +173,9 @@ class ServiceIndexRootView(AnsibleBaseDjangoAppApiView):
         '''Link other resource registry endpoints'''
 
         data = OrderedDict()
-        data['metadata'] = reverse('service-metadata')
-        data['resources'] = reverse('resource-list')
-        data['resource-types'] = reverse('resourcetype-list')
+        data['metadata'] = get_relative_url('service-metadata')
+        data['resources'] = get_relative_url('resource-list')
+        data['resource-types'] = get_relative_url('resourcetype-list')
         return Response(data)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ legacy_tox_ini = """
     [testenv:black]
     deps =
         black
-    commands = black {posargs:.}
+    commands = black --version && black {posargs:.}
 
     [testenv:isort]
     deps =

--- a/test_app/tests/activitystream/models/test_entry.py
+++ b/test_app/tests/activitystream/models/test_entry.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
+
+from ansible_base.lib.utils.response import get_relative_url
 
 
 def test_activitystream_entry_immutable(system_user, animal):
@@ -16,7 +17,7 @@ def test_activitystream_entry_immutable(system_user, animal):
 
 
 def test_activitystream_auditablemodel_related(admin_api_client, user, organization):
-    url = reverse('user-detail', kwargs={'pk': user.pk})
+    url = get_relative_url('user-detail', kwargs={'pk': user.pk})
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert 'activity_stream' in response.data['related']
@@ -26,7 +27,7 @@ def test_activitystream_auditablemodel_related(admin_api_client, user, organizat
     assert f'content_type={content_type.pk}' in activity_stream_url
 
     # organization isn't an AuditableModel, so it shouldn't show AS in related
-    url = reverse('organization-detail', kwargs={'pk': organization.pk})
+    url = get_relative_url('organization-detail', kwargs={'pk': organization.pk})
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert 'activity_stream' not in response.data['related']

--- a/test_app/tests/authentication/authenticator_plugins/test_azuread.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_azuread.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_azuread_auth_successful(authenticate, unauthenticated_api_client, azure
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_azuread_auth_failed(authenticate, unauthenticated_api_client, azuread_a
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_github.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_github.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_github_auth_successful(authenticate, unauthenticated_api_client, github
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_github_auth_failed(authenticate, unauthenticated_api_client, github_aut
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_github_enterprise.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_github_enterprise.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_github_enterprise_auth_successful(authenticate, unauthenticated_api_cli
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_github_enterprise_auth_failed(authenticate, unauthenticated_api_client,
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_github_enterprise_org.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_github_enterprise_org.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_github_enterprise_org_auth_successful(authenticate, unauthenticated_api
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_github_enterprise_org_auth_failed(authenticate, unauthenticated_api_cli
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_github_enterprise_team.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_github_enterprise_team.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_github_enterprise_team_auth_successful(authenticate, unauthenticated_ap
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_github_enterprise_team_auth_failed(authenticate, unauthenticated_api_cl
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_github_org.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_github_org.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_github_org_auth_successful(authenticate, unauthenticated_api_client, gi
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_github_org_auth_failed(authenticate, unauthenticated_api_client, github
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_github_team.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_github_team.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_github_team_auth_successful(authenticate, unauthenticated_api_client, g
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_github_team_auth_failed(authenticate, unauthenticated_api_client, githu
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_google_oauth2.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_google_oauth2.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -19,7 +18,7 @@ def test_oidc_auth_successful(authenticate, unauthenticated_api_client, google_o
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -33,6 +32,6 @@ def test_oidc_auth_failed(authenticate, unauthenticated_api_client, google_oauth
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401

--- a/test_app/tests/authentication/authenticator_plugins/test_keycloak.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_keycloak.py
@@ -1,9 +1,8 @@
 from unittest import mock
 
-from django.urls import reverse
-
 from ansible_base.authentication.authenticator_plugins.keycloak import AuthenticatorPlugin
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -21,7 +20,7 @@ def test_keycloak_auth_successful(authenticate, unauthenticated_api_client, keyc
     did_login = client.login()
     assert did_login, "Failed to login"
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -38,7 +37,7 @@ def test_keycloak_auth_failure(authenticate, unauthenticated_api_client, keycloa
     authenticate.return_value = None
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401
 

--- a/test_app/tests/authentication/authenticator_plugins/test_local.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_local.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 import pytest
 from django.test.client import RequestFactory
-from django.urls import reverse
 
 from ansible_base.authentication.authenticator_plugins.local import AuthenticatorPlugin
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -18,7 +18,7 @@ def test_local_auth_successful(unauthenticated_api_client, local_authenticator, 
     client = unauthenticated_api_client
     client.login(username="user", password="password")
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -41,7 +41,7 @@ def test_local_auth_failure(unauthenticated_api_client, local_authenticator, use
     client = unauthenticated_api_client
     client.login(username=username, password=password)
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401
 
@@ -58,7 +58,7 @@ def test_local_auth_create_configuration_must_be_empty(admin_api_client, configu
     Attempt to create a local authenticator with invalid configuration and test
     that it fails.
     """
-    url = reverse("authenticator-list")
+    url = get_relative_url("authenticator-list")
     data = {
         "name": "Test local authenticator created via API",
         "configuration": configuration,

--- a/test_app/tests/authentication/authenticator_plugins/test_oidc.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_oidc.py
@@ -2,11 +2,11 @@ import json
 from unittest import mock
 
 import pytest
-from django.urls import reverse
 from jwt.exceptions import PyJWTError
 
 from ansible_base.authentication.authenticator_plugins.oidc import AuthenticatorPlugin
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -23,7 +23,7 @@ def test_oidc_auth_successful(authenticate, unauthenticated_api_client, oidc_aut
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -37,7 +37,7 @@ def test_oidc_auth_failed(authenticate, unauthenticated_api_client, oidc_authent
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401
 
@@ -89,7 +89,7 @@ def test_oidc_endpoint_url_validation(
         "type": "ansible_base.authentication.authenticator_plugins.oidc",
     }
 
-    url = reverse("authenticator-list")
+    url = get_relative_url("authenticator-list")
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == expected_status_code
     if expected_error:

--- a/test_app/tests/authentication/authenticator_plugins/test_radius.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_radius.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 from django.contrib.auth.models import Group
 from django.test import RequestFactory
-from django.urls import reverse
 from pyrad.client import Timeout
 from pyrad.packet import AccessAccept, AccessReject, AccessRequest
 
@@ -13,6 +12,7 @@ from ansible_base.authentication.authenticator_plugins._radiusauth import RADIUS
 from ansible_base.authentication.authenticator_plugins.radius import AuthenticatorPlugin, RADIUSBackend, RADIUSUser
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 from test_app.models import User
 
 authenticated_test_page = "authenticator-list"
@@ -30,7 +30,7 @@ def test_oidc_auth_successful(authenticate, unauthenticated_api_client, radius_a
     authenticate.return_value = user
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -44,7 +44,7 @@ def test_oidc_auth_failed(authenticate, unauthenticated_api_client, radius_authe
     client = unauthenticated_api_client
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401
 
@@ -75,7 +75,7 @@ def test_authenticator_plugin(backend_cls, unauthenticated_api_client, radius_co
     client = unauthenticated_api_client
     client.login(username=random_username, password=random_password)
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -102,7 +102,7 @@ def test_authenticator_plugin_failed(backend_cls, unauthenticated_api_client, ra
     client = unauthenticated_api_client
     client.login(username="invalid", password="password")
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401
 
@@ -133,7 +133,7 @@ def test_base_radius_backend(pyrad_client_cls):
     )
     client.SendPacket.return_value = reply
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     requeest_factory = RequestFactory()
     request = requeest_factory.get(url)
 
@@ -175,7 +175,7 @@ def test_radius_realm_backend(pyrad_client_cls):
     )
     client.SendPacket.return_value = reply
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     requeest_factory = RequestFactory()
     request = requeest_factory.get(url)
 
@@ -216,7 +216,7 @@ def test_radius_backend(pyrad_client_cls):
     )
     client.SendPacket.return_value = reply
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     requeest_factory = RequestFactory()
     request = requeest_factory.get(url)
 
@@ -244,7 +244,7 @@ def test_radius_backend_access_reject(pyrad_client_cls):
     auth_packet = client.CreateAuthPacket.return_value
     client.SendPacket.return_value.code = AccessReject
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     requeest_factory = RequestFactory()
     request = requeest_factory.get(url)
 
@@ -266,7 +266,7 @@ def test_radius_backend_access_timeout(pyrad_client_cls):
     auth_packet = client.CreateAuthPacket.return_value
     client.SendPacket.side_effect = Timeout
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     requeest_factory = RequestFactory()
     request = requeest_factory.get(url)
 

--- a/test_app/tests/authentication/authenticator_plugins/test_tacacs.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_tacacs.py
@@ -5,10 +5,10 @@ from unittest.mock import MagicMock
 import pytest
 from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
-from django.urls import reverse
 
 from ansible_base.authentication.authenticator_plugins.tacacs import AuthenticatorPlugin, validate_tacacsplus_disallow_nonascii
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
 
@@ -29,7 +29,7 @@ def test_tacacs_auth_successful(authenticate, unauthenticated_api_client, tacacs
     did_login = client.login()
     assert did_login, "Failed to login"
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 200
 
@@ -46,7 +46,7 @@ def test_tacacs_auth_failure(authenticate, unauthenticated_api_client, tacacs_au
     authenticate.return_value = None
     client.login()
 
-    url = reverse(authenticated_test_page)
+    url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401
 
@@ -236,7 +236,7 @@ def test_tacacs_create_authenticator_error_handling(admin_api_client, tacacs_con
         else:
             tacacs_configuration[key] = value
 
-    url = reverse("authenticator-list")
+    url = get_relative_url("authenticator-list")
     data = {
         "name": "TACACS authenticator (should not get created)",
         "enabled": True,

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -49,7 +49,7 @@ class SubstringMatcher:
         ({'type': 'foo', 'name': 'bar', 'configuration': {}}, False, False, {'type': 'foo', 'name': 'bar', 'configuration': {'CALLBACK_URL': '/foo/bar'}}),
     ],
 )
-@mock.patch("ansible_base.authentication.social_auth.reverse")
+@mock.patch("ansible_base.authentication.social_auth.get_fully_qualified_url")
 @mock.patch("ansible_base.authentication.social_auth.generate_authenticator_slug")
 def test_social_auth_validate_callback_mixin(mocked_generate_slug, mocked_reverse, test_data, has_instance, has_slug, expected_result):
     mocked_reverse.return_value = '/foo/bar'

--- a/test_app/tests/authentication/views/test_authenticator_map.py
+++ b/test_app/tests/authentication/views/test_authenticator_map.py
@@ -1,14 +1,15 @@
 import pytest
 from django import VERSION
 from django.db import connection
-from django.urls import reverse
+
+from ansible_base.lib.utils.response import get_relative_url
 
 
 def test_authenticator_map_list_empty_by_default(admin_api_client):
     """
     Test that we can list authenticator maps. No maps are listed by default.
     """
-    url = reverse("authenticatormap-list")
+    url = get_relative_url("authenticatormap-list")
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert response.data['results'] == []
@@ -18,7 +19,7 @@ def test_authenticator_map_list(admin_api_client, local_authenticator_map):
     """
     Test that we can list authenticator maps, if they exist.
     """
-    url = reverse("authenticatormap-list")
+    url = get_relative_url("authenticatormap-list")
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert len(response.data['results']) == 1
@@ -30,7 +31,7 @@ def test_authenticator_map_detail(admin_api_client, local_authenticator_map):
     """
     Test that we can get a single authenticator map.
     """
-    url = reverse("authenticatormap-detail", kwargs={'pk': local_authenticator_map.id})
+    url = get_relative_url("authenticatormap-detail", kwargs={'pk': local_authenticator_map.id})
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert response.data['id'] == local_authenticator_map.id
@@ -51,7 +52,7 @@ def test_authenticator_map_create(admin_api_client, local_authenticator, trigger
     """
     Test that we can create an authenticator map.
     """
-    url = reverse("authenticatormap-list")
+    url = get_relative_url("authenticatormap-list")
     data = {
         'name': 'Rule 3',
         'authenticator': local_authenticator.id,
@@ -72,7 +73,7 @@ def test_authenticator_map_invalid_map_type(admin_api_client, local_authenticato
     """
     Invalid map_type should be rejected.
     """
-    url = reverse("authenticatormap-list")
+    url = get_relative_url("authenticatormap-list")
     data = {
         'authenticator': local_authenticator.id,
         'map_type': 'invalid',
@@ -164,7 +165,7 @@ def test_authenticator_map_validate(admin_api_client, local_authenticator, shut_
     """
     Create invalid authenticator maps and ensure that they are rejected.
     """
-    url = reverse("authenticatormap-list")
+    url = get_relative_url("authenticatormap-list")
     data = {
         'authenticator': local_authenticator.id,
     }
@@ -273,7 +274,7 @@ def test_authenticator_map_validate_trigger_data(admin_api_client, local_authent
     """
     Test trigger validation for authenticator maps.
     """
-    url = reverse("authenticatormap-list")
+    url = get_relative_url("authenticatormap-list")
     data = {
         'name': 'Rule 2',
         'triggers': triggers,

--- a/test_app/tests/authentication/views/test_authenticator_plugins.py
+++ b/test_app/tests/authentication/views/test_authenticator_plugins.py
@@ -1,6 +1,5 @@
-from django.urls import reverse
-
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugins
+from ansible_base.lib.utils.response import get_relative_url
 
 
 def test_plugin_authenticator_view(admin_api_client):
@@ -8,7 +7,7 @@ def test_plugin_authenticator_view(admin_api_client):
     Test the authenticator plugin view. It should show all available plugins
     (which exist on the system as python files, not database entries).
     """
-    url = reverse("authenticator_plugin-view")
+    url = get_relative_url("authenticator_plugin-view")
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert 'authenticators' in response.data
@@ -31,7 +30,7 @@ def test_plugin_authenticator_view_import_error(admin_api_client, shut_up_loggin
 
     get_authenticator_plugins.cache_clear()
 
-    url = reverse("authenticator_plugin-view")
+    url = get_relative_url("authenticator_plugin-view")
     response = admin_api_client.get(url)
 
     assert response.status_code == 200
@@ -58,7 +57,7 @@ def test_plugin_authenticator_plugin_from_custom_module(admin_user, unauthentica
         fixture_module,
     ]
 
-    url = reverse("authenticator-detail", kwargs={'pk': custom_authenticator.pk})
+    url = get_relative_url("authenticator-detail", kwargs={'pk': custom_authenticator.pk})
 
     client = unauthenticated_api_client
     client.login(username=admin_user.username, password="wrongpw")

--- a/test_app/tests/authentication/views/test_authenticator_user.py
+++ b/test_app/tests/authentication/views/test_authenticator_user.py
@@ -3,10 +3,10 @@ from functools import partial
 import pytest
 from django.http import Http404
 from django.test.utils import override_settings
-from django.urls import reverse
 
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.views.authenticator_users import get_authenticator_user_view
+from ansible_base.lib.utils.response import get_relative_url
 
 
 def test_authenticator_user_view_get_parent_view_unset_value(expected_log):
@@ -75,7 +75,7 @@ def test_authenticator_related_users_view(request, client_fixture, local_authent
     """
     AuthenticatorUser.objects.get_or_create(uid=user.username, user=user, provider=local_authenticator)
     client = request.getfixturevalue(client_fixture)
-    url = reverse("authenticator-users-list", kwargs={"pk": local_authenticator.pk})
+    url = get_relative_url("authenticator-users-list", kwargs={"pk": local_authenticator.pk})
     response = client.get(url)
 
     if client_fixture == "unauthenticated_api_client":
@@ -89,6 +89,6 @@ def test_authenticator_related_users_view(request, client_fixture, local_authent
 
 
 def test_authenticator_users_bad_pk(admin_api_client):
-    url = reverse("authenticator-users-list", kwargs={"pk": 10397})
+    url = get_relative_url("authenticator-users-list", kwargs={"pk": 10397})
     response = admin_api_client.get(url)
     assert response.status_code == 404

--- a/test_app/tests/authentication/views/test_authenticators.py
+++ b/test_app/tests/authentication/views/test_authenticators.py
@@ -1,5 +1,6 @@
 import pytest
-from django.urls import reverse
+
+from ansible_base.lib.utils.response import get_relative_url
 
 
 @pytest.mark.django_db
@@ -8,7 +9,7 @@ def test_authenticators_view_denies_delete_last_enabled_authenticator(admin_api_
     Test that the admin can't delete the last enabled authenticator.
     """
 
-    url = reverse("authenticator-detail", kwargs={'pk': local_authenticator.pk})
+    url = get_relative_url("authenticator-detail", kwargs={'pk': local_authenticator.pk})
     response = admin_api_client.delete(url)
     assert response.status_code == 400
     assert response.data['details'] == "Authenticator cannot be deleted, as no authenticators would be enabled"

--- a/test_app/tests/lib/serializers/test_validate.py
+++ b/test_app/tests/lib/serializers/test_validate.py
@@ -1,5 +1,6 @@
 import pytest
-from django.urls import reverse
+
+from ansible_base.lib.utils.response import get_relative_url
 
 authenticator_data = {
     "name": "Local Database Authenticator",
@@ -61,9 +62,9 @@ def test_validation_mixin_validate(
     local_authenticator, admin_api_client, reverse_name, method, query_params, same_name, configuration, response_code, response_body
 ):
     if reverse_name == 'authenticator-detail':
-        url = reverse(reverse_name, kwargs={'pk': local_authenticator.pk})
+        url = get_relative_url(reverse_name, kwargs={'pk': local_authenticator.pk})
     else:
-        url = reverse(reverse_name)
+        url = get_relative_url(reverse_name)
 
     if query_params:
         url = f'{url}?{query_params}'

--- a/test_app/tests/lib/utils/test_views.py
+++ b/test_app/tests/lib/utils/test_views.py
@@ -71,7 +71,6 @@ def test_ansible_base_view_parent_view_exception(caplog):
     with override_settings(ANSIBLE_BASE_CUSTOM_VIEW_PARENT='does.not.exist'):
         with caplog.at_level(logging.ERROR):
             with mock.patch('ansible_base.lib.utils.settings.get_from_import', side_effect=ImportError("Test Exception")):
-
                 import ansible_base.lib.utils.views.django_app_api
 
                 importlib.reload(ansible_base.lib.utils.views.django_app_api)

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 import pytest
-from django.urls import reverse
 from oauthlib.common import generate_token
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2AccessToken
 
 
@@ -19,7 +19,7 @@ def test_oauth2_bearer_get_user_correct(unauthenticated_api_client, oauth2_admin
     """
     Perform a GET with a bearer token and ensure the authed user is correct.
     """
-    url = reverse("user-me")
+    url = get_relative_url("user-me")
     response = unauthenticated_api_client.get(
         url,
         headers={'Authorization': f'Bearer {oauth2_admin_access_token.token}'},
@@ -39,7 +39,7 @@ def test_oauth2_bearer_get(unauthenticated_api_client, oauth2_admin_access_token
     """
     GET an animal with a bearer token.
     """
-    url = reverse("animal-detail", kwargs={"pk": animal.pk})
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
     token = oauth2_admin_access_token.token if token == 'fixture' else generate_token()
     response = unauthenticated_api_client.get(
         url,
@@ -61,7 +61,7 @@ def test_oauth2_bearer_post(unauthenticated_api_client, oauth2_admin_access_toke
     """
     POST an animal with a bearer token.
     """
-    url = reverse("animal-list")
+    url = get_relative_url("animal-list")
     token = oauth2_admin_access_token.token if token == 'fixture' else generate_token()
     data = {
         "name": "Fido",
@@ -88,7 +88,7 @@ def test_oauth2_bearer_patch(unauthenticated_api_client, oauth2_admin_access_tok
     """
     PATCH an animal with a bearer token.
     """
-    url = reverse("animal-detail", kwargs={"pk": animal.pk})
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
     token = oauth2_admin_access_token.token if token == 'fixture' else generate_token()
     data = {
         "name": "Fido",
@@ -114,7 +114,7 @@ def test_oauth2_bearer_put(unauthenticated_api_client, oauth2_admin_access_token
     """
     PUT an animal with a bearer token.
     """
-    url = reverse("animal-detail", kwargs={"pk": animal.pk})
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
     token = oauth2_admin_access_token.token if token == 'fixture' else generate_token()
     data = {
         "name": "Fido",
@@ -134,7 +134,7 @@ def test_oauth2_bearer_no_activitystream(unauthenticated_api_client, oauth2_admi
     """
     Ensure no activitystream entries for bearer token based auth
     """
-    url = reverse("animal-detail", kwargs={"pk": animal.pk})
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
     token = oauth2_admin_access_token.token
     existing_as_count = len(oauth2_admin_access_token.activity_stream_entries)
 
@@ -166,7 +166,7 @@ def test_oauth2_scope_permission(request, admin_user, oauth2_admin_access_token,
     oauth2_admin_access_token.scope = scope
     oauth2_admin_access_token.save()
 
-    url = reverse("animal-list")
+    url = get_relative_url("animal-list")
     data = {
         "name": "Fido",
         "owner": admin_user.pk,
@@ -184,7 +184,7 @@ def test_oauth2_scope_permission_not_oauth(user, user_api_client, only_oauth_sco
     Ensure that non-OAuth (but still authenticated) requests pass through.
     """
 
-    url = reverse("animal-list")
+    url = get_relative_url("animal-list")
     data = {
         "name": "Fido",
         "owner": user.pk,
@@ -198,7 +198,7 @@ def test_oauth2_scope_permission_not_authenticated(user, unauthenticated_api_cli
     Ensure that non-authenticated are blocked.
     """
 
-    url = reverse("animal-list")
+    url = get_relative_url("animal-list")
     data = {
         "name": "Fido",
         "owner": user.pk,

--- a/test_app/tests/oauth2_provider/test_rbac.py
+++ b/test_app/tests/oauth2_provider/test_rbac.py
@@ -11,8 +11,8 @@ conditions are not met).
 """
 
 import pytest
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2AccessToken
 from ansible_base.rbac.models import RoleDefinition
 
@@ -75,7 +75,7 @@ def test_oauth2_application_read_change_delete(
 
     if user is not None:
         unauthenticated_api_client.force_login(user)
-    url = reverse("application-detail", args=[app.id])
+    url = get_relative_url("application-detail", args=[app.id])
 
     # Read
     response = unauthenticated_api_client.get(url)
@@ -141,7 +141,7 @@ def test_oauth2_application_create(
 
     if user is not None:
         unauthenticated_api_client.force_login(user)
-    url = reverse("application-list")
+    url = get_relative_url("application-list")
     data = {
         'name': 'new app',
         'organization': organization.id,
@@ -223,7 +223,7 @@ def test_oauth2_application_token_read_change_delete(
 
     if user is not None:
         unauthenticated_api_client.force_login(user)
-    url = reverse("token-detail", args=[oauth2_user_application_token.id])
+    url = get_relative_url("token-detail", args=[oauth2_user_application_token.id])
 
     # Read
     response = unauthenticated_api_client.get(url)
@@ -298,7 +298,7 @@ def test_oauth2_application_token_create(
 
     if user is not None:
         unauthenticated_api_client.force_login(user)
-    url = reverse("token-list")
+    url = get_relative_url("token-list")
 
     # Create
     data = {
@@ -319,7 +319,7 @@ def test_oauth2_pat_create(request, org_member_rd, org_admin_rd, user, random_us
      - I am a user.  But I can only create a PAT for myself.
     """
 
-    url = reverse("token-list")
+    url = get_relative_url("token-list")
 
     # Create PAT
     data = {
@@ -388,7 +388,7 @@ def test_oauth2_pat_read_change_delete(request, user_case, has_access, org_membe
 
     if user is not None:
         unauthenticated_api_client.force_login(user)
-    url = reverse("token-detail", args=[oauth2_user_pat.id])
+    url = get_relative_url("token-detail", args=[oauth2_user_pat.id])
 
     # Read
     response = unauthenticated_api_client.get(url)

--- a/test_app/tests/oauth2_provider/views/test_authorization_root.py
+++ b/test_app/tests/oauth2_provider/views/test_authorization_root.py
@@ -1,11 +1,11 @@
-from django.urls import reverse
+from ansible_base.lib.utils.response import get_relative_url
 
 
 def test_oauth2_provider_authorization_root_view(admin_api_client, unauthenticated_api_client, user_api_client):
     """
     As an admin, accessing /o/ gives an index of oauth endpoints.
     """
-    url = reverse("oauth_authorization_root_view")
+    url = get_relative_url("oauth_authorization_root_view")
     for client in (admin_api_client, unauthenticated_api_client, user_api_client):
         response = admin_api_client.get(url)
         assert response.status_code == 200

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -1,12 +1,13 @@
-from django.urls import reverse
 from django.utils.http import urlencode
+
+from ansible_base.lib.utils.response import get_relative_url
 
 
 def test_oauth2_provider_authorize_view_as_admin(admin_api_client):
     """
     As an admin, accessing /o/authorize/ without client_id parameter should return a 400 error.
     """
-    url = reverse("authorize")
+    url = get_relative_url("authorize")
     response = admin_api_client.get(url)
 
     assert response.status_code == 400
@@ -17,7 +18,7 @@ def test_oauth2_provider_authorize_view_anon(client, settings):
     """
     As an anonymous user, accessing /o/authorize/ should redirect to the login page.
     """
-    url = reverse("authorize")
+    url = get_relative_url("authorize")
     response = client.get(url)
 
     assert response.status_code == 302
@@ -29,7 +30,7 @@ def test_oauth2_provider_authorize_view_flow(user_api_client, oauth2_application
     As a user, I should be able to complete the authorization flow and get an authorization code.
     """
     oauth2_application = oauth2_application[0]
-    url = reverse("authorize")
+    url = get_relative_url("authorize")
     query_params = {
         'client_id': oauth2_application.client_id,
         'response_type': 'code',

--- a/test_app/tests/rbac/api/test_ansible_id_assignments.py
+++ b/test_app/tests/rbac/api/test_ansible_id_assignments.py
@@ -2,8 +2,8 @@ from uuid import uuid4
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import ObjectRole, RoleEvaluation
 from ansible_base.resource_registry.models import Resource
 
@@ -11,7 +11,7 @@ from ansible_base.resource_registry.models import Resource
 @pytest.mark.django_db
 def test_user_assignment_ansible_id(admin_api_client, inv_rd, rando, inventory):
     resource = Resource.objects.get(object_id=rando.pk, content_type=ContentType.objects.get_for_model(rando).pk)
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     data = dict(role_definition=inv_rd.id, content_type='aap.inventory', user_ansible_id=str(resource.ansible_id), object_id=inventory.id)
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data
@@ -23,7 +23,7 @@ def test_team_assignment_ansible_id(admin_api_client, inv_rd, team, inventory, m
     member_rd.give_permission(rando, team)
     team_ct = ContentType.objects.get_for_model(team)
     resource = Resource.objects.get(object_id=team.pk, content_type=team_ct.pk)
-    url = reverse('roleteamassignment-list')
+    url = get_relative_url('roleteamassignment-list')
     data = dict(role_definition=inv_rd.id, content_type='aap.inventory', team_ansible_id=str(resource.ansible_id), object_id=inventory.id)
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data
@@ -41,7 +41,7 @@ def test_assignment_id_validation(admin_api_client, inv_rd, team, inventory, ran
     else:
         actor_obj = team
     resource = Resource.objects.get(object_id=actor_obj.pk, content_type=ContentType.objects.get_for_model(actor_obj).pk)
-    url = reverse(f'role{actor}assignment-list')
+    url = get_relative_url(f'role{actor}assignment-list')
     test_fields = (actor, f'{actor}_ansible_id')
 
     # Provide too little data
@@ -66,7 +66,7 @@ def test_assignment_id_validation(admin_api_client, inv_rd, team, inventory, ran
 @pytest.mark.django_db
 def test_object_ansible_id_user(admin_api_client, org_inv_rd, rando, inventory, organization):
     resource = Resource.objects.get(object_id=organization.pk, content_type=ContentType.objects.get_for_model(organization).pk)
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     data = dict(role_definition=org_inv_rd.id, user=rando.id, object_ansible_id=str(resource.ansible_id))
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data
@@ -75,7 +75,7 @@ def test_object_ansible_id_user(admin_api_client, org_inv_rd, rando, inventory, 
 
 @pytest.mark.django_db
 def test_missing_object(admin_api_client, inv_rd, rando):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     data = dict(role_definition=inv_rd.id, user=rando.id)
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 400, response.data
@@ -84,7 +84,7 @@ def test_missing_object(admin_api_client, inv_rd, rando):
 
 @pytest.mark.django_db
 def test_invalid_ansible_id(admin_api_client, org_inv_rd, rando):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     bad_ansible_id = f'{uuid4()}'
     data = dict(role_definition=org_inv_rd.id, user=rando.id, object_ansible_id=bad_ansible_id)
     response = admin_api_client.post(url, data=data, format="json")
@@ -101,7 +101,7 @@ def test_object_ansible_id_bad_type(admin_api_client, inv_rd, rando, organizatio
     This expects a validation error when the object type does not match the role type.
     """
     resource = Resource.objects.get(object_id=organization.pk, content_type=ContentType.objects.get_for_model(organization).pk)
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     data = dict(role_definition=inv_rd.id, user=rando.id, object_ansible_id=str(resource.ansible_id))
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 400, response.data

--- a/test_app/tests/rbac/api/test_assignment_permissions.py
+++ b/test_app/tests/rbac/api/test_assignment_permissions.py
@@ -1,6 +1,6 @@
 import pytest
-from rest_framework.reverse import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
 from test_app.models import ImmutableTask
@@ -28,7 +28,7 @@ def task_view_rd():
 def test_create_user_assignment_immutable(user_api_client, user, rando, task_admin_rd, task_view_rd, org_admin_rd, organization):
     task = ImmutableTask.objects.create()
     org_admin_rd.give_permission(user, organization)  # setup so that user can see rando
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     request_data = {"user": rando.pk, "role_definition": task_admin_rd.pk, "object_id": task.pk}
 
     response = user_api_client.post(url, data=request_data)
@@ -50,7 +50,7 @@ def test_create_user_assignment_immutable(user_api_client, user, rando, task_adm
 def test_remove_user_assignment_immutable(user_api_client, user, rando, task_admin_rd, task_view_rd):
     task = ImmutableTask.objects.create()
     assignment = task_admin_rd.give_permission(rando, task)
-    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
 
     response = user_api_client.delete(url)
     assert response.status_code == 404, response.data
@@ -71,7 +71,7 @@ def test_remove_user_assignment_immutable(user_api_client, user, rando, task_adm
 @pytest.mark.django_db
 def test_remove_user_assignment_with_global_role(user_api_client, user, inv_rd, global_inv_rd, rando, inventory):
     assignment = inv_rd.give_permission(rando, inventory)
-    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
     response = user_api_client.delete(url)
     assert response.status_code == 404, response.data
 
@@ -85,7 +85,7 @@ def test_remove_user_assignment_with_global_role(user_api_client, user, inv_rd, 
 @pytest.mark.django_db
 def test_remove_global_role_assignment(user_api_client, admin_api_client, user, global_inv_rd, rando):
     assignment = global_inv_rd.give_global_permission(rando)
-    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
     response = user_api_client.delete(url)
     assert response.status_code == 404, response.data
 
@@ -108,7 +108,7 @@ def test_remove_global_assignment_yourself(user_api_client, global_inv_rd, user,
     assignment = global_inv_rd.give_global_permission(user)
     assert user.has_obj_perm(inventory, 'change')
 
-    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
     response = user_api_client.delete(url)
     # Manually delete cache, because view operates on a User instance loaded anew from DB
     delattr(user, '_singleton_permissions')
@@ -126,7 +126,7 @@ def test_remove_object_assignment_yourself(user_api_client, user, inventory):
     assignment = rd.give_permission(user, inventory)
     assert user.has_obj_perm(inventory, 'view')
 
-    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
     response = user_api_client.delete(url)
     assert response.status_code == 204, response.data
     assert not user.has_obj_perm(inventory, 'change')

--- a/test_app/tests/rbac/api/test_rbac_fields.py
+++ b/test_app/tests/rbac/api/test_rbac_fields.py
@@ -1,6 +1,6 @@
 import pytest
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.api.serializers import RoleDefinitionSerializer
 
 
@@ -26,11 +26,11 @@ def test_invalid_permission(admin_api_client):
 
 @pytest.mark.django_db
 def test_parity_with_resource_registry(admin_api_client):
-    types_resp = admin_api_client.get(reverse("resourcetype-list"))
+    types_resp = admin_api_client.get(get_relative_url("resourcetype-list"))
     assert types_resp.status_code == 200
     res_types = set(r['name'] for r in types_resp.data['results'])
 
-    role_types = admin_api_client.options(reverse("roledefinition-list"))
+    role_types = admin_api_client.options(get_relative_url("roledefinition-list"))
     role_types = set(item['value'] for item in role_types.data['actions']['POST']['content_type']['choices'])
 
     # Check the types in both registries

--- a/test_app/tests/rbac/api/test_rbac_serializers.py
+++ b/test_app/tests/rbac/api/test_rbac_serializers.py
@@ -1,14 +1,14 @@
 import pytest
 from django.test.utils import override_settings
-from rest_framework.reverse import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from test_app.models import Inventory, User
 
 
 @pytest.mark.django_db
 def test_patch_system_role(admin_api_client, global_inv_rd):
     "Making a PATCH to a system role should not re-validate the content_type"
-    url = reverse('roledefinition-detail', kwargs={'pk': global_inv_rd.pk})
+    url = get_relative_url('roledefinition-detail', kwargs={'pk': global_inv_rd.pk})
     response = admin_api_client.patch(url, data={'name': 'my new name'})
     assert response.status_code == 200
     global_inv_rd.refresh_from_db()
@@ -21,7 +21,7 @@ def test_patch_system_role(admin_api_client, global_inv_rd):
 @override_settings(ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API=False)
 def test_patch_object_role(admin_api_client, inv_rd):
     "Making a PATCH to a system role should not re-validate the content_type"
-    url = reverse('roledefinition-detail', kwargs={'pk': inv_rd.pk})
+    url = get_relative_url('roledefinition-detail', kwargs={'pk': inv_rd.pk})
     response = admin_api_client.patch(url, data={'name': 'my new name'})
     assert response.status_code == 200
     inv_rd.refresh_from_db()
@@ -44,7 +44,7 @@ class TestAssignmentPermission:
         return Inventory.objects.create(name='inventory-2', organization=organization_2)
 
     def test_object_permission_needed(self, inventory_2, inv_rd, org_admin, user_api_client, view_inv_rd):
-        url = reverse('roleuserassignment-list')
+        url = get_relative_url('roleuserassignment-list')
         rando = User.objects.create(username='rando')
         create_data = {'object_id': inventory_2.id, 'user': rando.id, 'role_definition': inv_rd.id}
 
@@ -69,7 +69,7 @@ class TestAssignmentPermission:
         assert rando.has_obj_perm(inventory_2, 'change')
 
     def test_object_not_found(self, inv_rd, org_admin, user_api_client):
-        url = reverse('roleuserassignment-list')
+        url = get_relative_url('roleuserassignment-list')
         rando = User.objects.create(username='rando')
         create_data = {'object_id': 123456, 'user': rando.id, 'role_definition': inv_rd.id}
 
@@ -80,7 +80,7 @@ class TestAssignmentPermission:
         assert 'object does not exist' in response.data['object_id'][0]
 
     def test_user_not_found(self, inv_rd, inventory, org_admin, user_api_client):
-        url = reverse('roleuserassignment-list')
+        url = get_relative_url('roleuserassignment-list')
         create_data = {'object_id': inventory.id, 'user': 123456, 'role_definition': inv_rd.id}
 
         # Expect 400 error in cases where _related_ object is not found

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -2,9 +2,9 @@ import pytest
 from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.test.utils import override_settings
-from django.urls import reverse
 
 from ansible_base.lib.utils.auth import get_team_model
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
 
 Team = get_team_model()
@@ -17,14 +17,14 @@ class TestSharedAssignmentsDisabled:
 
     @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
     def test_team_member_role_not_assignable(self, member_rd, team, rando, admin_api_client):
-        url = reverse('roleuserassignment-list')
+        url = get_relative_url('roleuserassignment-list')
         response = admin_api_client.post(url, data={'object_id': team.id, 'role_definition': member_rd.id, 'user': rando.id})
         assert response.status_code == 400, response.data
         assert self.NON_LOCAL_MESSAGE in str(response.data)
 
     @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
     def test_custom_roles_for_shared_stuff_not_allowed(self, admin_api_client):
-        url = reverse('roledefinition-list')
+        url = get_relative_url('roledefinition-list')
         response = admin_api_client.post(
             url,
             data={
@@ -39,20 +39,20 @@ class TestSharedAssignmentsDisabled:
     @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
     def test_auditor_for_external_models(self, admin_api_client, rando, external_auditor_constructor):
         rd, created = external_auditor_constructor.get_or_create(apps)
-        url = reverse('roleuserassignment-list')
+        url = get_relative_url('roleuserassignment-list')
         response = admin_api_client.post(url, data={'role_definition': rd.id, 'user': rando.id})
         assert response.status_code == 400, response.data
         assert self.NON_LOCAL_MESSAGE in str(response.data)
 
     @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
     def test_resource_roles_still_assignable(self, org_inv_rd, organization, rando, admin_api_client):
-        url = reverse('roleuserassignment-list')
+        url = get_relative_url('roleuserassignment-list')
         response = admin_api_client.post(url, data={'object_id': organization.id, 'role_definition': org_inv_rd.id, 'user': rando.id})
         assert response.status_code == 201, response.data
 
     @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
     def test_org_resource_roles_creatable(self, admin_api_client):
-        url = reverse('roledefinition-list')
+        url = get_relative_url('roledefinition-list')
         # This only contains shared view_organization, which is necessary to create custom org-level roles for child resources
         response = admin_api_client.post(
             url,
@@ -69,7 +69,7 @@ class TestSharedAssignmentsDisabled:
 @pytest.mark.parametrize("method", ['delete', 'patch'])
 def test_cannot_modify_managed_role_definition(admin_api_client, method):
     rd = RoleDefinition.objects.create(name='foo role', managed=True)
-    url = reverse('roledefinition-detail', kwargs={'pk': rd.pk})
+    url = get_relative_url('roledefinition-detail', kwargs={'pk': rd.pk})
     if method == 'delete':
         response = admin_api_client.delete(url)
     else:
@@ -81,14 +81,14 @@ def test_cannot_modify_managed_role_definition(admin_api_client, method):
 @pytest.mark.django_db
 def test_assignments_are_immutable(admin_api_client, rando, inventory, inv_rd):
     assignment = inv_rd.give_permission(rando, inventory)
-    url = reverse('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+    url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
     response = admin_api_client.patch(url, data={'object_id': 2})
     assert response.status_code == 405
 
 
 @pytest.mark.django_db
 def test_permission_does_not_exist(admin_api_client):
-    url = reverse('roledefinition-list')
+    url = get_relative_url('roledefinition-list')
     response = admin_api_client.post(url, data={'name': 'foo', 'permissions': ['foo.foo_foooo'], 'content_type': 'aap.inventory'})
     assert response.status_code == 400
     assert 'object does not exist' in str(response.data['permissions'][0])
@@ -96,7 +96,7 @@ def test_permission_does_not_exist(admin_api_client):
 
 @pytest.mark.django_db
 def test_using_permission_for_wrong_model(admin_api_client):
-    url = reverse('roledefinition-list')
+    url = get_relative_url('roledefinition-list')
     response = admin_api_client.post(url, data={'name': 'foo', 'permissions': ['aap.view_inventory'], 'content_type': 'aap.namespace'})
     assert response.status_code == 400
     assert 'Permissions "view_inventory" are not valid for namespace roles' in str(response.data['permissions'])
@@ -108,7 +108,7 @@ def test_using_permission_for_wrong_model(admin_api_client):
 
 @pytest.mark.django_db
 def test_no_double_assignment(admin_api_client, rando, inventory, inv_rd):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     response = admin_api_client.post(url, data={'object_id': inventory.id, 'user': rando.id, 'role_definition': inv_rd.id})
     assert response.status_code == 201
     response = admin_api_client.post(url, data={'object_id': inventory.id, 'user': rando.id, 'role_definition': inv_rd.id})
@@ -117,7 +117,7 @@ def test_no_double_assignment(admin_api_client, rando, inventory, inv_rd):
 
 @pytest.mark.django_db
 def test_can_not_give_global_role_to_obj(admin_api_client, rando, inventory, global_inv_rd):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     response = admin_api_client.post(url, data={'object_id': inventory.id, 'user': rando.id, 'role_definition': global_inv_rd.id})
     assert response.status_code == 400, response.data
     assert 'System role does not allow for object assignment' in str(response.data['object_id'])
@@ -125,7 +125,7 @@ def test_can_not_give_global_role_to_obj(admin_api_client, rando, inventory, glo
 
 @pytest.mark.django_db
 def test_can_not_make_global_role_with_member_permission(admin_api_client):
-    url = reverse('roledefinition-list')
+    url = get_relative_url('roledefinition-list')
     response = admin_api_client.post(
         url, data={'name': 'foo', 'permissions': ['shared.view_organization', 'shared.view_team', 'shared.member_team'], 'content_type': ''}
     )
@@ -135,7 +135,7 @@ def test_can_not_make_global_role_with_member_permission(admin_api_client):
 
 @pytest.mark.django_db
 def test_callback_validate_role_user_assignment(admin_api_client, inventory, inv_rd):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     user = User.objects.create(username='user-allowed')
     response = admin_api_client.post(url, data={'object_id': inventory.id, 'user': user.id, 'role_definition': inv_rd.id})
     assert response.status_code == 201
@@ -153,7 +153,7 @@ def test_callback_validate_role_user_assignment(admin_api_client, inventory, inv
 
 @pytest.mark.django_db
 def test_callback_validate_role_team_assignment(admin_api_client, inventory, organization, inv_rd):
-    url = reverse('roleteamassignment-list')
+    url = get_relative_url('roleteamassignment-list')
     team = Team.objects.create(name='team-allowed', organization=organization)
     response = admin_api_client.post(url, data={'object_id': inventory.id, 'team': team.id, 'role_definition': inv_rd.id})
     assert response.status_code == 201

--- a/test_app/tests/rbac/app_api/test_options.py
+++ b/test_app/tests/rbac/app_api/test_options.py
@@ -1,6 +1,6 @@
 import pytest
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.policies import can_change_user, visible_users
@@ -18,7 +18,7 @@ def org_inv_admin():
 
 @pytest.mark.django_db
 def test_inventory_creator_options(user, user_api_client, organization, org_inv_admin):
-    url = reverse('inventory-list')
+    url = get_relative_url('inventory-list')
 
     # User has no ability to add an inventory, OPTIONS should not show POST
     r = user_api_client.options(url)
@@ -33,7 +33,7 @@ def test_inventory_creator_options(user, user_api_client, organization, org_inv_
 
 @pytest.mark.django_db
 def test_organization_creator_options(user, user_api_client, admin_api_client):
-    url = reverse('organization-list')
+    url = get_relative_url('organization-list')
 
     r = user_api_client.options(url)
     assert r.status_code == 200, r.data
@@ -46,7 +46,7 @@ def test_organization_creator_options(user, user_api_client, admin_api_client):
 
 @pytest.mark.django_db
 def test_object_change_permission(user, user_api_client, inventory, inv_rd, view_inv_rd):
-    url = reverse('inventory-detail', kwargs={'pk': inventory.pk})
+    url = get_relative_url('inventory-detail', kwargs={'pk': inventory.pk})
     view_inv_rd.give_permission(user, inventory)
 
     r = user_api_client.options(url)
@@ -63,7 +63,7 @@ def test_object_change_permission(user, user_api_client, inventory, inv_rd, view
 @pytest.mark.django_db
 def test_user_change_permission(user_api_client, user, organization, org_member_rd, org_admin_rd):
     other_user = User.objects.create(username='another-user')
-    url = reverse('user-detail', kwargs={'pk': other_user.pk})
+    url = get_relative_url('user-detail', kwargs={'pk': other_user.pk})
 
     # Give user ability to view other user, and OPTIONS should indicate PUT not possible
     for u in (user, other_user):
@@ -85,7 +85,7 @@ def test_user_change_permission(user_api_client, user, organization, org_member_
 
 @pytest.mark.django_db
 def test_user_creator_options(user, user_api_client, organization, org_admin_rd):
-    url = reverse('user-list')
+    url = get_relative_url('user-list')
 
     # Normal users can not create new users
     r = user_api_client.options(url)
@@ -101,7 +101,7 @@ def test_user_creator_options(user, user_api_client, organization, org_admin_rd)
 
 @pytest.mark.django_db
 def test_no_parent_objects(admin_api_client):
-    url = reverse('collectionimport-list')
+    url = get_relative_url('collectionimport-list')
 
     assert Namespace.objects.count() == 0  # sanity
 

--- a/test_app/tests/rbac/compatibility/test_codename_nonstandard.py
+++ b/test_app/tests/rbac/compatibility/test_codename_nonstandard.py
@@ -1,7 +1,7 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
 from test_app.models import WeirdPerm
 
@@ -38,7 +38,7 @@ def test_give_user_permission(user, wp_rd, weird_obj):
 
 @pytest.mark.django_db
 def test_make_non_id_api_assignment(admin_api_client, wp_rd, weird_obj, user):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     data = dict(role_definition=wp_rd.id, user=user.id, content_type='aap.weirdperm', object_id=weird_obj.id)
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data

--- a/test_app/tests/rbac/compatibility/test_non_id_primary_key.py
+++ b/test_app/tests/rbac/compatibility/test_non_id_primary_key.py
@@ -1,7 +1,7 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
 from test_app.models import PositionModel
 
@@ -34,7 +34,7 @@ def test_give_user_permission(user, nk_rd, position):
 
 @pytest.mark.django_db
 def test_make_non_id_api_assignment(admin_api_client, nk_rd, position, user):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     data = dict(role_definition=nk_rd.id, user=user.id, content_type='aap.positionmodel', object_id=position.position)
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data

--- a/test_app/tests/rbac/compatibility/test_parent_field_rename.py
+++ b/test_app/tests/rbac/compatibility/test_parent_field_rename.py
@@ -1,7 +1,7 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
 from test_app.models import Organization, ParentName
@@ -63,7 +63,7 @@ def test_give_user_organization_wide_permission(user, org_pn_rd, pn_obj, organiz
 
 @pytest.mark.django_db
 def test_make_org_api_assignment(admin_api_client, org_pn_rd, organization, pn_obj, user):
-    url = reverse('roleuserassignment-list')
+    url = get_relative_url('roleuserassignment-list')
     assert not user.has_obj_perm(pn_obj, 'change')
     data = dict(role_definition=org_pn_rd.id, user=user.id, content_type='aap.parentname', object_id=organization.id)
     response = admin_api_client.post(url, data=data, format="json")

--- a/test_app/tests/rbac/features/test_public_model.py
+++ b/test_app/tests/rbac/features/test_public_model.py
@@ -1,7 +1,7 @@
 import pytest
 from django.test.utils import override_settings
-from django.urls import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import DABPermission, RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
 from ansible_base.rbac.validators import validate_permissions_for_model
@@ -20,7 +20,7 @@ def test_unprivledged_user_can_view(public_item, rando):
 
 
 def test_unprivledged_user_can_view_api(public_item, user_api_client):
-    url = reverse('publicdata-detail', kwargs={'pk': public_item.pk})
+    url = get_relative_url('publicdata-detail', kwargs={'pk': public_item.pk})
     response = user_api_client.get(url)
     assert response.status_code == 200, response.data
     assert response.data['id'] == public_item.id
@@ -44,7 +44,7 @@ def test_org_level_validator_without_view():
 
 @pytest.mark.django_db
 def test_custom_role_for_public_model(admin_api_client, rando, public_item):
-    url = reverse('roledefinition-list')
+    url = get_relative_url('roledefinition-list')
     data = {'name': 'Public data editor', 'permissions': ['local.change_publicdata'], 'content_type': 'local.publicdata'}
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 201, response.data

--- a/test_app/tests/rbac/features/test_singleton_roles.py
+++ b/test_app/tests/rbac/features/test_singleton_roles.py
@@ -1,6 +1,6 @@
 import pytest
-from rest_framework.reverse import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
 from test_app.models import Inventory, User
 
@@ -37,7 +37,7 @@ def test_singleton_role_via_team(rando, organization, team, inventory, global_in
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", ["organization", "instancegroup"])
 def test_add_root_resource_admin(organization, admin_api_client, model):
-    url = reverse(f"{model}-list")
+    url = get_relative_url(f"{model}-list")
     response = admin_api_client.post(url, data={"name": "new"}, format="json")
     assert response.status_code == 201, response.data
 
@@ -45,7 +45,7 @@ def test_add_root_resource_admin(organization, admin_api_client, model):
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", ["organization", "instancegroup"])
 def test_add_root_resource_global_role(organization, user_api_client, user, model):
-    url = reverse(f"{model}-list")
+    url = get_relative_url(f"{model}-list")
     response = user_api_client.post(url, data={"name": "new"}, format="json")
     assert response.status_code == 403, response.data
 
@@ -70,7 +70,7 @@ def test_view_assignments_with_global_role(inventory, user, user_api_client, inv
     assignment = inv_rd.give_permission(rando, inventory)
 
     # you should be able to view that assignment if you are a global inventory viewer
-    response = user_api_client.get(reverse('roleuserassignment-list'), format="json")
+    response = user_api_client.get(get_relative_url('roleuserassignment-list'), format="json")
     assert response.status_code == 200, response.data
     returned_assignments = set(entry['id'] for entry in response.data['results'])
     expected_assignments = {global_assignment.id, assignment.id}
@@ -91,7 +91,7 @@ def test_view_assignments_with_global_and_org_role(inventory, organization, user
     assignment2 = org_inv_rd.give_permission(user, organization)
 
     # you should be able to view that assignment if you are a global inventory viewer
-    response = user_api_client.get(reverse('roleuserassignment-list'), format="json")
+    response = user_api_client.get(get_relative_url('roleuserassignment-list'), format="json")
     assert response.status_code == 200, response.data
     returned_assignments = set(entry['id'] for entry in response.data['results'])
     expected_assignments = {global_assignment.id, assignment1.id, assignment2.id}

--- a/test_app/tests/rbac/test_validators.py
+++ b/test_app/tests/rbac/test_validators.py
@@ -1,8 +1,8 @@
 import pytest
 from django.test.utils import override_settings
 from rest_framework.exceptions import ValidationError
-from rest_framework.reverse import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
 from test_app.models import Credential, Inventory, Organization
@@ -27,7 +27,7 @@ def test_custom_role_rules_do_not_apply_to_managed_roles():
 @pytest.mark.django_db
 @override_settings(ANSIBLE_BASE_ALLOW_CUSTOM_ROLES=False)
 def test_role_definition_enablement_validation_in_api(admin_api_client):
-    url = reverse('roledefinition-list')
+    url = get_relative_url('roledefinition-list')
     r = admin_api_client.post(url, data={'name': 'foo', 'permissions': ['view_inventory'], 'content_type': 'aap.inventory'})
     assert r.status_code == 400, r.data
     assert 'Creating custom roles is disabled' in str(r.data)

--- a/test_app/tests/resource_registry/test_metadata_api.py
+++ b/test_app/tests/resource_registry/test_metadata_api.py
@@ -1,11 +1,10 @@
-from django.urls import reverse
-
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.resource_registry.models import service_id
 
 
 def test_service_metadata(admin_api_client):
     """Test that the resource list is working."""
-    url = reverse("service-metadata")
+    url = get_relative_url("service-metadata")
     resp = admin_api_client.get(url)
 
     assert resp.status_code == 200

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import pytest
-from django.urls import reverse
 
 from ansible_base.lib.testing.util import StaticResourceAPIClient
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.resource_registry.tasks.sync import ResourceSyncHTTPError, SyncExecutor
 
 
@@ -58,9 +58,8 @@ def test_resource_sync(static_api_client, stdout):
 
 @pytest.mark.django_db
 def test_delete_orphans(admin_api_client, static_api_client, stdout):
-
     # Create a local user that is managed by resource_server but not returned from the manifest
-    url = reverse("resource-list")
+    url = get_relative_url("resource-list")
     resource = {
         "service_id": "57592fbc-7ecb-405f-9f5f-ebad20932d38",  # from fixtures/static/metadata
         "resource_type": "shared.user",
@@ -78,9 +77,8 @@ def test_delete_orphans(admin_api_client, static_api_client, stdout):
 
 @pytest.mark.django_db
 def test_update_existing_resource(admin_api_client, static_api_client, stdout):
-
     # Create a local user with different resource_data than the one manifest returns
-    url = reverse("resource-list")
+    url = get_relative_url("resource-list")
     resource = {
         "resource_type": "shared.user",
         "service_id": "57592fbc-7ecb-405f-9f5f-ebad20932d38",  # from fixtures/static/metadata
@@ -105,9 +103,8 @@ def test_update_existing_resource(admin_api_client, static_api_client, stdout):
 
 @pytest.mark.django_db
 def test_noop_existing_resource(admin_api_client, static_api_client, stdout):
-
     # Create a local user with EXACT resource_data of the one manifest returns
-    url = reverse("resource-list")
+    url = get_relative_url("resource-list")
     resource = {
         "resource_type": "shared.user",
         "service_id": "57592fbc-7ecb-405f-9f5f-ebad20932d38",  # from fixtures/static/metadata

--- a/test_app/tests/resource_registry/test_resource_types_api.py
+++ b/test_app/tests/resource_registry/test_resource_types_api.py
@@ -1,14 +1,14 @@
 import csv
 from io import StringIO
 
-from django.urls import reverse
+from ansible_base.lib.utils.response import get_relative_url
 
 
 def test_resource_type_list(admin_api_client):
     """
     Test list api view for resource types
     """
-    url = reverse("resourcetype-list")
+    url = get_relative_url("resourcetype-list")
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert set([x["name"] for x in response.data['results']]) == set(
@@ -20,7 +20,7 @@ def test_resource_type_detail(admin_api_client):
     """
     Test get api view for resource types
     """
-    url = reverse("resourcetype-detail", kwargs={"name": "shared.user"})
+    url = get_relative_url("resourcetype-detail", kwargs={"name": "shared.user"})
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert response.data["name"] == "shared.user"
@@ -30,7 +30,7 @@ def test_resource_type_manifest(admin_api_client):
     """
     Test get the csv for resource type manifest
     """
-    url = reverse("resourcetype-manifest", kwargs={"name": "shared.user"})
+    url = get_relative_url("resourcetype-manifest", kwargs={"name": "shared.user"})
     response = admin_api_client.get(url)
     assert response.status_code == 200
     response_data = list(response.streaming_content)
@@ -41,6 +41,6 @@ def test_resource_type_manifest(admin_api_client):
 
 
 def test_resource_type_manifest_404(admin_api_client):
-    url = reverse("resourcetype-manifest", kwargs={"name": "doesnt.exist"})
+    url = get_relative_url("resourcetype-manifest", kwargs={"name": "doesnt.exist"})
     response = admin_api_client.get(url)
     assert response.status_code == 404

--- a/test_app/tests/rest_filters/rest_framework/test_field_lookup_backend.py
+++ b/test_app/tests/rest_filters/rest_framework/test_field_lookup_backend.py
@@ -4,12 +4,12 @@ import pytest
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist, FieldError, ValidationError
 from django.test.utils import override_settings
-from django.urls import reverse
 from django.utils.http import urlencode
 from rest_framework.exceptions import ParseError, PermissionDenied
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap
 from ansible_base.authentication.views import AuthenticatorViewSet
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rest_filters.rest_framework.field_lookup_backend import FieldLookupBackend
 from test_app import models
 
@@ -161,7 +161,7 @@ def test_filter_queryset(query):
 
 def test_filter_jsonfield_as_text(admin_api_client):
     models.City.objects.create(name='city', extra_data={'mayor': 'John Doe', 'radius': 10, 'elevation': 1000, 'is_capital': True})
-    url = reverse('city-list')
+    url = get_relative_url('city-list')
 
     # negative test, backwards compatibility doesn't allow this case
     # JSONField isn't treated as structured data, but as a text blob
@@ -178,7 +178,7 @@ def test_filter_jsonfield_as_text(admin_api_client):
 
 
 def test_filter_unexpected_field(admin_api_client):
-    url = reverse('organization-list')
+    url = get_relative_url('organization-list')
     response = admin_api_client.get(url, data={'foofield': 'bar'})
     assert response.status_code == 400, response.data
 
@@ -186,14 +186,14 @@ def test_filter_unexpected_field(admin_api_client):
 def test_app_ignore_field(admin_api_client):
     base_list = tuple(settings.ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES)
     with override_settings(ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES=base_list + ('foofield',)):
-        url = reverse('organization-list')
+        url = get_relative_url('organization-list')
         response = admin_api_client.get(url, data={'foofield': 'bar'})
         assert response.status_code == 200, response.data
 
 
 def test_view_level_ignore_field(admin_api_client):
     """See CowViewSet definition which corresponds to expectations of this test"""
-    url = reverse('cow-list')
+    url = get_relative_url('cow-list')
     response = admin_api_client.get(url, data={'cud': 'chew'})
     assert response.status_code == 200, response.data
 

--- a/test_app/tests/rest_pagination/test_default_paginator.py
+++ b/test_app/tests/rest_pagination/test_default_paginator.py
@@ -1,7 +1,7 @@
 import pytest
 from django.test import override_settings
-from rest_framework.reverse import reverse
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.rest_pagination.default_paginator import DefaultPaginator
 from test_app.models import Organization
@@ -43,7 +43,7 @@ def test_default_paginator_ensure_proper_result_length(num_orgs, page_size_query
     assert get_setting('MAX_PAGE_SIZE', None) == max_page_size
 
     # Request with the page_size equal to the max with the variation
-    url = f"{reverse('organization-list')}?page_size={page_size_query_param}"
+    url = f"{get_relative_url('organization-list')}?page_size={page_size_query_param}"
     response = admin_api_client.get(url)
 
     # If we variation was not negative than we expect the max_page_size, if its less than we should get less
@@ -52,7 +52,7 @@ def test_default_paginator_ensure_proper_result_length(num_orgs, page_size_query
 
 @pytest.mark.parametrize("with_page_size", [(True), (False)])
 def test_default_paginator_count_disabled(with_page_size, admin_api_client):
-    url = f"{reverse('organization-list')}?count_disabled=True"
+    url = f"{get_relative_url('organization-list')}?count_disabled=True"
     if with_page_size:
         url = f'{url}&page_size=10'
     response = admin_api_client.get(url)
@@ -74,7 +74,7 @@ def test_default_paginator_next_and_previous_pages(page_index, admin_api_client)
     for org_index in range(num_orgs):
         Organization.objects.create(name=f"Test Organization {org_index}")
 
-    base_url = f"{reverse('organization-list')}"
+    base_url = f"{get_relative_url('organization-list')}"
     page_url = f"{base_url}?page={page_index}&page_size=1"
     next_page = f"{base_url}?page={page_index+1}&page_size=1"
     previous_page = f"{base_url}?page={page_index-1}&page_size=1"

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -6,9 +6,9 @@ from django.urls.exceptions import NoReverseMatch
 from django.urls.resolvers import URLPattern
 from rest_framework.decorators import action, api_view
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 from rest_framework.viewsets import ModelViewSet
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 from ansible_base.oauth2_provider.views import DABOAuth2UserViewsetMixin
 from ansible_base.rbac import permission_registry
@@ -160,7 +160,7 @@ def api_root(request, format=None):
         # want '^users/$' [name='user-list']
         # do not want '^users/(?P<pk>[^/.]+)/organizations/$' [name='user-organizations-list'],
         if '-list' in url.name and url.pattern._regex.count('/') == 1:
-            list_endpoints[url.name.removesuffix('-list')] = reverse(url.name, request=request, format=format)
+            list_endpoints[url.name.removesuffix('-list')] = get_relative_url(url.name, request=request, format=format)
 
     from ansible_base.api_documentation.urls import api_version_urls as docs_urls
     from ansible_base.authentication.urls import api_version_urls as authentication_urls
@@ -168,12 +168,12 @@ def api_root(request, format=None):
     for url in docs_urls + authentication_urls[1:]:
         if isinstance(url, URLPattern):
             try:
-                list_endpoints[url.name] = reverse(url.name, request=request, format=format)
+                list_endpoints[url.name] = get_relative_url(url.name, request=request, format=format)
             except NoReverseMatch:
                 pass
 
-    list_endpoints['service-index'] = reverse('service-index-root', request=request, format=format)
-    list_endpoints['role-metadata'] = reverse('role-metadata', request=request, format=format)
+    list_endpoints['service-index'] = get_relative_url('service-index-root', request=request, format=format)
+    list_endpoints['role-metadata'] = get_relative_url('role-metadata', request=request, format=format)
 
     return Response(list_endpoints)
 


### PR DESCRIPTION
AAP-26819

We somewhat arbitrarily used DRF reverse along with Django reverse. The difference is that Django reverse produces a relative URL and DRF reverse looks at the request and returns a fully qualified url.

This PR adds two functions: `get_fully_qualifed_url` and `get_relative_url` to `ansible_base.lib.utils.response`. This PR also converts all references to both `reverse` methods to our new method.

The `get_fully_qualified_url` will look for a setting called `FRONT_END_URL` and use that as the `protocol://server:port` portion of the URL if defined. If undefined it will allow DRF to attempt to do its normal reverse.

In most places in the API we should be using relative URLs. Hover, if we need a fully qualified URL for any reason we should attempt to use `get_fully_qualified_url`. These functions both take a view name and *args and **kwargs similar to the existing reverse methods.

In addition to being more explicit, this will help us to have a common method and seeing for constructing fully qualified URLs.