### PR TITLE
AAP-41636 Support extracting the groups claim from `id_token` when using social auth

### DIFF
--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -195,6 +195,18 @@ def create_user_claims_pipeline(*args, backend, response, **kwargs):
     groups_claim = backend.groups_claim if backend.groups_claim is not None else "Group"
 
     extra_groups = response[groups_claim] if groups_claim in response else []
+    logger.debug(f'groups extracted from UserInfo. "{groups_claim}": {extra_groups}')
+
+    # attempt to get group claims from id token if current backend has it
+    if hasattr(backend, "id_token"):
+        extra_groups_from_id_token = backend.id_token.get(groups_claim, [])
+        logger.debug(f'groups extracted from id_token. "{groups_claim}": {extra_groups_from_id_token}')
+
+        # Merge groups from UserInfo and groups_claim in id_token and remove duplicates
+        extra_groups = list(set(extra_groups + extra_groups_from_id_token))
+
+    logger.debug(f'updating user claims with groups claim "{groups_claim}": {extra_groups}')
+
     user = update_user_claims(kwargs["user"], backend.database_instance, backend.get_user_groups(extra_groups))
     if user is None:
         return SOCIAL_AUTH_PIPELINE_FAILED_STATUS

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -89,17 +89,49 @@ def test_social_auth_validate_callback_mixin(mocked_generate_slug, mocked_revers
         assert mocked_reverse.called
 
 
+id_token_no_groups = {
+    "ver": "2.0",
+    "iss": "https://login.microsoftonline.com/9122040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+    "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+    "aud": "6cb04018-a3f5-46a7-b995-940c78f5aef3",
+    "exp": 4073899721,
+    "iat": 1536274711,
+    "nbf": 1536274711,
+    "name": "Abe Lincoln",
+    "preferred_username": "AbeLi@microsoft.com",
+    "email": "AbeLi@microsoft.com",
+    "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+    "tid": "9122040d-6c67-4c5b-b112-36a304b66dad",
+    "nonce": "123523",
+    "aio": "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY",
+}
+
+id_token = {**id_token_no_groups, "groups": ["myidtokengroup"]}
+
+id_token_duplicate_group = {**id_token_no_groups, "groups": ["mygroup", "myidtokengroup"]}
+
+
 @pytest.mark.parametrize(
-    "groups_claim,returned_groups,expected_groups",
+    "groups_claim,user_info_groups,id_token,expected_groups",
     [
-        (None, ["mygroup"], ["mygroup"]),
-        ("groups", ["mygroup"], ["mygroup"]),
-        (None, None, []),
-        ("groups", None, []),
+        (None, ["mygroup"], {}, ["mygroup"]),
+        ("groups", ["mygroup"], {}, ["mygroup"]),
+        (None, None, {}, []),
+        ("groups", None, {}, []),
+        # Check extracting groups claim from id_token
+        ("groups", None, id_token, ["myidtokengroup"]),
+        # Test extracting groups claim from id_token when groups claim does not exist
+        (None, None, id_token, []),
+        # Test merging groups from UserInfo and id_token.
+        ("groups", ["mygroup"], id_token, ["myidtokengroup", "mygroup"]),
+        # Test merging groups from UserInfo and id_token where we have duplicate groups.
+        ("groups", ["mygroup"], id_token_duplicate_group, ["myidtokengroup", "mygroup"]),
+        # Test where id_token has no groups-claim.
+        ("groups", ["mygroup"], id_token_no_groups, ["mygroup"]),
     ],
 )
 @mock.patch("ansible_base.authentication.utils.claims.update_user_claims")
-def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, returned_groups, expected_groups):
+def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, user_info_groups, id_token, expected_groups):
     '''
     We are testing to see if extracting groups from a claim is working correctly
     '''
@@ -107,22 +139,24 @@ def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, retu
     class MockBackend(SocialAuthMixin):
         database_instance = None
 
-        def __init__(self, groups_claim=None):
+        def __init__(self, groups_claim=None, id_token=None):
             if groups_claim is not None:
                 self.groups_claim = groups_claim
+            if id_token is not None:
+                self.id_token = id_token
 
         def get_user_groups(self, extra_groups=[]):
             return extra_groups
 
-    backend = MockBackend(groups_claim=groups_claim)
+    backend = MockBackend(groups_claim=groups_claim, id_token=id_token)
 
     rData = {}
-    if returned_groups is not None:
-        rData[backend.groups_claim] = returned_groups
+    if user_info_groups is not None:
+        rData[backend.groups_claim] = user_info_groups
 
     user = {
         'auth_time': "2024-11-07T05:19:08.224936Z",
-        'id_token': "asdf",
+        'id_token': id_token,
         'refresh_token': None,
         'id': "ccd2cf13-d927-41ad-cd8c-adb18b2e5f78",
         'access_token': "asdf",
@@ -134,4 +168,6 @@ def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, retu
     assert mock_update_user_claims.called
     call_args = mock_update_user_claims.call_args
 
-    assert call_args == ((user, None, expected_groups),)
+    assert call_args[0][0] == user
+    assert call_args[0][1] is None
+    assert call_args[0][2].sort() == expected_groups.sort()


### PR DESCRIPTION
# Support extracting the groups claim from `id_token` when using social auth

## Description
Currently when using social auth we can only extract the groups claim if it it included in the UserInfo endpoint. 
Some IDPs do not support this (EntraID) and instead only include the groups claim in the `id_token`.

This add the capability to first look for the groups claim in the information returned by the UserInfo endpoint and if it is not found to then attempt to extract it from the `id_token`.

Fixes #681 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->