### PR TITLE
Allow removing permissions even when they are invalid

### DIFF
--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -198,7 +198,7 @@ class RoleDefinition(CommonModel):
             kwargs = dict(object_role=None, team=actor, role_definition=self)
             cls = RoleTeamAssignment
         else:
-            raise RuntimeError(f'Cannot give or remove permission to {actor}, must be a user or team')
+            raise RuntimeError(f'Cannot {giving and "give" or "remove"} permission for {actor}, must be a user or team')
 
         if giving:
             assignment, _ = cls.objects.get_or_create(**kwargs)

--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -184,11 +184,11 @@ class RoleDefinition(CommonModel):
         return self.give_or_remove_global_permission(actor, giving=False)
 
     def give_or_remove_global_permission(self, actor, giving=True):
-        if self.content_type is not None:
-            raise RuntimeError('Role definition content type must be null to assign globally')
+        if giving and (self.content_type is not None):
+            raise ValidationError('Role definition content type must be null to assign globally')
 
         if actor._meta.model_name == 'user':
-            if not settings.ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES:
+            if giving and (not settings.ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES):
                 raise ValidationError('Global roles are not enabled for users')
             kwargs = dict(object_role=None, user=actor, role_definition=self)
             cls = RoleUserAssignment
@@ -198,7 +198,7 @@ class RoleDefinition(CommonModel):
             kwargs = dict(object_role=None, team=actor, role_definition=self)
             cls = RoleTeamAssignment
         else:
-            raise RuntimeError(f'Cannot give permission to {actor}, must be a user or team')
+            raise RuntimeError(f'Cannot give or remove permission to {actor}, must be a user or team')
 
         if giving:
             assignment, _ = cls.objects.get_or_create(**kwargs)

--- a/test_app/tests/rbac/features/test_singleton_roles.py
+++ b/test_app/tests/rbac/features/test_singleton_roles.py
@@ -102,14 +102,14 @@ def test_view_assignments_with_global_and_org_role(inventory, organization, user
 
 
 @pytest.mark.django_db
-def test_invalid_global_role_assignment(rando, inv_rd, inventory):
+def test_invalid_global_role_assignment(rando, inv_rd):
     with pytest.raises(ValidationError) as exc:
         inv_rd.give_global_permission(rando)
     assert 'Role definition content type must be null to assign globally' in str(exc)
 
 
 @pytest.mark.django_db
-def test_remove_invalid_user_singleton_assignment(rando, inventory, global_inv_rd):
+def test_remove_invalid_user_singleton_assignment(rando, global_inv_rd):
     # normally give the global role to user
     global_inv_rd.give_global_permission(rando)
 

--- a/test_app/tests/rbac/features/test_singleton_roles.py
+++ b/test_app/tests/rbac/features/test_singleton_roles.py
@@ -1,12 +1,10 @@
 import pytest
-
 from rest_framework.exceptions import ValidationError
 
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac import permission_registry
-
-from test_app.models import Inventory, User, Organization
+from ansible_base.rbac.models import RoleDefinition
+from test_app.models import Inventory, Organization, User
 
 
 @pytest.mark.django_db
@@ -120,4 +118,3 @@ def test_remove_invalid_user_singleton_assignment(rando, inventory, global_inv_r
 
     # should still be able to remove the permission, even if the configuration is invalid
     global_inv_rd.remove_global_permission(rando)
-

--- a/test_app/tests/rbac/features/test_singleton_roles.py
+++ b/test_app/tests/rbac/features/test_singleton_roles.py
@@ -115,6 +115,7 @@ def test_remove_invalid_user_singleton_assignment(rando, inventory, global_inv_r
 
     # this will make the assignment from earlier invalid
     global_inv_rd.content_type = permission_registry.content_type_model.objects.get_for_model(Organization)
+    global_inv_rd.save(update_fields=['content_type'])
 
     # should still be able to remove the permission, even if the configuration is invalid
     global_inv_rd.remove_global_permission(rando)

--- a/test_app/tests/rbac/features/test_singleton_roles.py
+++ b/test_app/tests/rbac/features/test_singleton_roles.py
@@ -1,8 +1,12 @@
 import pytest
 
+from rest_framework.exceptions import ValidationError
+
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
-from test_app.models import Inventory, User
+from ansible_base.rbac import permission_registry
+
+from test_app.models import Inventory, User, Organization
 
 
 @pytest.mark.django_db
@@ -97,3 +101,23 @@ def test_view_assignments_with_global_and_org_role(inventory, organization, user
     expected_assignments = {global_assignment.id, assignment1.id, assignment2.id}
     assert expected_assignments == returned_assignments
     assert len(response.data['results']) == 3
+
+
+@pytest.mark.django_db
+def test_invalid_global_role_assignment(rando, inv_rd, inventory):
+    with pytest.raises(ValidationError) as exc:
+        inv_rd.give_global_permission(rando)
+    assert 'Role definition content type must be null to assign globally' in str(exc)
+
+
+@pytest.mark.django_db
+def test_remove_invalid_user_singleton_assignment(rando, inventory, global_inv_rd):
+    # normally give the global role to user
+    global_inv_rd.give_global_permission(rando)
+
+    # this will make the assignment from earlier invalid
+    global_inv_rd.content_type = permission_registry.content_type_model.objects.get_for_model(Organization)
+
+    # should still be able to remove the permission, even if the configuration is invalid
+    global_inv_rd.remove_global_permission(rando)
+


### PR DESCRIPTION
Discovered in testing in https://github.com/ansible/galaxy_ng/pull/2202

```
pulp_1          |   File "/src/galaxy_ng/galaxy_ng/app/signals/handlers.py", line 313, in delete_pulp_user_role
pulp_1          |     rd.remove_global_permission(instance.user)
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/ansible_base/rbac/models.py", line 184, in remove_global_permission
pulp_1          |     return self.give_or_remove_global_permission(actor, giving=False)
pulp_1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/ansible_base/rbac/models.py", line 188, in give_or_remove_global_permission
pulp_1          |     raise RuntimeError('Role definition content type must be null to assign globally')
pulp_1          | RuntimeError: Role definition content type must be null to assign globally
```

The reason for opening this is that we can't honestly fix this issue in the signals there. If we caught the exception, then the permission wouldn't be removed. And that's wrong, as  fail-deadly kind of situation.

Removing permissions should never give an error in a situation where we are _able_ to remove the permission. Because this would _prevent_ the app from fixing validation violations, which is the opposite of what we want.