### PR TITLE
 [AAP-37669] feat: Add factory functions to manage settings with Dynaconf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ RUN dnf -y install \
     libpq \
     postgresql
 
+# Create /etc/ansible-automation-platform/testapp folder
+RUN mkdir -p /etc/ansible-automation-platform/testapp
+# add settings.yaml to /etc/ansible-automation-platform/
+COPY test_app/example_files/*.yaml /etc/ansible-automation-platform/testapp/
+
 RUN python3.11 -m venv /venv
 
 COPY requirements/requirements_all.txt /tmp/requirements_all.txt

--- a/ansible_base/lib/dynamic_config/__init__.py
+++ b/ansible_base/lib/dynamic_config/__init__.py
@@ -1,0 +1,21 @@
+from .dynaconf_helpers import (
+    export,
+    factory,
+    load_dab_settings,
+    load_envvars,
+    load_python_file_with_injected_context,
+    load_standard_settings_files,
+    toggle_feature_flags,
+    validate,
+)
+
+__all__ = [
+    "export",
+    "factory",
+    "load_dab_settings",
+    "load_envvars",
+    "load_python_file_with_injected_context",
+    "load_standard_settings_files",
+    "toggle_feature_flags",
+    "validate",
+]

--- a/ansible_base/lib/dynamic_config/dynaconf_helpers.py
+++ b/ansible_base/lib/dynamic_config/dynaconf_helpers.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from django.core.exceptions import ImproperlyConfigured
+from dynaconf import Dynaconf, Validator
+from dynaconf.constants import YAML_EXTENSIONS
+from dynaconf.loaders import env_loader, execute_instance_hooks
+from dynaconf.loaders.base import BaseLoader
+from dynaconf.loaders.yaml_loader import yaml
+from dynaconf.utils.files import glob
+from dynaconf.utils.functional import empty
+
+from ansible_base.lib.dynamic_config.settings_logic import get_mergeable_dab_settings
+
+
+def factory(
+    module_name: str,  # name of the module that calls this function
+    app_name: str,  # main app name to be used to name env_switcher and envvar_prefix
+    *,
+    add_dab_settings: bool = True,  # add DAB settings to the settings object
+    validators: list[Validator] | None = None,  # custom validators to be used in Dynaconf
+    extra_envvar_prefixes: list[str] | None = None,  # extra prefixes to be used in envvar loader
+    **options,  # options to be passed to Dynaconf
+) -> Dynaconf:
+    """Create a Dynaconf instance for a specific service.
+
+    This function creates a Dynaconf instance with the following options:
+
+    - env_switcher: based on the app name
+    - envvar_prefix: based on the app name
+    - root_path: based on the caller module path
+    - loaders: empty list (to be loaded manually)
+    - options: any other options passed to the function (e.g. settings_files)
+      some options are not allowed and will raise an error if passed.
+
+    The Dynaconf instance returned will do the following:
+
+    - Define its mode based on the env_switcher e.g. "AWX_MODE"
+    - Define its envvar prefix based on the envvar_prefix e.g. "AWX"
+    - Consider multiple envvar_prefixes if extra_envvar_prefixes is passed (e.g. "AWX,FOO,BAR")
+    - Define STANDARD_SETTINGS_FILES for /etc/ansible-automation-platform/
+      first load yaml files from the base path, then from the app specific subfolder.
+    - Pass all the options to the Dynaconf instance (except the invalid ones)
+      e.g:
+        - `settings_files=["defaults.py"]`
+          static defaults for the service
+        - `environments=("development", "production", "quiet", "kube")`
+          allow the load of additional settings files such as `development_defaults.py`
+
+    All Validator instances passed to the function will be registered in the Dynaconf instance.
+
+    Once the Dynaconf is instantiated (and settings are loaded), the function will
+    add the DAB settings to the Dynaconf instance, if  `add_dab_settings` is True,
+    and set the `is_development_mode` flag based on the current mode.
+
+    Dynaconf object is returned and the caller can perform additional operations
+    such as read settings, set additional settings, load more settings files,
+    and finally export the settings to the caller module using the `export` function.
+    """
+
+    _check_options(options)
+    prefix = app_name.upper()
+    app_name = app_name.lower()
+
+    # attempt to get the caller path from the module name first
+    # if it fails, fallback to the inspect stack frame back
+    if module := sys.modules.get(module_name):
+        caller_path = os.path.dirname(inspect.getfile(module))
+    else:
+        caller_path = os.path.dirname(inspect.getfile(inspect.currentframe().f_back))
+
+    if extra_envvar_prefixes is not None:
+        envvar_prefix = ",".join([prefix, *extra_envvar_prefixes])
+    else:
+        envvar_prefix = prefix
+
+    std_base_path = Path("/etc/ansible-automation-platform/")
+    options.setdefault(
+        "ANSIBLE_STANDARD_SETTINGS_FILES",
+        [
+            std_base_path / "settings.yaml",
+            std_base_path / "flags.yaml",
+            std_base_path / ".secrets.yaml",
+            std_base_path / app_name / "settings.yaml",
+            std_base_path / app_name / "flags.yaml",
+            std_base_path / app_name / ".secrets.yaml",
+        ],
+    )
+
+    # Set DAB default variables
+    options.setdefault(
+        "ANSIBLE_BASE_OVERRIDABLE_SETTINGS",
+        [
+            'INSTALLED_APPS',
+            'REST_FRAMEWORK',
+            'AUTHENTICATION_BACKENDS',
+            'SPECTACULAR_SETTINGS',
+            'MIDDLEWARE',
+            'OAUTH2_PROVIDER',
+            'CACHES',
+            'TEMPLATES',
+        ],
+    )
+    options.setdefault("ANSIBLE_BASE_OVERRIDDEN_SETTINGS", [])
+    options.setdefault("INSTALLED_APPS", [])
+    options.setdefault("MIDDLEWARE", [])
+    options.setdefault("REST_FRAMEWORK", {})
+
+    # Create Dynaconf instance with the given options as defaults
+    settings = Dynaconf(
+        env_switcher=f"{prefix}_MODE",
+        envvar_prefix=envvar_prefix,
+        root_path=caller_path,
+        # Disable default loaders because each file/env will be loaded individually
+        loaders=[],
+        **options,
+    )
+
+    if validators:
+        settings.validators.register(*validators)
+
+    add_dab_settings and load_dab_settings(settings)
+
+    # Dynaconf allows composed modes
+    # so current_env can be a comma separated string of modes (e.g. "development,quiet")
+    settings.set(
+        "is_development_mode",
+        "development" in settings.current_env.lower(),
+        loader_identifier="is_development_mode_check",
+    )
+    return settings
+
+
+def export(module_name: str | type, settings: Dynaconf, validation: bool = True):
+    """Export the settings from Dynaconf object to the module that called this function.
+
+    module_name is usually `__name__` and is used to get the module object
+    arbitrary module objects can be passed as well so testing can be done on
+    a fake module object.
+
+    In a django-app/settings.py this will take all variables from the Dynaconf
+    instance and set them as attributes in the settings module
+    so they can be accessed as `settings.VARIABLE_NAME` from django.conf.settings.
+
+    unless `validation` is set to False, the settings will be validated before
+    being exported to the module.
+    """
+    if isinstance(module_name, str):
+        object_to_populate = sys.modules[module_name]
+    else:
+        object_to_populate = module_name
+
+    validation and validate(settings)
+    settings.populate_obj(
+        object_to_populate,
+        internal=False,
+        ignore=["IS_DEVELOPMENT_MODE"],
+        convert_to_dict=True,
+    )
+
+
+def load_dab_settings(settings: Dynaconf):
+    """Add DAB settings to the settings object."""
+    dab_settings = get_mergeable_dab_settings(settings.to_dict())
+    settings.set(
+        "ANSIBLE_BASE_OVERRIDDEN_SETTINGS",
+        list(dab_settings.keys() & settings.ANSIBLE_BASE_OVERRIDABLE_SETTINGS),
+        loader_identifier="load_dab_settings",
+    )
+    settings.update(dab_settings, loader_identifier="load_dab_settings")
+
+
+def load_standard_settings_files(settings: Dynaconf):
+    """Load the standard settings files for Ansible Automation Platform.
+
+    This function loops the `ANSIBLE_STANDARD_SETTINGS_FILES` list in the settings
+    and loads each file into the settings object without considering the current env,
+    as these files are meant to be environment agnostic.
+
+    NOTE: this function must be replaced by future implementation
+    of Dynaconf's `settings.load_file` that will support envless loading.
+    """
+    loader = BaseLoader(
+        obj=settings,
+        env=settings.current_env,
+        identifier="standard_settings_loader",
+        extensions=YAML_EXTENSIONS,
+        file_reader=yaml.safe_load,
+        string_reader=yaml.safe_load,
+        validate=False,
+    )
+    for path in settings.ANSIBLE_STANDARD_SETTINGS_FILES:
+        if not Path(path).exists():
+            continue
+        data = loader.get_source_data([str(path)])
+        loader._envless_load(data)
+
+
+def load_envvars(settings: Dynaconf):
+    """Loads environment variables into the settings object.
+
+    This function exists to be called on-demand after all settings are loaded
+    """
+    env_loader.load(settings, identifier="dab.dynamic_config")
+
+
+def _check_options(options):
+    """Raise Error if invalid options are passed.
+
+    Invalid options are those that are not allowed in the factory function,
+    and must be defined here by Django Ansible Base.
+    """
+    invalid_options = {
+        "envvar_prefix",  # defined based on app name
+        "env_switcher",  # defined based on app name
+        "root_path",  # defined dynamically by factory
+        "validators",  # Cannot be defined because would trigger eager validation
+    }
+    if invalid_options & set(options.keys()):
+        raise ImproperlyConfigured(f"Invalid Dynaconf options: {invalid_options}")
+
+
+def validate(settings: Dynaconf):
+    """Validate the settings according to the validators registered.
+    This function operates on a clone of the settings object to avoid
+    validation to write to the inspection data.
+    """
+    if settings.get_environ("BYPASS_DYNACONF_VALIDATION"):
+        return
+
+    settings.dynaconf_clone().validators.validate()
+
+
+def load_python_file_with_injected_context(*paths: str, settings: Dynaconf, run_hooks: bool = True):  # NOSONAR
+    """Load a file with context into the settings object.
+
+    This function is not encouraged to be used because it uses `exec` to load,
+    the right way to load settings is to use `settings.load_file` method.
+
+    This function exists to keep backwards compatibility with the previous
+    usage of `split_settings` that uses `exec` to load the settings files
+    with injected context.
+
+    Dynaconf doesn't support this (and will not support it) so this function
+    is a temporary solution until all settings files are migrated to be loaded
+    by Dynaconf itself from the YAML files only.
+
+    paths: a list of paths to the python files to be loaded, can be absolute or relative or glob
+    settings: Dynaconf instance
+    """
+    # Wanted to raise a warning here but it's not possible to raise a warning without breaking awx CI
+
+    for path in paths:
+        pattern = os.path.join(settings.ROOT_PATH_FOR_DYNACONF, path)
+        files_to_load = glob(pattern)
+        for file_path in files_to_load:
+            scope = settings.as_dict()
+            file_path = os.path.abspath(file_path)
+            with open(file_path, "rb") as to_compile:
+                code = compile(to_compile.read(), file_path, "exec")
+                exec(code, scope)
+
+            # Update the settings object with the new values coming from the scope
+            for key, value in scope.items():
+                if key.split("__")[0].isupper():  # this is a setting key
+                    # set only if the value have been changed from the executed file
+                    if value != settings.get(key, empty):
+                        settings.set(
+                            key,
+                            value,
+                            loader_identifier=f"python_file_with_injected_scope:{file_path}",
+                        )
+                elif key.startswith("_dynaconf_hook") and callable(value):
+                    settings._post_hooks.append(value)
+
+            settings._loaded_files.append(file_path)
+
+    if run_hooks:
+        execute_instance_hooks(
+            settings,
+            "post",
+            [_hook for _hook in settings._post_hooks if getattr(_hook, "_dynaconf_hook", False) is True and not getattr(_hook, "_called", False)],
+        )
+
+
+def toggle_feature_flags(settings: Dynaconf) -> dict[str, Any]:
+    """Toggle FLAGS based on installer settings.
+    FLAGS is a django-flags formatted dictionary.
+        FLAGS={
+            "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
+                {"condition": "boolean", "value": False, "required": True},
+                {"condition": "before date", "value": "2022-06-01T12:00Z"},
+            ]
+        }
+    Installers will place `FEATURE_SOME_PLATFORM_FLAG_ENABLED=True/False` in the settings file.
+    This function will update the value in the index 0 in FLAGS with the installer value.
+    """
+    data = {}
+    for feature_name, feature_content in settings.get("FLAGS", {}).items():
+        if (installer_value := settings.get(feature_name, empty)) is not empty:
+            feature_content[0]["value"] = installer_value
+            data[f"FLAGS__{feature_name}"] = feature_content
+    return data

--- a/ansible_base/lib/dynamic_config/dynamic_settings.py
+++ b/ansible_base/lib/dynamic_config/dynamic_settings.py
@@ -1,5 +1,6 @@
 # Loads the output from settings_logic into locals for this to be included
-
+# NOTE: This whole module is now deprecated and must be removed soon
+# when all consumers are migrated to the new dynamic settings using Dynaconf.
 
 from ansible_base.lib.dynamic_config.settings_logic import get_dab_settings
 
@@ -14,6 +15,7 @@ except NameError:
         'MIDDLEWARE',
         'OAUTH2_PROVIDER',
         'CACHES',
+        'TEMPLATES',
     ]
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,18 @@ services:
       postgres:
         condition: service_healthy
     environment:
+      DJANGO_SETTINGS_MODULE: test_app.settings
       DB_HOST: postgres
       DB_PORT: 5432
       DB_USER: dab
       DB_PASSWORD: dabing
+    
+    # the following 2 parameters makes the container interactive
+    # for debugging purposes, a breakpoint can be set in the code
+    # and the container can be attached to with `docker attach test_app`
+    # and the code can be debugged interactively 
+    stdin_open: true
+    tty: true
 
   # This is the intermediate application reverse proxy without ssl
   nginx:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -47,23 +47,22 @@ See the following table for a mapping.
 
 ## settings.py
 
-As a convenience, we can let django-ansible-base automatically add and modify the settings it needs to function:
+django-ansible-base requires a few settings to be set in your application, to make it easier to 
+define, validate and inspect the settings, DAB uses Dynaconf library to manage settings.
 
+In the `settings.py` of your Django application you have to load Dynaconf and export its settings
+back to Django.
+
+
+```python
+from ansible_base.lib.dynamic_config import factory, export
+
+DYNACONF = factory(__name__, "MYAPP", settings_files=["defaults.py"])
+# manipulate DYNACONF as needed
+export(__name__, DYNACONF)
 ```
-from split_settings.tools import include
 
-from ansible_base.lib import dynamic_config
-dab_settings = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_settings.py')
-include(dab_settings)
-```
-
-You can get a list of settings that may be modified from `ANSIBLE_BASE_OVERRIDABLE_SETTINGS` after
-running this code snippet in your settings.
-By default, this `include` will not modify a setting which is already defined before
-the it runs.
-
-Tthe settings which actually where modified as a result of the dynamic include can be
-found in the `ANSIBLE_BASE_OVERRIDDEN_SETTINGS` setting.
+Detailed information on how to configure your application settings can be found on [lib/dynamic_config](./lib/dynamic_config.md)
 
 ## urls.py
 

--- a/docs/apps/rest_filters.md
+++ b/docs/apps/rest_filters.md
@@ -39,15 +39,15 @@ due to the model not having an expected field.
 
 To deal with this, after including the dynamic settings, you can add your field to the "reserved" list:
 
+In your application settings defaults.
+
 ```python
-from split_settings.tools import include
-
-from ansible_base.lib import dynamic_config
-dab_settings = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_settings.py')
-include(dab_settings)
-
-ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES += ('extra_querystring',)
+ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES = '@merge extra_querystring'
 ```
+
+The `@merge` will be handled by Dynaconf and `extra_querystring` will be added to the reserved names,
+you can pass a comma separated list of reserved names.
+
 
 This will prevent 400 errors for requests like `/api/v1/organizations/?extra_querystring=foo`.
 No filtering would be done in this case, the query string would simply be ignored.

--- a/docs/lib/dynamic_config.md
+++ b/docs/lib/dynamic_config.md
@@ -1,0 +1,571 @@
+# Dynamic Configuration
+
+Application configuration is managed by [dynaconf] a dynamic configuration system that allows you to define configuration settings in a variety of formats and sources.
+
+Django Ansible Base provides a set of functions to help Ansible Applications to instantiate
+the dynaconf object, load settings from standard locations, export settings back to django settings and more.
+
+On top of Dynaconf, Django Ansible Base also defines a set of standards for file locations, environment variable naming, and settings validation.
+
+
+## Integrating a DAB service with Dynaconf
+
+
+Django settings lifecycle starts by loading the `DJANGO_SETTINGS_MODULE` module, which is usually the `settings` module inside the application, that is the place where the Dynaconf object is created and the settings manipulated to be exported back to Django settings.
+
+That could be done by creating Dynaconf instance directly on the Django app setttings file,
+but DAB helpers are provided to make this process easier and more standardized.
+
+Start by importing the functions from `ansible_base.lib.dynamic_config`:
+
+`myapp/settings.py`:
+```python
+from ansible_base.lib.dynamic_config import (
+    factory,  # Create a dynaconf object
+    export,  # Export dynaconf settings back to django.conf.settings
+    load_envvars, # Load settings from environment variables
+    load_standard_settings_files, # Load settings from standard locations
+    toggle_feature_flags, # Toggle feature flags based on values set by installer or envvars
+)
+```
+
+Those functions are provided separately to allow the application to choose which ones to use and which
+order to call them.
+
+### Creating the Dynaconf object
+
+Assuming `DJANGO_SETTINGS_MODULE` is set to `myapp.settings`:
+
+On the `settings` module (`settings.py` or `settings/__init__.py`), create an object named 
+`DYNACONF` using the `ansible_base.lib.dynamic_config.factory` function.
+
+The `factory` function will accept the following arguments:
+
+- **module_name**: The name of the module
+  The module_name is used to determine the caller module path.
+- **app_name**: The name of the application
+  This name is used to determine some configuration defaults such as the main envvar prefix `{NAME}_` and the standard settings file name on `/etc/ansible-automation-platform/{name}/settings.yaml` and the mode switcher on `{name}_MODE`.
+- **extra_envvar_prefixes**: A list of environment variable prefixes to search for settings
+  If the application needs to load settings filtering additional prefixes, this list can be used to specify them.
+- **options**: Additional options to pass to dynaconf
+- **validators**: A list of dynaconf.Validator objects to validate the settings after loading
+- **add_dab_settings**: A boolean to toggle the addition of DAB required settings, if set to false, 
+  then the function `load_dab_settings` can be called later to load the DAB settings.
+
+
+`myapp/settings.py`:
+```python
+DYNACONF = factory(
+    __name__,
+    "MYAPP",
+    # Options passed directly to dynaconf
+    environments=("development", "production", "testing"),
+    settings_files=["defaults.py"],
+    validators=[
+        Validator("KEY", required=True),
+        Validator("NUMBER", is_type_of=int, gte=0, lte=100),
+        Validator("LIST", len_min=1, when=Validator("OTHER", eq="value")),
+        Validator("DICT", condition=lambda x: x.get("key") == "value"),
+    ],
+)
+```
+
+With the above configuration DYNACONF will load 
+
+- settings passed directly to the factory function if any upper case variable is passed.
+- settings from `defaults.py` file
+- settings from `development_defaults.py` file if the file exists and the mode is development (which is the default mode)
+- settings from `production_defaults.py` file if the file exists and the mode is production (set with `export MYAPP_MODE=production`)
+- required settings from `django_ansible_base` dynamic configuration (DAB) if `add_dab_settings` is set to `True` (which is the default) in the case you want to load the DAB settings later, set it to `False` and call `load_dab_settings(DYNACONF)` later.
+
+### Manipulating the DYNACONF object
+
+Inside the `settings` module the DYNACONF object is available to be instrumented in any way needed,
+read more on [dynaconf] documentation to see how to use the settings object.
+
+From outside the `settings` module the DYNACONF object can be accessed from `django.conf.settings.DYNACONF`.
+
+The basic operations are:
+
+#### Read a setting 
+
+> DYNACONF is a dict-like object that also exposes attribute lookup.
+
+```python
+DYNACONF.get("key")
+DYNACONF.key
+DYNACONF.key.subkey
+DYNACONF["key"]
+```
+
+#### Set a setting
+
+```python
+DYNACONF.set("key", "value")
+DYNACONF.set("key__subkey", "value")
+DYNACONF.set("key.subkey", "value")
+DYNACONF.key = "value"
+DYNACONF.key.subkey = "value"
+DYNACONF["key"] = "value"
+DYNACONF.update({"key": "value"})
+DYNACONF.setdefault("key", "value")
+```
+
+NOTE: When manipulating the setting, the operation is stored in the inspection history only if the `loader_identifier` passed, e.g: `DYNACONF.update({"key": "value"}, loader_identifier="set_foo")`
+
+
+#### Load extra files 
+
+```python
+DYNACONF.load_file("path/to/file.yaml")
+DYNACONF.load_file("path/to/file.toml")
+DYNACONF.load_file("path/to/file.json")
+DYNACONF.load_file("path/to/file.ini")
+DYNACONF.load_file("local_*.py")
+DYNACONF.load_file("/etc/location/conf.d/*.py")
+```
+
+> [!NOTE]  
+> Every time a key is set, or a new file is loaded, Dynaconf will apply **merging** rules to the settings, so the last loaded file or the last set key will override the previous ones.
+> Dynaconf has some merging strategies that can be configured, read more on [dynaconf] documentation.
+> By default the latest set key will completely override the previous one.
+> unless it explicitly uses one of the `@merge`. "@merge_unique", "@insert" or "dynaconf_merge" directives.
+>
+> If `merge=True` is passed to the `factory` function, then dynaconf will operate on the global merging > strategy, which means lists and dictionaries will be merged back to previous by default (even without the directives) instead of replaced.
+>
+> Notice that DAB doesn't use the `merge=True` option by default, so the default behavior is to replace the previous settings, this allows more granular control over the settings merge.
+
+
+#### Check the current mode 
+
+For example `export MYAPP_MODE=production` will set the mode to production,
+modes can also be composed like `export MYAPP_MODE=production,extra`
+
+```python
+DYNACONF.is_development_mode # True if development
+"production" in DYNACONF.current_env.lower() # True if production
+```
+
+#### Loading Standard Ansible Automation Platform settings files
+
+The `load_standard_settings_files` function will load settings from the standard locations,
+the base location is standardized as `/etc/ansible-automation-platform/` and the function will load
+in order.
+
+- `/etc/ansible-automation-platform/{settings, flags, .secrets}.yaml`
+- `/etc/ansible-automation-platform/{name}/{settings, flags, .secrets}.yaml`
+
+where `{name}` is the lowercase name passed to the factory function.
+
+```python
+load_standard_settings_files(DYNACONF)
+```
+
+Those files will be loaded in order and the merging strategy will be applied.
+
+#### Load settings from environment variables
+
+The `load_envvars` function will load settings from environment variables using the standard prefix
+`{NAME}_` where `{NAME}` is the upper name passed to the factory function.
+
+```python
+load_envvars(DYNACONF)
+```
+
+and then the settings can be externally overridden as:
+
+```bash
+export MYAPP_KEY=value
+export MYAPP_KEY__SUBKEY=value
+export MYAPP_DATABASES__default__NAME=mydb
+export MYAPP_NUMBER=42
+export MYAPP_LIST="[1, 2, 3]"
+export MYAPP_DICT='@json {"key": "value"}'
+# or a valid toml
+export MYAPP_DICT='{key="value"}'
+export MYAPP_BOOL=true
+export MYAPP_FLOAT=3.14
+export MYAPP_INTERPOLATE="@format The key value is {this.KEY}"
+export MYAPP_INTERPOLATE_COMPLEX="@int @jinja {{ this.NUMBER * 4}}"
+export MYAPP_INSTALLED_APPS="@merge new_app_to_add"
+```
+
+More on [dynaconf] documentation.
+
+
+### Export settings back to django settings
+
+The export function will take all variables from the dynaconf object and export them back to django settings so it will be available as `django.conf.settings`:
+
+It is important to call this function at the very end of the `settings` module.
+
+```python
+export(__name__, DYNACONF)
+```
+
+All the registered Validators will be called before exporting the settings.
+
+
+## Setting Settings 
+
+With Dynaconf, settings can come from a variety of sources, each service can define individually its default settings that can be either hardcoded passed directly to the factory function or loaded from a file defined as the `settings_files` option,
+then DAB after loading the defaults will conditionally inject its own required settings depending on the `INSTALLED_APPS` 
+settings, then in the settings.py each service can manipulate the dynaconf object individually in order to set new settings, load extra files, or override the defaults.
+
+DAB also provides helpers to load settings from standard locations and environment variables, and to validate the settings.
+
+### Defaults
+
+Assuming `settings_files=["defaults.py"]` is passed to the factory function, the `defaults.py` file will be loaded by default.
+
+`myapp/defaults.py`:
+```python
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "db.sqlite3",
+    }
+}
+DEBUG = False
+ANYTHING = "value"
+```
+
+Each service can name that file differently, but the `defaults.py` is a convention, it is also possible to pass multiple files to the `settings_files` option, so dynaconf loads them in order and applies the merging strategy to overrides the previous loaded settings, the `settings_files` option can also be paths to files in formats such as `yaml`, `json`, `toml`, `ini`, or python files.
+
+If the service prefers, the defaults can be passed directly to the factory function as a uppercase variables, but the file is recommended to keep the settings organized and have better visualization when inspecting the settings.
+
+```python
+DYNACONF = factory(
+    __name__,
+    "MYAPP",
+    # defaults
+    DATABASES={
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": "db.sqlite3",
+        }
+    },
+    DEBUG=False,
+    ANYTHING="value",
+)
+```
+
+### Environment Variables
+
+Environment variables can be used to override the settings, the standard prefix is `{NAME}_` where `{NAME}` is the uppercase name passed to the factory function, but extra prefixes can be passed to the `load_envvars` function.
+
+```bash
+export MYAPP_KEY=value
+export MYAPP_KEY__SUBKEY=value
+export MYAPP_DATABASES__default__NAME=mydb
+export MYAPP_NUMBER=42
+export MYAPP_LIST="[1, 2, 3]"
+export MYAPP_DICT='@json {"key": "value"}'
+# or a valid toml
+export MYAPP_DICT='{key="value"}'
+export MYAPP_BOOL=true
+export MYAPP_FLOAT=3.14
+export MYAPP_INTERPOLATE="@format The key value is {this.KEY}"
+export MYAPP_INTERPOLATE_COMPLEX="@int @jinja {{ this.NUMBER * 4}}"
+export MYAPP_INSTALLED_APPS="@merge new_app_to_add"
+```
+
+### Merge Strategy
+
+As Dynaconf will load multiple sources separately in order to build the final state of the settings, there are
+some common Django patterns that works in a different with Dynaconf.
+
+In the scope of a Dynaconf settings file, it is not possible to `import` the previous loaded file to 
+assert conditionals or to merge settings, but Dynaconf provides a set of directives that can be used to merge settings.
+
+Dynaconf has multiple ways of defining the intention to merge a setting with previously loaded settings.
+
+#### Converters
+
+
+- `@merge` will merge the setting with the previous one, if the setting is a list or a dictionary, the new setting will be appended to the previous one.
+    - ```python
+      INSTALLED_APPS = "@merge new_app_to_add"
+      ``` 
+      Converts to `INSTALLED_APPS.append("new_app_to_add")`<br><br>
+    - ```python
+      INSTALLED_APPS = "@merge new_app1,new_app2"
+      ```
+      Converts to `INSTALLED_APPS.extend(['new_app1', 'new_app2'])`<br><br>  
+    - ```python
+      DATABASES = "@merge {'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'db.sqlite3'}}"
+      ```
+      Converts to `DATABASES.update({'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'db.sqlite3'}})`  <br><br>
+    - ```python
+      PERSON = "@merge name=John"
+      ```
+      Converts to `PERSON.update({'name': 'John'})`<br><br>  
+
+- `@merge_unique` will merge the setting with the previous one, but only if the setting is not already present in the previous one.
+    - ```python
+      INSTALLED_APPS = "@merge_unique new_app_to_add_only_if_not_present_yet"
+      ```
+      Converts to `if "new_app" not in INSTALLED_APPS: INSTALLED_APPS.append("new_app")`  <br><br>
+
+- `@insert` will insert the setting in the previous one, if the setting is a list, the new setting will be inserted in the first position or the provided index.
+    - ```python
+      INSTALLED_APPS = "@insert new_app_to_add"
+      ```
+      Converts to `INSTALLED_APPS.insert(0, "new_app_to_add")`  <br><br>
+    - ```python
+      INSTALLED_APPS = "@insert 2 new_app_to_add"
+      ```
+      Converts to `INSTALLED_APPS.insert(2, "new_app_to_add")`  <br><br>
+
+#### Meta Values
+
+Besides the converters, Dynaconf also provides a set of meta values that can be used to define the intention of merging the settings in the value itself,
+metavalues can be added to lists as string and to dictionaries as keys.
+
+
+- `dynaconf_merge`
+    - ```python
+      INSTALLED_APPS = ["new_app_to_add", "dynaconf_merge"]
+      ```
+      Converts to `INSTALLED_APPS.append("new_app_to_add")`  <br><br>
+    - ```python
+      DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite3", "dynaconf_merge": True}}
+      ```
+      Converts to `DATABASES.update({'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'db.sqlite3'}})`  <br><br>
+
+- `dynaconf_merge_unique`
+    - ```python
+      INSTALLED_APPS = ["new_app_to_add_only_if_not_present", "dynaconf_merge_unique"]
+      ```
+      Converts to `if "new_app" not in INSTALLED_APPS: INSTALLED_APPS.append("new_app")`  <br><br>
+
+
+The metavalue itself will be removed from the setting after the conversion.
+
+
+#### Deferred Post Hooks
+
+In some scenarios the value that needs to be set is dependent on other setting values that are not available yet, because dynaconf will have the final state only after resolving the load of all the files and environment variables, it is possible to use deferred post hooks to set the value after the final state is resolved.
+
+Dynaconf will collect hooks for post_execution from any `.py` file loaded and the decorated object must be 
+a callable that takes settings and returns a dictionary with the values to be merged.
+
+```python
+from dynaconf import post_hook
+
+@post_hook
+def add_ldap_only_if_flag_is_set(settings) -> dict:
+    data = {}  # this is the value to be merged
+    if settings.get("LDAP_ENABLED"): 
+        data["INSTALLED_APPS"] = "@merge_unique ldap_app"
+        data["LDAP_SERVER] = "ldap://server"
+        data["LDAP_PORT] = 389
+    return data
+```
+
+The registered hook will be invoked later after the whole settings is resolved, and the return dict will be merged to the setting, so the 
+dict is laid out using the same format as the settings file, and the values will be merged according to the converters and metavalues.
+
+#### Static Files 
+
+Settings can come from other files such as `yaml`, `json`, `toml`, `ini` and on those cases the same merging strategy can be applied using the converters and metavalues.
+
+```yaml
+installed_apps: "@merge new_app_to_add"
+```
+
+```json
+{"installed_apps": "@merge new_app_to_add"}
+```
+
+```toml
+installed_apps = "@merge new_app_to_add"
+```
+
+## Full example 
+
+`myapp/settings.py`:
+```python
+from dynaconf import Validator
+from ansible_base.lib.dynamic_config import factory, export, load_envvars, load_standard_settings_files
+
+DYNACONF = factory(
+    __name__,
+    "MYAPP",
+    # Options passed directly to dynaconf
+    environments=("development", "production", "testing"),
+    settings_files=["defaults.py"],
+    validators=[
+        Validator("KEY", required=True),
+        Validator("NUMBER", is_type_of=int, gte=0, lte=100),
+        Validator("LIST", len_min=1, when=Validator("OTHER", eq="value")),
+        Validator("DICT", condition=lambda x: x.get("key") == "value"),
+    ],
+)
+load_standard_settings_files(DYNACONF)
+load_envvars(DYNACONF)
+export(__name__, DYNACONF)
+```
+
+`myapp/defaults.py`:
+```python
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "db.sqlite3",
+    }
+}
+DEBUG = False
+ANYTHING = "value"
+
+# all django settings can be set here
+# use dynaconf idioms to set them like:
+# DATABASES__default__NAME = "db.sqlite3"
+# INSTALLED_APPS = "@merge_unique new_app_to_add_only_if_not_present"
+```
+
+`myapp/development_defaults.py`:
+```python
+DEBUG = True
+DATABASES__default__NAME = "devdb.sqlite3"
+```
+
+
+`myapp/production_defaults.py`:
+```python
+DEBUG = False
+DATABASES__default__NAME = "proddb.sqlite3"
+```
+
+`/etc/ansible-automation-platform/myapp/settings.yaml`:
+```yaml
+KEY: value
+NUMBER: 42
+LIST:
+    - 1
+    - 2
+    - 3
+DICT:
+    key: value
+
+# Merging also available
+DATABASES__default__NAME: prod_db
+INSTALLED_APPS: "@merge_unique new_app_to_add"
+```
+
+`/etc/ansible-automation-platform/myapp/flags.yaml`:
+```yaml
+FEATURE_FOO_ENABLED: true
+FEATURE_BAR_ENABLED: false
+```
+
+`/etc/ansible-automation-platform/myapp/.secrets.yaml`:
+```yaml
+SECRET_KEY: "@vault secret/myapp/secret_key"  # this will be fetched from vault if vault loader is set
+PASSWORD: "@op namespace/key"  # this will be fetched from 1password if op loader is set
+TOKEN: "R4ND0M_T0K3N"  # Just a string
+```
+
+Environment variables:
+```bash
+export MYAPP_KEY=value
+export MYAPP_KEY__SUBKEY=value
+export MYAPP_DATABASES__default__NAME=mydb
+```
+
+Runtime:
+```python
+from django.conf import settings
+
+# Regular Django Settings
+print(settings.DEBUG)
+
+# Accessing dynaconf object for inspection
+print(settings.DYNACONF.KEY)
+```
+
+## Dynaconf CLI
+
+Dynaconf also provides a CLI to inspect settings:
+
+To use the CLI it is required to set DJANGO_SETTINGS_MODULE variable.
+
+```bash
+export DJANGO_SETTINGS_MODULE=myapp.settings
+```
+
+> Optionally, if the variable is not set, `-i path` can be passed to the CLI, e.g: `dynaconf -i myapp.settings.DYNACONF command`
+
+
+```bash
+
+# List Human Friendly
+$ dynaconf list
+$ dynaconf list -k KEY
+$ dynaconf list -k DATABASES --json
+$ dynaconf list -k DATABASES__default__NAME
+
+
+# Inspect Settings Loading History
+$ dynaconf inspect
+$ dynaconf inspect -k KEY
+$ dynaconf inspect -k DATABASES__default__NAME
+
+# Detailed history of loaders and loaded files
+$ dynaconf inspect -m debug -vv
+
+# Get raw value as string on stdout
+$ dynaconf get KEY
+```
+
+Read more on [dynaconf] documentation.
+
+
+## Diagram
+
+### Flowchart
+
+```mermaid
+graph TD;
+    A[from django.conf import settings] --> B[Django loads DJANGO_SETTINGS_MODULE e.g: app.settings];
+    B --> C[app.settings creates a DYNACONF object];
+    C --> C1[DYNACONF object sets naming standards and common options <br> e.g: envvar_prefix=APPNAME, settings_files=defaults.py];
+    C1 --> C2[DYNACONF object loads settings from defaults.py];
+    C2 -->|APPNAME_MODE=production| C3[DYNACONF loads settings from production_defaults.py];
+    C2 -->|APPNAME_MODE=development| C4[DYNACONF loads settings from development_defaults.py];
+    C4 --> C5[DYNACONF loads DAB required defaults];
+    C3 --> C5
+    C5 --> D["DYNACONF object can be instrumented e.g <br> (load_file, set, update, setdefault, get)"];
+    D --> E["**load_standard_settings_files** <br> is called to load platform standard file locations"];
+    E --> E1["_/etc/ansible-automation-platform/appname_ <br> /settings.yaml <br> /flags.yaml <br> /.secrets.yaml "]
+    E1 --> F
+    E --> F["At this point variables can be manually overriden <br> e.g DYNACONF.set(key, value)"];
+    F --> G["**load_envvars** is called to load prefixed environment variables <br> e.g: _APPNAME_DATABASES__default__name=db_"];
+    G --> H["**export** is called to populate values from **DYNACONF** to **django.conf.settings**"];
+    H --> I[DYNACONF validators can be registered and called];
+    I --> J["django.conf.settings is ready"]
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant DjangoApp
+    participant Django
+    participant app_settings as app.settings
+    participant Dynaconf
+
+    DjangoApp->>Django: Import django.conf.settings
+    Django->>app_settings: Load module (DJANGO_SETTINGS_MODULE)
+    app_settings->>Dynaconf: Create DYNACONF object
+    Note over Dynaconf: a. Set naming standards<br/>b. Load defaults.py<br/>c. Load env-specific defaults (e.g., production_defaults.py)<br/>d. Load dab dynamic_config
+    Note over Dynaconf, app_settings: Instrumentation (e.g., load_file, set, update, setdefault, get)
+    app_settings->>Dynaconf: load_standard_settings_files(/etc/ansible-automation-platform/*.yaml)
+    app_settings->>Dynaconf: Apply manual overrides
+    app_settings->>Dynaconf: load_envvars (prefixed)
+    app_settings->>Django: Export to django.conf.settings
+    app_settings->>Dynaconf: Register and call validators
+```
+
+
+[dynaconf]: https://dynaconf.com

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -6,6 +6,6 @@ cryptography
 Django>=4.2.16,<4.3.0 # CVE-2024-45230
 djangorestframework
 django-crum
-django-split-settings
 inflection
 sqlparse>=0.5.2 # https://github.com/ansible/django-ansible-base/security/dependabot/9
+dynaconf>=3.2.10,<4.0.0  # Dynaconf 4.0.0 is expected to be a major release with breaking changes

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -47,14 +47,14 @@ django-oauth-toolkit==2.3.0
     # via -r requirements/requirements_oauth2_provider.in
 django-redis==5.4.0
     # via -r requirements/requirements_redis_client.in
-django-split-settings==1.3.2
-    # via -r requirements/requirements.in
 djangorestframework==3.15.2
     # via
     #   -r requirements/requirements.in
     #   drf-spectacular
 drf-spectacular==0.28.0
     # via -r requirements/requirements_api_documentation.in
+dynaconf==3.2.10
+    # via -r requirements/requirements.in
 idna==3.10
     # via requests
 inflection==0.5.1

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -5,7 +5,6 @@ django==4.2.17
 django-debug-toolbar
 django-extensions
 djangorestframework
-django-split-settings
 flake8==7.1.1           # Linting tool, if changed update pyproject.toml as well
 Flake8-pyproject==1.2.3 # Linting tool, if changed update pyproject.toml as well
 ipython

--- a/test_app/defaults.py
+++ b/test_app/defaults.py
@@ -1,0 +1,226 @@
+"""
+Variables defined in this file will be loaded by Dynaconf and populated into the Django settings module.
+"""
+
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'request_id_filter': {
+            '()': 'ansible_base.lib.logging.filters.RequestIdFilter',
+        },
+    },
+    'formatters': {
+        'simple': {'format': '%(asctime)s %(levelname)-8s [%(request_id)s]  %(name)s %(message)s'},
+    },
+    'handlers': {
+        'console': {
+            '()': 'logging.StreamHandler',
+            'level': 'DEBUG',
+            'formatter': 'simple',
+            'filters': ['request_id_filter'],
+        },
+    },
+    'loggers': {
+        'ansible_base': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+        '': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}
+for logger in LOGGING["loggers"]:  # noqa: F405
+    # We want to ensure that all loggers are at DEBUG because we have tests which validate log messages
+    LOGGING["loggers"][logger]["level"] = "DEBUG"  # noqa: F405
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'social_django',
+    'ansible_base.api_documentation',
+    'ansible_base.authentication',
+    'ansible_base.rest_filters',
+    'ansible_base.jwt_consumer',
+    'ansible_base.resource_registry',
+    'ansible_base.rest_pagination',
+    'ansible_base.rbac',
+    'ansible_base.oauth2_provider',
+    'test_app',
+    'django_extensions',
+    'debug_toolbar',
+    'ansible_base.activitystream',
+    'ansible_base.help_text_check',
+    'ansible_base.feature_flags',
+]
+
+MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'crum.CurrentRequestUserMiddleware',
+    'ansible_base.lib.middleware.logging.LogRequestMiddleware',
+    'ansible_base.lib.middleware.logging.LogTracebackMiddleware',
+]
+
+# set some vanilla social auth plugins so that we can test the social_auth based
+# users in the resource registry
+AUTHENTICATION_BACKENDS = [
+    'ansible_base.lib.backends.prefixed_user_auth.PrefixedUserAuthBackend',
+    'social_core.backends.github.GithubOAuth2',
+]
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'test_app.authentication.logged_basic_auth.LoggedBasicAuthentication',
+        'test_app.authentication.service_token_auth.ServiceTokenAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'ansible_base.oauth2_provider.permissions.OAuth2ScopePermission',
+        'ansible_base.rbac.api.permissions.AnsibleBaseObjectPermissions',
+    ],
+}
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "HOST": os.getenv("DB_HOST", "127.0.0.1"),
+        "PORT": os.getenv("DB_PORT", 55432),
+        "USER": os.getenv("DB_USER", "dab"),
+        "PASSWORD": os.getenv("DB_PASSWORD", "dabing"),
+        "NAME": os.getenv("DB_NAME", "dab_db"),
+    }
+}
+
+AUTH_USER_MODEL = 'test_app.User'
+
+ROOT_URLCONF = 'test_app.urls'
+
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(BASE_DIR, 'test_app', 'templates')],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
+            ]
+        },
+    },
+]
+
+INTERNAL_IPS = [
+    "127.0.0.1",
+]
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_TZ = True
+
+DEMO_DATA_COUNTS = {'organization': 150, 'user': 379, 'team': 43}
+
+ANSIBLE_BASE_TEAM_MODEL = 'test_app.Team'
+ANSIBLE_BASE_ORGANIZATION_MODEL = 'test_app.Organization'
+
+STATIC_URL = '/static/'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+SECRET_KEY = "asdf1234"
+
+ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES = ['ansible_base.authentication.authenticator_plugins']
+
+ANSIBLE_BASE_RESOURCE_CONFIG_MODULE = "test_app.resource_api"
+
+SYSTEM_USERNAME = '_system'
+
+ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
+    'sys_auditor': {'name': "Platform Auditor"},
+    'team_member': {},
+    'team_admin': {},
+    'org_admin': {},
+    'org_member': {},
+    'cow_admin': {'shortname': 'admin_base', 'model_name': 'test_app.cow', 'name': 'Cow Admin'},
+    'cow_moo': {'shortname': 'action_base', 'model_name': 'test_app.cow', 'name': 'Cow Mooer', 'action': 'say_cow'},
+}
+ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
+ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
+ANSIBLE_BASE_RBAC_MODEL_REGISTRY = {
+    "test_app.inventory": {"parent_field_name": "organization"},
+    "test_app.credential": {},
+    "test_app.immutabletask": {"parent_field_name": None},
+}
+ANSIBLE_BASE_OAUTH2_PROVIDER_PERMISSIONS_CHECK_IGNORED_VIEWS = ["drf_spectacular.views.SpectacularSwaggerView"]
+ALLOW_SHARED_RESOURCE_CUSTOM_ROLES = True  # Allow making custom roles with org change permission, for example
+ALLOW_LOCAL_ASSIGNING_JWT_ROLES = False
+
+ANSIBLE_BASE_USER_VIEWSET = 'test_app.views.UserViewSet'
+
+LOGIN_URL = "/login/login"
+
+RESOURCE_SERVER = {
+    "URL": "http://localhost",
+    "SECRET_KEY": "my secret key",
+    "VALIDATE_HTTPS": False,
+}
+RESOURCE_SERVICE_PATH = "/api/v1/service-index/"
+# Backwards sync turned off, because for most of the duration of the tests
+# the resource server will not actually be running
+# so it will be flipped true only for specific tests that test this
+RESOURCE_SERVER_SYNC_ENABLED = False
+
+RENAMED_USERNAME_PREFIX = "dab:"
+
+JUST_A_TEST = 41
+
+FLAGS = {
+    "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
+        {
+            "condition": "boolean",
+            "value": False,
+            "required": True,
+        },
+        {
+            "condition": "before date",
+            "value": '2022-06-01T12:00Z',
+        },
+    ],
+    "FEATURE_SOME_PLATFORM_FLAG_FOO_ENABLED": [
+        {
+            "condition": "boolean",
+            "value": False,
+        },
+    ],
+    "FEATURE_SOME_PLATFORM_FLAG_BAR_ENABLED": [
+        {
+            "condition": "boolean",
+            "value": True,
+        },
+    ],
+}

--- a/test_app/example_files/settings.yaml
+++ b/test_app/example_files/settings.yaml
@@ -1,0 +1,4 @@
+# This file exists only for testing the dynamic settings loader
+# capabilities of loading yaml settings from the standard location
+# which is /etc/ansible-automation-platform/{appname}/settings.yaml
+just_a_test: 42

--- a/test_app/scripts/container_startup_uwsgi.sh
+++ b/test_app/scripts/container_startup_uwsgi.sh
@@ -5,11 +5,18 @@ set -x
 
 PIP=/venv/bin/pip
 PYTHON=/venv/bin/python3
+DYNACONF=/venv/bin/dynaconf
 
 $PIP install uwsgi
 
 echo "settings.DATABASE ..."
 $PYTHON manage.py shell -c 'from django.conf import settings; print(settings.DATABASES)'
+
+echo "DAB overridden settings ..."
+$DYNACONF -i test_app.settings.DYNACONF list -k ANSIBLE_BASE_OVERRIDDEN_SETTINGS --json
+
+echo "Read the custom settings file data just as a test"
+$DYNACONF -i test_app.settings.DYNACONF inspect -k JUST_A_TEST
 
 $PYTHON manage.py migrate
 DJANGO_SUPERUSER_PASSWORD=password DJANGO_SUPERUSER_USERNAME=admin DJANGO_SUPERUSER_EMAIL=admin@stuff.invalid $PYTHON manage.py createsuperuser --noinput || true

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -1,9 +1,13 @@
-import os
+"""
+Instantiate the DYNACONF instance and export the settings to Django settings.
+Any variable is overridable by environment variables prefixed with TESTAPP_.
+Application current mode can be configured with TESTAPP_MODE environment variable.
+by default it will be development.
+"""
+
 import sys
 
-from split_settings.tools import include
-
-DEBUG = True
+from ansible_base.lib.dynamic_config import export, factory, load_envvars, load_standard_settings_files
 
 if "pytest" in sys.modules:
     # https://github.com/agronholm/typeguard/issues/260
@@ -15,225 +19,30 @@ if "pytest" in sys.modules:
 
     install_import_hook(packages=["ansible_base"])
 
-ALLOWED_HOSTS = ["*"]
+# Create a the standard DYNACONF instance which will come with DAB defaults
+# this loads the files passed to `settings_files` list
+# and environment specific file e.g: development_{filename}.py
+# assuming the current env is development and files are located in the same folder
+DYNACONF = factory(
+    __name__,
+    "TESTAPP",
+    environments=("development", "sqlite"),
+    settings_files=["defaults.py"],
+)
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'filters': {
-        'request_id_filter': {
-            '()': 'ansible_base.lib.logging.filters.RequestIdFilter',
-        },
-    },
-    'formatters': {
-        'simple': {'format': '%(asctime)s %(levelname)-8s [%(request_id)s]  %(name)s %(message)s'},
-    },
-    'handlers': {
-        'console': {
-            '()': 'logging.StreamHandler',
-            'level': 'DEBUG',
-            'formatter': 'simple',
-            'filters': ['request_id_filter'],
-        },
-    },
-    'loggers': {
-        'ansible_base': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-        },
-        '': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-    },
-}
-for logger in LOGGING["loggers"]:  # noqa: F405
-    # We want to ensure that all loggers are at DEBUG because we have tests which validate log messages
-    LOGGING["loggers"][logger]["level"] = "DEBUG"  # noqa: F405
+# Load new standard settings files from
+#  /etc/ansible-automation-platform/ and /etc/ansible-automation-platform/testapp/
+load_standard_settings_files(DYNACONF)
 
-INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'social_django',
-    'ansible_base.api_documentation',
-    'ansible_base.authentication',
-    'ansible_base.rest_filters',
-    'ansible_base.jwt_consumer',
-    'ansible_base.resource_registry',
-    'ansible_base.rest_pagination',
-    'ansible_base.rbac',
-    'ansible_base.oauth2_provider',
-    'test_app',
-    'django_extensions',
-    'debug_toolbar',
-    'ansible_base.activitystream',
-    'ansible_base.help_text_check',
-    'ansible_base.feature_flags',
-]
+# Set overrides that must be set after DAB and file settings are loaded
+DYNACONF.set(
+    "ANSIBLE_BASE_JWT_MANAGED_ROLES",
+    "@merge System Auditor",
+    loader_identifier="add_system_auditor",
+)
 
-MIDDLEWARE = [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'crum.CurrentRequestUserMiddleware',
-    'ansible_base.lib.middleware.logging.LogRequestMiddleware',
-    'ansible_base.lib.middleware.logging.LogTracebackMiddleware',
-]
+# Load envvars at the end to allow them to override everything loaded so far
+load_envvars(DYNACONF)
 
-# set some vanilla social auth plugins so that we can test the social_auth based
-# users in the resource registry
-AUTHENTICATION_BACKENDS = [
-    'ansible_base.lib.backends.prefixed_user_auth.PrefixedUserAuthBackend',
-    'social_core.backends.github.GithubOAuth2',
-]
-
-REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'test_app.authentication.logged_basic_auth.LoggedBasicAuthentication',
-        'test_app.authentication.service_token_auth.ServiceTokenAuthentication',
-    ],
-    'DEFAULT_PERMISSION_CLASSES': [
-        'ansible_base.oauth2_provider.permissions.OAuth2ScopePermission',
-        'ansible_base.rbac.api.permissions.AnsibleBaseObjectPermissions',
-    ],
-}
-
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "HOST": os.getenv("DB_HOST", "127.0.0.1"),
-        "PORT": os.getenv("DB_PORT", 55432),
-        "USER": os.getenv("DB_USER", "dab"),
-        "PASSWORD": os.getenv("DB_PASSWORD", "dabing"),
-        "NAME": os.getenv("DB_NAME", "dab_db"),
-    }
-}
-
-AUTH_USER_MODEL = 'test_app.User'
-
-ROOT_URLCONF = 'test_app.urls'
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-TEMPLATES = [
-    {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [os.path.join(BASE_DIR, 'test_app', 'templates')],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            'context_processors': [
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'django.template.context_processors.request',
-            ]
-        },
-    },
-]
-
-INTERNAL_IPS = [
-    "127.0.0.1",
-]
-
-LANGUAGE_CODE = 'en-us'
-
-TIME_ZONE = 'UTC'
-
-USE_I18N = True
-
-USE_TZ = True
-
-DEMO_DATA_COUNTS = {'organization': 150, 'user': 379, 'team': 43}
-
-ANSIBLE_BASE_TEAM_MODEL = 'test_app.Team'
-ANSIBLE_BASE_ORGANIZATION_MODEL = 'test_app.Organization'
-
-STATIC_URL = '/static/'
-
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
-SECRET_KEY = "asdf1234"
-
-ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES = ['ansible_base.authentication.authenticator_plugins']
-
-from ansible_base.lib import dynamic_config  # noqa: E402
-
-settings_file = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_settings.py')
-include(settings_file)
-
-ANSIBLE_BASE_RESOURCE_CONFIG_MODULE = "test_app.resource_api"
-
-SYSTEM_USERNAME = '_system'
-
-ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
-    'sys_auditor': {'name': "Platform Auditor"},
-    'team_member': {},
-    'team_admin': {},
-    'org_admin': {},
-    'org_member': {},
-    'cow_admin': {'shortname': 'admin_base', 'model_name': 'test_app.cow', 'name': 'Cow Admin'},
-    'cow_moo': {'shortname': 'action_base', 'model_name': 'test_app.cow', 'name': 'Cow Mooer', 'action': 'say_cow'},
-}
-ANSIBLE_BASE_JWT_MANAGED_ROLES.append("System Auditor")  # noqa: F821 this is set by dynamic settings for jwt_consumer
-ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
-ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
-ANSIBLE_BASE_RBAC_MODEL_REGISTRY = {
-    "test_app.inventory": {"parent_field_name": "organization"},
-    "test_app.credential": {},
-    "test_app.immutabletask": {"parent_field_name": None},
-}
-ANSIBLE_BASE_OAUTH2_PROVIDER_PERMISSIONS_CHECK_IGNORED_VIEWS = ["drf_spectacular.views.SpectacularSwaggerView"]
-ALLOW_SHARED_RESOURCE_CUSTOM_ROLES = True  # Allow making custom roles with org change permission, for example
-ALLOW_LOCAL_ASSIGNING_JWT_ROLES = False
-
-ANSIBLE_BASE_USER_VIEWSET = 'test_app.views.UserViewSet'
-
-LOGIN_URL = "/login/login"
-
-RESOURCE_SERVER = {
-    "URL": "http://localhost",
-    "SECRET_KEY": "my secret key",
-    "VALIDATE_HTTPS": False,
-}
-RESOURCE_SERVICE_PATH = "/api/v1/service-index/"
-# Backwards sync turned off, because for most of the duration of the tests
-# the resource server will not actually be running
-# so it will be flipped true only for specific tests that test this
-RESOURCE_SERVER_SYNC_ENABLED = False
-
-RENAMED_USERNAME_PREFIX = "dab:"
-
-FLAGS = {
-    "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
-        {
-            "condition": "boolean",
-            "value": False,
-            "required": True,
-        },
-        {
-            "condition": "before date",
-            "value": '2022-06-01T12:00Z',
-        },
-    ],
-    "FEATURE_SOME_PLATFORM_FLAG_FOO_ENABLED": [
-        {
-            "condition": "boolean",
-            "value": False,
-        },
-    ],
-    "FEATURE_SOME_PLATFORM_FLAG_BAR_ENABLED": [
-        {
-            "condition": "boolean",
-            "value": True,
-        },
-    ],
-}
+# Update django.conf.settings with DYNACONF keys.
+export(__name__, DYNACONF)

--- a/test_app/sqlite3settings.py
+++ b/test_app/sqlite3settings.py
@@ -1,8 +1,11 @@
-from test_app.settings import *  # noqa
+"""
+This is kept for backwards compatibility with deployments settings
+DJANGO_SETTINGS_MODULE to test_app.sqlite3settings
+"""
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "db.sqlite3",
-    }
-}
+from ansible_base.lib.dynamic_config import export
+
+from .settings import DYNACONF
+
+DYNACONF.load_file("sqlite_defaults.py")
+export(__name__, DYNACONF)

--- a/test_app/sqlite_defaults.py
+++ b/test_app/sqlite_defaults.py
@@ -1,0 +1,29 @@
+"""
+Variables defined in this file will override the settings from defaults.py
+to merge back to existing settings, use the following dynaconf pattern:
+
+# Dunder merging
+EXISTING_STRUCTURE__NESTED_KEY = value
+EXISTING_STRUCTURE__NESTED_KEY__NESTED_KEY = value
+
+# Merge Marker as @token
+EXISTING_STRUCTURE = "@merge key=value"
+EXISTING_STRUCTURE = '@merge {"key": "value"}'
+EXISTING_LIST = "@merge item1, item2, item3"
+EXISTING_LIST = "@merge_unique item1"
+EXISTING_LIST = "@insert 0 item"
+
+# Merge marker as item
+EXISTING_STRUCTURE = {
+  "key": "value",
+  "dynaconf_merge": True
+}
+EXISTING_LIST = ["item1", "dynaconf_merge"]
+"""
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "db.sqlite3",
+    }
+}

--- a/test_app/tests/lib/dynamic_config/test_dynaconf_settings.py
+++ b/test_app/tests/lib/dynamic_config/test_dynaconf_settings.py
@@ -1,0 +1,267 @@
+from dynaconf import ValidationError, Validator
+
+from ansible_base.lib.dynamic_config import (
+    export,
+    factory,
+    load_envvars,
+    load_python_file_with_injected_context,
+    load_standard_settings_files,
+    toggle_feature_flags,
+    validate,
+)
+
+
+def test_swagger_disabled():
+    settings = factory("", "TEST", INSTALLED_APPS=[])
+    assert 'drf_spectacular' not in settings['INSTALLED_APPS']
+
+
+def test_swagger_enabled():
+    settings = factory("", "TEST", INSTALLED_APPS=['ansible_base.api_documentation'])
+    assert 'drf_spectacular' in settings['INSTALLED_APPS']
+    assert "DEFAULT_SCHEMA_CLASS" in settings['REST_FRAMEWORK']
+
+    assert "TITLE" in settings['SPECTACULAR_SETTINGS']
+    assert "DESCRIPTION" in settings['SPECTACULAR_SETTINGS']
+    assert "VERSION" in settings['SPECTACULAR_SETTINGS']
+    assert "SCHEMA_PATH_PREFIX" in settings['SPECTACULAR_SETTINGS']
+
+
+def test_authentication_with_backends():
+    settings = factory(
+        "",
+        "TEST",
+        AUTHENTICATION_BACKENDS=['something'],
+        INSTALLED_APPS=['ansible_base.authentication'],
+    )
+    assert "social_django" in settings['INSTALLED_APPS']
+    assert 'ansible_base.authentication.backend.AnsibleBaseAuth' in settings['AUTHENTICATION_BACKENDS']
+    assert 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware' in settings['MIDDLEWARE']
+    assert 'ansible_base.authentication.session.SessionAuthentication' in settings['REST_FRAMEWORK']['DEFAULT_AUTHENTICATION_CLASSES']
+    assert 'ansible_base.authentication.authenticator_plugins' in settings['ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES']
+    assert 'SOCIAL_AUTH_LOGIN_REDIRECT_URL' in settings
+    assert "SOCIAL_AUTH_PIPELINE" in settings
+    assert "SOCIAL_AUTH_STORAGE" in settings
+    assert "SOCIAL_AUTH_STRATEGY" in settings
+    assert "SOCIAL_AUTH_LOGIN_REDIRECT_URL" in settings
+
+
+def test_authentication_no_backends():
+    settings = factory("", "TEST", INSTALLED_APPS=['ansible_base.authentication'])
+    assert 'ansible_base.authentication.backend.AnsibleBaseAuth' in settings['AUTHENTICATION_BACKENDS']
+
+
+def test_append_middleware():
+    settings = factory("", "TEST", INSTALLED_APPS=['ansible_base.authentication'], REST_FRAMEWORK={}, MIDDLEWARE=['something'])
+    assert 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware' == settings['MIDDLEWARE'][-1]
+
+
+def test_insert_middleware():
+    settings = factory(
+        "", "TEST", INSTALLED_APPS=['ansible_base.authentication'], MIDDLEWARE=['something', 'django.contrib.auth.middleware.AuthenticationMiddleware', 'else']
+    )
+    assert 'ansible_base.authentication.middleware.AuthenticatorBackendMiddleware' == settings['MIDDLEWARE'][2]
+
+
+def test_dont_update_class_prefixes():
+    settings = factory("", "TEST", INSTALLED_APPS=['ansible_base.authentication'], ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES=['other.things'])
+    assert 'ansible_base.authentication.authenticator_plugins' not in settings['ANSIBLE_BASE_AUTHENTICATOR_CLASS_PREFIXES']
+
+
+def test_filtering():
+    settings = factory("", "TEST", INSTALLED_APPS=['ansible_base.rest_filters'], REST_FRAMEWORK={'something': 'else'})
+    assert 'ansible_base.rest_filters.rest_framework.type_filter_backend.TypeFilterBackend' in settings['REST_FRAMEWORK']['DEFAULT_FILTER_BACKENDS']
+    assert 'something' in settings['REST_FRAMEWORK']
+
+
+def test_rbac_required_settings():
+    settings = factory("", "TEST", INSTALLED_APPS=['ansible_base.rbac'])
+    rbac_expected_settings = [
+        'ANSIBLE_BASE_MANAGED_ROLE_REGISTRY',
+        'ANSIBLE_BASE_CREATOR_DEFAULTS',
+        'ANSIBLE_BASE_CHECK_RELATED_PERMISSIONS',
+        'ANSIBLE_BASE_ROLE_CREATOR_NAME',
+        'ANSIBLE_BASE_ROLES_REQUIRE_VIEW',
+        'ANSIBLE_BASE_DELETE_REQUIRE_CHANGE',
+        'ANSIBLE_BASE_ALLOW_TEAM_PARENTS',
+        'ANSIBLE_BASE_ALLOW_TEAM_ORG_PERMS',
+        'ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER',
+        'ANSIBLE_BASE_ALLOW_TEAM_ORG_ADMIN',
+        'ANSIBLE_BASE_ALLOW_CUSTOM_ROLES',
+        'ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES',
+        'ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES',
+        'ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES',
+        'ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API',
+        'ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS',
+        'ANSIBLE_BASE_BYPASS_SUPERUSER_FLAGS',
+        'ANSIBLE_BASE_BYPASS_ACTION_FLAGS',
+        'ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS',
+        'ALLOW_LOCAL_RESOURCE_MANAGEMENT',
+        'ALLOW_LOCAL_ASSIGNING_JWT_ROLES',
+        'ALLOW_SHARED_RESOURCE_CUSTOM_ROLES',
+        'MANAGE_ORGANIZATION_AUTH',
+        'ANSIBLE_BASE_RBAC_MODEL_REGISTRY',
+        'ORG_ADMINS_CAN_SEE_ALL_USERS',
+    ]
+    assert set(rbac_expected_settings) == set(settings.keys() & rbac_expected_settings)
+
+
+def test_resource_registry_required_settings():
+    settings = factory("", "TEST", INSTALLED_APPS=['ansible_base.resource_registry'])
+    resource_registry_expected_settings = [
+        'RESOURCE_SERVER_SYNC_ENABLED',
+        'RESOURCE_SERVICE_PATH',
+        'ENABLE_SERVICE_BACKED_SSO',
+    ]
+    assert set(resource_registry_expected_settings) == set(settings.keys() & resource_registry_expected_settings)
+
+
+def test_export():
+    """Assert export function sets variables back to module object"""
+    settings = factory("", "TEST")
+    settings.set("KEY", 123)
+
+    class FakeModule: ...  # noqa: E701
+
+    fake_module = FakeModule()
+    export(fake_module, settings)
+    assert fake_module.KEY == 123
+
+
+def test_load_envvars(monkeypatch):
+    monkeypatch.setenv("TEST_KEY", "123")
+    settings = factory("", "TEST")
+    load_envvars(settings)
+    assert settings.KEY == 123
+
+
+def test_load_standard_settings_files(tmpdir):
+    settings_file = tmpdir.join("settings.yaml")  # /etc/ansible-automation-platform/settings.yaml
+    settings_file.write("key: 123")
+    flags_file = tmpdir.join("flags.yaml")  # /etc/ansible-automation-platform/flags.yaml
+    flags_file.write("FEATURE_NAME_ENABLED: true")
+    secrets_file = tmpdir.join(".secrets.yaml")  # /etc/ansible-automation-platform/.secrets.yaml
+    secrets_file.write("SECRET_KEY: 'b4t4t4'")
+
+    settings = factory("", "TEST")
+    settings.set("ANSIBLE_STANDARD_SETTINGS_FILES", [str(settings_file), str(flags_file), str(secrets_file)])
+    load_standard_settings_files(settings)
+    assert settings.key == 123
+    assert settings.FEATURE_NAME_ENABLED is True
+    assert settings.SECRET_KEY == "b4t4t4"
+
+
+def test_validate():
+    settings = factory("", "TEST", validators=[Validator("KEY", required=True, is_type_of=int, gt=10, lt=99)])
+
+    # Ensure Raises ValidationError when key is not set
+    try:
+        validate(settings)
+    except ValidationError as e:
+        assert "KEY" in str(e)
+
+    # Ensure Raises ValidationError when key is not an int
+    settings.set("KEY", "potato")
+    try:
+        validate(settings)
+    except ValidationError as e:
+        assert "KEY" in str(e)
+
+    # Ensure Raises ValidationError when key is less than 10
+    settings.set("KEY", 9)
+    try:
+        validate(settings)
+    except ValidationError as e:
+        assert "KEY" in str(e)
+
+    # Ensure Raises ValidationError when key is greater than 99
+    settings.set("KEY", 100)
+    try:
+        validate(settings)
+    except ValidationError as e:
+        assert "KEY" in str(e)
+
+    # Ensure key is set to 50 and no exception is raised
+    settings.set("KEY", 50)
+    validate(settings)
+    assert settings.KEY == 50
+
+
+def test_bypass_validation(monkeypatch):
+    monkeypatch.setenv("BYPASS_DYNACONF_VALIDATION", "True")
+    settings = factory("", "TEST", validators=[Validator("KEY", required=True, is_type_of=int, gt=10, lt=99)])
+
+    # Ensure Raises ValidationError when key is not set is not raised
+    validate(settings)
+
+    # Ensure key is set to 9 and no exception is raised
+    settings.set("KEY", 9)
+    validate(settings)
+    assert settings.KEY == 9
+
+    # Ensure key is set to 100 and no exception is raised
+    settings.set("KEY", 100)
+    validate(settings)
+    assert settings.KEY == 100
+
+    # ENsure key is set to string and no exception is raised
+    settings.set("KEY", "potato")
+    validate(settings)
+    assert settings.KEY == "potato"
+
+
+def test_validates_before_export():
+    """Assert export function validates before setting variables back to module object"""
+    settings = factory("", "TEST", validators=[Validator("KEY", required=True, is_type_of=int, gt=10, lt=99)])
+    settings.set("KEY", 123)
+
+    class FakeModule: ...  # noqa: E701
+
+    fake_module = FakeModule()
+    try:
+        export(fake_module, settings)
+    except ValidationError as e:
+        assert "KEY" in str(e)
+
+    assert not hasattr(fake_module, "KEY")
+
+
+def test_load_python_file_with_injected_scope(tmp_path):
+
+    defaults = tmp_path / "defaults.py"
+    defaults.write_text("COLORS = ['red']")
+
+    extra_file = tmp_path / "test.py"
+    extra_python = (
+        "COLORS.append('green')",
+        "from dynaconf import post_hook",
+        "@post_hook",
+        "def post_hook(settings):",
+        "    return {'COLORS': '@merge blue'}",
+    )
+    extra_file.write_text("\n".join(extra_python))
+
+    settings = factory("", "TEST", settings_files=[str(defaults)])
+    load_python_file_with_injected_context(str(extra_file), settings=settings)
+    assert settings.COLORS == ['red', 'green', 'blue']
+    assert settings._loaded_files == [str(defaults), str(extra_file)]
+
+
+def test_toggle_feature_flags():
+    """Ensure that the toggle_feature_flags function works as expected."""
+
+    settings = {
+        "FLAGS": {
+            "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
+                {"condition": "boolean", "value": False, "required": True},
+                {"condition": "before date", "value": "2022-06-01T12:00Z"},
+            ]
+        },
+        "FEATURE_SOME_PLATFORM_FLAG_ENABLED": True,
+    }
+    assert toggle_feature_flags(settings) == {
+        "FLAGS__FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
+            {"condition": "boolean", "value": True, "required": True},
+            {"condition": "before date", "value": "2022-06-01T12:00Z"},
+        ]
+    }


### PR DESCRIPTION
# [AAP-37669] Implement Dynaconf Settings Factory and Helper functions

READ the docs here: https://github.com/rochacbruno/django-ansible-base/blob/dynaconf_settings/docs/lib/dynamic_config.md 

## Description
- What is being changed?

Adding a factory function to generate a Dynaconf object and some helper functions.

- Why is this change needed?

Standardize settings

- Reviewing tip

The implementation is on 3 files only

```bash
ansible_base/lib/dynamic_config/
    /__init__.py
    /dynamic_settings.py
    /settings_logic.py
```

The other 15 files are docs, requirements, tests and dev env

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test update
- [x] Refactoring (no functional changes)
- [x] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Note

This **doesn't** introduce breaking changes


---

## Usage

`myapp/settings.py`:
```python
from dynaconf import Validator
from ansible_base.lib.dynamic_config import (
    factory, export, load_envvars, load_standard_settings_files, validate
)

DYNACONF = factory(
    __name__,
    "MYAPP",
    # Options passed directly to dynaconf
    environments=("development", "production", "testing"),
    settings_files=["defaults.py"],
    validators=[
      Validator("KEY", required=True),
      Validator("NUMBER", is_type_of=int, gte=0, lte=100),
      Validator("LIST", len_min=1, when=Validator("OTHER", eq="value")),
      Validator("DICT", condition=lambda x: x.get("key") == "value"),
    ]
)

load_standard_settings_files(DYNACONF)  # /etc/ansible-automation-platform/*.yaml
load_envvars(DYNACONF)  # load envvars prefixed with MYAPP_
export(__name__, DYNACONF)  # export back to django.conf.settings

```

`myapp/defaults.py`:
```python
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.sqlite3",
        "NAME": "db.sqlite3",
    }
}
DEBUG = False
ANYTHING = "value"
...
```

`myapp/development_defaults.py`:
```python
DEBUG = True
# Dynaconf merging strategies can be used
DATABASES__default__NAME = "devdb.sqlite3"
```


`myapp/production_defaults.py`:
```python
DEBUG = False
DATABASES__default__NAME = "proddb.sqlite3"
```

`/etc/ansible-automation-platform/myapp/settings.yaml`:
```yaml
KEY: value
NUMBER: 42
LIST:
    - 1
    - 2
    - 3
DICT:
    key: value

# Merging also available
DATABASES__default__NAME: prod_db
INSTALLED_APPS: "@merge_unique new_app_to_add"
```

`/etc/ansible-automation-platform/myapp/flags.yaml`:
```yaml
FEATURE_FOO_ENABLED: true
FEATURE_BAR_ENABLED: false
```

`/etc/ansible-automation-platform/myapp/.secrets.yaml`:
```yaml
SECRET_KEY: "@vault secret/myapp/secret_key"  # this will be fetched from vault if vault loader is set
PASSWORD: "@op namespace/key"  # this will be fetched from 1password if op loader is set
TOKEN: "R4ND0M_T0K3N"  # Just a string
```

Environment variables:
```bash
export MYAPP_KEY=value
export MYAPP_KEY__SUBKEY=value
export MYAPP_DATABASES__default__NAME=mydb
```

Runtime:
```python
from django.conf import settings

# Regular Django Settings
print(settings.DEBUG)

# Acessing dynaconf object for inspection
print(settings.DYNACONF.KEY)
```

## Dynaconf CLI

Dynaconf also provides a CLI to inspect settings:

To use the CLI it is required to set DJANGO_SETTINGS_MODULE variable.

```bash
export DJANGO_SETTINGS_MODULE=myapp.settings
```

> Optionally, if the variable is not set, `-i path` can be passed to the CLI, e.g: `dynaconf -i myapp.settings.DYNACONF command`


```bash

# List Human Friendly
$ dynaconf list
$ dynaconf list -k KEY
$ dynaconf list -k DATABASES --json
$ dynaconf list -k DATABASES__default__NAME


# Inspect Settings Loading History
$ dynaconf inspect
$ dynaconf inspect -k KEY
$ dynaconf inspect -k DATABASES__default__NAME


# Get raw value as string on stdout
$ dynaconf get KEY
```

Read more on [dynaconf] documentation.


[dynaconf]: https://dynaconf.com

## Diagram

### Flowchart

```mermaid
graph TD;
    A[from django.conf import settings] --> B[Django loads DJANGO_SETTINGS_MODULE e.g: app.settings];
    B --> C[app.settings creates a DYNACONF object];
    C --> C1[DYNACONF object sets naming standards and common options <br> e.g: envvar_prefix=APPNAME, settings_files=defaults.py];
    C1 --> C2[DYNACONF object loads settings from defaults.py];
    C2 -->|APPNAME_MODE=production| C3[DYNACONF loads settings from production_defaults.py];
    C2 -->|APPNAME_MODE=development| C4[DYNACONF loads settings from development_defaults.py];
    C4 --> C5[DYNACONF loads DAB required defaults];
    C3 --> C5
    C5 --> D["DYNACONF object can be instrumented e.g <br> (load_file, set, update, setdefault, get)"];
    D --> E["**load_standard_settings_files** <br> is called to load platform standard file locations"];
    E --> E1["_/etc/ansible-automation-platform/appname_ <br> /settings.yaml <br> /flags.yaml <br> /.secrets.yaml "]
    E1 --> F
    E --> F["At this point variables can be manually overriden <br> e.g DYNACONF.set(key, value)"];
    F --> G["**load_envvars** is called to load prefixed environment variables <br> e.g: _APPNAME_DATABASES__default__name=db_"];
    G --> H["**export** is called to populate values from **DYNACONF** to **django.conf.settings**"];
    H --> I[DYNACONF validators can be registered and called];
    I --> J["django.conf.settings is ready"]
```

### Sequence Diagram

```mermaid
sequenceDiagram
    participant DjangoApp
    participant Django
    participant app_settings as app.settings
    participant Dynaconf

    DjangoApp->>Django: Import django.conf.settings
    Django->>app_settings: Load module (DJANGO_SETTINGS_MODULE)
    app_settings->>Dynaconf: Create DYNACONF object
    Note over Dynaconf: a. Set naming standards<br/>b. Load defaults.py<br/>c. Load env-specific defaults (e.g., production_defaults.py)<br/>d. Load dab dynamic_config
    Note over Dynaconf, app_settings: Instrumentation (e.g., load_file, set, update, setdefault, get)
    app_settings->>Dynaconf: load_standard_settings_files(/etc/ansible-automation-platform/*.yaml)
    app_settings->>Dynaconf: Apply manual overrides
    app_settings->>Dynaconf: load_envvars (prefixed)
    app_settings->>Django: Export to django.conf.settings
    app_settings->>Dynaconf: Register and call validators
```
