### PR TITLE
Manage team memberships in hub jwt consumer.

### DIFF
--- a/ansible_base/jwt_consumer/hub/auth.py
+++ b/ansible_base/jwt_consumer/hub/auth.py
@@ -51,7 +51,7 @@ class HubJWTAuth(JWTAuthentication):
 
         self.common_auth.user.groups.set(groups)
 
-		# manage org membership ...
+        # manage org membership ...
         org_pks = [org.pk for org in orgs]
         for org in Organization.objects.exclude(pk__in=org_pks).filter(users=self.common_auth.user):
             org.users.remove(self.common_auth.user)

--- a/ansible_base/jwt_consumer/hub/auth.py
+++ b/ansible_base/jwt_consumer/hub/auth.py
@@ -10,16 +10,22 @@ logger = logging.getLogger('ansible_base.jwt_consumer.hub.auth')
 
 
 class HubJWTAuth(JWTAuthentication):
-    def process_permissions(self):
-        # Map teams in the JWT to Automation Hub groups.
+
+    def get_galaxy_models_and_functions(self):
+        '''This is separate from process_permissions purely for testability.'''
         try:
             from galaxy_ng.app.models import Organization, Team
             from pulpcore.plugin.util import assign_role, remove_role
-
-            self.team_content_type = ContentType.objects.get_for_model(Team)
-            self.org_content_type = ContentType.objects.get_for_model(Organization)
         except ImportError:
             raise InvalidService("automation-hub")
+
+        return Organization, Team, assign_role, remove_role
+
+    def process_permissions(self):
+        # Map teams in the JWT to Automation Hub groups.
+        Organization, Team, assign_role, remove_role = self.get_galaxy_models_and_functions()
+        self.team_content_type = ContentType.objects.get_for_model(Team)
+        self.org_content_type = ContentType.objects.get_for_model(Organization)
 
         orgs = []
         teams = []

--- a/test_app/tests/jwt_consumer/hub/test_auth.py
+++ b/test_app/tests/jwt_consumer/hub/test_auth.py
@@ -63,8 +63,11 @@ def test_hub_jwt_teams(user, token, num_roles):
 @patch('ansible_base.jwt_consumer.hub.auth.ContentType')
 def test_hub_jwt_orgs_teams_groups_memberships(mock_contenttype, mock_resource):
 
-    content_type = ContentType.objects.get_for_model(Team)
-    team_member_role, _ = RoleDefinition.objects.get_or_create(name="Team Member", content_type=content_type)
+    org_content_type = ContentType.objects.get_for_model(Organization)
+    org_member_role, _ = RoleDefinition.objects.get_or_create(name="Organization Member", content_type=org_content_type)
+
+    team_content_type = ContentType.objects.get_for_model(Team)
+    team_member_role, _ = RoleDefinition.objects.get_or_create(name="Team Member", content_type=team_content_type)
 
     assign_role = MagicMock()
     remove_role = MagicMock()
@@ -100,7 +103,10 @@ def test_hub_jwt_orgs_teams_groups_memberships(mock_contenttype, mock_resource):
     auth.common_auth.user = testuser
     auth.common_auth.token = {
         "object_roles": {
-            # 'Organization Member': [],
+            'Organization Member': {
+                'content_type': 'organization',
+                'objects': [0]
+            },
             'Team Member': {
                 'content_type': 'team',
                 'objects': [0]
@@ -126,6 +132,7 @@ def test_hub_jwt_orgs_teams_groups_memberships(mock_contenttype, mock_resource):
 
     auth.process_permissions()
 
+    assert testorg.users.filter(pk=testuser.pk).exists()
     assert testuser.groups.filter(pk=testgroup.pk).exists()
     assert testteam.users.filter(pk=testuser.pk).exists()
     assert remove_role.called


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-3346

This won't distinguish between member vs owner, but galaxy doesn't have that anyway.