### PR TITLE
Give 400 respones when roles violate RBAC validators

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -225,6 +225,10 @@ class BaseAssignmentSerializer(CommonModelSerializer):
                 obj = serializers.PrimaryKeyRelatedField(queryset=model.access_qs(requesting_user)).to_internal_value(validated_data['object_id'])
             except ValidationError as exc:
                 raise ValidationError({'object_id': exc.detail})
+            except AttributeError:
+                if not permission_registry.is_registered(model):
+                    raise ValidationError({'role_definition': 'Given role definition is for a model not registered in the permissions system'})
+                raise  # in this case no idea what went wrong
         elif validated_data.get('object_ansible_id'):
             obj = self.get_by_ansible_id(validated_data.get('object_ansible_id'), requesting_user, for_field='object_ansible_id')
             if permission_registry.content_type_model.objects.get_for_model(obj) != role_definition.content_type:

--- a/ansible_base/rbac/evaluations.py
+++ b/ansible_base/rbac/evaluations.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models.functions import Cast
 from django.db.models.query import QuerySet
+from rest_framework.serializers import ValidationError
 
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import DABPermission, RoleDefinition, get_evaluation_model
@@ -99,7 +100,7 @@ class AccessibleIdsDescriptor(BaseEvaluationDescriptor):
 
 def bound_has_obj_perm(self, obj, codename) -> bool:
     if not permission_registry.is_registered(obj):
-        raise RuntimeError(f'Object of {obj._meta.model_name} type is not registered with DAB RBAC')
+        raise ValidationError(f'Object of {obj._meta.model_name} type is not registered with DAB RBAC')
     full_codename = validate_codename_for_model(codename, obj)
     if has_super_permission(self, full_codename):
         return True

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -171,15 +171,6 @@ def test_callback_validate_role_team_assignment(admin_api_client, inventory, org
 
 
 @pytest.mark.django_db
-def test_unregistered_model_type_for_rd(admin_api_client):
-    # the secret color model is not registered with DAB RBAC
-    url = get_relative_url('roledefinition-list')
-    r = admin_api_client.post(url, data={'name': 'bad role', 'permissions': ['local.view_inventory'], 'content_type': 'secretcolor'})
-    assert r.status_code == 400
-    assert 'does not track permissions for model secretcolor' in str(r.data)
-
-
-@pytest.mark.django_db
 def test_unregistered_model_type_for_assignment(admin_api_client, inventory, inv_rd, user):
     url = get_relative_url('roleuserassignment-list')
     # force invalid state of role definition, should not really happen

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -6,6 +6,7 @@ from django.test.utils import override_settings
 from ansible_base.lib.utils.auth import get_team_model
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
+from ansible_base.rbac import permission_registry
 
 Team = get_team_model()
 User = get_user_model()
@@ -167,3 +168,31 @@ def test_callback_validate_role_team_assignment(admin_api_client, inventory, org
     response = admin_api_client.post(url, data={'object_id': inventory.id, 'team': team.id, 'role_definition': inv_rd.id})
     assert response.status_code == 403
     assert "Role assignment not allowed 403" in str(response.data)
+
+
+@pytest.mark.django_db
+def test_unregistered_model_type_for_rd(admin_api_client):
+    # the secret color model is not registered with DAB RBAC
+    url = get_relative_url('roledefinition-list')
+    r = admin_api_client.post(url, data={'name': 'bad role', 'permissions': ['local.view_inventory'], 'content_type': 'secretcolor'})
+    assert r.status_code == 400
+    assert 'does not track permissions for model secretcolor' in str(r.data)
+
+
+@pytest.mark.django_db
+def test_unregistered_model_type_for_assignment(admin_api_client, inventory, inv_rd, user):
+    url = get_relative_url('roleuserassignment-list')
+    # force invalid state of role definition, should not really happen
+    cls = apps.get_model('test_app.secretcolor')
+    inv_rd.content_type = permission_registry.content_type_model.objects.get_for_model(cls)
+    inv_rd.save(update_fields=['content_type'])
+    r = admin_api_client.post(url, data={'object_id': inventory.pk, 'user': user.pk, 'role_definition': inv_rd.pk})
+    assert r.status_code == 400
+    assert 'Given role definition is for a model not registered in the permissions system' in str(r.data)
+
+    # Temporarily abusing user model to test this via ansible_id reference, this testing method may not work forever
+    inv_rd.content_type = permission_registry.content_type_model.objects.get_for_model(user)
+    inv_rd.save(update_fields=['content_type'])
+    r = admin_api_client.post(url, data={'object_ansible_id': str(user.resource.ansible_id), 'user': user.pk, 'role_definition': inv_rd.pk})
+    assert r.status_code == 400
+    assert 'user type is not registered with DAB RBAC' in str(r.data)

--- a/test_app/tests/rbac/api/test_rbac_validation.py
+++ b/test_app/tests/rbac/api/test_rbac_validation.py
@@ -5,8 +5,8 @@ from django.test.utils import override_settings
 
 from ansible_base.lib.utils.auth import get_team_model
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac import permission_registry
+from ansible_base.rbac.models import RoleDefinition
 
 Team = get_team_model()
 User = get_user_model()


### PR DESCRIPTION
Reported in https://issues.redhat.com/browse/AAH-3350

This really has to be fixed in the role creation logic (you shouldn't be able to create such roles through the API) so that the roles in the database don't violate the validation rules. But if you have invalid roles around, it gives 500 errors, as reported. This changes those to 400 errors.

```
pulp [9eabe274542a4ffd869b81645e37fee5]: django.request:ERROR: Internal Server Error: /api/galaxy/_ui/v2/role_user_assignments/
Traceback (most recent call last):
  File "/venv/lib64/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/rest_framework/viewsets.py", line 124, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/venv/lib64/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/venv/lib64/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/venv/lib64/python3.11/site-packages/ansible_base/rbac/api/views.py", line 133, in perform_create
    return super().perform_create(serializer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/rest_framework/mixins.py", line 24, in perform_create
    serializer.save()
  File "/venv/lib64/python3.11/site-packages/ansible_base/lib/serializers/validation.py", line 26, in save
    return super().save(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/rest_framework/serializers.py", line 208, in save
    self.instance = self.create(validated_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/rbac/api/serializers.py", line 244, in create
    obj = self.get_object_from_data(validated_data, rd, requesting_user)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/rbac/api/serializers.py", line 222, in get_object_from_data
    obj = serializers.PrimaryKeyRelatedField(queryset=model.access_qs(requesting_user)).to_internal_value(validated_data['object_id'])
                                                      ^^^^^^^^^^^^^^^
AttributeError: type object 'ContainerNamespace' has no attribute 'access_qs'
('pulp [9eabe274542a4ffd869b81645e37fee5]: 10.42.0.41 - - [06/Aug/2024:19:55:05 +0000] "POST /api/galaxy/_ui/v2/role_user_assignments/ HTTP/1.0" 500 145 "https://galaxy.test-galaxy-20240805.gcp.testing.ansible.com/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0"',)
```