### PR TITLE
[get_fully_qualified_url] Fallback to crum request

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -152,8 +152,8 @@ class SAMLConfiguration(BaseAuthenticatorConfiguration):
         required=False,
         allow_null=True,
         help_text=_(
-            '''Register the service as a service provider (SP) with each identity provider (IdP) you have configured.'''
-            '''Provide your SP Entity ID and this ACS URL for your application.'''
+            "Register the service as a service provider (SP) with each identity provider (IdP) you have configured. "
+            "Provide your SP Entity ID and this ACS URL for your application."
         ),
         ui_field_label=_('SAML Assertion Consumer Service (ACS) URL'),
     )


### PR DESCRIPTION
In the event where we a request isn't passed in to DRF `reverse()`, it will return a relative URL. This is unexpected, given the name of our wrapper, `get_fully_qualified_url()`.

In one case, in social auth completion, we weren't passing in a request and were getting a relative URL back. This is used as a default `CALLBACK_URL` in SAML. That field gets url-validated, and since we were ending up with a relative URL there, validation failed. This means that any attempt to create a SAML authenticator without a `CALLBACK_URL` explicitly defined, was failing validation and not saving.

With this patch, `get_fully_qualified_url()` defaults to django-crum's `get_current_request()`, if a request isn't passed in. It will still fall back to a relative URL if `get_current_request()` isn't able to identify a request (e.g. if `get_fully_qualified_url()` ends up being called somewhere in the lifespan of a CLI command where there's no request).

Test plan:
Added new test_app test to use the API to create a SAML authenticator with no `CALLBACK_URL` set. Before this patch, the test failed. After this patch, the test passes. Also added more test cases for `get_fully_qualified_url()`.