### PR TITLE
Alter how we detect username from a social authenticator

### DIFF
--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -95,7 +95,8 @@ def check_system_username(uid: str) -> None:
 
 
 def determine_username_from_uid_social(**kwargs) -> dict:
-    selected_username = kwargs.get('details', {}).get('username', None)
+    uid_field = getattr(kwargs.get('backend', None), 'ID_KEY', 'username')
+    selected_username = kwargs.get('details', {}).get(uid_field, None)
     if not selected_username:
         raise AuthException(_('Unable to get associated username from: %(details)s') % {'details': kwargs.get("details", None)})
 


### PR DESCRIPTION
In playing around with social auths, some of them don't seem to have a way to remap attributes to what we need (like username) but there is a built in function that  gets an "ID_KEY". This change will attempt to get the ID_KEY for an authenticator and then fallback to our expected `username`. 