### PR TITLE
Use single postgres definition in compose file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ check_isort:
 #  -q, --quiet: Surpress the pull output, mainly to condence output in CI
 #  --rm: automatically remove the container when it is stopped
 postgres:
-	docker start dab_postgres || docker run -dq --rm --name dab_postgres -p 55432:5432 -e POSTGRES_USER=dab -e POSTGRES_PASSWORD=dabing -e POSTGRES_DB=dab_db postgres:15
+	docker start dab_postgres || docker compose up -d postgres --quiet-pull
 
 ## Stops the postgres container started with 'make postgres'
 stop-postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 ---
 services:
   postgres:
-    image: "postgres:latest"
+    image: "postgres:15"
+    container_name: dab_postgres
     environment:
       POSTGRES_DB: dab_db
       POSTGRES_USER: dab
@@ -11,6 +12,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    ports:
+      - "55432:5432"
 
   test_app:
     build:


### PR DESCRIPTION
If checks pass, I'll be happy with this.

The environment / image / ports for postgres container is a thing, and it's a thing we have to maintain. We should not maintain 2 versions of it.