### PR TITLE
Fix validation bug creating invalid custom system roles

### DIFF
--- a/test_app/tests/rbac/api/test_rbac_serializers.py
+++ b/test_app/tests/rbac/api/test_rbac_serializers.py
@@ -29,23 +29,17 @@ class TestRoleDefinitions:
         assert response.data['content_type'] == 'aap.inventory'
 
     def test_create_invalid_custom_system_role(self, admin_api_client):
-        response = admin_api_client.post(get_relative_url('roledefinition-list'), data={
-            'name': 'global inventory changer but not viewer',
-            'permissions': [
-                'aap.change_inventory'
-            ]
-        })
+        response = admin_api_client.post(
+            get_relative_url('roledefinition-list'), data={'name': 'global inventory changer but not viewer', 'permissions': ['aap.change_inventory']}
+        )
         assert response.status_code == 400, response.data
         assert 'Permissions for model global role needs to include view' in str(response.data)
 
     def test_create_custom_system_role(self, admin_api_client):
         "Make a POST to create a custom role with system permissions"
-        response = admin_api_client.post(get_relative_url('roledefinition-list'), data={
-            'name': 'global inventory viewer',
-            'permissions': [
-                'aap.view_inventory'
-            ]
-        })
+        response = admin_api_client.post(
+            get_relative_url('roledefinition-list'), data={'name': 'global inventory viewer', 'permissions': ['aap.view_inventory']}
+        )
         assert response.status_code == 201, response.data
         assert response.data['permissions'] == ['aap.view_inventory']
 

--- a/test_app/tests/rbac/api/test_rbac_serializers.py
+++ b/test_app/tests/rbac/api/test_rbac_serializers.py
@@ -6,28 +6,48 @@ from test_app.models import Inventory, User
 
 
 @pytest.mark.django_db
-def test_patch_system_role(admin_api_client, global_inv_rd):
-    "Making a PATCH to a system role should not re-validate the content_type"
-    url = get_relative_url('roledefinition-detail', kwargs={'pk': global_inv_rd.pk})
-    response = admin_api_client.patch(url, data={'name': 'my new name'})
-    assert response.status_code == 200
-    global_inv_rd.refresh_from_db()
-    assert global_inv_rd.name == 'my new name'
-    assert global_inv_rd.content_type is None
-    assert response.data['content_type'] is None
+class TestRoleDefinitions:
+    def test_patch_system_role(self, admin_api_client, global_inv_rd):
+        "Making a PATCH to a system role should not re-validate the content_type"
+        url = get_relative_url('roledefinition-detail', kwargs={'pk': global_inv_rd.pk})
+        response = admin_api_client.patch(url, data={'name': 'my new name'})
+        assert response.status_code == 200
+        global_inv_rd.refresh_from_db()
+        assert global_inv_rd.name == 'my new name'
+        assert global_inv_rd.content_type is None
+        assert response.data['content_type'] is None
 
+    @override_settings(ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API=False)
+    def test_patch_object_role(self, admin_api_client, inv_rd):
+        "Making a PATCH to a system role should not re-validate the content_type"
+        url = get_relative_url('roledefinition-detail', kwargs={'pk': inv_rd.pk})
+        response = admin_api_client.patch(url, data={'name': 'my new name'})
+        assert response.status_code == 200
+        inv_rd.refresh_from_db()
+        assert inv_rd.name == 'my new name'
+        assert inv_rd.content_type.model == 'inventory'
+        assert response.data['content_type'] == 'aap.inventory'
 
-@pytest.mark.django_db
-@override_settings(ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API=False)
-def test_patch_object_role(admin_api_client, inv_rd):
-    "Making a PATCH to a system role should not re-validate the content_type"
-    url = get_relative_url('roledefinition-detail', kwargs={'pk': inv_rd.pk})
-    response = admin_api_client.patch(url, data={'name': 'my new name'})
-    assert response.status_code == 200
-    inv_rd.refresh_from_db()
-    assert inv_rd.name == 'my new name'
-    assert inv_rd.content_type.model == 'inventory'
-    assert response.data['content_type'] == 'aap.inventory'
+    def test_create_invalid_custom_system_role(self, admin_api_client):
+        response = admin_api_client.post(get_relative_url('roledefinition-list'), data={
+            'name': 'global inventory changer but not viewer',
+            'permissions': [
+                'aap.change_inventory'
+            ]
+        })
+        assert response.status_code == 400, response.data
+        assert 'Permissions for model global role needs to include view' in str(response.data)
+
+    def test_create_custom_system_role(self, admin_api_client):
+        "Make a POST to create a custom role with system permissions"
+        response = admin_api_client.post(get_relative_url('roledefinition-list'), data={
+            'name': 'global inventory viewer',
+            'permissions': [
+                'aap.view_inventory'
+            ]
+        })
+        assert response.status_code == 201, response.data
+        assert response.data['permissions'] == ['aap.view_inventory']
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes a traceback you'll see with the tests here in `devel`.

```
ERROR    django.request:log.py:241 Internal Server Error: /api/v1/role_definitions/
Traceback (most recent call last):
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/viewsets.py", line 124, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/mixins.py", line 18, in create
    serializer.is_valid(raise_exception=True)
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/serializers.py", line 223, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/rest_framework/serializers.py", line 445, in run_validation
    value = self.validate(value)
            ^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/api/serializers.py", line 147, in validate
    validate_permissions_for_model(permissions, content_type)
  File "/home/alancoding/repos/awx/testing/django-ansible-base/ansible_base/rbac/validators.py", line 117, in validate_permissions_for_model
    raise ValidationError({'permissions': f'Permissions for model {role_model._meta.verbose_name} needs to include view, got: {display_perms}'})
                                                                   ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '_meta'
```

Not actually a huge deal (validation error). But a bug.