### PR TITLE
Only return entries for local service_id

### DIFF
--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -131,7 +131,15 @@ class ResourceTypeViewSet(
         if not resource_type.serializer_class:  # pragma: no cover
             return HttpResponseNotFound()
 
-        resources = Resource.objects.filter(content_type__resource_type=resource_type).prefetch_related("content_object")
+        if 'service_id' in request.query_params:
+            list_service_id = request.query_params['service_id']
+        else:
+            list_service_id = service_id()
+
+        resources = Resource.objects.filter(
+            content_type__resource_type=resource_type,
+            service_id=list_service_id
+        ).prefetch_related("content_object")
 
         if name == "shared.user" and (system_user := getattr(settings, "SYSTEM_USERNAME", None)):
             resources = resources.exclude(name=system_user)

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -139,9 +139,7 @@ class ResourceTypeViewSet(
         else:
             service_filter = {'service_id': service_id()}
 
-        resources = Resource.objects.filter(
-            content_type__resource_type=resource_type, **service_filter
-        ).prefetch_related("content_object")
+        resources = Resource.objects.filter(content_type__resource_type=resource_type, **service_filter).prefetch_related("content_object")
 
         if name == "shared.user" and (system_user := getattr(settings, "SYSTEM_USERNAME", None)):
             resources = resources.exclude(name=system_user)

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -132,10 +132,10 @@ class ResourceTypeViewSet(
             return HttpResponseNotFound()
 
         if 'service_id' in request.query_params:
-            if request.query_params['service_id']:
-                service_filter = {'service_id': request.query_params['service_id']}
-            else:
+            if request.query_params['service_id'] == 'all':
                 service_filter = {}
+            else:
+                service_filter = {'service_id': request.query_params['service_id']}
         else:
             service_filter = {'service_id': service_id()}
 

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -132,13 +132,15 @@ class ResourceTypeViewSet(
             return HttpResponseNotFound()
 
         if 'service_id' in request.query_params:
-            list_service_id = request.query_params['service_id']
+            if request.query_params['service_id']:
+                service_filter = {'service_id': request.query_params['service_id']}
+            else:
+                service_filter = {}
         else:
-            list_service_id = service_id()
+            service_filter = {'service_id': service_id()}
 
         resources = Resource.objects.filter(
-            content_type__resource_type=resource_type,
-            service_id=list_service_id
+            content_type__resource_type=resource_type, **service_filter
         ).prefetch_related("content_object")
 
         if name == "shared.user" and (system_user := getattr(settings, "SYSTEM_USERNAME", None)):

--- a/test_app/tests/resource_registry/test_views.py
+++ b/test_app/tests/resource_registry/test_views.py
@@ -1,4 +1,8 @@
+from uuid import uuid4
+
+
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.resource_registry.models import ResourceType
 
 
 def test_validate_local_user(unauthenticated_api_client, admin_user, local_authenticator, settings_override_mutable, settings):
@@ -20,3 +24,28 @@ def test_validate_local_user(unauthenticated_api_client, admin_user, local_authe
         assert response.status_code == 200
         assert 'ansible_id' in response.data
         assert response.data['auth_code'] is None
+
+
+def get_users_manifest(client, data=None, expect=200):
+    if data is None:
+        data = {}
+    url = get_relative_url('resourcetype-manifest', kwargs={'name': 'shared.user'})
+    r = client.get(url, data=data)
+    assert r.status_code == expect, f'request data: {data}, url: {url}, response: {r}'
+    return '\n'.join([str(line) for line in r])
+
+
+def test_resource_type_manifest(admin_api_client, user):
+    r_text = get_users_manifest(admin_api_client)
+    assert str(user.resource.ansible_id) in r_text
+
+    # Expect a 404 because no records should be returned for this service_id
+    r_text = get_users_manifest(admin_api_client, data={'service_id': str(uuid4())}, expect=404)
+    assert str(user.resource.ansible_id) not in r_text
+
+    user.resource.service_id = str(uuid4())
+    user.resource.save(update_fields=['service_id'])
+
+    # Expect to get some user entries, but this particular user will not be returned
+    r_text = get_users_manifest(admin_api_client)
+    assert str(user.resource.ansible_id) not in r_text

--- a/test_app/tests/resource_registry/test_views.py
+++ b/test_app/tests/resource_registry/test_views.py
@@ -35,10 +35,10 @@ def get_users_manifest(client, data=None, expect=200):
     return '\n'.join([str(line) for line in r])
 
 
-def test_resource_type_manifest_default(admin_api_client, user):
+def test_resource_type_manifest_default(admin_api_client, admin_user, user):
     r_text = get_users_manifest(admin_api_client)
     assert str(user.resource.ansible_id) in r_text
-    assert str(user.resource.ansible_id) in r_text
+    assert str(admin_user.resource.ansible_id) in r_text
 
 
 def test_resource_manifest_non_default_service_id(admin_api_client, admin_user, user):

--- a/test_app/tests/resource_registry/test_views.py
+++ b/test_app/tests/resource_registry/test_views.py
@@ -35,10 +35,14 @@ def get_users_manifest(client, data=None, expect=200):
     return '\n'.join([str(line) for line in r])
 
 
-def test_resource_type_manifest(admin_api_client, user):
+def test_resource_type_manifest_default(admin_api_client, user):
     r_text = get_users_manifest(admin_api_client)
     assert str(user.resource.ansible_id) in r_text
+    assert str(user.resource.ansible_id) in r_text
 
+
+def test_resource_manifest_non_default_service_id(admin_api_client, admin_user, user):
+    "Tests that we can use query param to filter the manifest list to a different service_id"
     # Expect a 404 because no records should be returned for this service_id
     r_text = get_users_manifest(admin_api_client, data={'service_id': str(uuid4())}, expect=404)
     assert str(user.resource.ansible_id) not in r_text
@@ -49,3 +53,18 @@ def test_resource_type_manifest(admin_api_client, user):
     # Expect to get some user entries, but this particular user will not be returned
     r_text = get_users_manifest(admin_api_client)
     assert str(user.resource.ansible_id) not in r_text
+
+    # Filtering by the modified service_id should give exactly ONE entry
+    r_text = get_users_manifest(admin_api_client, data={'service_id': str(user.resource.service_id)}, expect=200)
+    assert len(r_text.strip().split('\n')) == 2  # headers and the ONE entry
+    assert str(admin_user.resource.ansible_id) not in r_text
+    assert str(user.resource.ansible_id) in r_text
+
+
+def test_resource_manifest_no_service_id_filter(admin_api_client, admin_user, user):
+    user.resource.service_id = str(uuid4())
+    user.resource.save(update_fields=['service_id'])
+
+    r_text = get_users_manifest(admin_api_client, data={'service_id': ''}, expect=200)
+    assert str(user.resource.ansible_id) in r_text
+    assert str(admin_user.resource.ansible_id) in r_text

--- a/test_app/tests/resource_registry/test_views.py
+++ b/test_app/tests/resource_registry/test_views.py
@@ -64,6 +64,6 @@ def test_resource_manifest_no_service_id_filter(admin_api_client, admin_user, us
     user.resource.service_id = str(uuid4())
     user.resource.save(update_fields=['service_id'])
 
-    r_text = get_users_manifest(admin_api_client, data={'service_id': ''}, expect=200)
+    r_text = get_users_manifest(admin_api_client, data={'service_id': 'all'}, expect=200)
     assert str(user.resource.ansible_id) in r_text
     assert str(admin_user.resource.ansible_id) in r_text

--- a/test_app/tests/resource_registry/test_views.py
+++ b/test_app/tests/resource_registry/test_views.py
@@ -2,7 +2,6 @@ from uuid import uuid4
 
 
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.resource_registry.models import ResourceType
 
 
 def test_validate_local_user(unauthenticated_api_client, admin_user, local_authenticator, settings_override_mutable, settings):

--- a/test_app/tests/resource_registry/test_views.py
+++ b/test_app/tests/resource_registry/test_views.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
 
-
 from ansible_base.lib.utils.response import get_relative_url
 
 


### PR DESCRIPTION
AAP-27844

This will avoid pulling entries for periodic resource sync if they are not marked as belonging to the resource server. I'm still unsure if this behavior is desirable.