### PR TITLE
Use updated heuristic for identifying locally managed roles

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -211,6 +211,8 @@ def get_dab_settings(
 
         # API clients can assign users and teams roles for shared resources
         dab_data['ALLOW_LOCAL_RESOURCE_MANAGEMENT'] = True
+        # API clients can create custom roles that change shared resources
+        dab_data['ALLOW_SHARED_RESOURCE_CUSTOM_ROLES'] = True
 
         dab_data['MANAGE_ORGANIZATION_AUTH'] = True
 

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -211,6 +211,10 @@ def get_dab_settings(
 
         # API clients can assign users and teams roles for shared resources
         dab_data['ALLOW_LOCAL_RESOURCE_MANAGEMENT'] = True
+        # API clients can assign roles provided by the JWT
+        # this should only be left as True for testing purposes
+        # TODO: change this default to False
+        dab_data['ALLOW_LOCAL_ASSIGNING_JWT_ROLES'] = True
         # API clients can create custom roles that change shared resources
         dab_data['ALLOW_SHARED_RESOURCE_CUSTOM_ROLES'] = False
 

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -161,6 +161,7 @@ def get_dab_settings(
             # Shadow local variable so subsequent conditionals works.
             installed_apps = dab_data['INSTALLED_APPS']
 
+    if ('ansible_base.jwt_consumer' in installed_apps) or ('ansible_base.rbac' in installed_apps):
         dab_data['ANSIBLE_BASE_JWT_MANAGED_ROLES'] = ["Platform Auditor", "Organization Admin", "Organization Member", "Team Admin", "Team Member"]
 
     if 'ansible_base.rbac' in installed_apps:

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -212,7 +212,7 @@ def get_dab_settings(
         # API clients can assign users and teams roles for shared resources
         dab_data['ALLOW_LOCAL_RESOURCE_MANAGEMENT'] = True
         # API clients can create custom roles that change shared resources
-        dab_data['ALLOW_SHARED_RESOURCE_CUSTOM_ROLES'] = True
+        dab_data['ALLOW_SHARED_RESOURCE_CUSTOM_ROLES'] = False
 
         dab_data['MANAGE_ORGANIZATION_AUTH'] = True
 

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -148,7 +148,8 @@ class RoleDefinitionSerializer(CommonModelSerializer):
         else:
             content_type = self.instance.content_type
         validate_permissions_for_model(permissions, content_type)
-        check_locally_managed(permissions, content_type)
+        if getattr(self, 'instance', None):
+            check_locally_managed(self.instance)
         return super().validate(validated_data)
 
 
@@ -258,7 +259,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
             obj.validate_role_assignment(actor, rd)
 
         # Return a 400 if the role is not managed locally
-        check_locally_managed(rd.permissions.prefetch_related('content_type'), rd.content_type)
+        check_locally_managed(rd)
 
         if rd.content_type:
             # Object role assignment

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -134,7 +134,7 @@ class BaseAssignmentViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
 
     def perform_destroy(self, instance):
         check_can_remove_assignment(self.request.user, instance)
-        check_locally_managed(instance.role_definition.permissions.prefetch_related('content_type'), role_content_type=instance.content_type)
+        check_locally_managed(instance.role_definition)
 
         if instance.content_type_id:
             with transaction.atomic():

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -1,6 +1,5 @@
 import re
 from collections import defaultdict
-from collections.abc import Iterable
 from typing import Optional, Type, Union
 
 from django.conf import settings
@@ -156,7 +155,7 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
     if settings.ANSIBLE_BASE_DELETE_REQUIRE_CHANGE and role_model is not None:
         check_has_change_with_delete(codename_set, permissions_by_model)
 
-    if not managed:
+    if (not managed) and (not settings.ALLOW_SHARED_RESOURCE_CUSTOM_ROLES):
         for perm in permissions:
             # View permission for shared objects is interpreted as permission to view
             # the resource locally, which is needed to be able to view parent objects

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -165,7 +165,7 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
                 continue
             model = perm.content_type.model_class()
             if permission_registry.get_resource_prefix(model) == 'shared':
-                raise ValidationError({'permissions', 'Not managed locally, local custom roles can only include view'})
+                raise ValidationError({'permissions', 'Local custom roles can only include view permission for shared models'})
 
 
 def validate_codename_for_model(codename: str, model: Union[Model, Type[Model]]) -> str:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -250,7 +250,7 @@ def check_locally_managed(rd: Model) -> None:
     This rule is a bridge solution until the RoleDefinition model declares
     explicitly whether it is managed locally or by a remote system.
     """
-    if settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT is True:
+    if not (('ansible_base.jwt_consumer' in settings.INSTALLED_APPS) and (not settings.ALLOW_LOCAL_ASSIGNING_JWT_ROLES)):
         return
     if rd.name in settings.ANSIBLE_BASE_JWT_MANAGED_ROLES:
         raise ValidationError('Not managed locally, use the resource server instead')

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -183,6 +183,7 @@ ANSIBLE_BASE_JWT_MANAGED_ROLES.append("System Auditor")  # noqa: F821 this is se
 ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
 ALLOW_SHARED_RESOURCE_CUSTOM_ROLES = True  # Allow making custom roles with org change permission, for example
+ALLOW_LOCAL_ASSIGNING_JWT_ROLES = False
 
 ANSIBLE_BASE_USER_VIEWSET = 'test_app.views.UserViewSet'
 

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -182,6 +182,7 @@ ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
 ANSIBLE_BASE_JWT_MANAGED_ROLES.append("System Auditor")  # noqa: F821 this is set by dynamic settings for jwt_consumer
 ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
+ALLOW_SHARED_RESOURCE_CUSTOM_ROLES = True  # Allow making custom roles with org change permission, for example
 
 ANSIBLE_BASE_USER_VIEWSET = 'test_app.views.UserViewSet'
 

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -5,7 +5,6 @@ from django.test.utils import override_settings
 
 from ansible_base.lib.utils.auth import get_team_model
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
 

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -23,7 +23,7 @@ class TestSharedAssignmentsDisabled:
         assert response.status_code == 400, response.data
         assert self.NON_LOCAL_MESSAGE in str(response.data)
 
-    @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
+    @override_settings(ALLOW_SHARED_RESOURCE_CUSTOM_ROLES=False)
     def test_custom_roles_for_shared_stuff_not_allowed(self, admin_api_client):
         url = get_relative_url('roledefinition-list')
         response = admin_api_client.post(
@@ -35,7 +35,7 @@ class TestSharedAssignmentsDisabled:
             },
         )
         assert response.status_code == 400, response.data
-        assert self.NON_LOCAL_MESSAGE in str(response.data)
+        assert 'Local custom roles can only include view permission for shared models' in str(response.data)
 
     @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
     def test_auditor_for_external_models(self, admin_api_client, rando, external_auditor_constructor):

--- a/test_app/tests/rbac/api/test_rbac_views.py
+++ b/test_app/tests/rbac/api/test_rbac_views.py
@@ -155,6 +155,7 @@ def test_remove_team_assignment(user_api_client, user, inv_rd, team, inventory):
 
 
 @pytest.mark.django_db
+@override_settings(ALLOW_LOCAL_ASSIGNING_JWT_ROLES=True)
 def test_team_assignment_validation_error(admin_api_client, team, organization, org_member_rd):
     url = get_relative_url('roleteamassignment-list')
     response = admin_api_client.post(url, data={'team': team.id, 'object_id': organization.id, 'role_definition': org_member_rd.id})

--- a/test_app/tests/rbac/api/test_user_permissions.py
+++ b/test_app/tests/rbac/api/test_user_permissions.py
@@ -164,6 +164,7 @@ class TestUserDetailView:
 
 @pytest.mark.django_db
 class TestRoleBasedAssignment:
+    @override_settings(ALLOW_LOCAL_ASSIGNING_JWT_ROLES=True)
     def test_org_admins_can_add_members(self, user, user_api_client, organization, org_member_rd, org_admin_rd):
         rando = User.objects.create(username='rando')
         unrelated_org = Organization.objects.create(name='another-org')
@@ -184,6 +185,7 @@ class TestRoleBasedAssignment:
         assert response.status_code == 201, response.data
         assert rando.has_obj_perm(organization, 'member')
 
+    @override_settings(ALLOW_LOCAL_ASSIGNING_JWT_ROLES=True)
     def test_team_admins_can_add_children(self, user, user_api_client, organization, inventory, inv_rd, admin_rd, member_rd):
         url = get_relative_url('roleteamassignment-list')
 


### PR DESCRIPTION
See the prior criteria `if permission_registry.get_resource_prefix(model) == 'shared':`, I always knew this wasn't perfect and would, at some point, kind of not work.

This is hard to talk out - whether or not you can do permission management is going to be kind of divorced from whether the permissions that role gives are for shared resources.

I still don't think you should be able to create custom roles that give
 - team membership or change permission --> covered by `ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES`
 - organization "change" permission --> kind of tough, added criteria back here to cover this

The PR https://github.com/ansible/django-ansible-base/pull/486 essentially introduced a new distinction of RoleDefinitions, where some are external, and some are local, determined by the setting. This distinction is completely separate from whether shared resources are managed by the roles.