### PR TITLE
RBAC content filter should consider the app_label.

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -80,8 +80,11 @@ class ContentTypeField(ChoiceLikeMixin):
 
     def get_dynamic_object(self, data):
         app_label, model = data.rsplit('.')
-        if permission_registry.content_type_model.objects.get(model=model, app_label=app_label).exists():
-            return permission_registry.content_type_model.objects.get(model=model, app_label=app_label)
+        try:
+            if permission_registry.content_type_model.objects.get(model=model, app_label=app_label).exists():
+                return permission_registry.content_type_model.objects.get(model=model, app_label=app_label)
+        except Exception:
+            pass
         return permission_registry.content_type_model.objects.get(model=model)
 
     def to_representation(self, value):

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -79,8 +79,10 @@ class ContentTypeField(ChoiceLikeMixin):
         return list(sorted((self.get_resource_type_name(cls), cls._meta.verbose_name.title()) for cls in permission_registry.all_registered_models))
 
     def get_dynamic_object(self, data):
-        model = data.rsplit('.')[-1]
-        return permission_registry.content_type_model.objects.get(model=model)
+        app_label, model = data.rsplit('.')
+        if permission_registry.content_type_model.objects.filter(model=model).count() == 1:
+            return permission_registry.content_type_model.objects.filter(model=model)
+        return permission_registry.content_type_model.objects.get(model=model, app_label=app_label)
 
     def to_representation(self, value):
         if isinstance(value, str):

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.utils import IntegrityError
@@ -80,11 +81,9 @@ class ContentTypeField(ChoiceLikeMixin):
 
     def get_dynamic_object(self, data):
         app_label, model = data.rsplit('.')
-        try:
-            if permission_registry.content_type_model.objects.get(model=model, app_label=app_label).exists():
+        if app_label in permission_registry.apps.all_models:
+            if permission_registry.content_type_model.objects.filter(model=model, app_label=app_label).exists():
                 return permission_registry.content_type_model.objects.get(model=model, app_label=app_label)
-        except Exception:
-            pass
         return permission_registry.content_type_model.objects.get(model=model)
 
     def to_representation(self, value):

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -1,5 +1,4 @@
 from django.apps import apps
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.utils import IntegrityError

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -79,11 +79,11 @@ class ContentTypeField(ChoiceLikeMixin):
         return list(sorted((self.get_resource_type_name(cls), cls._meta.verbose_name.title()) for cls in permission_registry.all_registered_models))
 
     def get_dynamic_object(self, data):
-        app_label, model = data.rsplit('.')
-        if app_label in permission_registry.apps.all_models:
-            if permission_registry.content_type_model.objects.filter(model=model, app_label=app_label).exists():
-                return permission_registry.content_type_model.objects.get(model=model, app_label=app_label)
-        return permission_registry.content_type_model.objects.get(model=model)
+        model = data.rsplit('.')[-1]
+        cls = permission_registry.get_model_by_name(model)
+        if cls is None:
+            return permission_registry.content_type_model.objects.none().get()  # raises correct DoesNotExist
+        return permission_registry.content_type_model.objects.get_for_model(cls)
 
     def to_representation(self, value):
         if isinstance(value, str):

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -80,9 +80,9 @@ class ContentTypeField(ChoiceLikeMixin):
 
     def get_dynamic_object(self, data):
         app_label, model = data.rsplit('.')
-        if permission_registry.content_type_model.objects.filter(model=model).count() == 1:
-            return permission_registry.content_type_model.objects.filter(model=model)
-        return permission_registry.content_type_model.objects.get(model=model, app_label=app_label)
+        if permission_registry.content_type_model.objects.get(model=model, app_label=app_label).exists():
+            return permission_registry.content_type_model.objects.get(model=model, app_label=app_label)
+        return permission_registry.content_type_model.objects.get(model=model)
 
     def to_representation(self, value):
         if isinstance(value, str):

--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -228,5 +228,12 @@ class PermissionRegistry:
         """Tells if the given object or class is a type tracked by DAB RBAC"""
         return any((obj._meta.model_name == cls._meta.model_name and obj._meta.app_label == cls._meta.app_label) for cls in self._registry)
 
+    def get_model_by_name(self, model_name: str) -> Optional[Type[Model]]:
+        """Returns class with given model_name if registered, returns None otherwise"""
+        for cls in self._registry:
+            if model_name == cls._meta.model_name:
+                return cls
+        return None
+
 
 permission_registry = PermissionRegistry()

--- a/test_app/tests/rbac/compatibility/test_model_name_conflict.py
+++ b/test_app/tests/rbac/compatibility/test_model_name_conflict.py
@@ -2,6 +2,7 @@ import pytest
 from django.apps import apps
 from django.contrib.admin.models import LogEntry as AdminLogEntry
 
+from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac import permission_registry
 from ansible_base.rbac.management import create_dab_permissions
 from ansible_base.rbac.models import DABPermission
@@ -19,3 +20,12 @@ def test_does_not_create_unregistered_permission_entries():
     # we should not have anything in the admin app registered
     create_dab_permissions(apps.get_app_config('admin'), apps=apps)
     assert permission_ct == DABPermission.objects.count()  # permission count did not change
+
+
+@pytest.mark.django_db
+def test_create_custom_role_name_conflict_model(admin_api_client):
+    url = get_relative_url('roledefinition-list')
+    data = dict(name='Single Log Entry Viewer', content_type='aap.logentry', permissions=['aap.view_logentry'])
+    response = admin_api_client.post(url, data=data, format="json")
+    assert response.status_code == 201, response.data
+    assert 'id' in response.data, response.data


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-29363

Sometimes there are multiple models with the same name and different app labels. Example: container.containernamespace and galaxy.containernamespace

If there is only one matching model name, return that, otherwise filter on the app label as well so that only one object is returned.

