### PR TITLE
Upgrade django based on dependabot security alerts

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
 cryptography
-Django>=4.2.15,<4.3.0
+Django == 4.2.15 # pinned to version productization already has available
 djangorestframework
 django-crum
 django-split-settings

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
 cryptography
-Django>=4.2.15,<4.3.0 # pinned to version productization already has available
+Django>=4.2.16,<4.3.0 # CVE-2024-45230
 djangorestframework
 django-crum
 django-split-settings

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
 cryptography
-Django>=4.2.5,<4.3.0
+Django>=4.2.15,<4.3.0
 djangorestframework
 django-crum
 django-split-settings

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
 cryptography
-Django == 4.2.15 # pinned to version productization already has available
+Django>=4.2.15,<4.3.0 # pinned to version productization already has available
 djangorestframework
 django-crum
 django-split-settings

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -24,7 +24,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==4.2.11
+django==4.2.16
     # via
     #   -r requirements/requirements.in
     #   channels

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -24,7 +24,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==4.2.15
+django==4.2.16
     # via
     #   -r requirements/requirements.in
     #   channels

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -24,7 +24,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==4.2.16
+django==4.2.15
     # via
     #   -r requirements/requirements.in
     #   channels

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,6 +1,6 @@
 ansible  # Used in build process to generate some configs
 build
-Django>=4.2.5,<4.3.0
+Django == 4.2.15
 django-debug-toolbar
 django-extensions
 djangorestframework

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,6 +1,6 @@
 ansible  # Used in build process to generate some configs
 build
-Django==4.2.15
+Django==4.2.16
 django-debug-toolbar
 django-extensions
 djangorestframework

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,6 +1,6 @@
 ansible  # Used in build process to generate some configs
 build
-Django == 4.2.15
+Django==4.2.15
 django-debug-toolbar
 django-extensions
 djangorestframework


### PR DESCRIPTION
This PR upgrades Django to address following dependabot alerts:

**Critical:**
https://github.com/ansible/django-ansible-base/security/dependabot/21
**High:**
https://github.com/ansible/django-ansible-base/security/dependabot/18
https://github.com/ansible/django-ansible-base/security/dependabot/16
https://github.com/ansible/django-ansible-base/security/dependabot/15
**Moderate:**
https://github.com/ansible/django-ansible-base/security/dependabot/17
https://github.com/ansible/django-ansible-base/security/dependabot/22
https://github.com/ansible/django-ansible-base/security/dependabot/20
https://github.com/ansible/django-ansible-base/security/dependabot/19