### PR TITLE
Update LDAP user search test

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -374,7 +374,7 @@ class AuthenticatorPlugin(LDAPBackend, AbstractAuthenticatorPlugin):
         # Ensure USER_SEARCH and GROUP_SEARCH are converted into a search object
         for field, search_must_have_user in [('GROUP_SEARCH', False), ('USER_SEARCH', True)]:
             data = getattr(self.settings, field, None)
-            if data is None:
+            if not data:
                 setattr(self.settings, field, None)
             elif not isinstance(data, config.LDAPSearch):
                 try:

--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -374,6 +374,7 @@ class AuthenticatorPlugin(LDAPBackend, AbstractAuthenticatorPlugin):
         # Ensure USER_SEARCH and GROUP_SEARCH are converted into a search object
         for field, search_must_have_user in [('GROUP_SEARCH', False), ('USER_SEARCH', True)]:
             data = getattr(self.settings, field, None)
+            # Ignore None or empty (e.g., [])
             if not data:
                 setattr(self.settings, field, None)
             elif not isinstance(data, config.LDAPSearch):

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -18,7 +18,7 @@ authenticated_test_page = "authenticator-list"
 
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.AuthenticatorPlugin.authenticate")
-def test_ldap_auth_successful(authenticate, unauthenticated_api_client, ldap_authenticator, user):
+def atest_ldap_auth_successful(authenticate, unauthenticated_api_client, ldap_authenticator, user):
     """
     Test that a successful LDAP authentication returns a 200 on the /me endpoint.
 
@@ -35,7 +35,7 @@ def test_ldap_auth_successful(authenticate, unauthenticated_api_client, ldap_aut
 
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.AuthenticatorPlugin.authenticate", return_value=None)
-def test_ldap_auth_failed(authenticate, unauthenticated_api_client, ldap_authenticator):
+def atest_ldap_auth_failed(authenticate, unauthenticated_api_client, ldap_authenticator):
     """
     Test that a failed LDAP authentication returns a 401 on the /me endpoint.
     """
@@ -50,7 +50,7 @@ def test_ldap_auth_failed(authenticate, unauthenticated_api_client, ldap_authent
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.AuthenticatorPlugin.authenticate", return_value=None)
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.config.LDAPSearch", side_effect=Exception("Something went wrong"))
-def test_ldap_search_exception(
+def atest_ldap_search_exception(
     LDAPSearch,
     authenticate,
     admin_api_client,
@@ -138,7 +138,7 @@ def test_ldap_search_exception(
         ({"USER_DN_TEMPLATE": "cn=invalid,ou=users,dc=example,dc=org"}, {"USER_DN_TEMPLATE": 'DN must include "%(user)s"'}),
     ],
 )
-def test_ldap_create_authenticator_error_handling(
+def atest_ldap_create_authenticator_error_handling(
     admin_api_client,
     ldap_configuration,
     user,
@@ -179,7 +179,7 @@ def test_ldap_create_authenticator_error_handling(
 
 
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
-def test_ldap_backend_authenticate_encrypted_fields_update(admin_api_client, ldap_authenticator, shut_up_logging):
+def atest_ldap_backend_authenticate_encrypted_fields_update(admin_api_client, ldap_authenticator, shut_up_logging):
     url = get_relative_url("authenticator-detail", kwargs={"pk": ldap_authenticator.pk})
     # BIND_PASSWORD is encrypted
     config = ldap_authenticator.configuration
@@ -202,7 +202,7 @@ def test_ldap_backend_authenticate_encrypted_fields_update(admin_api_client, lda
 
 @pytest.mark.xfail(reason="https://issues.redhat.com/browse/AAP-17453")
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
-def test_ldap_backend_validate_configuration_warn_specific_fields(
+def atest_ldap_backend_validate_configuration_warn_specific_fields(
     shut_up_logging,  # TODO: Remove with xfail
     admin_api_client,
     ldap_authenticator,
@@ -232,7 +232,7 @@ def test_ldap_backend_validate_configuration_warn_specific_fields(
         ({}, None),  # no extra settings, just show the "could not be authenticated" message
     ],
 )
-def test_ldap_backend_authenticate_invalid_user(
+def atest_ldap_backend_authenticate_invalid_user(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -269,7 +269,7 @@ def test_ldap_backend_authenticate_invalid_user(
         ("", ""),
     ],
 )
-def test_ldap_backend_authenticate_empty_username_password(
+def atest_ldap_backend_authenticate_empty_username_password(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -292,7 +292,7 @@ def test_ldap_backend_authenticate_empty_username_password(
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def test_ldap_backend_authenticate_valid_user(
+def atest_ldap_backend_authenticate_valid_user(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -324,7 +324,7 @@ def test_ldap_backend_authenticate_valid_user(
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def test_ldap_backend_authenticate_unbind_exception(
+def atest_ldap_backend_authenticate_unbind_exception(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -353,7 +353,7 @@ def test_ldap_backend_authenticate_unbind_exception(
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def test_ldap_backend_authenticate_exception(
+def atest_ldap_backend_authenticate_exception(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -377,7 +377,7 @@ def ldap_settings(ldap_configuration):
     return LDAPSettings(defaults=ldap_configuration)
 
 
-def test_ldap_validate_connection_options_newctx_comes_last(ldap_configuration):
+def atest_ldap_validate_connection_options_newctx_comes_last(ldap_configuration):
     ldap_configuration["CONNECTION_OPTIONS"]["OPT_X_TLS_NEWCTX"] = 0
     ldap_configuration["CONNECTION_OPTIONS"]["OPT_X_TLS_PACKAGE"] = "GnuTLS"
     settings = LDAPSettings(defaults=ldap_configuration)
@@ -387,7 +387,7 @@ def test_ldap_validate_connection_options_newctx_comes_last(ldap_configuration):
     assert last_key == ldap.OPT_X_TLS_NEWCTX
 
 
-def test_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
+def atest_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
     """
     Ensure we handle invalid subfilters correctly.
 
@@ -401,7 +401,7 @@ def test_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def test_AuthenticatorPlugin_authenticate_authenticator_disabled(logger, ldap_authenticator, ldap_settings):
+def atest_AuthenticatorPlugin_authenticate_authenticator_disabled(logger, ldap_authenticator, ldap_settings):
     """
     Ensure we handle disabled authenticators correctly in AuthenticatorPlugin.authenticate.
 
@@ -421,7 +421,7 @@ def test_AuthenticatorPlugin_authenticate_authenticator_disabled(logger, ldap_au
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def test_AuthenticatorPlugin_authenticate_no_authenticator(logger):
+def atest_AuthenticatorPlugin_authenticate_no_authenticator(logger):
     """
     Test how AuthenticatorPlugin.authenticate handles no authenticator.
     """
@@ -429,6 +429,22 @@ def test_AuthenticatorPlugin_authenticate_no_authenticator(logger):
     request = MagicMock()
     assert backend.authenticate(request, username="foo", password="bar") is None
     logger.error.assert_called_with("AuthenticatorPlugin was missing an authenticator")
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
+def test_empty_user_search(logger, ldap_authenticator):
+    """
+    Test that user_search = [] does not break validation
+    """
+    config = ldap_authenticator.configuration
+    config["USER_SEARCH"] = []
+    backend = AuthenticatorPlugin(database_instance=ldap_authenticator)
+    request = MagicMock()
+    # Goal of test is just to ensure this does not error out (no exception, just logging
+    # of failure to create search, "Failed to instantiate...") for user_search = []
+    backend.authenticate(request, username="foo", password="bar")
+    logger.error.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -458,7 +474,7 @@ def test_AuthenticatorPlugin_authenticate_no_authenticator(logger):
         "Existing OPT_X_TLS_NEWCTX gets preserved (START_TLS disabled)",
     ],
 )
-def test_AuthenticatorPlugin_authenticate_start_tls(authenticate, ldap_authenticator, extra_settings, newctx_value, shut_up_logging):
+def atest_AuthenticatorPlugin_authenticate_start_tls(authenticate, ldap_authenticator, extra_settings, newctx_value, shut_up_logging):
     """
     Ensure we force OPT_X_TLS_NEWCTX to 0 (only) when START_TLS is enabled.
 
@@ -522,7 +538,7 @@ def test_AuthenticatorPlugin_authenticate_start_tls(authenticate, ldap_authentic
         ),
     ],
 )
-def test_ldap_user_search_validation(
+def atest_ldap_user_search_validation(
     admin_api_client, group_type, group_type_params, server_uri, user_attr_map, user_search, expected_status_code, expected_error, saved_user_search
 ):
     config = {

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -18,7 +18,7 @@ authenticated_test_page = "authenticator-list"
 
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.AuthenticatorPlugin.authenticate")
-def atest_ldap_auth_successful(authenticate, unauthenticated_api_client, ldap_authenticator, user):
+def test_ldap_auth_successful(authenticate, unauthenticated_api_client, ldap_authenticator, user):
     """
     Test that a successful LDAP authentication returns a 200 on the /me endpoint.
 
@@ -35,7 +35,7 @@ def atest_ldap_auth_successful(authenticate, unauthenticated_api_client, ldap_au
 
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.AuthenticatorPlugin.authenticate", return_value=None)
-def atest_ldap_auth_failed(authenticate, unauthenticated_api_client, ldap_authenticator):
+def test_ldap_auth_failed(authenticate, unauthenticated_api_client, ldap_authenticator):
     """
     Test that a failed LDAP authentication returns a 401 on the /me endpoint.
     """
@@ -50,7 +50,7 @@ def atest_ldap_auth_failed(authenticate, unauthenticated_api_client, ldap_authen
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.AuthenticatorPlugin.authenticate", return_value=None)
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.config.LDAPSearch", side_effect=Exception("Something went wrong"))
-def atest_ldap_search_exception(
+def test_ldap_search_exception(
     LDAPSearch,
     authenticate,
     admin_api_client,
@@ -138,7 +138,7 @@ def atest_ldap_search_exception(
         ({"USER_DN_TEMPLATE": "cn=invalid,ou=users,dc=example,dc=org"}, {"USER_DN_TEMPLATE": 'DN must include "%(user)s"'}),
     ],
 )
-def atest_ldap_create_authenticator_error_handling(
+def test_ldap_create_authenticator_error_handling(
     admin_api_client,
     ldap_configuration,
     user,
@@ -179,7 +179,7 @@ def atest_ldap_create_authenticator_error_handling(
 
 
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
-def atest_ldap_backend_authenticate_encrypted_fields_update(admin_api_client, ldap_authenticator, shut_up_logging):
+def test_ldap_backend_authenticate_encrypted_fields_update(admin_api_client, ldap_authenticator, shut_up_logging):
     url = get_relative_url("authenticator-detail", kwargs={"pk": ldap_authenticator.pk})
     # BIND_PASSWORD is encrypted
     config = ldap_authenticator.configuration
@@ -202,7 +202,7 @@ def atest_ldap_backend_authenticate_encrypted_fields_update(admin_api_client, ld
 
 @pytest.mark.xfail(reason="https://issues.redhat.com/browse/AAP-17453")
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
-def atest_ldap_backend_validate_configuration_warn_specific_fields(
+def test_ldap_backend_validate_configuration_warn_specific_fields(
     shut_up_logging,  # TODO: Remove with xfail
     admin_api_client,
     ldap_authenticator,
@@ -232,7 +232,7 @@ def atest_ldap_backend_validate_configuration_warn_specific_fields(
         ({}, None),  # no extra settings, just show the "could not be authenticated" message
     ],
 )
-def atest_ldap_backend_authenticate_invalid_user(
+def test_ldap_backend_authenticate_invalid_user(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -269,7 +269,7 @@ def atest_ldap_backend_authenticate_invalid_user(
         ("", ""),
     ],
 )
-def atest_ldap_backend_authenticate_empty_username_password(
+def test_ldap_backend_authenticate_empty_username_password(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -292,7 +292,7 @@ def atest_ldap_backend_authenticate_empty_username_password(
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def atest_ldap_backend_authenticate_valid_user(
+def test_ldap_backend_authenticate_valid_user(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -324,7 +324,7 @@ def atest_ldap_backend_authenticate_valid_user(
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def atest_ldap_backend_authenticate_unbind_exception(
+def test_ldap_backend_authenticate_unbind_exception(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -353,7 +353,7 @@ def atest_ldap_backend_authenticate_unbind_exception(
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def atest_ldap_backend_authenticate_exception(
+def test_ldap_backend_authenticate_exception(
     logger,
     authenticate,
     unauthenticated_api_client,
@@ -377,7 +377,7 @@ def ldap_settings(ldap_configuration):
     return LDAPSettings(defaults=ldap_configuration)
 
 
-def atest_ldap_validate_connection_options_newctx_comes_last(ldap_configuration):
+def test_ldap_validate_connection_options_newctx_comes_last(ldap_configuration):
     ldap_configuration["CONNECTION_OPTIONS"]["OPT_X_TLS_NEWCTX"] = 0
     ldap_configuration["CONNECTION_OPTIONS"]["OPT_X_TLS_PACKAGE"] = "GnuTLS"
     settings = LDAPSettings(defaults=ldap_configuration)
@@ -387,7 +387,7 @@ def atest_ldap_validate_connection_options_newctx_comes_last(ldap_configuration)
     assert last_key == ldap.OPT_X_TLS_NEWCTX
 
 
-def atest_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
+def test_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
     """
     Ensure we handle invalid subfilters correctly.
 
@@ -401,7 +401,7 @@ def atest_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def atest_AuthenticatorPlugin_authenticate_authenticator_disabled(logger, ldap_authenticator, ldap_settings):
+def test_AuthenticatorPlugin_authenticate_authenticator_disabled(logger, ldap_authenticator, ldap_settings):
     """
     Ensure we handle disabled authenticators correctly in AuthenticatorPlugin.authenticate.
 
@@ -421,7 +421,7 @@ def atest_AuthenticatorPlugin_authenticate_authenticator_disabled(logger, ldap_a
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")
-def atest_AuthenticatorPlugin_authenticate_no_authenticator(logger):
+def test_AuthenticatorPlugin_authenticate_no_authenticator(logger):
     """
     Test how AuthenticatorPlugin.authenticate handles no authenticator.
     """
@@ -474,7 +474,7 @@ def test_empty_user_search(logger, ldap_authenticator):
         "Existing OPT_X_TLS_NEWCTX gets preserved (START_TLS disabled)",
     ],
 )
-def atest_AuthenticatorPlugin_authenticate_start_tls(authenticate, ldap_authenticator, extra_settings, newctx_value, shut_up_logging):
+def test_AuthenticatorPlugin_authenticate_start_tls(authenticate, ldap_authenticator, extra_settings, newctx_value, shut_up_logging):
     """
     Ensure we force OPT_X_TLS_NEWCTX to 0 (only) when START_TLS is enabled.
 
@@ -538,7 +538,7 @@ def atest_AuthenticatorPlugin_authenticate_start_tls(authenticate, ldap_authenti
         ),
     ],
 )
-def atest_ldap_user_search_validation(
+def test_ldap_user_search_validation(
     admin_api_client, group_type, group_type_params, server_uri, user_attr_map, user_search, expected_status_code, expected_error, saved_user_search
 ):
     config = {


### PR DESCRIPTION
 * Blank UI field for user search results in the value []
 * Current test to ignore is "if field is None:", which fails since [] is not None
 * With "if field:", [] is False and properly ignored

LDAP auth should require one of User Search or User DN Template, but not both.  Currently LDAP auth is blocked if User Search is empty ([]), this change fixes this issue and allows auth when only User DN Template is specified.

This is for: https://issues.redhat.com/browse/AAP-28020

That Jira is now closed, but this is good to fix anyway.