### PR TITLE
Redis flushdb

### DIFF
--- a/test_app/tests/lib/cache/test_fallback_cache.py
+++ b/test_app/tests/lib/cache/test_fallback_cache.py
@@ -97,7 +97,10 @@ def test_fallback_cache():
     # Check until primary is back
     timeout = time.time() + 30
     while True:
-        if cache.get_active_cache() == PRIMARY_CACHE:
+        # Tell the cache to get a key, this should cause it to check the primary cache
+        cache.get("key")
+        active_cache = cache.get_active_cache()
+        if active_cache == PRIMARY_CACHE:
             break
         if time.time() > timeout:
             assert False


### PR DESCRIPTION
2 commits in here:
1.  Simplifying how exceptions are handled with a raised translated message. This allows us to catch other exceptions we weren't expecting and exiting with clean errors.
2. Overriding the flushdb method. Currently, in our version of Redis, the flushdb command does not respect ACLs. So when gateway switches from the fallback cache to the primary cache it calls `cache.clear()` this eventually does a `flushdb` command. The flushdb command will not check the connected users to see if they have access to  keys, it  just obliterates everything in the Redis DB. This causes issues in a shared Redis installation. This new method is less efficient but will load all of the keys and then attempt to delete them all and just ignores a `NoPermissionError` if it tried to delete something it didn't have access to.