### PR TITLE
Remove social-auth-app-django from requirements/requirements_resource……_registry.in

### DIFF
--- a/requirements/requirements_resource_registry.in
+++ b/requirements/requirements_resource_registry.in
@@ -3,5 +3,4 @@
 asgiref
 pyjwt
 requests
-social-auth-app-django
 urllib3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is to address 'relation "social_auth_usersocialauth" does not exist' error 
<!---
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change
