### PR TITLE
JWT Auth ignore is_superuser value if False

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -122,7 +122,7 @@ class JWTCommonAuth:
             except IntegrityError as exc:
                 logger.debug(f'Existing user {self.token["user_data"]} is a conflict with local user, error: {exc}')
                 with no_reverse_sync():
-                    if user_defaults['is_superuser'] == False:
+                    if user_defaults['is_superuser'] is False:
                         user_defaults.pop('is_superuser')
                     self.user, created = get_user_model().objects.update_or_create(
                         username=self.token["user_data"]['username'],

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -122,6 +122,8 @@ class JWTCommonAuth:
             except IntegrityError as exc:
                 logger.debug(f'Existing user {self.token["user_data"]} is a conflict with local user, error: {exc}')
                 with no_reverse_sync():
+                    if user_defaults['is_superuser'] == False:
+                        user_defaults.pop('is_superuser')
                     self.user, created = get_user_model().objects.update_or_create(
                         username=self.token["user_data"]['username'],
                         defaults=user_defaults,
@@ -145,6 +147,8 @@ class JWTCommonAuth:
             old_value = getattr(self.user, attribute, None)
             new_value = self.token.get('user_data', {}).get(attribute, None)
             if old_value != new_value:
+                if attribute == 'is_superuser' and new_value is False:
+                    continue
                 logger.debug(f"Changing {attribute} for {self.user.username} from {old_value} to {new_value}")
                 setattr(self.user, attribute, new_value)
                 user_needs_save = True

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -431,13 +431,11 @@ class TestJWTAuthentication:
     @pytest.mark.django_db()
     @pytest.mark.parametrize(
         "original_is_superuser, token_is_superuser, expected_is_superuser",
-        [(True, False, True),
-         (False, True, True),
-         (True, True, True),
-         (False, False, False)]
-         )
-    def test_authenticate_is_superuser(self, jwt_token, django_user_model, mocked_http, test_encryption_public_key,
-                                       original_is_superuser, token_is_superuser, expected_is_superuser):
+        [(True, False, True), (False, True, True), (True, True, True), (False, False, False)],
+    )
+    def test_authenticate_is_superuser(
+        self, jwt_token, django_user_model, mocked_http, test_encryption_public_key, original_is_superuser, token_is_superuser, expected_is_superuser
+    ):
         """
         JWT auth should retain the original is_superuser value, except when jwt token is True
         """

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -439,7 +439,7 @@ class TestJWTAuthentication:
     def test_authenticate_is_superuser(self, jwt_token, django_user_model, mocked_http, test_encryption_public_key,
                                        original_is_superuser, token_is_superuser, expected_is_superuser):
         """
-        JWT auth should retain the original is_supervalue, except when going from False to True
+        JWT auth should retain the original is_superuser value, except when jwt token is True
         """
         with override_settings(ANSIBLE_BASE_JWT_KEY=test_encryption_public_key):
             jwt_username = jwt_token.unencrypted_token['user_data']['username']

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -428,6 +428,23 @@ class TestJWTAuthentication:
             created_user, _ = jwt_auth.authenticate(request)
             assert user == created_user
 
+    @pytest.mark.parametrize("original_is_superuser, token_is_superuser, expected_is_superuser",
+                            [(True, False, True), (False, True, True), (True, True, True), (False, False, False)])
+    def test_authenticate_is_superuser(self, jwt_token, django_user_model, mocked_http, test_encryption_public_key, original_is_superuser, token_is_superuser, expected_is_superuser):
+        """
+        JWT auth should retain the original is_supervalue, except when going from False to True
+        """
+        with override_settings(ANSIBLE_BASE_JWT_KEY=test_encryption_public_key):
+            user = django_user_model.objects.create_user(username=jwt_token.unencrypted_token['sub'], password="password", is_superuser=original_is_superuser)
+            jwt_auth = JWTAuthentication()
+            jwt_auth.common_auth.user = user
+            jwt_auth.common_auth.token = jwt_token.unencrypted_token
+            jwt_auth.common_auth.token['user_data']['is_superuser'] = token_is_superuser
+            jwt_auth.process_user_data()
+            request = mocked_http.mocked_parse_jwt_token_get_request('with_headers')
+            created_user, _ = jwt_auth.authenticate(request)
+            assert created_user.is_superuser == expected_is_superuser
+
     def test_authenticate_no_user(self, user):
         with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.parse_jwt_token') as mock_parse:
             mock_parse.return_value = (None, None)


### PR DESCRIPTION
Fixes scenario where bob is a normal user in gateway, but is superuser in controller.

JWTAuth logic will update the bob user with is_superuser False, which is not what we want.

Instead, ignore is_superuser, unless the value is True