### PR TITLE
Enforce CSRF mitigations for JWT authentication

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -6,11 +6,11 @@ from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Model
-from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
 from ansible_base.jwt_consumer.common.cache import JWTCache
 from ansible_base.jwt_consumer.common.cert import JWTCert, JWTCertException
+from ansible_base.lib.authentication import AnsibleBaseAuthentication
 from ansible_base.lib.utils.auth import get_user_by_ansible_id
 from ansible_base.lib.utils.translations import translatableConditionally as _
 from ansible_base.resource_registry.models import Resource, ResourceType
@@ -270,7 +270,7 @@ class JWTCommonAuth:
             return None, None
 
 
-class JWTAuthentication(BaseAuthentication):
+class JWTAuthentication(AnsibleBaseAuthentication):
     map_fields = default_mapped_user_fields
     use_rbac_permissions = False
 
@@ -281,6 +281,7 @@ class JWTAuthentication(BaseAuthentication):
         self.common_auth.parse_jwt_token(request)
 
         if self.common_auth.user:
+            self.enforce_csrf(request)
             self.process_user_data()
             self.process_permissions()
 

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -284,6 +284,8 @@ class JWTAuthentication(AnsibleBaseAuthentication):
             token_from_header = request.headers.get("X-DAB-JW-TOKEN", None)
             if not token_from_header:
                 self.enforce_csrf(request)
+            else:
+                logger.warning("X-DAB-JW-TOKEN found, moving forward without csrf protections")
             self.process_user_data()
             self.process_permissions()
 

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -281,7 +281,9 @@ class JWTAuthentication(AnsibleBaseAuthentication):
         self.common_auth.parse_jwt_token(request)
 
         if self.common_auth.user:
-            self.enforce_csrf(request)
+            token_from_header = request.headers.get("X-DAB-JW-TOKEN", None)
+            if not token_from_header:
+                self.enforce_csrf(request)
             self.process_user_data()
             self.process_permissions()
 

--- a/ansible_base/lib/authentication/__init__.py
+++ b/ansible_base/lib/authentication/__init__.py
@@ -1,0 +1,1 @@
+from .authenticators import *  # noqa: F401, F403

--- a/ansible_base/lib/authentication/authenticators.py
+++ b/ansible_base/lib/authentication/authenticators.py
@@ -1,6 +1,10 @@
 # Contains extensions for DRF authenticator classes
+import logging
+
 from rest_framework.authentication import BaseAuthentication, CSRFCheck
 from rest_framework.exceptions import PermissionDenied
+
+logger = logging.getLogger("ansible_base.lib.authentication.authenticators")
 
 
 class AnsibleBaseAuthentication(BaseAuthentication):
@@ -22,4 +26,6 @@ class AnsibleBaseAuthentication(BaseAuthentication):
         reason = check.process_view(request, None, (), {})
         if reason:
             # CSRF failed, bail with explicit error message
+            logger.error('CSRF Failed: %s' % reason)
+
             raise PermissionDenied('CSRF Failed: %s' % reason)

--- a/ansible_base/lib/authentication/authenticators.py
+++ b/ansible_base/lib/authentication/authenticators.py
@@ -1,0 +1,25 @@
+# Contains extensions for DRF authenticator classes
+from rest_framework.authentication import BaseAuthentication, CSRFCheck
+from rest_framework.exceptions import PermissionDenied
+
+
+class AnsibleBaseAuthentication(BaseAuthentication):
+    def enforce_csrf(self, request):
+        """
+        Enforce CSRF validation for DRF Authenticator
+        needs to be called by AnsibleBaseAuthentication.authenticate
+        to take effect
+
+        Copied from DRF SessionAuthentication, including the comments
+        """
+
+        def dummy_get_response(request):
+            return None
+
+        check = CSRFCheck(dummy_get_response)
+        # populates request.META['CSRF_COOKIE'], which is used in process_view()
+        check.process_request(request)
+        reason = check.process_view(request, None, (), {})
+        if reason:
+            # CSRF failed, bail with explicit error message
+            raise PermissionDenied('CSRF Failed: %s' % reason)

--- a/test_app/tests/lib/authentication/test_authenticators.py
+++ b/test_app/tests/lib/authentication/test_authenticators.py
@@ -1,0 +1,32 @@
+import pytest
+from django.conf import settings
+from django.middleware.csrf import _get_new_csrf_string, _mask_cipher_secret
+from django.test.client import RequestFactory
+from rest_framework.exceptions import PermissionDenied
+
+from ansible_base.lib.authentication.authenticators import AnsibleBaseAuthentication
+
+
+class TestAnsibleBaseAuthentication:
+    def test_csrf_enforce_enforces(self):
+        rf = RequestFactory()
+        authenication = AnsibleBaseAuthentication()
+        csrf_secret = _get_new_csrf_string()
+        data = {
+            "csrfmiddlewaretoken": _mask_cipher_secret(csrf_secret),
+        }
+
+        # Create a POST request for any endpoint
+        request = rf.post("/api/gateway/v1/tokens", data)
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = csrf_secret
+
+        # Fail if PermissionDenied
+        authenication.enforce_csrf(request)
+
+        # Make CSRF params bad by making the field token invalid
+        request = rf.post("/api/gateway/v1/tokens", data)
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = _get_new_csrf_string()
+
+        # Fail if not Permission Denied
+        with pytest.raises(PermissionDenied):
+            authenication.enforce_csrf(request)


### PR DESCRIPTION
Impement enforce_csrf for JWT authenticatior, enabling django CsrfMiddleware.
This fixes disabled CSRF protections on sites that use jwt_consumer for authentication.

AAP-20597