### PR TITLE
[Alt 1] Flip default of reverse sync to True

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -226,7 +226,10 @@ def get_dab_settings(
         dab_data['ORG_ADMINS_CAN_SEE_ALL_USERS'] = True
 
     if 'ansible_base.resource_registry' in installed_apps:
-        dab_data['RESOURCE_SERVER_SYNC_ENABLED'] = False
+        # Sync local changes to the resource server
+        # This will not do anything if RESOURCE_SERVER is not defined
+        dab_data['RESOURCE_SERVER_SYNC_ENABLED'] = True
+        # The API path on the resource server to use to update resources
         dab_data['RESOURCE_SERVICE_PATH'] = "/api/gateway/v1/service-index/"
 
         # Disable legacy SSO by default

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -197,6 +197,9 @@ RESOURCE_SERVER = {
     "VALIDATE_HTTPS": False,
 }
 RESOURCE_SERVICE_PATH = "/api/v1/service-index/"
+# Backwards sync turned off, because for most of the duration of the tests
+# the resource server will not actually be running
+# so it will be flipped true only for specific tests that test this
 RESOURCE_SERVER_SYNC_ENABLED = False
 
 RENAMED_USERNAME_PREFIX = "dab:"


### PR DESCRIPTION
While revisiting https://github.com/ansible/eda-server/pull/1061, I realized that `RESOURCE_SERVER_SYNC_ENABLED` is not set to True.

This will not work to do what we want.

As of https://github.com/ansible/django-ansible-base/pull/603, for any practical system (excluding test_app specifically here), we will be safe to have a True value.

For some reason, we had planned to make this change in apps like AWX / eda-server, but this doesn't make sense to me. Making this change seems like the most reasonable.