### PR TITLE
Throw error if reverse-sync needed, but not allowed

### DIFF
--- a/ansible_base/resource_registry/utils/sync_to_resource_server.py
+++ b/ansible_base/resource_registry/utils/sync_to_resource_server.py
@@ -55,6 +55,16 @@ def sync_to_resource_server(instance, action, ansible_id=None):
         logger.info(f"Skipping sync of resource {instance} because its service_id is local")
         return
 
+    # By this point we have passed the exit conditions
+    # If an edit requires a resource sync, but we intended to not allow local edits
+    # that has led to a contradiction, normally this is enforced by the service API
+    # but for direct ORM actions we throw an error as a last-resort safety measure
+    if not getattr(settings, "ALLOW_LOCAL_RESOURCE_MANAGEMENT"):
+        raise ValidationError(
+            "Configured to resource sync, which conflicts with ALLOW_LOCAL_RESOURCE_MANAGEMENT. "
+            "Try setting environment variable ANSIBLE_REVERSE_RESOURCE_SYNC to false."
+        )
+
     user_ansible_id = None
     user = get_current_user()
     if user:


### PR DESCRIPTION
This is a re-do of https://github.com/ansible/django-ansible-base/pull/618 that attempts to answer the question "what if someone runs `awx-manage createsuperuser` manually?"

If that command is ran with explicit disabling of reverse-sync, then it will be allowed. It _will be_ confusing that doing this is still permitted even through local_resource_management is off.

But what's the _most_ wrong is to have
 - ALLOW_LOCAL_RESOURCE_MANAGEMENT False
 - reverse sync enabled (multiple mechanisms involved)

The argument is that this configuration is so dangerously contradictory that we should throw an error so that we can front-load debugging of the situation.