### PR TITLE
[AAP-41963] Fix SonarCloud security hotspots

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -1,0 +1,4 @@
+## `compose` Directory
+This directory contains the Dockerfile and configuration files for Nginx and Ingress services used in the `test_app`.
+At the moment, this code is only for testing and development purposes, and is not used in production.
+

--- a/compose/ingress/Dockerfile
+++ b/compose/ingress/Dockerfile
@@ -2,3 +2,17 @@ FROM mirror.gcr.io/library/nginx:latest
 
 COPY entrypoint.sh /entrypoint.sh
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Modify the default Nginx configuration to allow it to run as a non-root user
+# This follows Nginx Docker Hub instructions: https://hub.docker.com/_/nginx
+# By default, Nginx writes its PID file to /var/run/nginx.pid, which is a restricted location.
+# We change it to /tmp/nginx.pid so that it can be accessed by a non-root user.
+RUN sed -i 's|pid        /var/run/nginx.pid;|pid        /tmp/nginx.pid;|' /etc/nginx/nginx.conf && \
+    sed -i '/http {/a \
+    client_body_temp_path /tmp/client_temp;\n\
+    proxy_temp_path       /tmp/proxy_temp;\n\
+    fastcgi_temp_path     /tmp/fastcgi_temp;\n\
+    uwsgi_temp_path       /tmp/uwsgi_temp;\n\
+    scgi_temp_path        /tmp/scgi_temp;' /etc/nginx/nginx.conf
+
+USER nginx

--- a/compose/ingress/Dockerfile
+++ b/compose/ingress/Dockerfile
@@ -10,8 +10,8 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # This follows Nginx Docker Hub instructions: https://hub.docker.com/_/nginx
 # By default, Nginx writes its PID file to /var/run/nginx.pid, which is a restricted location.
 # We change it to /tmp/nginx.pid so that it can be accessed by a non-root user.
-RUN sed -i '/^user  nginx;/d' /etc/nginx/nginx.conf && \
-    sed -i 's|pid        /var/run/nginx.pid;|pid        /tmp/nginx.pid;|' /etc/nginx/nginx.conf && \
+RUN sed -i -E '/^user\s+nginx;/d' /etc/nginx/nginx.conf && \
+    sed -i -E 's|pid\s+/var/run/nginx.pid;|pid        /tmp/nginx.pid;|' /etc/nginx/nginx.conf && \
     sed -i '/http {/a \
     client_body_temp_path /tmp/client_temp;\n\
     proxy_temp_path       /tmp/proxy_temp;\n\

--- a/compose/ingress/Dockerfile
+++ b/compose/ingress/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to build the image for dab_ingress service
 
-FROM mirror.gcr.io/library/nginx:latest
+FROM mirror.gcr.io/library/nginx:1.27
 
 RUN mkdir -p /etc/nginx/ssl && chown -R nginx:nginx /etc/nginx/ssl
 COPY entrypoint.sh /entrypoint.sh

--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,9 +1,7 @@
-# Dockerfile to build the image for dab_ingress service
+# Dockerfile to build the image for dab_nginx service
 
 FROM mirror.gcr.io/library/nginx:latest
 
-RUN mkdir -p /etc/nginx/ssl && chown -R nginx:nginx /etc/nginx/ssl
-COPY entrypoint.sh /entrypoint.sh
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Modify the default Nginx configuration to allow it to run as a non-root user

--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to build the image for dab_nginx service
 
-FROM mirror.gcr.io/library/nginx:latest
+FROM mirror.gcr.io/library/nginx:1.27
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -8,8 +8,8 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # This follows Nginx Docker Hub instructions: https://hub.docker.com/_/nginx
 # By default, Nginx writes its PID file to /var/run/nginx.pid, which is a restricted location.
 # We change it to /tmp/nginx.pid so that it can be accessed by a non-root user.
-RUN sed -i '/^user  nginx;/d' /etc/nginx/nginx.conf && \
-    sed -i 's|pid        /var/run/nginx.pid;|pid        /tmp/nginx.pid;|' /etc/nginx/nginx.conf && \
+RUN sed -i -E '/^user\s+nginx;/d' /etc/nginx/nginx.conf && \
+    sed -i -E 's|pid\s+/var/run/nginx.pid;|pid        /tmp/nginx.pid;|' /etc/nginx/nginx.conf && \
     sed -i '/http {/a \
     client_body_temp_path /tmp/client_temp;\n\
     proxy_temp_path       /tmp/proxy_temp;\n\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   # This is the intermediate application reverse proxy without ssl
   nginx:
     build: ./compose/nginx
-    image: "dab_nginx:latest"
+    image: "dab_nginx:1.27"
     ports:
       - '80:80'
     depends_on:
@@ -46,7 +46,7 @@ services:
   # This is the ssl terminated "ingress" reverse proxy
   ingress:
     build: ./compose/ingress
-    image: "dab_ingress:latest"
+    image: "dab_ingress:1.27"
     command: './entrypoint.sh'
     ports:
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,8 @@ services:
 
   # This is the intermediate application reverse proxy without ssl
   nginx:
-    image: "nginx:latest"
-    volumes:
-      - './compose/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:z'
+    build: ./compose/nginx
+    image: "dab_nginx:latest"
     ports:
       - '80:80'
     depends_on:
@@ -47,9 +46,8 @@ services:
   # This is the ssl terminated "ingress" reverse proxy
   ingress:
     build: ./compose/ingress
+    image: "dab_ingress:latest"
     command: './entrypoint.sh'
-    volumes:
-      - './compose/ingress/certs:/etc/nginx/ssl:z'
     ports:
       - "443:443"
     depends_on:

--- a/tools/dev_postgres/Dockerfile
+++ b/tools/dev_postgres/Dockerfile
@@ -4,6 +4,9 @@ ENV POSTGRES_DB=dab_db
 ENV POSTGRES_USER=dab
 ENV POSTGRES_PASSWORD=dabing
 
+USER postgres
+
 EXPOSE 5432
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["pg_isready", "-U", "$${POSTGRES_USER}", "-d", "$${POSTGRES_DB}"]
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD sh -c 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+

--- a/tools/dev_postgres/Dockerfile
+++ b/tools/dev_postgres/Dockerfile
@@ -9,5 +9,3 @@ USER postgres
 EXPOSE 5432
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
-
-

--- a/tools/dev_postgres/Dockerfile
+++ b/tools/dev_postgres/Dockerfile
@@ -8,5 +8,6 @@ USER postgres
 
 EXPOSE 5432
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD sh -c 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
+
 


### PR DESCRIPTION
# [AAP-41963] Fix SonarCloud security hotspots

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Dockerfile to build image for dab postgres service and ingress service
- Why is this change needed?
Currently, the `postgres` and `ingress` containers are run as root, about which SonarCloud is complaining.
- How does this change address the issue?
1. in `tools/dev_postgres/Dockerfile`: add `USER` directive to run the container as `postgres` non-root user; fix `$${} ` error for environment variables expansion
2. in `compose/ingress/Dockerfile`: modify the `nginx.conf` file to add appropriate configurations for non-root nginx user (reference: https://hub.docker.com/_/nginx), and add `USER` directive
## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. remove existing `django-ansible-base-postgres`, `nginx` and `django-ansible-base-ingress` container images in your local
2. in `django-ansible-base` dir, run command `make docker compose build`, then run `make docker compose up`
3. check the logs of all containers and confirm that the services are running fine.

### Expected Results
<!-- Describe what should happen after following the steps -->
- All services in dab should run fine.
- `django-ansible-base-ingress-1` container is run as `nginx` user.
- `django-ansible-base-nginx-1` container is run as `nginx` user.
- `django-ansible-base-postgres` container is run as `postgres` user.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->