### PR TITLE
Force social-auth-app-django to 5.4.1

### DIFF
--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -137,7 +137,7 @@ six==1.16.0
     #   isodate
     #   pyrad
     #   tacacs-plus
-social-auth-app-django==5.4.0
+social-auth-app-django==5.4.1
     # via -r requirements/requirements_authentication.in
 social-auth-core==4.5.3
     # via social-auth-app-django

--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -1,4 +1,4 @@
-social-auth-app-django
+social-auth-app-django==5.4.1
 tabulate
 
 # These should eventually be split out when the authentications move into their own repo


### PR DESCRIPTION
  * Fixes bug with Github SSO login
  * Compatible with social-auth-core 5.4.4 (latest) which is left unpinned
 
The combination previously in dev worked fine, but the combo in production did not (github social login broken).

It turns out that there was a defect fix partly in social auth core and partly in social-auth-app-django and updating both to latest again works fine.

PDE is making the same updates in production build environment.