### PR TITLE
Add upload of Junit XML test result files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,23 @@ jobs:
           - env: check
             python-version: "3.11"
             sonar: false
+            junit-xml-upload: false
           - env: py39
             python-version: "3.9"
             sonar: false
+            junit-xml-upload: false
           - env: py310
             python-version: "3.10"
             sonar: false
+            junit-xml-upload: false
           - env: py311
             python-version: "3.11"
             sonar: true
+            junit-xml-upload: true
           - env: py311sqlite
             python-version: "3.11"
             sonar: false
+            junit-xml-upload: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,3 +72,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Upload jUnit XML test results
+        if: matrix.tests.junit-xml-upload && github.event_name == 'push' && github.repository == 'ansible/django-ansible-base' && github.ref_name == 'devel'
+        continue-on-error: true
+        run: >-
+          curl -v --user "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
+          --form "xunit_xml=@django-ansible-base-test-results.xml"
+          --form "component_name=django-ansible-base"
+          --form "git_commit_sha=${{ github.sha }}"
+          --form "git_repository_url=https://github.com/${{ github.repository }}"
+          "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}/api/results/upload/"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__
 .coverage*
 coverage.xml
 coverage.json
+django-ansible-base-test-results.xml
 htmlcov
 *.tox
 venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ legacy_tox_ini = """
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
     allowlist_externals = sh
-    commands = sh -c 'make postgres && pytest -n auto --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}'
+    commands = sh -c 'make postgres && pytest -n auto --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch --junit-xml=django-ansible-base-test-results.xml {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}'
 
     [testenv:check]
     deps =


### PR DESCRIPTION
This PR adds storing test results in Junit XML file when the unit test are running and then uploading them to the platform readiness dashboard.

Jira: https://issues.redhat.com/browse/AAP-29787

Documentation: https://handbook.eng.ansible.com/docs/Testing/xunit-junit

The sample repo in Gitlab(link in the documentation) uses `httpie` for upload however the github runner already provides `curl` so this PR is making use of that instead.