### PR TITLE
Fix: Implement LDAP specific authenticator_map group check

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/base.py
+++ b/ansible_base/authentication/authenticator_plugins/base.py
@@ -56,12 +56,27 @@ class BaseAuthenticatorConfiguration(serializers.Serializer):
         return schema
 
 
+class BaseGroupComparison:
+    @classmethod
+    def has_or(cls, condition_groups: set, user_groups: set) -> bool:
+        return bool(user_groups.intersection(condition_groups))
+
+    @classmethod
+    def has_and(cls, condition_groups: set, user_groups: set) -> bool:
+        return condition_groups.issubset(user_groups)
+
+    @classmethod
+    def has_not(cls, condition_groups: set, user_groups: set) -> bool:
+        return not bool(user_groups.intersection(condition_groups))
+
+
 class AbstractAuthenticatorPlugin:
     """
     Base class for non social auth backends
     """
 
     configuration_class = BaseAuthenticatorConfiguration
+    group_comparison_class = BaseGroupComparison
     configuration_encrypted_fields = []
 
     def __init__(self, database_instance=None, *args, **kwargs):

--- a/ansible_base/lib/testing/fixtures.py
+++ b/ansible_base/lib/testing/fixtures.py
@@ -285,7 +285,7 @@ def ldap_configuration():
 
 
 @pytest.fixture
-def ldap_authenticator(ldap_configuration):
+def ldap_authenticator(db, ldap_configuration):
     from ansible_base.authentication.models import Authenticator
 
     authenticator = Authenticator.objects.create(


### PR DESCRIPTION
This alleiviates case-sensitivity problems when processing groups

Other change:
re-factor: move logic for evaluating group claims into the authenticator plugin

Current logic moved to the BaseAuthenticatorPlugin, but this allows other
plugins to override these check with their own logic for evaluating these
strings.

Preliminary change for introducing a comparison class to the
LDAPAuthenticatorPlugin.

AAP-33304
