### PR TITLE
Save simple default settings in a separate module

### DIFF
--- a/ansible_base/lib/dynamic_config/default_settings.py
+++ b/ansible_base/lib/dynamic_config/default_settings.py
@@ -2,9 +2,9 @@ from types import SimpleNamespace
 
 
 authentication = SimpleNamespace(
-    ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES = ["ansible_base.authentication.authenticator_plugins"],
+    ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES=["ansible_base.authentication.authenticator_plugins"],
 
-    SOCIAL_AUTH_PIPELINE = (
+    SOCIAL_AUTH_PIPELINE=(
         'social_core.pipeline.social_auth.social_details',
         'social_core.pipeline.social_auth.social_uid',
         'social_core.pipeline.social_auth.auth_allowed',
@@ -16,74 +16,74 @@ authentication = SimpleNamespace(
         'social_core.pipeline.user.user_details',
         'ansible_base.authentication.social_auth.create_user_claims_pipeline',
     ),
-    SOCIAL_AUTH_STORAGE = "ansible_base.authentication.social_auth.AuthenticatorStorage",
-    SOCIAL_AUTH_STRATEGY = "ansible_base.authentication.social_auth.AuthenticatorStrategy",
-    SOCIAL_AUTH_LOGIN_REDIRECT_URL = "/",
+    SOCIAL_AUTH_STORAGE="ansible_base.authentication.social_auth.AuthenticatorStorage",
+    SOCIAL_AUTH_STRATEGY="ansible_base.authentication.social_auth.AuthenticatorStrategy",
+    SOCIAL_AUTH_LOGIN_REDIRECT_URL="/",
 
-    ANSIBLE_BASE_SOCIAL_AUDITOR_FLAG = "is_system_auditor",
+    ANSIBLE_BASE_SOCIAL_AUDITOR_FLAG="is_system_auditor",
 
     # URL to send users when social auth login fails
-    LOGIN_ERROR_URL = "/?auth_failed"
+    LOGIN_ERROR_URL="/?auth_failed"
 )
 
 rbac = SimpleNamespace(
     # The settings-based specification of managed roles from DAB RBAC vendored ones
-    ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {},
+    ANSIBLE_BASE_MANAGED_ROLE_REGISTRY={},
 
     # Permissions a user will get when creating a new item
-    ANSIBLE_BASE_CREATOR_DEFAULTS = ['add', 'change', 'delete', 'view'],
+    ANSIBLE_BASE_CREATOR_DEFAULTS=['add', 'change', 'delete', 'view'],
     # Permissions API will check for related items, think PATCH/PUT
     # This is a precedence order, so first action related model has will be used
-    ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS = ['use', 'change', 'view'],
+    ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS=['use', 'change', 'view'],
     # If a role does not already exist that can give those object permissions
     # then the system must create one, this is used for naming the auto-created role
-    ANSIBLE_BASE_ROLE_CREATOR_NAME = '{obj._meta.model_name}-creator-permission',
+    ANSIBLE_BASE_ROLE_CREATOR_NAME='{obj._meta.model_name}-creator-permission',
 
     # Require change permission to get delete permission
-    ANSIBLE_BASE_DELETE_REQUIRE_CHANGE = True,
+    ANSIBLE_BASE_DELETE_REQUIRE_CHANGE=True,
     # Specific feature enablement bits
     # For assignments
-    ANSIBLE_BASE_ALLOW_TEAM_PARENTS = True,
-    ANSIBLE_BASE_ALLOW_TEAM_ORG_PERMS = True,
-    ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER = False,
-    ANSIBLE_BASE_ALLOW_TEAM_ORG_ADMIN = True,
+    ANSIBLE_BASE_ALLOW_TEAM_PARENTS=True,
+    ANSIBLE_BASE_ALLOW_TEAM_ORG_PERMS=True,
+    ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER=False,
+    ANSIBLE_BASE_ALLOW_TEAM_ORG_ADMIN=True,
     # For role definitions
-    ANSIBLE_BASE_ALLOW_CUSTOM_ROLES = True,
-    ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES = False,
+    ANSIBLE_BASE_ALLOW_CUSTOM_ROLES=True,
+    ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES=False,
     # Allows managing singleton permissions
-    ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = False,
-    ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = False,
-    ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API = True,
+    ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES=False,
+    ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES=False,
+    ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API=True,
 
     # Pass ignore_conflicts=True for bulk_create calls for role evaluations
     # this should be fine to resolve cross-process conflicts as long as
     # directionality is the same - adding or removing permissions
     # A value of False would result in more errors but be more conservative
-    ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS = True,
+    ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS=True,
 
     # User flags that can grant permission before consulting roles
-    ANSIBLE_BASE_BYPASS_SUPERUSER_FLAGS = ['is_superuser'],
-    ANSIBLE_BASE_BYPASS_ACTION_FLAGS = {},
+    ANSIBLE_BASE_BYPASS_SUPERUSER_FLAGS=['is_superuser'],
+    ANSIBLE_BASE_BYPASS_ACTION_FLAGS={},
 
     # Save RoleEvaluation entries for child permissions on parent models
     # ex: organization roles giving view_inventory permission will save
     # entries mapping that permission to the assignment's organization
-    ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS = False,
+    ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS=False,
 
     # API clients can assign users and teams roles for shared resources
-    ALLOW_LOCAL_RESOURCE_MANAGEMENT = True,
+    ALLOW_LOCAL_RESOURCE_MANAGEMENT=True,
 
-    MANAGE_ORGANIZATION_AUTH = True,
-    ORG_ADMINS_CAN_SEE_ALL_USERS = True,
+    MANAGE_ORGANIZATION_AUTH=True,
+    ORG_ADMINS_CAN_SEE_ALL_USERS=True,
 )
 
 
 oauth2_provider = SimpleNamespace(
     # These have to be defined for the migration to function
-    OAUTH2_PROVIDER_APPLICATION_MODEL = 'dab_oauth2_provider.OAuth2Application',
-    OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = 'dab_oauth2_provider.OAuth2AccessToken',
-    OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL = "dab_oauth2_provider.OAuth2RefreshToken",
-    OAUTH2_PROVIDER_ID_TOKEN_MODEL = "dab_oauth2_provider.OAuth2IDToken",
+    OAUTH2_PROVIDER_APPLICATION_MODEL='dab_oauth2_provider.OAuth2Application',
+    OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL='dab_oauth2_provider.OAuth2AccessToken',
+    OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL="dab_oauth2_provider.OAuth2RefreshToken",
+    OAUTH2_PROVIDER_ID_TOKEN_MODEL="dab_oauth2_provider.OAuth2IDToken",
 
-    ALLOW_OAUTH2_FOR_EXTERNAL_USERS = False
+    ALLOW_OAUTH2_FOR_EXTERNAL_USERS=False
 )

--- a/ansible_base/lib/dynamic_config/default_settings.py
+++ b/ansible_base/lib/dynamic_config/default_settings.py
@@ -1,5 +1,29 @@
 from types import SimpleNamespace
 
+general = SimpleNamespace(
+    # The org and team abstract models cause errors if not set, even if not used
+    ANSIBLE_BASE_TEAM_MODEL='auth.Group',
+    ANSIBLE_BASE_ORGANIZATION_MODEL='auth.Group',
+
+    # This is needed for the rest_filters app, but someone may use the filter class
+    # without enabling the ansible_base.rest_filters app explicitly
+    # we also apply this to views from other apps so we should always define it
+    ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES=(
+        'page',
+        'page_size',
+        'format',
+        'order',
+        'order_by',
+        'search',
+        'type',
+        'host_filter',
+        'count_disabled',
+        'no_truncate',
+        'limit',
+        'validate',
+    )
+)
+
 authentication = SimpleNamespace(
     ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES=["ansible_base.authentication.authenticator_plugins"],
 

--- a/ansible_base/lib/dynamic_config/default_settings.py
+++ b/ansible_base/lib/dynamic_config/default_settings.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+
+authentication = SimpleNamespace(
+    ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES = ["ansible_base.authentication.authenticator_plugins"],
+
+    SOCIAL_AUTH_PIPELINE = (
+        'social_core.pipeline.social_auth.social_details',
+        'social_core.pipeline.social_auth.social_uid',
+        'social_core.pipeline.social_auth.auth_allowed',
+        'social_core.pipeline.social_auth.social_user',
+        'ansible_base.authentication.utils.authentication.determine_username_from_uid_social',
+        'social_core.pipeline.user.create_user',
+        'social_core.pipeline.social_auth.associate_user',
+        'social_core.pipeline.social_auth.load_extra_data',
+        'social_core.pipeline.user.user_details',
+        'ansible_base.authentication.social_auth.create_user_claims_pipeline',
+    ),
+    SOCIAL_AUTH_STORAGE = "ansible_base.authentication.social_auth.AuthenticatorStorage",
+    SOCIAL_AUTH_STRATEGY = "ansible_base.authentication.social_auth.AuthenticatorStrategy",
+    SOCIAL_AUTH_LOGIN_REDIRECT_URL = "/",
+
+    ANSIBLE_BASE_SOCIAL_AUDITOR_FLAG = "is_system_auditor",
+
+    # URL to send users when social auth login fails
+    LOGIN_ERROR_URL = "/?auth_failed"
+)
+
+rbac = SimpleNamespace(
+    # The settings-based specification of managed roles from DAB RBAC vendored ones
+    ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {},
+
+    # Permissions a user will get when creating a new item
+    ANSIBLE_BASE_CREATOR_DEFAULTS = ['add', 'change', 'delete', 'view'],
+    # Permissions API will check for related items, think PATCH/PUT
+    # This is a precedence order, so first action related model has will be used
+    ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS = ['use', 'change', 'view'],
+    # If a role does not already exist that can give those object permissions
+    # then the system must create one, this is used for naming the auto-created role
+    ANSIBLE_BASE_ROLE_CREATOR_NAME = '{obj._meta.model_name}-creator-permission',
+
+    # Require change permission to get delete permission
+    ANSIBLE_BASE_DELETE_REQUIRE_CHANGE = True,
+    # Specific feature enablement bits
+    # For assignments
+    ANSIBLE_BASE_ALLOW_TEAM_PARENTS = True,
+    ANSIBLE_BASE_ALLOW_TEAM_ORG_PERMS = True,
+    ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER = False,
+    ANSIBLE_BASE_ALLOW_TEAM_ORG_ADMIN = True,
+    # For role definitions
+    ANSIBLE_BASE_ALLOW_CUSTOM_ROLES = True,
+    ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES = False,
+    # Allows managing singleton permissions
+    ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = False,
+    ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = False,
+    ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API = True,
+
+    # Pass ignore_conflicts=True for bulk_create calls for role evaluations
+    # this should be fine to resolve cross-process conflicts as long as
+    # directionality is the same - adding or removing permissions
+    # A value of False would result in more errors but be more conservative
+    ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS = True,
+
+    # User flags that can grant permission before consulting roles
+    ANSIBLE_BASE_BYPASS_SUPERUSER_FLAGS = ['is_superuser'],
+    ANSIBLE_BASE_BYPASS_ACTION_FLAGS = {},
+
+    # Save RoleEvaluation entries for child permissions on parent models
+    # ex: organization roles giving view_inventory permission will save
+    # entries mapping that permission to the assignment's organization
+    ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS = False,
+
+    # API clients can assign users and teams roles for shared resources
+    ALLOW_LOCAL_RESOURCE_MANAGEMENT = True,
+
+    MANAGE_ORGANIZATION_AUTH = True,
+    ORG_ADMINS_CAN_SEE_ALL_USERS = True,
+)
+
+
+oauth2_provider = SimpleNamespace(
+    # These have to be defined for the migration to function
+    OAUTH2_PROVIDER_APPLICATION_MODEL = 'dab_oauth2_provider.OAuth2Application',
+    OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = 'dab_oauth2_provider.OAuth2AccessToken',
+    OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL = "dab_oauth2_provider.OAuth2RefreshToken",
+    OAUTH2_PROVIDER_ID_TOKEN_MODEL = "dab_oauth2_provider.OAuth2IDToken",
+
+    ALLOW_OAUTH2_FOR_EXTERNAL_USERS = False
+)

--- a/ansible_base/lib/dynamic_config/default_settings.py
+++ b/ansible_base/lib/dynamic_config/default_settings.py
@@ -1,6 +1,5 @@
 from types import SimpleNamespace
 
-
 authentication = SimpleNamespace(
     ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES=["ansible_base.authentication.authenticator_plugins"],
 

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -4,7 +4,7 @@
 #     Add a new requirements/requirements_<section>.in /even if its an empty file/
 #
 
-from ansible_base.lib.dynamic_config import default_settings
+from ansible_base.lib.dynamic_config import default_settings as _dab_default_settings
 
 # The org and team abstract models cause errors if not set, even if not used
 try:
@@ -124,7 +124,7 @@ if 'ansible_base.authentication' in INSTALLED_APPS:
     if drf_authentication_class not in REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']:  # noqa: F821
         REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].insert(0, drf_authentication_class)  # noqa: F821
 
-    for key, value in vars(default_settings.authentication).items():
+    for key, value in vars(_dab_default_settings.authentication).items():
         if key in locals():
             continue
         locals()[key] = value
@@ -140,7 +140,7 @@ if 'ansible_base.jwt_consumer' in INSTALLED_APPS:
     ANSIBLE_BASE_JWT_MANAGED_ROLES = ["Platform Auditor", "Organization Admin", "Organization Member", "Team Admin", "Team Member"]
 
 if 'ansible_base.rbac' in INSTALLED_APPS:
-    for key, value in vars(default_settings.rbac).items():
+    for key, value in vars(_dab_default_settings.rbac).items():
         if key in locals():
             continue
         locals()[key] = value
@@ -177,9 +177,9 @@ if 'ansible_base.oauth2_provider' in INSTALLED_APPS:  # noqa: F821
         REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].insert(0, oauth2_authentication_class)  # noqa: F821
 
     # Process non dictionary settings
-    for key, value in vars(default_settings.oauth2_provider).items():
+    for key, value in vars(_dab_default_settings.oauth2_provider).items():
         if key in locals():
             continue
         locals()[key] = value
 
-del default_settings
+del _dab_default_settings

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -6,16 +6,6 @@
 
 from ansible_base.lib.dynamic_config import default_settings as _dab_default_settings
 
-# The org and team abstract models cause errors if not set, even if not used
-try:
-    ANSIBLE_BASE_TEAM_MODEL
-except NameError:
-    ANSIBLE_BASE_TEAM_MODEL = 'auth.Group'
-
-try:
-    ANSIBLE_BASE_ORGANIZATION_MODEL
-except NameError:
-    ANSIBLE_BASE_ORGANIZATION_MODEL = 'auth.Group'
 
 try:
     INSTALLED_APPS  # noqa: F821
@@ -28,26 +18,10 @@ except NameError:
     REST_FRAMEWORK = {}
 
 
-# This is needed for the rest_filters app, but someone may use the filter class
-# without enabling the ansible_base.rest_filters app explicitly
-# we also apply this to views from other apps so we should always define it
-try:
-    ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES
-except NameError:
-    ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES = (
-        'page',
-        'page_size',
-        'format',
-        'order',
-        'order_by',
-        'search',
-        'type',
-        'host_filter',
-        'count_disabled',
-        'no_truncate',
-        'limit',
-        'validate',
-    )
+for key, value in vars(_dab_default_settings.general).items():
+    if key in locals():
+        continue
+    locals()[key] = value
 
 
 if 'ansible_base.api_documentation' in INSTALLED_APPS:


### PR DESCRIPTION
Working through https://github.com/ansible/galaxy_ng/pull/2202 with @jctanner I discovered it wasn't loading the settings. In short, I don't think we can rely on accurately having `INSTALLED_APPS` populated at the time we needed to load the defaults.

But we shouldn't need this. If an app wants to bypass our recommended system (which it is already doing), then it should have a constant data structure to import.

I wanted to do this with dictionaries too, but it seems we have special cases for each entry, which... I can't tough. So this is unfortunately incomplete.