### PR TITLE
Add example svc to service_type

### DIFF
--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -97,7 +97,7 @@ class ResourceRegistry:
             - Viewsets have the correct serializer, pagination and filter classes
             - Service type is set to one of awx, galaxy, eda or aap
         """
-        assert config.service_type in ["aap", "awx", "galaxy", "eda"]
+        assert config.service_type in ["aap", "awx", "galaxy", "eda", "example"]
 
     def get_resources(self):
         return self.registry


### PR DESCRIPTION
https://github.com/ansible/platform-service-template/ establish a minimal example svc that can work with the platform and we want to add the example as a service_type