### PR TITLE
Fix bug with reference to id as opposed to pk

### DIFF
--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -252,12 +252,12 @@ def rbac_post_delete_remove_object_roles(instance, *args, **kwargs):
         ObjectRole.objects.filter(users__isnull=True, teams__isnull=True).delete()
 
     ct = permission_registry.content_type_model.objects.get_for_model(instance)
-    ObjectRole.objects.filter(content_type=ct, object_id=instance.id).delete()
+    ObjectRole.objects.filter(content_type=ct, object_id=instance.pk).delete()
 
     parent_field_name = permission_registry.get_parent_fd_name(instance)
     if parent_field_name:
         # Delete all evaluations from inherited permissions
-        get_evaluation_model(instance).objects.filter(content_type_id=ct.id, object_id=instance.id).delete()
+        get_evaluation_model(instance).objects.filter(content_type_id=ct.id, object_id=instance.pk).delete()
 
 
 def rbac_post_user_delete(instance, *args, **kwargs):
@@ -338,7 +338,7 @@ class TrackedRelationship:
             actor_set = pk_set
         elif action == 'post_clear':
             ct = permission_registry.content_type_model.objects.get_for_model(instance)
-            role = ObjectRole.objects.get(object_id=instance.id, content_type=ct, role_definition=rd)
+            role = ObjectRole.objects.get(object_id=instance.pk, content_type=ct, role_definition=rd)
             if actor_model._meta.model_name == 'team':
                 actor_set = set(role.teams.values_list('id', flat=True))
             else:

--- a/test_app/tests/rbac/compatibility/test_non_id_primary_key.py
+++ b/test_app/tests/rbac/compatibility/test_non_id_primary_key.py
@@ -41,3 +41,9 @@ def test_make_non_id_api_assignment(admin_api_client, nk_rd, position, user):
 
     assert user.has_obj_perm(position, 'change')
     assert set(PositionModel.access_qs(user)) == set([position])
+
+
+@pytest.mark.django_db
+def test_delete_non_id_after_obj_assignment(admin_api_client, nk_rd, position, user):
+    nk_rd.give_permission(user, position)
+    position.delete()


### PR DESCRIPTION
Demonstrated bug with the test before the code change:

```
=============================================== FAILURES ===============================================
_______________________________ test_delete_non_id_after_obj_assignment ________________________________

admin_api_client = <rest_framework.test.APIClient object at 0x7f83cdb8b980>
nk_rd = <RoleDefinition: RoleDefinition(pk=6, name=name-key-admin)>
position = <PositionModel: PositionModel object (4)>, user = <User: user>

    @pytest.mark.django_db
    def test_delete_non_id_after_obj_assignment(admin_api_client, nk_rd, position, user):
        nk_rd.give_permission(user, position)
>       position.delete()

test_app/tests/rbac/compatibility/test_non_id_primary_key.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../venvs/awx/lib64/python3.12/site-packages/django/db/models/base.py:1132: in delete
    return collector.delete()
../../../../venvs/awx/lib64/python3.12/site-packages/django/db/models/deletion.py:512: in delete
    signals.post_delete.send(
../../../../venvs/awx/lib64/python3.12/site-packages/django/dispatch/dispatcher.py:177: in send
    (receiver, receiver(signal=self, sender=sender, **named))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

instance = <PositionModel: PositionModel object (4)>, args = ()
kwargs = {'origin': <PositionModel: PositionModel object (4)>, 'sender': <class 'test_app.models.PositionModel'>, 'signal': <django.db.models.signals.ModelSignal object at 0x7f83d006d220>, 'using': 'default'}
ct = <ContentType: test_app | position model>

    def rbac_post_delete_remove_object_roles(instance, *args, **kwargs):
        """
        Call this when deleting an object to cascade delete its object roles
        Deleting a team can have consequences for the rest of the graph
        """
        if instance._meta.model_name == permission_registry.team_model._meta.model_name:
            indirectly_affected_roles = set()
            indirectly_affected_roles.update(team_ancestor_roles(instance))
            for team_role in instance.__rbac_stashed_member_roles:
                indirectly_affected_roles.update(team_role.descendent_roles())
            compute_team_member_roles()
            compute_object_role_permissions(object_roles=indirectly_affected_roles)
    
            # Similar to user deletion, clean up any orphaned object roles
            ObjectRole.objects.filter(users__isnull=True, teams__isnull=True).delete()
    
        ct = permission_registry.content_type_model.objects.get_for_model(instance)
>       ObjectRole.objects.filter(content_type=ct, object_id=instance.id).delete()
E       AttributeError: 'PositionModel' object has no attribute 'id'

ansible_base/rbac/triggers.py:255: AttributeError
```