### PR TITLE
A whole bucket of fixes to resource sync

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -137,7 +137,7 @@ class JWTCommonAuth:
 
                     resource.ansible_id = self.token['sub']
                     resource.service_id = self.token['service_id']
-                    resource.save()
+                    resource.save(update_fields=['ansible_id', 'service_id'])
 
         setattr(self.user, "resource_api_actions", self.token.get("resource_api_actions", None))
 
@@ -171,7 +171,6 @@ class JWTCommonAuth:
         if user_needs_save:
             with no_reverse_sync():
                 logger.info(f"Saving user {self.user.username}")
-
                 self.user.save()
 
     def validate_token(self, unencrypted_token, decryption_key):

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -102,6 +102,7 @@ class JWTCommonAuth:
             self.token = self.validate_token(token_from_header, cert_object.key)
 
         # Let's see if we have the same user info in the cache already
+        # Note: we're not using the "_, user_defaults=" trick here because _ is used for our translation function.
         user_defaults = self.cache.check_user_in_cache(self.token)[1]
 
         self.user = None

--- a/ansible_base/resource_registry/management/commands/resource_sync.py
+++ b/ansible_base/resource_registry/management/commands/resource_sync.py
@@ -19,7 +19,6 @@ Optional parameters::
 
     `--retries number` to retry failed syncs
     `--retrysleep seconds` to set interval between retries
-    `--retain_seconds` to set how much seconds to retain deleted resources
     `--asyncio` Flag to enable asyncio executor
 """
 
@@ -60,13 +59,6 @@ class Command(BaseCommand):  # pragma: no cover
             type=int,
             default=30,
             help="Interval between retries",
-            required=False,
-        )
-        parser.add_argument(
-            "--retain_seconds",
-            type=int,
-            default=120,
-            help="Seconds to retain orphan resources from deletion.",
             required=False,
         )
         parser.add_argument("--asyncio", action="store_true", default=False, help="Enable asyncio executor")

--- a/ansible_base/resource_registry/management/commands/resource_sync.py
+++ b/ansible_base/resource_registry/management/commands/resource_sync.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):  # pragma: no cover
 
     def handle(self, *args, **options):
         """Handle RESOURCE_PROVIDER sync"""
-        arguments = ["resource_type_names", "retries", "retrysleep", "retain_seconds", "asyncio"]
+        arguments = ["resource_type_names", "retries", "retrysleep", "asyncio"]
         options = {k: v for k, v in options.items() if k in arguments}
         try:
             executor = SyncExecutor(**options, stdout=self.stdout)

--- a/ansible_base/resource_registry/models/resource.py
+++ b/ansible_base/resource_registry/models/resource.py
@@ -111,7 +111,12 @@ class Resource(models.Model):
 
     @classmethod
     def create_resource(
-        cls, resource_type: ResourceType, resource_data: dict, ansible_id: Union[str, uuid.UUID, None] = None, service_id: Union[str, uuid.UUID, None] = None
+        cls,
+        resource_type: ResourceType,
+        resource_data: dict,
+        ansible_id: Union[str, uuid.UUID, None] = None,
+        service_id: Union[str, uuid.UUID, None] = None,
+        is_partially_migrated=False,
     ):
         from ..signals.handlers import no_reverse_sync
 
@@ -127,6 +132,7 @@ class Resource(models.Model):
             with no_reverse_sync():
                 content_object.save(resource_data, is_new=True)
             resource = cls.objects.get(object_id=content_object.instance.pk, content_type=c_type)
+            resource.is_partially_migrated = is_partially_migrated
 
             if ansible_id:
                 resource.ansible_id = ansible_id

--- a/ansible_base/resource_registry/rest_client.py
+++ b/ansible_base/resource_registry/rest_client.py
@@ -157,5 +157,5 @@ class ResourceAPIClient:
     def list_resource_types(self, filters: Optional[dict] = None):
         return self._make_request("get", "resource-types/", params=filters)
 
-    def get_resource_type_manifest(self, name):
-        return self._make_request("get", f"resource-types/{name}/manifest/", stream=True)
+    def get_resource_type_manifest(self, name, filters: Optional[dict] = None):
+        return self._make_request("get", f"resource-types/{name}/manifest/", params=filters, stream=True)

--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -84,7 +84,11 @@ class ResourceListSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({"resource_type": _(f"Resource type: {resource_type.name} cannot be managed by Resources.")})
 
             return Resource.create_resource(
-                resource_type, validated_data["resource_data"], ansible_id=validated_data.get("ansible_id"), service_id=validated_data.get("service_id")
+                resource_type,
+                validated_data["resource_data"],
+                ansible_id=validated_data.get("ansible_id"),
+                service_id=validated_data.get("service_id"),
+                is_partially_migrated=validated_data.get("is_partially_migrated", False),
             )
 
         except ResourceType.DoesNotExist:

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -92,7 +92,7 @@ def fetch_manifest(
     resp_metadata = api_client.get_service_metadata()
     resp_metadata.raise_for_status()
 
-    manifest_stream = api_client.get_resource_type_manifest(resource_type_name, filters={"service_id": str(service_id())})
+    manifest_stream = api_client.get_resource_type_manifest(resource_type_name, filters={"service_id": service_id()})
     if manifest_stream.status_code == 404:
         msg = f"manifest for {resource_type_name} NOT FOUND."
         raise ManifestNotFound(msg)
@@ -335,9 +335,6 @@ class SyncExecutor:
         if self.deleted_count:
             self.write(f"Deleting {self.deleted_count} orphaned resources")
             for orphan in resources_to_cleanup:
-                # Skip items that owned by this service, but are partially migrated
-                # if orphan.service_id == service_id() and orphan.is_partially_migrated is True:
-                #     continue
                 try:
                     _sc = orphan.content_type.resource_type.serializer_class
                     data = _sc(orphan.content_object).data

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -161,7 +161,7 @@ def _attempt_update_resource(
         return SyncResult(SyncStatus.CONFLICT, manifest_item)
     except Error as e:
         logger.error(f"Failed to update resource {resource.ansible_id}. Received error: {e}")
-        return SyncResult(SyncStatus.ERROR, ManifestItem)
+        return SyncResult(SyncStatus.ERROR, manifest_item)
     else:
         return SyncResult(SyncStatus.UPDATED, manifest_item)
 
@@ -298,7 +298,7 @@ class SyncExecutor:
             f"Conflict {conflicted_count} | "
             f"Unavailable {len(self.unavailable)} | "
             f"Skipped {skipped_count} | "
-            f"Deleted {self.deleted_count}"
+            f"Deleted {self.deleted_count} | "
             f"Errors {error_count}"
         )
 

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -109,9 +109,7 @@ def get_orphan_resources(
     """QuerySet with orphaned managed resources to be deleted."""
     return Resource.objects.filter(
         content_type__resource_type__name=resource_type_name,
-    ).exclude(
-        ansible_id__in=[item.ansible_id for item in manifest_list]
-    )
+    ).exclude(ansible_id__in=[item.ansible_id for item in manifest_list])
 
 
 def delete_resource(resource: Resource):
@@ -317,7 +315,7 @@ class SyncExecutor:
             self.write(f"Deleting {self.deleted_count} orphaned resources")
             for orphan in resources_to_cleanup:
                 # Skip items that owned by this service, but are partially migrated
-                if orphan.service_id == service_id() and orphan.is_partially_migrated == True:
+                if orphan.service_id == service_id() and orphan.is_partially_migrated is True:
                     # TODO: how do I log skip?
                     continue
                 try:

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from django.conf import settings
 from django.http import HttpResponseNotFound
 from django.shortcuts import get_object_or_404
+from django.db.models import Q
 from rest_framework import permissions
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
@@ -136,13 +137,14 @@ class ResourceTypeViewSet(
 
         if 'service_id' in request.query_params:
             if request.query_params['service_id'] == 'all':
-                service_filter = {}
+                service_filter = Q()
             else:
-                service_filter = {'service_id': request.query_params['service_id']}
+                # Return this services resources plus the resources from the service requested
+                service_filter = Q(service_id=service_id()) | Q(service_id=request.query_params['service_id'])
         else:
-            service_filter = {'service_id': service_id()}
+            service_filter = Q(service_id=service_id())
 
-        resources = Resource.objects.filter(content_type__resource_type=resource_type, **service_filter).prefetch_related("content_object")
+        resources = Resource.objects.filter(content_type__resource_type=resource_type).filter(service_filter).prefetch_related("content_object")
 
         if name == "shared.user" and (system_user := getattr(settings, "SYSTEM_USERNAME", None)):
             resources = resources.exclude(name=system_user)

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -2,9 +2,9 @@ import logging
 from collections import OrderedDict
 
 from django.conf import settings
+from django.db.models import Q
 from django.http import HttpResponseNotFound
 from django.shortcuts import get_object_or_404
-from django.db.models import Q
 from rest_framework import permissions
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -61,7 +61,7 @@ class TestJWTCommonAuth:
             assert "X-DAB-JW-TOKEN header not set for JWT authentication" in caplog.text
 
     @pytest.mark.django_db
-    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'test_app'])
+    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'test_app', 'ansible_base.resource_registry'])
     def test_parse_jwt_happy_path(self, mocked_http, test_encryption_public_key, shut_up_logging, jwt_token):
         with override_settings(ANSIBLE_BASE_JWT_KEY=test_encryption_public_key):
             my_auth = JWTCommonAuth()


### PR DESCRIPTION
# 40296 Fixes for the sync task

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

This PR includes fixes for the following:
- https://issues.redhat.com/browse/AAP-39958
- https://issues.redhat.com/browse/AAP-40123
- https://issues.redhat.com/browse/AAP-40446
- https://issues.redhat.com/browse/AAP-40298

To summarize those tickets these changes are:
- Removing the check on the user.created field because Hub doesn't have it (AAP_40123)
- Fixing the delete function to use `Resource.delete_resource()` so that we don't accidentally trigger reverse sync
- Updating service owned resources (ie resources where the service ID is set to one of hub, controller or eda) so that they are kept in sync with the Gateway (AAP-40298)
  - The majority of the fixes are related to this. One big one is that the `service_id` query param now returns the resources owned by the service represented by `service_id` and the resource server.
- Fixing the user not getting loaded from their ansible_id on initial login (AAP-40446)
- Adding better error handling so that if a username conflicts during login, we log the user in with their old username.
  - The user's username should be fixed next time sync runs.
- Adding better error handling so that the sync task can continue if individual resources fail

Should these all be separate PRs? Probably. In my defense, they are all small fixes, and I need them to all be in place in order to adequately test this.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

Use the new tests in ATF.