### PR TITLE
Allow turning off role view requirement with setting

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -174,6 +174,9 @@ def get_dab_settings(
         # If a role does not already exist that can give those object permissions
         # then the system must create one, this is used for naming the auto-created role
         dab_data['ANSIBLE_BASE_ROLE_CREATOR_NAME'] = '{obj._meta.model_name}-creator-permission'
+        # Require view permission in roles containing any other permission
+        # this requirement does not apply to models that do not have view permission
+        dab_data['ANSIBLE_BASE_ROLES_REQUIRE_VIEW'] = True
         # Require change permission to get delete permission
         dab_data['ANSIBLE_BASE_DELETE_REQUIRE_CHANGE'] = True
         # Specific feature enablement bits

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -22,7 +22,7 @@ def printable_model_name(model: Optional[Type[Model]]) -> str:
     return model._meta.model_name if model else 'global role'
 
 
-def printable_codenames(codename_set: set[str]) -> str:
+def prnt_codenames(codename_set: set[str]) -> str:
     return ', '.join(codename_set)
 
 
@@ -98,11 +98,11 @@ def check_view_permission_criteria(codename_set: set[str], permissions_by_model:
     for cls, valid_model_permissions in permissions_by_model.items():
         if 'view' in cls._meta.default_permissions:
             model_permissions = set(valid_model_permissions) & codename_set
-            non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
-            if non_add_model_permissions and not any('view' in codename for codename in non_add_model_permissions):
+            local_codenames = {codename for codename in model_permissions if not is_add_perm(codename)}
+            if local_codenames and not any('view' in codename for codename in local_codenames):
                 raise ValidationError(
                     {
-                        'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include view, got: {printable_codenames(non_add_model_permissions)}'
+                        'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include view, got: {prnt_codenames(local_codenames)}'
                     }
                 )
 
@@ -118,11 +118,11 @@ def check_has_change_with_delete(codename_set: set[str], permissions_by_model: d
     for cls, valid_model_permissions in permissions_by_model.items():
         if 'delete' in cls._meta.default_permissions and 'change' in cls._meta.default_permissions:
             model_permissions = set(valid_model_permissions) & codename_set
-            non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
-            if any('delete' in codename for codename in non_add_model_permissions) and not any('change' in codename for codename in non_add_model_permissions):
+            local_codenames = {codename for codename in model_permissions if not is_add_perm(codename)}
+            if any('delete' in codename for codename in local_codenames) and not any('change' in codename for codename in local_codenames):
                 raise ValidationError(
                     {
-                        'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include change, got: {printable_codenames(non_add_model_permissions)}'
+                        'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include change, got: {prnt_codenames(local_codenames)}'
                     }
                 )
 

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -31,7 +31,7 @@ def codenames_for_cls(cls) -> list[str]:
     return [t[0] for t in cls._meta.permissions] + [f'{act}_{cls._meta.model_name}' for act in cls._meta.default_permissions]
 
 
-def permissions_allowed_for_system_role() -> dict[type, list[str]]:
+def permissions_allowed_for_system_role() -> dict[Type[Model], list[str]]:
     "Permission codenames useable in system-wide roles, which have content_type set to None"
     permissions_by_model = defaultdict(list)
     for cls in sorted(permission_registry.all_registered_models, key=lambda cls: cls._meta.model_name):
@@ -43,7 +43,7 @@ def permissions_allowed_for_system_role() -> dict[type, list[str]]:
     return permissions_by_model
 
 
-def permissions_allowed_for_role(cls) -> dict[type, list[str]]:
+def permissions_allowed_for_role(cls) -> dict[Type[Model], list[str]]:
     "Permission codenames valid for a RoleDefinition of given class, organized by permission class"
     if cls is None:
         return permissions_allowed_for_system_role()
@@ -62,7 +62,7 @@ def permissions_allowed_for_role(cls) -> dict[type, list[str]]:
     return permissions_by_model
 
 
-def combine_values(data: dict[type, list[str]]) -> set[str]:
+def combine_values(data: dict[Type[Model], list[str]]) -> set[str]:
     "Utility method to merge everything in .values() into a single set"
     ret = set()
     for this_list in data.values():

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -18,7 +18,7 @@ def system_roles_enabled():
     )
 
 
-def printable_model_name(model: Optional[Type[Model]]) -> str:
+def prnt_model_name(model: Optional[Type[Model]]) -> str:
     return model._meta.model_name if model else 'global role'
 
 
@@ -150,7 +150,7 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
     invalid_codenames = codename_set - combine_values(permissions_by_model)
     if invalid_codenames:
         print_codenames = ', '.join(f'"{codename}"' for codename in invalid_codenames)
-        raise ValidationError({'permissions': f'Permissions {print_codenames} are not valid for {printable_model_name(role_model)} roles'})
+        raise ValidationError({'permissions': f'Permissions {print_codenames} are not valid for {prnt_model_name(role_model)} roles'})
 
     # Check that view permission is given for every model that has update/delete/special actions listed
     if settings.ANSIBLE_BASE_ROLES_REQUIRE_VIEW:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -111,13 +111,14 @@ def validate_permissions_for_model(permissions, content_type: Optional[Model], m
         raise ValidationError({'permissions': f'Permissions {print_codenames} are not valid for {printable_model_name(role_model)} roles'})
 
     # Check that view permission is given for every model that has update/delete/special actions listed
-    for cls, valid_model_permissions in permissions_by_model.items():
-        if 'view' in cls._meta.default_permissions:
-            model_permissions = set(valid_model_permissions) & codename_list
-            non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
-            if non_add_model_permissions and not any('view' in codename for codename in non_add_model_permissions):
-                display_perms = ', '.join(non_add_model_permissions)
-                raise ValidationError({'permissions': f'Permissions for model {printable_model_name(role_model)} needs to include view, got: {display_perms}'})
+    if settings.ANSIBLE_BASE_ROLES_REQUIRE_VIEW:
+        for cls, valid_model_permissions in permissions_by_model.items():
+            if 'view' in cls._meta.default_permissions:
+                model_permissions = set(valid_model_permissions) & codename_list
+                non_add_model_permissions = {codename for codename in model_permissions if not is_add_perm(codename)}
+                if non_add_model_permissions and not any('view' in codename for codename in non_add_model_permissions):
+                    display_perms = ', '.join(non_add_model_permissions)
+                    raise ValidationError({'permissions': f'Permissions for model {printable_model_name(role_model)} needs to include view, got: {display_perms}'})
 
     # Check requires change and role_model is a system-wide role (None means it is), skip this validation.
     if settings.ANSIBLE_BASE_DELETE_REQUIRE_CHANGE and role_model is not None:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -101,9 +101,7 @@ def check_view_permission_criteria(codename_set: set[str], permissions_by_model:
             local_codenames = {codename for codename in model_permissions if not is_add_perm(codename)}
             if local_codenames and not any('view' in codename for codename in local_codenames):
                 raise ValidationError(
-                    {
-                        'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include view, got: {prnt_codenames(local_codenames)}'
-                    }
+                    {'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include view, got: {prnt_codenames(local_codenames)}'}
                 )
 
 
@@ -121,9 +119,7 @@ def check_has_change_with_delete(codename_set: set[str], permissions_by_model: d
             local_codenames = {codename for codename in model_permissions if not is_add_perm(codename)}
             if any('delete' in codename for codename in local_codenames) and not any('change' in codename for codename in local_codenames):
                 raise ValidationError(
-                    {
-                        'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include change, got: {prnt_codenames(local_codenames)}'
-                    }
+                    {'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include change, got: {prnt_codenames(local_codenames)}'}
                 )
 
 

--- a/test_app/tests/rbac/api/test_rbac_serializers.py
+++ b/test_app/tests/rbac/api/test_rbac_serializers.py
@@ -33,7 +33,7 @@ class TestRoleDefinitions:
             get_relative_url('roledefinition-list'), data={'name': 'global inventory changer but not viewer', 'permissions': ['aap.change_inventory']}
         )
         assert response.status_code == 400, response.data
-        assert 'Permissions for model global role needs to include view' in str(response.data)
+        assert 'Permissions for model inventory needs to include view' in str(response.data)
 
     def test_create_custom_system_role(self, admin_api_client):
         "Make a POST to create a custom role with system permissions"


### PR DESCRIPTION
See https://github.com/jctanner/galaxy_ng/pull/15

> 2024-08-10T03:26:22.8611631Z pulp-1    | pulp [b1a1dfe7d1b04d9ea9356d555cfc3c72]: galaxy_ng.app.signals.handlers:WARNING: Assignment to galaxy.collection_namespace_owner for <class 'galaxy_ng.app.models.namespace.Namespace'> violates a DAB role validation rule: {'permissions': ErrorDetail(string='Permissions for model namespace needs to include view, got: change_namespace, upload_to_namespace', code='invalid')}

In the plan for galaxy_ng, they will be doing the evaluations. So (for now at least) even if their roles don't "make sense", it's not our problem here, and this makes it so galaxy_ng can turn this off and make view-less roles.