### PR TITLE
AAP-39202 Fix update for SAML keys

### DIFF
--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -28,6 +28,7 @@ jobs:
           FROM ghcr.io/ansible/awx_devel:devel
           COPY . /opt/dab/
           RUN pip install -e /opt/dab/
+          RUN pip install jq
           EOF
           docker build -t awx-with-dab:latest -f awx-dockerfile/Dockerfile .
 

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -162,10 +162,10 @@ class SAMLConfiguration(BaseAuthenticatorConfiguration):
     def validate(self, attrs):
         # attrs is only the data in the configuration field
         errors = {}
-        # pull the cert_info out of the existing object (if we have one)
+        # pull the cert_info out of provided attrs or the existing object (if we have one)
         cert_info = {
             "SP_PRIVATE_KEY": getattr(self.instance, 'configuration', {}).get('SP_PRIVATE_KEY', None),
-            "SP_PUBLIC_CERT": getattr(self.instance, 'configuration', {}).get('SP_PUBLIC_CERT', attrs.get('SP_PUBLIC_CERT', None)),
+            "SP_PUBLIC_CERT": attrs.get('SP_PUBLIC_CERT', getattr(self.instance, 'configuration', {}).get('SP_PUBLIC_CERT', None)),
         }
 
         # Now get the SP_PRIVATE_KEY out of the passed in attrs (if there is any)

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -162,11 +162,16 @@ class SAMLConfiguration(BaseAuthenticatorConfiguration):
     def validate(self, attrs):
         # attrs is only the data in the configuration field
         errors = {}
-        # pull the cert_info out of provided attrs or the existing object (if we have one)
+        # pull the cert_info out of the existing object (if we have one)
         cert_info = {
             "SP_PRIVATE_KEY": getattr(self.instance, 'configuration', {}).get('SP_PRIVATE_KEY', None),
-            "SP_PUBLIC_CERT": attrs.get('SP_PUBLIC_CERT', getattr(self.instance, 'configuration', {}).get('SP_PUBLIC_CERT', None)),
+            "SP_PUBLIC_CERT": getattr(self.instance, 'configuration', {}).get('SP_PUBLIC_CERT', None),
         }
+
+        # Get public cert if provided
+        public_cert = attrs.get('SP_PUBLIC_CERT', None)
+        if public_cert is not None:
+            cert_info['SP_PUBLIC_CERT'] = public_cert
 
         # Now get the SP_PRIVATE_KEY out of the passed in attrs (if there is any)
         private_key = attrs.get('SP_PRIVATE_KEY', None)


### PR DESCRIPTION
## Description
Fixes a bug that prevented the public cert from being updated for SAML authenticators.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Deploy gateway with keycloak/saml enabled 
2. Generate a new certificate/keypair
3. Update the SAML authenticator with the cert and private key
4. See that the update is accepted (was always blocked with error before)
5. If desired, configure the new key in keycloak and log in with an SSO user

### Expected Results
SAML authenticators can have their key/cert updated successfully

## Additional Context


### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

### Screenshots/Logs
