### PR TITLE
fix(lib.validation): properly validate ca-signed keypairs

### DIFF
--- a/test_app/tests/lib/utils/test_validation.py
+++ b/test_app/tests/lib/utils/test_validation.py
@@ -101,6 +101,16 @@ def test_validate_cert_with_key_mismatch(rsa_keypair_with_cert_1, rsa_keypair_wi
     assert "The certificate and private key do not match" in str(e.value)
 
 
+def test_validate_cert_with_signed_certificate(rsa_keypair_with_signed_cert_1):
+    """
+    Ensure that validate_cert_with_key raises a ValidationError when the cert and key don't match.
+    """
+    keypair = rsa_keypair_with_signed_cert_1.root
+    assert validate_cert_with_key(keypair.certificate, keypair.private)
+    keypair = rsa_keypair_with_signed_cert_1.subordinate
+    assert validate_cert_with_key(keypair.certificate, keypair.private)
+
+
 def test_validate_image_data_with_valid_data():
     """
     Ensure that validate_image_data accepts valid data.


### PR DESCRIPTION
Change the mechanism we use to validate keypairs to not assume that a 
certificate is self-signed. This causes some valid keypairs to fail.

Testing steps:
- tox -e py311 -- -n0 -k test_validate_cert_with_signed_certificate
- verify passing
- drop commit "fix(lib.validation): Do not treat ca-signed keypairs as invalid"
  - Save the commit digest from most recent commit before doing this
  - Or branch before doing this, so you can just switch back to the actual PR branch
- tox -e py311 -- -n0 -k test_validate_cert_with_signed_certificate
- verify failing test
- Cleanup: git reset --hard ${remote-branch or commit you reset from)

AAP-33294
