### PR TITLE
Adding requirements file for resource_registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ optional-dependencies.all = { file = [
     "requirements/requirements_testing.in",
     "requirements/requirements_redis_client.in",
     "requirements/requirements_oauth2_provider.in",
+    "requirements/requirements_resource_registry.in",
 ] }
 optional-dependencies.activitystream = { file = [ "requirements/requirements_activitystream.in" ] }
 optional-dependencies.authentication = { file = [ "requirements/requirements_authentication.in" ] }
@@ -55,6 +56,7 @@ optional-dependencies.jwt_consumer = { file = [ "requirements/requirements_jwt_c
 optional-dependencies.testing = { file = [ "requirements/requirements_testing.in" ] }
 optional-dependencies.redis_client = { file = [ "requirements/requirements_redis_client.in" ] }
 optional-dependencies.oauth2_provider = { file = [ "requirements/requirements_oauth2_provider.in" ] }
+optional-dependencies.resource_registry = { file = [ "requirements/requirements_resource_registry.in" ] }
 
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm>=8"]

--- a/requirements/requirements_resource_registry.in
+++ b/requirements/requirements_resource_registry.in
@@ -1,0 +1,7 @@
+# NOTE: Only dependencies needed to use ansible_base.resource_registry.* should go here.
+# Deps specific to django-ansible-base tests should go in requirements_dev.txt
+asgiref
+pyjwt
+requests
+social-auth-app-django
+urllib3


### PR DESCRIPTION
In creating a new Django application I found that the resource registry was missing a requirements file. I went through all of the imports and created one specifically for the registry.