### PR TITLE
[oauth2_provider] Disable PKCE by default

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -228,6 +228,10 @@ if 'ansible_base.oauth2_provider' in INSTALLED_APPS:  # noqa: F821
         OAUTH2_PROVIDER['AUTHORIZATION_CODE_EXPIRE_SECONDS'] = 600
     if 'REFRESH_TOKEN_EXPIRE_SECONDS' not in OAUTH2_PROVIDER:
         OAUTH2_PROVIDER['REFRESH_TOKEN_EXPIRE_SECONDS'] = 2628000
+    if 'PKCE_REQUIRED' not in OAUTH2_PROVIDER:
+        # For compat with awx, we don't require PKCE, but the new version
+        # of DOT that we are using requires it by default.
+        OAUTH2_PROVIDER['PKCE_REQUIRED'] = False
 
     OAUTH2_PROVIDER['APPLICATION_MODEL'] = 'dab_oauth2_provider.OAuth2Application'
     OAUTH2_PROVIDER['ACCESS_TOKEN_MODEL'] = 'dab_oauth2_provider.OAuth2AccessToken'


### PR DESCRIPTION
This is enabled by default in new DOT and breaks
compatibility with awx.