### PR TITLE
Fix incorrect mock object calls

### DIFF
--- a/test_app/tests/authentication/authenticator_plugins/test_oidc.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_oidc.py
@@ -146,7 +146,7 @@ def test_user_data(mockedrequest, mockeddecode, mocksetting):
     mockeddecode.return_value = mr.json()
     data = ap.user_data("token")
 
-    assert mockeddecode.called_with("token", "VALUE", "VALUE", "VALUE")
+    mockeddecode.assert_called_once_with("token", "VALUE", "VALUE", "VALUE")
     assert "key" in data
 
     # Decode failure

--- a/test_app/tests/authentication/authenticator_plugins/test_oidc.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_oidc.py
@@ -146,7 +146,7 @@ def test_user_data(mockedrequest, mockeddecode, mocksetting):
     mockeddecode.return_value = mr.json()
     data = ap.user_data("token")
 
-    mockeddecode.assert_called_once_with("token", "VALUE", "VALUE", "VALUE")
+    mockeddecode.assert_called_once_with('token', key='-----BEGIN PUBLIC KEY-----\nVALUE\n-----END PUBLIC KEY-----', algorithms='VALUE', audience='VALUE')
     assert "key" in data
 
     # Decode failure

--- a/test_app/tests/authentication/authenticator_plugins/test_radius.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_radius.py
@@ -85,7 +85,7 @@ def test_authenticator_plugin(backend_cls, unauthenticated_api_client, radius_co
         "RADIUS_PORT": radius_configuration["PORT"],
         "RADIUS_SECRET": radius_configuration["SECRET"],
     }
-    backend.authenticate.assert_called_once_with(username=random_username, password=random_password)
+    backend.authenticate.assert_called_once_with(None, random_username, random_password)
     assert AuthenticatorUser.objects.filter(uid=random_username, provider=radius_authenticator).exists()
     assert User.objects.filter(username=random_username).exists()
 

--- a/test_app/tests/authentication/authenticator_plugins/test_radius.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_radius.py
@@ -85,7 +85,7 @@ def test_authenticator_plugin(backend_cls, unauthenticated_api_client, radius_co
         "RADIUS_PORT": radius_configuration["PORT"],
         "RADIUS_SECRET": radius_configuration["SECRET"],
     }
-    backend.authenticate.called_once_with(username=random_username, password=random_password)
+    backend.authenticate.assert_called_once_with(username=random_username, password=random_password)
     assert AuthenticatorUser.objects.filter(uid=random_username, provider=radius_authenticator).exists()
     assert User.objects.filter(username=random_username).exists()
 


### PR DESCRIPTION
The problem with mocked objects is that any properties will return a "fake" method. So `mockeddecode.called_with` just gives you a made-up method that does nothing. If you `assert mocked_obj.called_with('foo')`, then the fake method says "ok", returns some other made-up thing, and test passes.

I don't know what the consequence of these failures are, but I want to identify them and hopefully assign someone to either fix them or do something else.