### PR TITLE
AAP-40006 Empty docker directive on linting testenvs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,11 +118,13 @@ legacy_tox_ini = """
     deps =
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
+    docker = db
     commands =
         python3 manage.py check
         python3 manage.py makemigrations --check
 
     [testenv:py311sqlite]
+    docker = db
     setenv =
         DJANGO_SETTINGS_MODULE = test_app.sqlite3settings
 
@@ -135,17 +137,20 @@ legacy_tox_ini = """
     deps =
         flake8==7.1.1
         Flake8-pyproject==1.2.3
+    docker =
     commands = flake8 {posargs:.}
 
     [testenv:black]
     deps =
         black==25.1.0
     allowlist_externals = sh
+    docker =
     commands = sh -c 'black --version && black {posargs:.}'
 
     [testenv:isort]
     deps =
         isort==6.0.0
+    docker =
     commands = isort {posargs:.}
 """
 


### PR DESCRIPTION
linting testenvs do not need the database container

# [AAP-40006] Do not create DB container on linting tox testenvs

## Description
- What is being changed? overriding default `docker` directive on linting targets with an empty one
- Why is this change needed? Speed up lint targets
- How does this change address the issue? Not creating and starting a database to run black, flake8, or isort testenvs, which do not use the database container

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [X] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
Fresh venv, if your working environment is old

### Steps to Test
1. run `tox -m lint`

### Expected Results
docker should not run as a result of this command

