### PR TITLE
Handle unsupported media type in django-oauth-toolkit

### DIFF
--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -235,6 +235,8 @@ if 'ansible_base.oauth2_provider' in INSTALLED_APPS:  # noqa: F821
         # of DOT that we are using requires it by default.
         OAUTH2_PROVIDER['PKCE_REQUIRED'] = False
 
+    OAUTH2_PROVIDER['OAUTH2_BACKEND_CLASS'] = 'ansible_base.oauth2_provider.authentication.OAuthLibCore'
+
     OAUTH2_PROVIDER['APPLICATION_MODEL'] = 'dab_oauth2_provider.OAuth2Application'
     OAUTH2_PROVIDER['ACCESS_TOKEN_MODEL'] = 'dab_oauth2_provider.OAuth2AccessToken'
 

--- a/ansible_base/oauth2_provider/authentication.py
+++ b/ansible_base/oauth2_provider/authentication.py
@@ -2,8 +2,18 @@ import logging
 
 from django.utils.encoding import smart_str
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+from oauth2_provider.oauth2_backends import OAuthLibCore as _OAuthLibCore
+from rest_framework.exceptions import UnsupportedMediaType
 
 logger = logging.getLogger('ansible_base.oauth2_provider.authentication')
+
+
+class OAuthLibCore(_OAuthLibCore):
+    def extract_body(self, request):
+        try:
+            return request.POST.items()
+        except UnsupportedMediaType:
+            return ()
 
 
 class LoggedOAuth2Authentication(OAuth2Authentication):

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -205,3 +205,10 @@ def test_oauth2_scope_permission_not_authenticated(user, unauthenticated_api_cli
     }
     response = unauthenticated_api_client.post(url, data=data)
     assert response.status_code == 401, response.status_code
+
+
+def test_oauth2_unsupported_media_type(user, user_api_client, only_oauth_scope_permission):
+    url = get_relative_url("animal-upload")
+    data = b'TESTDATA'
+    response = user_api_client.post(url, data=data, content_type='application/octet-stream')
+    assert response.status_code == 200, response.status_code

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -191,6 +191,10 @@ class AnimalViewSet(TestAppViewSet):
     serializer_class = serializers.AnimalSerializer
     queryset = models.Animal.objects.all()
 
+    @action(detail=False, methods=['post'])
+    def upload(self, request):
+        return Response({'result': 'ok'})
+
 
 class CityViewSet(TestAppViewSet):
     serializer_class = serializers.CitySerializer


### PR DESCRIPTION
When ansible_base.oauth2_provider is used, any POST request that contains content type not supported by the rest framework will end up with HTTP 415 Unsupported Media Type.

This happens because in the `oauth2_provider.contrib.rest_framework.OAuth2Authentication` authentication class oauth2_provider library unconditionally makes an attempt to access `requsest.POST`. When DRF fails to parse incoming request body, an exception is raised, which prevents further request handling.

Normally OAuth2Authentication will only work with access token passed in request `Authorization` header. This patch handles this situation and prevents request processing failure when request body contains data that cannot be parsed by DRF.