### PR TITLE
AAP-36328 Remove DAB validation of service type

### DIFF
--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -86,18 +86,9 @@ class ResourceRegistry:
     registry = {}
 
     def __init__(self, resource_list: List[ResourceConfig], service_api_config: ServiceAPIConfig = None):
-        self._validate_api_config(service_api_config)
         self.api_config = service_api_config
         for r in resource_list:
             self.registry[r.model_label] = r
-
-    def _validate_api_config(self, config):
-        """
-        Needs to validate that:
-            - Viewsets have the correct serializer, pagination and filter classes
-            - Service type is set to one of awx, galaxy, eda or aap
-        """
-        assert config.service_type in ["aap", "awx", "galaxy", "eda", "example"]
 
     def get_resources(self):
         return self.registry


### PR DESCRIPTION
Gateway is being modified to have configurable ServiceType (which can be added via API on the fly), so it does not make sense to validate against a hard-coded list in DAB as was done prior.

One approach could be to add a client in DAB to fetch the current list from gateway and use that to validate.  However, that is complicated and doesn't buy much.  Creating and setting the service type would be a one time activity for a new service.

In the case that an invalid service type is used in a service descending from DAB, no errors occur in DAB or gateway until the "migrate_service_data" command is executed, which is a step in registration of the service w/ gateway for resource sync.  At that point, the error output looks like this:

CommandError: Migrations are not allowed for services of type <bad type>

So this is straightforward and clear about what should be fixed and should be sufficient.

This change is also safe to merge before the ServiceType changes on gateway since it just removes the validation.