### PR TITLE
[AAP-35559] Change logging level from info to debug when JWT token header is not present in the request.

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -66,7 +66,7 @@ class JWTCommonAuth:
 
         token_from_header = request.headers.get("X-DAB-JW-TOKEN", None)
         if not token_from_header:
-            logger.info("X-DAB-JW-TOKEN header not set for JWT authentication")
+            logger.debug("X-DAB-JW-TOKEN header not set for JWT authentication")
             return
         logger.debug(f"Received JWT auth token: {token_from_header}")
 

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -55,7 +55,7 @@ class TestJWTCommonAuth:
 
     @pytest.mark.django_db
     def test_parse_jwt_no_header(self, caplog, mocked_http, shut_up_logging):
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             my_auth = JWTCommonAuth()
             my_auth.parse_jwt_token(mocked_http.mocked_parse_jwt_token_get_request('without_headers'))
             assert "X-DAB-JW-TOKEN header not set for JWT authentication" in caplog.text


### PR DESCRIPTION
Changed logging level when the JWT token was not present in the header.