### PR TITLE
Allow registering models via a setting

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -223,6 +223,9 @@ def get_dab_settings(
 
         dab_data['MANAGE_ORGANIZATION_AUTH'] = True
 
+        # Alternative to permission_registry.register
+        dab_data['ANSIBLE_BASE_RBAC_MODEL_REGISTRY'] = {}
+
         dab_data['ORG_ADMINS_CAN_SEE_ALL_USERS'] = True
 
     if 'ansible_base.resource_registry' in installed_apps:

--- a/docs/apps/rbac/for_app_developers.md
+++ b/docs/apps/rbac/for_app_developers.md
@@ -140,6 +140,25 @@ model of `MyModel`, or `None`.
 TODO: Update to allow ManyToMany parent relationship in addition to ForeignKey
 https://github.com/ansible/django-ansible-base/issues/78
 
+#### Registering via a Setting
+
+If you don't want to register models in your Django models definition,
+then you can do the same thing with a setting.
+
+```
+ANSIBLE_BASE_RBAC_MODEL_REGISTRY = {
+    "my_app.mymodel": {"parent_field_name": "organization"}
+}
+```
+
+You might want to do this if `MyModel` isn't from your own app,
+and you want to avoid changing import order without additional thought.
+
+Models declared here are registered _in addition to_ the calls to
+`permission_registry.register`.
+Note that settings should never contain imported python objects.
+The model is referenced by app_label.model_name string.
+
 #### Django Model, Apps, and Permission Constraints
 
 It is fine to register models from multiple apps, but among the registered models,

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -353,7 +353,12 @@ class PublicData(NamedCommonModel):
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='public_data')
 
 
-permission_registry.register(Organization, Inventory, Credential, Namespace, Team, Cow, UUIDModel, PositionModel, WeirdPerm, PublicData)
+# Intentionally, for testing purposes, we register these models in settings
+# - Inventory
+# - Credential
+# - ImmutableTask, parent_field_name=None
+
+permission_registry.register(Organization, Namespace, Team, Cow, UUIDModel, PositionModel, WeirdPerm, PublicData)
 permission_registry.register(ParentName, parent_field_name='my_organization')
 permission_registry.register(CollectionImport, parent_field_name='namespace')
 permission_registry.register(InstanceGroup, ImmutableTask, LogEntry, parent_field_name=None)

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -185,6 +185,11 @@ ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
 ANSIBLE_BASE_JWT_MANAGED_ROLES.append("System Auditor")  # noqa: F821 this is set by dynamic settings for jwt_consumer
 ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
+ANSIBLE_BASE_RBAC_MODEL_REGISTRY = {
+    "test_app.inventory": {"parent_field_name": "organization"},
+    "test_app.credential": {},
+    "test_app.immutabletask": {"parent_field_name": None},
+}
 ANSIBLE_BASE_OAUTH2_PROVIDER_PERMISSIONS_CHECK_IGNORED_VIEWS = ["drf_spectacular.views.SpectacularSwaggerView"]
 ALLOW_SHARED_RESOURCE_CUSTOM_ROLES = True  # Allow making custom roles with org change permission, for example
 ALLOW_LOCAL_ASSIGNING_JWT_ROLES = False


### PR DESCRIPTION
This is a need come up looking at @jctanner 's integration work at https://github.com/ansible/galaxy_ng/pull/2202

See the management command in particular and stuff like:

```python
        galaxy_role_description = {
            'core.task_owner': 'Allow all actions on a task.',
            'core.taskschedule_owner': 'Allow all actions on a task schedule.',
            'galaxy.ansible_repository_owner': 'Manage ansible repositories.',
            'galaxy.collection_admin': 'Create, delete and change collection namespaces. Upload and delete collections. Sync collections from remotes. Approve and reject collections.',
            'galaxy.collection_curator': 'Approve, reject and sync collections from remotes.',
            'galaxy.collection_namespace_owner': 'Change and upload collections to namespaces.',
            'galaxy.collection_publisher': 'Upload and modify collections.',
            'galaxy.collection_remote_owner': 'Manage collection remotes.',
            'galaxy.content_admin': 'Manage all content types.',
            'galaxy.execution_environment_admin': 'Push, delete and change execution environments. Create, delete and change remote registries.',
            'galaxy.execution_environment_collaborator': 'Change existing execution environments.',
            'galaxy.execution_environment_namespace_owner': 'Create and update execution environments under existing container namespaces.',
            'galaxy.execution_environment_publisher': 'Push and change execution environments.',
            'galaxy.group_admin': 'View, add, remove and change groups.',
            'galaxy.synclist_owner': 'View, add, remove and change synclists.',
            'galaxy.task_admin': 'View and cancel any task.',
            'galaxy.user_admin': 'View, add, remove and change users.',
        }
```

This seems to get us a list of "app_label.model_name" references of models. The current advice is to call `permission_registry.register` passing the model classes for all of those. Without getting into the technical constraints, there seems to be a pretty clear preference to just list these in a setting, which DAB RBAC can obvious handle without import-order-changing stuff.