### PR TITLE
Error if Delete permission is issued without Change permission

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -170,6 +170,8 @@ if 'ansible_base.rbac' in INSTALLED_APPS:
     # then the system must create one, this is used for naming the auto-created role
     ANSIBLE_BASE_ROLE_CREATOR_NAME = '{obj._meta.model_name}-creator-permission'
 
+    # Require change permission to get delete permission
+    ANSIBLE_BASE_DELETE_REQUIRE_CHANGE = True
     # Specific feature enablement bits
     # For assignments
     ANSIBLE_BASE_ALLOW_TEAM_PARENTS = True

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -116,19 +116,22 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
                 display_perms = ', '.join(non_add_model_permissions)
                 raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include view, got: {display_perms}'})
 
-    # check change edit permissions is given for every model that has update/delete/special actions listed
+    # Check change edit permissions is given for every model that has update/delete/special actions listed
     if settings.ANSIBLE_BASE_DELETE_REQUIRE_CHANGE:
-        for cls, valid_model_permissions in permissions_by_model.items():
-            if 'delete' in cls._meta.default_permissions and 'change' in cls._meta.default_permissions:
-                model_permissions = set(valid_model_permissions) & codename_list
-                non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
-                if any('delete' in codename for codename in non_add_model_permissions) and not any(
-                    'change' in codename for codename in non_add_model_permissions
-                ):
-                    display_perms = ', '.join(non_add_model_permissions)
-                    raise ValidationError(
-                        {'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include change, got: {display_perms}'}
-                    )
+        # If role_model is a system-wide role (None means it is), skip this validation.
+        if role_model != None:
+            for cls, valid_model_permissions in permissions_by_model.items():
+                # import pdb; pdb.set_trace()
+                if 'delete' in cls._meta.default_permissions and 'change' in cls._meta.default_permissions:
+                    model_permissions = set(valid_model_permissions) & codename_list
+                    non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
+                    if any('delete' in codename for codename in non_add_model_permissions) and not any(
+                        'change' in codename for codename in non_add_model_permissions
+                    ):
+                        display_perms = ', '.join(non_add_model_permissions)
+                        raise ValidationError(
+                            {'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include change, got: {display_perms}'}
+                        )
 
 
 def validate_codename_for_model(codename: str, model: Union[Model, Type[Model]]) -> str:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -117,14 +117,18 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
                 raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include view, got: {display_perms}'})
 
     # check change edit permissions is given for every model that has update/delete/special actions listed
-    for cls, valid_model_permissions in permissions_by_model.items():
-        if 'delete' in cls._meta.default_permissions:
-            # import pdb; pdb.set_trace()
-            model_permissions = set(valid_model_permissions) & codename_list
-            non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
-            if 'delete' in non_add_model_permissions and not any('change' in codename for codename in non_add_model_permissions):
-                display_perms = ', '.join(non_add_model_permissions)
-                raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include change, got: {display_perms}'})
+    if settings.ANSIBLE_BASE_DELETE_REQUIRE_CHANGE:
+        for cls, valid_model_permissions in permissions_by_model.items():
+            if 'delete' and 'change' in cls._meta.default_permissions:
+                model_permissions = set(valid_model_permissions) & codename_list
+                non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
+                if any('delete' in codename for codename in non_add_model_permissions) and not any(
+                    'change' in codename for codename in non_add_model_permissions
+                ):
+                    display_perms = ', '.join(non_add_model_permissions)
+                    raise ValidationError(
+                        {'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include change, got: {display_perms}'}
+                    )
 
 
 def validate_codename_for_model(codename: str, model: Union[Model, Type[Model]]) -> str:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -116,22 +116,19 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
                 display_perms = ', '.join(non_add_model_permissions)
                 raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include view, got: {display_perms}'})
 
-    # Check change edit permissions is given for every model that has update/delete/special actions listed
-    if settings.ANSIBLE_BASE_DELETE_REQUIRE_CHANGE:
-        # If role_model is a system-wide role (None means it is), skip this validation.
-        if role_model != None:
-            for cls, valid_model_permissions in permissions_by_model.items():
-                # import pdb; pdb.set_trace()
-                if 'delete' in cls._meta.default_permissions and 'change' in cls._meta.default_permissions:
-                    model_permissions = set(valid_model_permissions) & codename_list
-                    non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
-                    if any('delete' in codename for codename in non_add_model_permissions) and not any(
-                        'change' in codename for codename in non_add_model_permissions
-                    ):
-                        display_perms = ', '.join(non_add_model_permissions)
-                        raise ValidationError(
-                            {'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include change, got: {display_perms}'}
-                        )
+    # Check requires change and role_model is a system-wide role (None means it is), skip this validation.
+    if settings.ANSIBLE_BASE_DELETE_REQUIRE_CHANGE and role_model is not None:
+        for cls, valid_model_permissions in permissions_by_model.items():
+            if 'delete' in cls._meta.default_permissions and 'change' in cls._meta.default_permissions:
+                model_permissions = set(valid_model_permissions) & codename_list
+                non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
+                if any('delete' in codename for codename in non_add_model_permissions) and not any(
+                    'change' in codename for codename in non_add_model_permissions
+                ):
+                    display_perms = ', '.join(non_add_model_permissions)
+                    raise ValidationError(
+                        {'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include change, got: {display_perms}'}
+                    )
 
 
 def validate_codename_for_model(codename: str, model: Union[Model, Type[Model]]) -> str:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -116,14 +116,15 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
                 display_perms = ', '.join(non_add_model_permissions)
                 raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include view, got: {display_perms}'})
 
-    # check that edit permissions is given for every model that has update/delete/special actions listed
+    # check change edit permissions is given for every model that has update/delete/special actions listed
     for cls, valid_model_permissions in permissions_by_model.items():
-        if 'change' in cls._meta.default_permissions:
+        if 'delete' in cls._meta.default_permissions:
+            # import pdb; pdb.set_trace()
             model_permissions = set(valid_model_permissions) & codename_list
             non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
-            if non_add_model_permissions and not any('change' in codename for codename in non_add_model_permissions):
+            if 'delete' in non_add_model_permissions and not any('change' in codename for codename in non_add_model_permissions):
                 display_perms = ', '.join(non_add_model_permissions)
-                raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include edit, got: {display_perms}'})
+                raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include change, got: {display_perms}'})
 
 
 def validate_codename_for_model(codename: str, model: Union[Model, Type[Model]]) -> str:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -116,6 +116,15 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
                 display_perms = ', '.join(non_add_model_permissions)
                 raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include view, got: {display_perms}'})
 
+    # check that edit permissions is given for every model that has update/delete/special actions listed
+    for cls, valid_model_permissions in permissions_by_model.items():
+        if 'change' in cls._meta.default_permissions:
+            model_permissions = set(valid_model_permissions) & codename_list
+            non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
+            if non_add_model_permissions and not any('change' in codename for codename in non_add_model_permissions):
+                display_perms = ', '.join(non_add_model_permissions)
+                raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include edit, got: {display_perms}'})
+
 
 def validate_codename_for_model(codename: str, model: Union[Model, Type[Model]]) -> str:
     """Shortcut method and validation to allow action name, codename, or app_name.codename

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -119,7 +119,7 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
     # check change edit permissions is given for every model that has update/delete/special actions listed
     if settings.ANSIBLE_BASE_DELETE_REQUIRE_CHANGE:
         for cls, valid_model_permissions in permissions_by_model.items():
-            if 'delete' and 'change' in cls._meta.default_permissions:
+            if 'delete' in cls._meta.default_permissions and 'change' in cls._meta.default_permissions:
                 model_permissions = set(valid_model_permissions) & codename_list
                 non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
                 if any('delete' in codename for codename in non_add_model_permissions) and not any(

--- a/test_app/tests/rbac/features/test_public_model.py
+++ b/test_app/tests/rbac/features/test_public_model.py
@@ -26,6 +26,7 @@ def test_unprivledged_user_can_view_api(public_item, user_api_client):
     assert response.data['id'] == public_item.id
 
 
+@override_settings(ANSIBLE_BASE_DELETE_REQUIRE_CHANGE=False)
 @pytest.mark.django_db
 def test_role_definition_validator_without_view():
     pd_ct = permission_registry.content_type_model.objects.get_for_model(PublicData)

--- a/test_app/tests/rbac/features/test_public_model.py
+++ b/test_app/tests/rbac/features/test_public_model.py
@@ -1,4 +1,5 @@
 import pytest
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from ansible_base.rbac.models import DABPermission, RoleDefinition
@@ -32,6 +33,7 @@ def test_role_definition_validator_without_view():
     validate_permissions_for_model(permissions=[permission], content_type=pd_ct)  # does not raise error
 
 
+@override_settings(ANSIBLE_BASE_DELETE_REQUIRE_CHANGE=False)
 @pytest.mark.django_db
 def test_org_level_validator_without_view():
     org_ct = permission_registry.content_type_model.objects.get_for_model(Organization)

--- a/test_app/tests/rbac/test_validators.py
+++ b/test_app/tests/rbac/test_validators.py
@@ -5,7 +5,7 @@ from rest_framework.reverse import reverse
 
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
-from test_app.models import Inventory, Organization
+from test_app.models import Credential, Inventory, Organization
 
 
 @pytest.mark.django_db
@@ -107,10 +107,13 @@ class TestProhibitedRoleDefinitions:
             RoleDefinition.objects.create_from_permissions(name='system-inventory-viewer', permissions=['view_inventory'], content_type=None)
         assert 'System-wide roles are not enabled' in str(exc)
 
+
 @pytest.mark.django_db
 def test_no_delete_capability_without_change():
     with pytest.raises(ValidationError) as exc:
         RoleDefinition.objects.create_from_permissions(
-            name='anything', permissions=['view_credential', 'delete_credential'], content_type=permission_registry.content_type_model.objects.get_for_model(Credential)
+            name='anything',
+            permissions=['view_credential', 'delete_credential'],
+            content_type=permission_registry.content_type_model.objects.get_for_model(Credential),
         )
-    assert 'Role definitions must have change permission' in str(exc)
+    assert 'Permissions for model credential needs to include change, got:' in str(exc)

--- a/test_app/tests/rbac/test_validators.py
+++ b/test_app/tests/rbac/test_validators.py
@@ -106,3 +106,11 @@ class TestProhibitedRoleDefinitions:
         with pytest.raises(ValidationError) as exc:
             RoleDefinition.objects.create_from_permissions(name='system-inventory-viewer', permissions=['view_inventory'], content_type=None)
         assert 'System-wide roles are not enabled' in str(exc)
+
+@pytest.mark.django_db
+def test_no_delete_capability_without_change():
+    with pytest.raises(ValidationError) as exc:
+        RoleDefinition.objects.create_from_permissions(
+            name='anything', permissions=['view_credential', 'delete_credential'], content_type=permission_registry.content_type_model.objects.get_for_model(Credential)
+        )
+    assert 'Role definitions must have change permission' in str(exc)


### PR DESCRIPTION
Currently, we have no logic to check if a combination of role permissions that includes delete is allowed which causes some issues when appropriately reflecting things in the UI and user_capabilities field. While at first we thought that this was caused because the permissions were not boiling up correctly, the system was actually working as intended but we were not warning the user of the bad combination of permissions. 

This PR addresses that by warning the user of the bad combination and alerting them that they need to include the `change` permission in order to appropriately assign the `delete` permission.

