### PR TITLE
Fix the docker-compose serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ tools/generated/*
 
 # generated ssl certs
 compose/ingress/certs/*
+
+# static files
+test_app/static_collected/

--- a/test_app/defaults.py
+++ b/test_app/defaults.py
@@ -148,7 +148,14 @@ DEMO_DATA_COUNTS = {'organization': 150, 'user': 379, 'team': 43}
 ANSIBLE_BASE_TEAM_MODEL = 'test_app.Team'
 ANSIBLE_BASE_ORGANIZATION_MODEL = 'test_app.Organization'
 
+STATIC_ROOT = os.path.join(BASE_DIR, 'test_app', 'static_collected')
 STATIC_URL = '/static/'
+
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static'),
+]
+
+CSRF_TRUSTED_ORIGINS = ['http://localhost', 'https://localhost']
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/test_app/scripts/container_startup_uwsgi.sh
+++ b/test_app/scripts/container_startup_uwsgi.sh
@@ -19,6 +19,7 @@ echo "Read the custom settings file data just as a test"
 $DYNACONF -i test_app.settings.DYNACONF inspect -k JUST_A_TEST
 
 $PYTHON manage.py migrate
+$PYTHON manage.py collectstatic --clear --noinput
 DJANGO_SUPERUSER_PASSWORD=password DJANGO_SUPERUSER_USERNAME=admin DJANGO_SUPERUSER_EMAIL=admin@stuff.invalid $PYTHON manage.py createsuperuser --noinput || true
 $PYTHON manage.py authenticators --initialize
 $PYTHON manage.py create_demo_data

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path
 
@@ -22,4 +24,4 @@ urlpatterns = [
     path('api/v1/timeout_view/', views.timeout_view, name='test-timeout-view'),
     path('login/', include('rest_framework.urls')),
     path("__debug__/", include("debug_toolbar.urls")),
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/test_app/uwsgi.ini
+++ b/test_app/uwsgi.ini
@@ -7,7 +7,7 @@ chmod-socket = 660
 vacuum = true
 
 # Log to stdout
-logto = /dev/stdout
+# logto = /dev/stdout
 log-master = true
 #disable-logging = true
 

--- a/tools/dev_postgres/Dockerfile
+++ b/tools/dev_postgres/Dockerfile
@@ -6,4 +6,4 @@ ENV POSTGRES_PASSWORD=dabing
 
 EXPOSE 5432
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["pg_isready", "-U", "$${POSTGRES_USER}", "-d", "$${POSTGRES_DB}"]
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["pg_isready", "-U", "dab", "-d", "dab_db"]


### PR DESCRIPTION
This fixes a grab bag of problems for me, but still doesn't get it to usability. The static files makes this render.

![Screenshot from 2025-02-05 15-04-56](https://github.com/user-attachments/assets/7007d6f0-3f75-40a8-9013-74569b5b9948)

And then the other changes address the errors in logs

```
dab_postgres  | 2025-02-05 18:39:53.062 UTC [58] FATAL:  role "$${POSTGRES_USER}" does not exist
```

and

```
test_app-1    | uwsgi_check_logrotate()/lseek(): Illegal seek [core/logging.c line 494]
```

This is addressed by the uwsgi config file change, and to the startup script.

I think this is some progress, but unfortunately, I'm still blocked on using the docker-compose environment as I get a CSRF error when trying to log in.