### PR TITLE
SAML fixes

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -298,7 +298,7 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
         data = super().extra_data(user, backend, response, *args, **kwargs)
 
         # Ideally we would always have a DB instance
-        # But if something was mocked in a test or somehow a db_instance just wasn't past in we don't want to error here
+        # But if something was mocked in a test or somehow a db_instance just wasn't passed in we don't want to error here
         if self.database_instance is None:
             return data
 

--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -37,7 +37,11 @@ class AnsibleBaseAuth(ModelBackend):
         last_modified = None if last_modified_item is None else last_modified_item.get('modified')
 
         for authenticator_id, authenticator_object in get_authentication_backends(last_modified).items():
-            user = authenticator_object.authenticate(request, *args, **kwargs)
+            try:
+                user = authenticator_object.authenticate(request, *args, **kwargs)
+            except Exception:
+                logger.exception(f"Exception raised while trying to authenticate with {authenticator_object.database_instance.name}")
+                continue
 
             # Social Auth pipeline can return status string when update_user_claims fails (authentication maps deny access)
             if user == SOCIAL_AUTH_PIPELINE_FAILED_STATUS:

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -96,9 +96,13 @@ def check_system_username(uid: str) -> None:
 
 def determine_username_from_uid_social(**kwargs) -> dict:
     uid_field = getattr(kwargs.get('backend', None), 'ID_KEY', 'username')
+    if uid_field is None:
+        uid_field = 'username'
     selected_username = kwargs.get('details', {}).get(uid_field, None)
     if not selected_username:
-        raise AuthException(_('Unable to get associated username from: %(details)s') % {'details': kwargs.get("details", None)})
+        raise AuthException(
+            _('Unable to get associated username from attribute {uid_field}: %(details)s') % {'uid_field': uid_field, 'details': kwargs.get("details", None)}
+        )
 
     authenticator = kwargs.get('backend')
     if not authenticator:

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from django.conf import settings
 from social_core.exceptions import AuthException
@@ -197,3 +199,17 @@ class TestAuthenticationUtilsAuthentication:
             uid="Bob",
         )
         assert response == {'username': 'Bob'}
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_uid_field",
+        [
+            ({}, 'username'),
+            ({'backend': None}, 'username'),
+            ({'backend': SimpleNamespace(ID_KEY='testing')}, 'testing'),
+            ({'backend': SimpleNamespace(ID_KEY=None)}, 'testing'),
+        ],
+    )
+    def test_determine_username_from_uid_social_authenticator_ID_KEY(self, kwargs, expected_uid_field):
+        with pytest.raises(AuthException) as ae:
+            authentication.determine_username_from_uid_social(**kwargs)
+            assert f'Unable to get associated username from attribute {expected_uid_field}' in ae


### PR DESCRIPTION
This ensures that the firstname/lastname/email/etc attributes that are entered into the IdP fields are returned out of the assertion. If additional information is needed admins will have to either set `GET_ALL_EXTRA_DATA` to get it all or they can set `EXTRA_DATA` to get specific fields.