### PR TITLE
fix: handle missing RESOURCE_SERVICE_PATH in sync task

### DIFF
--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -66,10 +66,15 @@ class SyncResult:
 def create_api_client() -> ResourceAPIClient:
     """Factory for pre-configured ResourceAPIClient."""
     params = {"raise_if_bad_request": False}
+
     if jwt_user_id := getattr(settings, "RESOURCE_JWT_USER_ID", None):
         params["jwt_user_id"] = jwt_user_id
-    if service_path := getattr(settings, "RESOURCE_SERVICE_PATH", None):
-        params["service_path"] = service_path
+
+    service_path = getattr(settings, "RESOURCE_SERVICE_PATH", None)
+    if not service_path:
+        raise ValueError("RESOURCE_SERVICE_PATH is not set.")
+    params["service_path"] = service_path
+
     client = get_resource_server_client(**params)
     return client
 


### PR DESCRIPTION
There is an error in eda-server when running the periodic task to sync shared resources:
```
default-worker.log:Sep 20 18:52:40 ip-10-0-14-133 automation-eda-controller-worker-0[86746]: 2024-09-20 18:52:40,887 aap_eda.tasks.shared_resources ERROR    Failed to sync shared resources. Error: get_resource_server_client() missing 1 required positional argument: 'service_path'
```

That is solved by @AlanCoding through https://github.com/ansible/eda-server/pull/1059
Here I just handle the error for the absence of the mandatory param in `get_resource_server_client`. According to the code, this param can not be empty. I wonder if this eventuality should be handled in the constructor:
https://github.com/Alex-Izquierdo/django-ansible-base/blob/b7e9271ef7952dddff32d37927a3fa1060515bc6/ansible_base/resource_registry/rest_client.py#L66-L67

Jira: https://issues.redhat.com/browse/AAP-31736