### PR TITLE
AAP-30325 Downgrade reverse-sync log to debug

### DIFF
--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -103,7 +103,7 @@ def proxies_of_model(cls):
 def _should_reverse_sync():
     enabled = getattr(settings, 'RESOURCE_SERVER_SYNC_ENABLED', False)
     if enabled and (not resource_server_defined()):
-        logger.error("RESOURCE_SERVER is not configured. Reverse sync will not be enabled.")
+        logger.debug("RESOURCE_SERVER is not configured. Reverse sync will not be enabled.")
         enabled = False
     if enabled and resource_server_defined() and ('SECRET_KEY' not in settings.RESOURCE_SERVER or not settings.RESOURCE_SERVER['SECRET_KEY']):
         logger.error("RESOURCE_SERVER['SECRET_KEY'] is not configured. Reverse sync will not be enabled.")


### PR DESCRIPTION
In AWX this is super noisy

```
tools_awx_1       | 2024-11-12 14:07:31,708 ERROR    [-] ansible_base.resource_registry.apps RESOURCE_SERVER is not configured. Reverse sync will not be enabled.
```

At a point our plan changed, so that this case is intended. So No need to issue an error log if it's intended.