### PR TITLE
AAP-36818 Enable configurable group key for keycloak

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/keycloak.py
+++ b/ansible_base/authentication/authenticator_plugins/keycloak.py
@@ -41,6 +41,14 @@ class KeycloakConfiguration(BaseAuthenticatorConfiguration):
         ui_field_label=_('Keycloak OIDC Secret'),
     )
 
+    GROUPS_CLAIM = CharField(
+        help_text=_("The JSON key used to extract the user's groups from the ID token or userinfo endpoint."),
+        required=False,
+        allow_null=True,
+        default="Group",
+        ui_field_label=_("Groups Claim"),
+    )
+
 
 class AuthenticatorPlugin(SocialAuthMixin, KeycloakOAuth2, AbstractAuthenticatorPlugin):
     configuration_class = KeycloakConfiguration
@@ -48,6 +56,10 @@ class AuthenticatorPlugin(SocialAuthMixin, KeycloakOAuth2, AbstractAuthenticator
     logger = logger
     category = "sso"
     configuration_encrypted_fields = ['SECRET']
+
+    @property
+    def groups_claim(self):
+        return self.setting('GROUPS_CLAIM')
 
     def extra_data(self, user, backend, response, *args, **kwargs):
         for perm in ["is_superuser", "is_platform_auditor"]:


### PR DESCRIPTION
## Description
- Replicate configurable group claim key from oidc (see pr #640)
- For keycloak, we force groups to be in an attribute called "Group", which might not be possible or desired
- This adds GROUPS_CLAIM config item for keycloak (same as was done for OIDC) so it can be configured

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
Start gateway with keycloak enabled.

### Steps to Test
1. Remove default authenticator maps for keycloak (if desired)
2. Add a group based authenticator map for keycloak (to set superuser or whatever) that will match the user's group(s)
3. Modify keycloak configuration to use a non-standard group claim key
4. Log in via keycloak and see that superuser (or whatever was used) is not set
5. Modify keycloak authenticator configuration with GROUPS_CLAIM set to whatever was used in keycloak
6. Clear session for user in keycloak and log in again via keycloak SSO
7. See that expected attribute (such as superuser) is set when the groups match

### Expected Results
Arbitrary configured group attribute allows for group based authenticator maps to work normally when they match.

