### PR TITLE
Adding setting to prevent modification of settings in AoC environment

### DIFF
--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -1,13 +1,12 @@
 import logging
 
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.models import Authenticator
-from ansible_base.lib.utils.settings import get_setting
-from ansible_base.lib.utils.validation import to_python_boolean, validate_image_data, validate_url
+from ansible_base.lib.utils.settings import get_setting, is_aoc_instance
+from ansible_base.lib.utils.validation import validate_image_data, validate_url
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 logger = logging.getLogger('ansible_base.authentication.views.ui_auth')
@@ -82,10 +81,6 @@ def generate_ui_auth_data():
         logger.error("custom_logo was set but was not a valid image data, ignoring")
 
     # The cloud managed setting is not customizable outside of a conf file
-    managed_cloud_setting = 'ANSIBLE_BASE_MANAGED_CLOUD_INSTALL'
-    try:
-        response['managed_cloud_install'] = to_python_boolean(getattr(settings, managed_cloud_setting, False))
-    except ValueError:
-        logger.error(f'{managed_cloud_setting} was set but could not be converted to a boolean, assuming false')
+    response['managed_cloud_install'] = is_aoc_instance()
 
     return response

--- a/ansible_base/lib/utils/settings.py
+++ b/ansible_base/lib/utils/settings.py
@@ -5,6 +5,8 @@ from typing import Any
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
+from ansible_base.lib.utils.validation import to_python_boolean
+
 logger = logging.getLogger('ansible_base.lib.utils.settings')
 
 
@@ -51,3 +53,12 @@ def get_from_import(module_name, attr):
     "Thin wrapper around importlib.import_module, mostly exists so that we can safely mock this in tests"
     module = importlib.import_module(module_name, package=attr)
     return getattr(module, attr)
+
+
+def is_aoc_instance():
+    managed_cloud_setting = 'ANSIBLE_BASE_MANAGED_CLOUD_INSTALL'
+    try:
+        return to_python_boolean(getattr(settings, managed_cloud_setting, False))
+    except ValueError:
+        logger.error(f'{managed_cloud_setting} was set but could not be converted to a boolean, assuming false')
+        return False

--- a/test_app/tests/authentication/views/test_ui_auth.py
+++ b/test_app/tests/authentication/views/test_ui_auth.py
@@ -76,35 +76,20 @@ def test_generate_ui_auth_data_bad_logo_image_data(logger):
 
 
 @pytest.mark.parametrize(
-    "setting,expected_result",
+    "is_cloud",
     [
-        (None, None),
-        (True, True),
-        (False, False),
-        ('a', None),
+        (True),
+        (False),
     ],
 )
 @pytest.mark.django_db
-def test_generate_ui_auth_data_managed_cloud(expected_log, setting, expected_result):
-    with override_settings(ANSIBLE_BASE_MANAGED_CLOUD_INSTALL=setting):
-        expect_log_called = False
-        if expected_result is None:
-            expect_log_called = True
-            expected_result = False
-        with expected_log(
-            'ansible_base.authentication.views.ui_auth.logger',
-            'error',
-            'was set but could not be converted to a boolean, assuming false',
-            assert_not_called=(not expect_log_called),
-        ):
-            result = generate_ui_auth_data()
-            assert result['managed_cloud_install'] == expected_result
+def test_generate_ui_auth_data_managed_cloud(is_cloud):
+    with override_settings(ANSIBLE_BASE_MANAGED_CLOUD_INSTALL=is_cloud):
+        result = generate_ui_auth_data()
+        assert result['managed_cloud_install'] == is_cloud
 
 
 @pytest.mark.django_db
-def test_generate_ui_auth_data_managed_cloud_no_setting(expected_log):
-    with expected_log(
-        'ansible_base.authentication.views.ui_auth.logger', 'error', 'was set but could not be converted to a boolean, assuming false', assert_not_called=True
-    ):
-        result = generate_ui_auth_data()
-        assert result['managed_cloud_install'] is False
+def test_generate_ui_auth_data_managed_cloud_no_setting():
+    result = generate_ui_auth_data()
+    assert result['managed_cloud_install'] is False


### PR DESCRIPTION
AAP-26871

This adds a setting `AOC_UNCHANGEABLE_PREFERENCES` which is an array of additional settings names which should not be allowed to be modified if the setting `ANSIBLE_BASE_MANAGED_CLOUD_INSTALL` is True.