### PR TITLE
Ensure that LDAP User Search field can be set to null or an empty list

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -74,6 +74,9 @@ class LDAPSearchField(ListField):
         super().__init__(**kwargs)
 
         def validator(value):
+            if not value:
+                return
+
             errors = {}
 
             if len(value) != 3:
@@ -253,7 +256,7 @@ class LDAPConfiguration(BaseAuthenticatorConfiguration):
             'need to be supported use of "LDAPUnion" is possible. See '
             'the documentation for details.'
         ),
-        allow_null=False,
+        allow_null=True,
         required=False,
         search_must_have_user=True,
         ui_field_label=_('LDAP User Search'),


### PR DESCRIPTION
Ensure that `LDAP User Search` field can be set to a null or an empty list.

If the `LDAP User Search` field is not an empty list, ensure that the following validation requirement is satisfied -
```
('Must be an array of 3 items: search DN, search scope and a filter')
```

Fixes https://issues.redhat.com/browse/AAP-28614