### PR TITLE
Do not error when missing some JWT item

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -117,6 +117,7 @@ class JWTCommonAuth:
             for resource_key, token_key in (('resource_data', 'user_data'), ('ansible_id', 'sub'), ('service_id', 'service_id')):
                 if token_key not in self.token:
                     logger.warning(f'Missing {token_key} in JWT data, omitting {resource_key} from local resource entry')
+                else:
                     resource_kwargs[resource_key] = self.token[token_key]
             try:
                 resource = Resource.create_resource(ResourceType.objects.get(name="shared.user"), **resource_kwargs)

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -113,13 +113,13 @@ class JWTCommonAuth:
 
         if not self.user:
             # Either the user wasn't cached or the requested user was not in the DB so we need to make a new one
+            resource_kwargs = {}
+            for resource_key, token_key in (('resource_data', 'user_data'), ('ansible_id', 'sub'), ('service_id', 'service_id')):
+                if token_key not in self.token:
+                    logger.warning(f'Missing {token_key} in JWT data, omitting {resource_key} from local resource entry')
+                    resource_kwargs[resource_key] = self.token[token_key]
             try:
-                resource = Resource.create_resource(
-                    ResourceType.objects.get(name="shared.user"),
-                    resource_data=self.token["user_data"],
-                    ansible_id=self.token["sub"],
-                    service_id=self.token["service_id"],
-                )
+                resource = Resource.create_resource(ResourceType.objects.get(name="shared.user"), **resource_kwargs)
                 self.user = resource.content_object
                 logger.info(f"New user {self.user.username} created from JWT auth")
             except IntegrityError as exc:


### PR DESCRIPTION
Scary exception from controller, caused by https://github.com/ansible/django-ansible-base/pull/612 without corresponding JWT data

```
2024-11-26 19:13:52,705 ERROR    [e0865bd6f310443c8f478a142ab84642] django.request Internal Server Error: /api/controller/v2/service-index/metadata/
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/api/generics.py", line 375, in dispatch
    return super(APIView, self).dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 492, in dispatch
    request = self.initialize_request(request, *args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/api/generics.py", line 202, in initialize_request
    request.drf_request_user = getattr(drf_request, 'user', False)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/request.py", line 231, in user
    self._authenticate()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/request.py", line 384, in _authenticate
    user_auth_tuple = authenticator.authenticate(self)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/ansible_base/jwt_consumer/common/auth.py", line 330, in authenticate
    self.common_auth.parse_jwt_token(request)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/ansible_base/jwt_consumer/common/auth.py", line 121, in parse_jwt_token
    service_id=self.token["service_id"],
               ~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'service_id'
```

It should be there in the JWT, but let's just not take chances since the reasons for that being there or not are so hard for us to pin down at this moment.