### PR TITLE
Fix keycloak public key help text typo

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/keycloak.py
+++ b/ansible_base/authentication/authenticator_plugins/keycloak.py
@@ -31,7 +31,7 @@ class KeycloakConfiguration(BaseAuthenticatorConfiguration):
         ui_field_label=_('Keycloak OIDC Key'),
     )
     PUBLIC_KEY = CharField(
-        help_text=_("RS256 public key provided by your Keycloak ream."),
+        help_text=_("RS256 public key provided by your Keycloak realm."),
         allow_null=False,
         ui_field_label=_('Keycloak Public Key'),
     )


### PR DESCRIPTION
AAP-22822

ream -> realm

I'm realizing https://github.com/ansible/django-ansible-base/pull/462 was an update to our documentation.  This change actually updates the help text