### PR TITLE
fix(dynamic_config): Warn on PermissionError instead of erroring.

### DIFF
--- a/ansible_base/lib/dynamic_config/dynaconf_helpers.py
+++ b/ansible_base/lib/dynamic_config/dynaconf_helpers.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 from typing import Any
+from warnings import warn
 
 from django.core.exceptions import ImproperlyConfigured
 from dynaconf import Dynaconf, Validator
@@ -195,8 +196,16 @@ def load_standard_settings_files(settings: Dynaconf):
         validate=False,
     )
     for path in settings.ANSIBLE_STANDARD_SETTINGS_FILES:
-        if not Path(path).exists():
+        found = False
+        try:
+            found = Path(path).exists()
+        except OSError as e:
+            # Checking on path may raise PermissionError or another OSError if the file is not accessible
+            warn(f"Could not check {path} because it is not accessible due to {e}")
+
+        if not found:
             continue
+
         data = loader.get_source_data([str(path)])
         loader._envless_load(data)
 


### PR DESCRIPTION
When the system has the standard path but fails with permission error, it should continue with warning instead of erroring.

Context: When building the container image for EDA it was raised PermissionError because the current images are mouting `/etc/ansible-automation-platform` without permission for the app user.

```bash
automation-eda-api[80307]:   File "/usr/lib/python3.11/site-packages/ansible_base/lib/dynamic_config/dynaconf_helpers.py", line 198, in load_standard_settings_files
automation-eda-api[80307]:     if not Path(path).exists():
automation-eda-api[80307]:            ^^^^^^^^^^^^^^^^^^^
automation-eda-api[80307]:   File "/usr/lib64/python3.11/pathlib.py", line 1235, in exists
automation-eda-api[80307]:     self.stat()
automation-eda-api[80307]:   File "/usr/lib64/python3.11/pathlib.py", line 1013, in stat
automation-eda-api[80307]:     return os.stat(self, follow_symlinks=follow_symlinks)
automation-eda-api[80307]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
automation-eda-api[80307]: PermissionError: [Errno 13] Permission denied: '/etc/ansible-automation-platform/eda/settings.yaml'
automation-eda-api[80307]: [2025-03-18 02:24:36 +0000] [8] [INFO] Worker exiting (pid: 8)
```