### PR TITLE
Hide certain plugins from /authenticator_plugins/

### DIFF
--- a/ansible_base/authentication/views/authenticator_plugins.py
+++ b/ansible_base/authentication/views/authenticator_plugins.py
@@ -12,6 +12,9 @@ class AuthenticatorPluginView(AnsibleBaseDjangoAppApiView):
         for p in plugins:
             try:
                 klass = get_authenticator_class(p)
+                if getattr(klass, "type", "") == "internal":
+                    # Allow for 'hiding' some plugins from this list so the UI doesn't show them as a choice.
+                    continue
                 config = klass.configuration_class()
                 config_schema = config.get_configuration_schema()
                 resp['authenticators'].append(

--- a/ansible_base/authentication/views/authenticator_plugins.py
+++ b/ansible_base/authentication/views/authenticator_plugins.py
@@ -12,7 +12,7 @@ class AuthenticatorPluginView(AnsibleBaseDjangoAppApiView):
         for p in plugins:
             try:
                 klass = get_authenticator_class(p)
-                if getattr(klass, "type", "") == "internal":
+                if getattr(klass, "internal", False):
                     # Allow for 'hiding' some plugins from this list so the UI doesn't show them as a choice.
                     continue
                 config = klass.configuration_class()

--- a/test_app/tests/fixtures/authenticator_plugins/definitely_not_public.py
+++ b/test_app/tests/fixtures/authenticator_plugins/definitely_not_public.py
@@ -9,8 +9,9 @@ logger = logging.getLogger('test_app.tests.fixtures.authenticator_plugins.defini
 
 class AuthenticatorPlugin(AbstractAuthenticatorPlugin):
     configuration_encrypted_fields = []
-    type = "internal"
+    type = "definitely_not_public"
     category = "password"
+    internal = True
 
     def __init__(self, database_instance=None, *args, **kwargs):
         super().__init__(database_instance, *args, **kwargs)

--- a/test_app/tests/fixtures/authenticator_plugins/definitely_not_public.py
+++ b/test_app/tests/fixtures/authenticator_plugins/definitely_not_public.py
@@ -4,12 +4,12 @@ from django.contrib.auth import get_user_model
 
 from ansible_base.authentication.authenticator_plugins.base import AbstractAuthenticatorPlugin
 
-logger = logging.getLogger('test_app.tests.fixtures.authenticator_plugins.custom')
+logger = logging.getLogger('test_app.tests.fixtures.authenticator_plugins.definitely_not_public')
 
 
 class AuthenticatorPlugin(AbstractAuthenticatorPlugin):
     configuration_encrypted_fields = []
-    type = "custom"
+    type = "internal"
     category = "password"
 
     def __init__(self, database_instance=None, *args, **kwargs):


### PR DESCRIPTION
Be able to have some authenticator plugins be marked as "internal" and thus not shown in the UI as an option when configuring an authenticator.