### PR TITLE
AAP-38380: Fix dynaconf handling of spectacular

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -80,7 +80,7 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
     oauth2_provider: dict = copy(settings.get("OAUTH2_PROVIDER", {}))
     templates: list = copy(settings.get("TEMPLATES", []))
     authentication_backends: list = copy(settings.get("AUTHENTICATION_BACKENDS", []))
-    spectacular_settings = settings.get('SPECTACULAR_SETTINGS', {})
+    spectacular_settings: dict = copy(settings.get('SPECTACULAR_SETTINGS', {}))
 
     # The org and team abstract models cause errors if not set, even if not used
     if settings.get('ANSIBLE_BASE_TEAM_MODEL') is None:


### PR DESCRIPTION
## Description

For some reason spectacular_settings was copied by ref unlike the rest of the dynamic defaulted settings, causing it to get skipped and not applied (regression in https://issues.redhat.com/browse/AAP-39124).  In these later lines, this caused a self comparison and skipping of the application of the DAB default settings:

lines 345-346 in settings_logic.py:
    if spectacular_settings != settings.get('SPECTACULAR_SETTINGS', {}):
        dab_data['SPECTACULAR_SETTINGS'] = spectacular_settings


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Without fix, check gw docs (api/gateway/v1/docs) and see that (for instance) user object has almost all params set to required
2. With fix, check the same and see that only username is required, which is correct.
3. 

