### PR TITLE
fix(authenticator.utils): get ID_KEY from authenticator configuration, not defaults

### DIFF
--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -101,7 +101,7 @@ def determine_username_from_uid_social(**kwargs) -> dict:
     selected_username = kwargs.get('details', {}).get(uid_field, None)
     if not selected_username:
         raise AuthException(
-            _('Unable to get associated username from attribute {uid_field}: %(details)s') % {'uid_field': uid_field, 'details': kwargs.get("details", None)}
+            _('Unable to get associated username from attribute %(uid_field)s: %(details)s') % {'uid_field': uid_field, 'details': kwargs.get("details", None)}
         )
 
     authenticator = kwargs.get('backend')

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -98,8 +98,8 @@ def determine_username_from_uid_social(**kwargs) -> dict:
     backend = kwargs.get('backend', None)
     uid_field = 'username'
     if backend:
-        # Update our fallback if the authenticator has an ID_KEY field
-        if hasattr(backend, "ID_KEY"):
+        # Update our fallback if the authenticator has an ID_KEY field, ignore if ID_KEY is None
+        if getattr(backend, "ID_KEY", None) is not None:
             uid_field = backend.ID_KEY
         # Favor the authenticator configuration variable ID_KEY if present
         if hasattr(backend, "setting"):

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -97,8 +97,15 @@ def check_system_username(uid: str) -> None:
 def determine_username_from_uid_social(**kwargs) -> dict:
     backend = kwargs.get('backend', None)
     uid_field = 'username'
-    if backend and hasattr(backend, "setting"):
-        uid_field = backend.setting('ID_KEY', default='username')
+    if backend:
+        # Update our fallback if the authenticator has an ID_KEY field
+        if hasattr(backend, "ID_KEY"):
+            uid_field = backend.ID_KEY
+        # Favor the authenticator configuration variable ID_KEY if present
+        if hasattr(backend, "setting"):
+            uid_field_setting = backend.setting('ID_KEY', default=None)
+            if uid_field_setting is not None:
+                uid_field = uid_field_setting
     selected_username = kwargs.get('details', {}).get(uid_field, None)
     if not selected_username:
         raise AuthException(

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -95,9 +95,10 @@ def check_system_username(uid: str) -> None:
 
 
 def determine_username_from_uid_social(**kwargs) -> dict:
-    uid_field = getattr(kwargs.get('backend', None), 'ID_KEY', 'username')
-    if uid_field is None:
-        uid_field = 'username'
+    backend = kwargs.get('backend', None)
+    uid_field = 'username'
+    if backend and hasattr(backend, "setting"):
+        uid_field = backend.setting('ID_KEY', default='username')
     selected_username = kwargs.get('details', {}).get(uid_field, None)
     if not selected_username:
         raise AuthException(

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -18,11 +18,6 @@ def oidc_authenticator_plugin_uid_key_overridden(oidc_authenticator, random_name
     yield (oidc_authenticator, random_name)
 
 
-# Empty class to be patched, so I can parameterize test_determine_username_from_uid_social_authenticator_ID_KEY
-class PlaceholderAuthenticator:
-    pass
-
-
 @pytest.mark.django_db
 class TestAuthenticationUtilsAuthentication:
     logger = 'ansible_base.authentication.utils.authentication.logger'

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -2,7 +2,7 @@ import pytest
 from django.conf import settings
 from social_core.exceptions import AuthException
 
-from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class, get_authenticator_plugin
+from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.utils import authentication
 from ansible_base.lib.utils.response import get_relative_url
@@ -212,7 +212,7 @@ class TestAuthenticationUtilsAuthentication:
 
     def test_determine_username_from_uid_social_authenticator_ID_KEY(self, oidc_authenticator_plugin_uid_key_overridden):
         backend_authenticator_class, uid_key = oidc_authenticator_plugin_uid_key_overridden
-        backend = get_authenticator_plugin(backend_authenticator_class.type)
+        backend = get_authenticator_class(backend_authenticator_class.type)(database_instance=backend_authenticator_class)
         kwargs = {
             'backend': backend,
         }

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from django.conf import settings
 from social_core.exceptions import AuthException
@@ -225,6 +227,7 @@ class TestAuthenticationUtilsAuthentication:
         [
             ({}, 'username'),
             ({'backend': None}, 'username'),
+            ({'backend': SimpleNamespace(ID_KEY="id_key_test_value")}, 'id_key_test_value'),
         ],
     )
     def test_determine_username_from_uid_social_authenticator_ID_KEY_fallback(self, kwargs, expected_uid_field):

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -1,14 +1,24 @@
-from types import SimpleNamespace
-
 import pytest
 from django.conf import settings
 from social_core.exceptions import AuthException
 
-from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class
+from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class, get_authenticator_plugin
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.utils import authentication
 from ansible_base.lib.utils.response import get_relative_url
 from test_app.models import User
+
+
+@pytest.fixture
+def oidc_authenticator_plugin_uid_key_overridden(oidc_authenticator, random_name):
+    oidc_authenticator.configuration['ID_KEY'] = random_name
+    oidc_authenticator.save()
+    yield (oidc_authenticator, random_name)
+
+
+# Empty class to be patched, so I can parameterize test_determine_username_from_uid_social_authenticator_ID_KEY
+class PlaceholderAuthenticator:
+    pass
 
 
 @pytest.mark.django_db
@@ -200,16 +210,24 @@ class TestAuthenticationUtilsAuthentication:
         )
         assert response == {'username': 'Bob'}
 
+    def test_determine_username_from_uid_social_authenticator_ID_KEY(self, oidc_authenticator_plugin_uid_key_overridden):
+        backend_authenticator_class, uid_key = oidc_authenticator_plugin_uid_key_overridden
+        backend = get_authenticator_plugin(backend_authenticator_class.type)
+        kwargs = {
+            'backend': backend,
+        }
+        with pytest.raises(AuthException) as ae:
+            authentication.determine_username_from_uid_social(**kwargs)
+        assert f'Unable to get associated username from attribute {uid_key}' in ae.value.backend
+
     @pytest.mark.parametrize(
         "kwargs,expected_uid_field",
         [
             ({}, 'username'),
             ({'backend': None}, 'username'),
-            ({'backend': SimpleNamespace(ID_KEY='testing')}, 'testing'),
-            ({'backend': SimpleNamespace(ID_KEY=None)}, 'testing'),
         ],
     )
-    def test_determine_username_from_uid_social_authenticator_ID_KEY(self, kwargs, expected_uid_field):
+    def test_determine_username_from_uid_social_authenticator_ID_KEY_fallback(self, kwargs, expected_uid_field):
         with pytest.raises(AuthException) as ae:
             authentication.determine_username_from_uid_social(**kwargs)
-            assert f'Unable to get associated username from attribute {expected_uid_field}' in ae
+        assert f'Unable to get associated username from attribute {expected_uid_field}' in ae.value.backend

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -223,6 +223,7 @@ class TestAuthenticationUtilsAuthentication:
             ({}, 'username'),
             ({'backend': None}, 'username'),
             ({'backend': SimpleNamespace(ID_KEY="id_key_test_value")}, 'id_key_test_value'),
+            ({'backend': SimpleNamespace(ID_KEY=None)}, 'username'),
         ],
     )
     def test_determine_username_from_uid_social_authenticator_ID_KEY_fallback(self, kwargs, expected_uid_field):

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -1,5 +1,6 @@
 import random
 import re
+import string
 from collections import defaultdict
 from datetime import datetime, timedelta
 from unittest import mock
@@ -27,6 +28,11 @@ from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.resource_registry.models.service_identifier import service_id
 from test_app import models
+
+
+@pytest.fixture
+def random_name(length: int = 10) -> str:
+    return ''.join(random.choices(string.ascii_lowercase, k=length))
 
 
 @pytest.fixture()


### PR DESCRIPTION
- **tests(authentication): fix UID_KEY tests for authentication.determine_username_from_uid_social, introduce failing test**
- **fix(authenticator.utils): get ID_KEY from authenticator configuration, not defaults**

AAP-37203
