### PR TITLE
Load migration modules very python-like, handle replaces

### DIFF
--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -56,7 +56,7 @@ def test_migrations_okay(*args, **kwargs):
 
         migration_module = app_config.module.migrations
         for step in dir(migration_module):
-            if not re.match(r'\d{4}', step):
+            if not re.match(r'\d{4}_', step):
                 continue
             step_module = getattr(migration_module, step)
             migration_name = step_module.__name__.rsplit('.')[-1]

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -56,7 +56,7 @@ def test_migrations_okay(*args, **kwargs):
 
         migration_module = app_config.module.migrations
         for step in dir(migration_module):
-            if not re.match(r'\d\d\d\d_', step):
+            if not re.match(r'\d{4}', step):
                 continue
             step_module = getattr(migration_module, step)
             migration_name = step_module.__name__.rsplit('.')[-1]

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -1,6 +1,4 @@
-import os
 import random
-import re
 from collections import defaultdict
 from datetime import datetime, timedelta
 from unittest import mock
@@ -54,15 +52,26 @@ def test_migrations_okay(*args, **kwargs):
             app_config = apps.get_app_config(app)
         except LookupError:
             raise RuntimeError(f'App {app} is present in the recorded migrations but not installed, perhaps you need --create-db?')
-        for path in os.listdir(os.path.join(app_config.path, 'migrations')):
-            if re.match(r'^\d{4}_.*.py$', path):
-                disk_steps[app].add(path.rsplit('.')[0])
+
+        migration_module = app_config.module.migrations
+        for step in dir(migration_module):
+            if not step.startswith('00'):
+                continue
+            step_module = getattr(migration_module, step)
+            migration_name = step_module.__name__.rsplit('.')[-1]
+            disk_steps[app].add(migration_name)
+
+            migration_cls = step_module.Migration
+            for replaces_app_name, replaces_migration_name in getattr(migration_cls, 'replaces', []):
+                disk_steps[app].add(replaces_migration_name)
+
     db_steps = defaultdict(set)
     for record in MigrationRecorder.Migration.objects.only('app', 'name'):
         if record.app in app_exceptions:
             continue
         app_name = app_exceptions.get(record.app, record.app)
         db_steps[app_name].add(record.name)
+
     for app in disk_steps:
         assert disk_steps[app] == db_steps[app], f'Migrations not expected for app {app}, perhaps you need --create-db?'
 

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -1,4 +1,5 @@
 import random
+import re
 from collections import defaultdict
 from datetime import datetime, timedelta
 from unittest import mock
@@ -55,7 +56,7 @@ def test_migrations_okay(*args, **kwargs):
 
         migration_module = app_config.module.migrations
         for step in dir(migration_module):
-            if not step.startswith('00'):
+            if not re.match(r'\d\d\d\d_', step):
                 continue
             step_module = getattr(migration_module, step)
             migration_name = step_module.__name__.rsplit('.')[-1]


### PR DESCRIPTION
Needed for https://github.com/ansible/django-ansible-base/pull/650 by @john-westcott-iv 

Before this change

```
py.test test_app/tests/resource_registry/test_resource_types_api.py --create-db
```

would give

> ERROR test_app/tests/resource_registry/test_resource_types_api.py::test_resource_type_manifest - AssertionError: Migrations not expected for app flags, perhaps you need --create-db?

with

```
  Extra items in the right set:
  '0006_auto_20151217_2003'
  '0010_delete_flag_site_fk'
  '0004_remove_flag_hidden'
  '0007_unique_flag_site'
  '0003_flag_hidden'
  '0001_initial'
  '0009_migrate_to_conditional_state'
  '0008_add_state_conditions'
  '0002_auto_20151030_1401'
  '0005_flag_enabled_by_default'
  '0011_migrate_path_data_startswith_to_matches'
  
  Full diff:
    {
  -     '0001_initial',
  -     '0002_auto_20151030_1401',
  -     '0003_flag_hidden',
  -     '0004_remove_flag_hidden',
  -     '0005_flag_enabled_by_default',
  -     '0006_auto_20151217_2003',
  -     '0007_unique_flag_site',
  -     '0008_add_state_conditions',
  -     '0009_migrate_to_conditional_state',
  -     '0010_delete_flag_site_fk',
  -     '0011_migrate_path_data_startswith_to_matches',
        '0012_replace_migrations_for_wagtail_independence',
        '0013_add_required_field',
    }
```

The fixture was treating migrations as "dumb files". This is kind of obviously non-standard, but it was really the faster solution (as this diff shows). The more compliant solution is to use the python object level data to get the imported content... which in fairness tends to already be imported, so we'll use nice cached stuff. This will give us `Migration` classes which gives us the rest of what we need to make that above not happen.

This makes that test command above pass in John's branch, after running in devel previously.

Now to wrap this up, back on devel run `py.test test_app/tests/resource_registry/test_resource_types_api.py` and you'll get:

> RuntimeError: App flags is present in the recorded migrations but not installed, perhaps you need --create-db?

Correct, actually!

Running again with `--create-db` makes it work again.