### PR TITLE
Pass requesting user into validate role assignment

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -256,7 +256,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         # the callback should raise DRF exceptions directly if
         # necessary
         if getattr(obj, 'validate_role_assignment', None):
-            obj.validate_role_assignment(actor, rd)
+            obj.validate_role_assignment(actor, rd, requesting_user=requesting_user)
 
         # Return a 400 if the role is not managed locally
         check_locally_managed(rd)

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -21,14 +21,14 @@ For this, django-ansible-base will call out to `validate_role_assignment` method
 
 The signature of this callback is
 
-`validate_role_assignment(self, actor, role_definition)`
+`validate_role_assignment(self, actor, role_definition, **kwargs)`
 
 This method is reponsible for raising the appropriate exception if necessary, for example,
 
 ```python
 from rest_framework.exceptions import ValidationError
 class MyDjangoModel:
-    def validate_role_assignment(self, actor, role_definition):
+    def validate_role_assignment(self, actor, role_definition, **kwargs):
         raise ValidationError({'detail': 'Role assignment not allowed.'})
 ```
 

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -182,7 +182,7 @@ class Inventory(models.Model):
     def summary_fields(self):
         return {"id": self.id, "name": self.name}
 
-    def validate_role_assignment(self, actor, role_definition):
+    def validate_role_assignment(self, actor, role_definition, **kwargs):
         if isinstance(actor, User):
             name = actor.username
         if isinstance(actor, Team):


### PR DESCRIPTION
For credential and execution env, the callback will attempt to make extra requests to gateway, so it
needs the requesting user.