### PR TITLE
Add some nuance to the on-off logic for RESOURCE_SERVER

### DIFF
--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -101,10 +101,11 @@ def proxies_of_model(cls):
 
 def _should_reverse_sync():
     enabled = getattr(settings, 'RESOURCE_SERVER_SYNC_ENABLED', False)
-    if not getattr(settings, 'RESOURCE_SERVER', False):
+    resource_server_defined = bool(getattr(settings, 'RESOURCE_SERVER', {}).get('URL', {}))
+    if enabled and (not resource_server_defined):
         logger.error("RESOURCE_SERVER is not configured. Reverse sync will not be enabled.")
         enabled = False
-    if hasattr(settings, 'RESOURCE_SERVER') and ('SECRET_KEY' not in settings.RESOURCE_SERVER or not settings.RESOURCE_SERVER['SECRET_KEY']):
+    if enabled and resource_server_defined and ('SECRET_KEY' not in settings.RESOURCE_SERVER or not settings.RESOURCE_SERVER['SECRET_KEY']):
         logger.error("RESOURCE_SERVER['SECRET_KEY'] is not configured. Reverse sync will not be enabled.")
         enabled = False
     return enabled

--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -8,6 +8,7 @@ from django.db.utils import IntegrityError
 
 import ansible_base.lib.checks  # noqa: F401 - register checks
 from ansible_base.lib.utils.db import ensure_transaction, migrations_are_complete
+from ansible_base.resource_registry.utils.settings import resource_server_defined
 
 logger = logging.getLogger('ansible_base.resource_registry.apps')
 
@@ -101,11 +102,10 @@ def proxies_of_model(cls):
 
 def _should_reverse_sync():
     enabled = getattr(settings, 'RESOURCE_SERVER_SYNC_ENABLED', False)
-    resource_server_defined = bool(getattr(settings, 'RESOURCE_SERVER', {}).get('URL', ''))
-    if enabled and (not resource_server_defined):
+    if enabled and (not resource_server_defined()):
         logger.error("RESOURCE_SERVER is not configured. Reverse sync will not be enabled.")
         enabled = False
-    if enabled and resource_server_defined and ('SECRET_KEY' not in settings.RESOURCE_SERVER or not settings.RESOURCE_SERVER['SECRET_KEY']):
+    if enabled and resource_server_defined() and ('SECRET_KEY' not in settings.RESOURCE_SERVER or not settings.RESOURCE_SERVER['SECRET_KEY']):
         logger.error("RESOURCE_SERVER['SECRET_KEY'] is not configured. Reverse sync will not be enabled.")
         enabled = False
     return enabled

--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -101,7 +101,7 @@ def proxies_of_model(cls):
 
 def _should_reverse_sync():
     enabled = getattr(settings, 'RESOURCE_SERVER_SYNC_ENABLED', False)
-    resource_server_defined = bool(getattr(settings, 'RESOURCE_SERVER', {}).get('URL', {}))
+    resource_server_defined = bool(getattr(settings, 'RESOURCE_SERVER', {}).get('URL', ''))
     if enabled and (not resource_server_defined):
         logger.error("RESOURCE_SERVER is not configured. Reverse sync will not be enabled.")
         enabled = False

--- a/ansible_base/resource_registry/utils/service_backed_sso_pipeline.py
+++ b/ansible_base/resource_registry/utils/service_backed_sso_pipeline.py
@@ -3,6 +3,7 @@ from django.shortcuts import redirect
 
 from ansible_base.resource_registry.resource_server import get_resource_server_config
 from ansible_base.resource_registry.utils.auth_code import get_user_auth_code
+from ansible_base.resource_registry.utils.settings import resource_server_defined
 
 
 def redirect_to_resource_server(*args, social=None, user=None, **kwargs):
@@ -11,7 +12,9 @@ def redirect_to_resource_server(*args, social=None, user=None, **kwargs):
     """
 
     # Allow for disabling this pipeline without removing it from the settings.
-    if not getattr(settings, 'ENABLE_SERVICE_BACKED_SSO', False):
+    # If resource server is defined, also silently quit
+    # for ease of connected vs disconnected configs
+    if (not getattr(settings, 'ENABLE_SERVICE_BACKED_SSO', False)) or (not resource_server_defined()):
         return None
 
     oidc_alt_key = None

--- a/ansible_base/resource_registry/utils/settings.py
+++ b/ansible_base/resource_registry/utils/settings.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def resource_server_defined() -> bool:
+    return bool(getattr(settings, 'RESOURCE_SERVER', {}).get('URL', ''))

--- a/test_app/tests/resource_registry/test_utils.py
+++ b/test_app/tests/resource_registry/test_utils.py
@@ -214,7 +214,7 @@ class TestReverseResourceSync:
             (
                 {
                     'RESOURCE_SERVER_SYNC_ENABLED': True,
-                    'RESOURCE_SERVER': {'url': 'http://localhost:8000', 'SECRET_KEY': 'foo'},
+                    'RESOURCE_SERVER': {'URL': 'http://localhost:8000', 'SECRET_KEY': 'foo'},
                     'RESOURCE_SERVICE_PATH': "/foo",
                 },
                 True,
@@ -223,7 +223,7 @@ class TestReverseResourceSync:
             (
                 {
                     'RESOURCE_SERVER_SYNC_ENABLED': False,
-                    'RESOURCE_SERVER': {'url': 'http://localhost:8000', 'SECRET_KEY': 'foo'},
+                    'RESOURCE_SERVER': {'URL': 'http://localhost:8000', 'SECRET_KEY': 'foo'},
                     'RESOURCE_SERVICE_PATH': "/foo",
                 },
                 False,


### PR DESCRIPTION
Due to dynaconf implementation details, I discovered that eda-server may set `{"URL": None}` for the `RESOURCE_SERVER` setting. This is totally fine with me, and should be the same as not defining that setting. But it requires this code change.

Fixes https://github.com/ansible/django-ansible-base/issues/602