### PR TITLE
Ignore permissions given twice in migrations

### DIFF
--- a/ansible_base/rbac/migrations/_utils.py
+++ b/ansible_base/rbac/migrations/_utils.py
@@ -30,7 +30,7 @@ def give_permissions(apps, rd, users=(), teams=(), object_id=None, content_type_
             RoleUserAssignment(object_role=object_role, user=user, **object_role_fields)
             for user in users
         ]
-        RoleUserAssignment.objects.bulk_create(user_assignments)
+        RoleUserAssignment.objects.bulk_create(user_assignments, ignore_conflicts=True)
     if teams:
         RoleTeamAssignment = apps.get_model('dab_rbac', 'RoleTeamAssignment')
         # AWX has trouble getting the team object, conditionally accept team id list
@@ -44,4 +44,4 @@ def give_permissions(apps, rd, users=(), teams=(), object_id=None, content_type_
                 RoleTeamAssignment(object_role=object_role, team_id=team_id, **object_role_fields)
                 for team_id in teams
             ]
-        RoleTeamAssignment.objects.bulk_create(team_assignments)
+        RoleTeamAssignment.objects.bulk_create(team_assignments, ignore_conflicts=True)

--- a/test_app/tests/rbac/test_migrations.py
+++ b/test_app/tests/rbac/test_migrations.py
@@ -16,12 +16,18 @@ def test_give_permissions(organization, inventory, inv_rd):
     assert RoleUserAssignment.objects.filter(user=user).exists()
     assert RoleTeamAssignment.objects.filter(team=team).exists()
 
+    # Make sure it can be ran twice
+    give_permissions(apps, inv_rd, users=[user], teams=[team], object_id=inventory.id, content_type_id=ContentType.objects.get_for_model(inventory).id)
+
 
 @pytest.mark.django_db
 def test_give_permissions_by_id(organization, inventory, inv_rd):
     team = Team.objects.create(name='ateam', organization=organization)
     give_permissions(apps, inv_rd, teams=[team.id], object_id=inventory.id, content_type_id=ContentType.objects.get_for_model(inventory).id)
     assert RoleTeamAssignment.objects.filter(team=team).exists()
+
+    # Make sure it can be ran twice
+    give_permissions(apps, inv_rd, teams=[team.id], object_id=inventory.id, content_type_id=ContentType.objects.get_for_model(inventory).id)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
I ran into this trying to test migrations in galaxy_ng. I need to test by running with current apps, but `IntegrityError` is obviously going to make that error, because all the data is filled in.