### PR TITLE
AAP-41636 Add configurable group claim and reading groups from backend

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/azuread.py
+++ b/ansible_base/authentication/authenticator_plugins/azuread.py
@@ -46,7 +46,6 @@ class AzureADConfiguration(BaseAuthenticatorConfiguration):
     )
 
 
-
 class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, AzureADOAuth2, AbstractAuthenticatorPlugin):
     configuration_class = AzureADConfiguration
     type = "azuread"
@@ -57,6 +56,6 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, Azur
     @property
     def groups_claim(self):
         return self.setting('GROUPS_CLAIM')
-    
+
     def get_user_groups(self, extra_groups=[]):
         return extra_groups

--- a/ansible_base/authentication/authenticator_plugins/azuread.py
+++ b/ansible_base/authentication/authenticator_plugins/azuread.py
@@ -40,7 +40,7 @@ class AzureADConfiguration(BaseAuthenticatorConfiguration):
     GROUPS_CLAIM = CharField(
         help_text=_("The JSON key used to extract the user's groups from the ID token or userinfo endpoint."),
         required=False,
-        allow_null=True,
+        allow_null=False,
         default="Group",
         ui_field_label=_("Groups Claim"),
     )

--- a/ansible_base/authentication/authenticator_plugins/azuread.py
+++ b/ansible_base/authentication/authenticator_plugins/azuread.py
@@ -37,6 +37,15 @@ class AzureADConfiguration(BaseAuthenticatorConfiguration):
         ui_field_label=_('OIDC Secret'),
     )
 
+    GROUPS_CLAIM = CharField(
+        help_text=_("The JSON key used to extract the user's groups from the ID token or userinfo endpoint."),
+        required=False,
+        allow_null=True,
+        default="Group",
+        ui_field_label=_("Groups Claim"),
+    )
+
+
 
 class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, AzureADOAuth2, AbstractAuthenticatorPlugin):
     configuration_class = AzureADConfiguration
@@ -44,3 +53,10 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, Azur
     logger = logger
     category = "sso"
     configuration_encrypted_fields = ['SECRET']
+
+    @property
+    def groups_claim(self):
+        return self.setting('GROUPS_CLAIM')
+    
+    def get_user_groups(self, extra_groups=[]):
+        return extra_groups

--- a/test_app/tests/authentication/authenticator_plugins/test_azuread.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_azuread.py
@@ -101,11 +101,11 @@ def test_groups_setting_and_user_groups(keycloak_authenticator):
 
     ad = get_authenticator_plugin("ansible_base.authentication.authenticator_plugins.azuread")
     ad.database_instance = MockedDb(custom_groups_claim)
-    
+
     # assert that groups claim setting is there and AD has the expected groups claim
     assert ad.strategy.get_setting('GROUPS_CLAIM', backend) == custom_groups_claim
     assert ad.groups_claim == custom_groups_claim
-    
+
     # assert that AD returns expected user groups
     assert ad.get_user_groups() == []
-    assert ad.get_user_groups(["a","b"]) == ["a","b"]
+    assert ad.get_user_groups(["a", "b"]) == ["a", "b"]

--- a/test_app/tests/authentication/authenticator_plugins/test_azuread.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_azuread.py
@@ -3,7 +3,9 @@ from unittest import mock
 import pytest
 from django.test import override_settings
 
+from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin
 from ansible_base.authentication.session import SessionAuthentication
+from ansible_base.authentication.social_auth import SocialAuthMixin
 from ansible_base.lib.utils.response import get_fully_qualified_url, get_relative_url
 
 authenticated_test_page = "authenticator-list"
@@ -79,3 +81,31 @@ def test_azuread_auth_failed(authenticate, unauthenticated_api_client, azuread_a
     url = get_relative_url(authenticated_test_page)
     response = client.get(url)
     assert response.status_code == 401
+
+
+def test_groups_setting_and_user_groups(keycloak_authenticator):
+    custom_groups_claim = "some_groups"
+
+    class MockedDb:
+        def __init__(self, group_claim):
+            self.slug = "fake"
+            self.configuration = {"GROUPS_CLAIM": group_claim}
+
+    class MockBackend(SocialAuthMixin):
+        database_instance = MockedDb(custom_groups_claim)
+
+        def __init__(self):
+            pass
+
+    backend = MockBackend()
+
+    ad = get_authenticator_plugin("ansible_base.authentication.authenticator_plugins.azuread")
+    ad.database_instance = MockedDb(custom_groups_claim)
+    
+    # assert that groups claim setting is there and AD has the expected groups claim
+    assert ad.strategy.get_setting('GROUPS_CLAIM', backend) == custom_groups_claim
+    assert ad.groups_claim == custom_groups_claim
+    
+    # assert that AD returns expected user groups
+    assert ad.get_user_groups() == []
+    assert ad.get_user_groups(["a","b"]) == ["a","b"]


### PR DESCRIPTION
# [AAP-41636] Allow configurable name of "groups" claim for Azure AD and add support for reading groups from this claim

**NOTE:** This PR depends on PR #682 .

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - The AzureAD plugin gets a new configuration option and the inherited function for reading groups is overriden so it does return the groups populated from the claim
- Why is this change needed?
  - Without this change the authentication with Azure AD always defaults the name of groups claim to "Group" however that is not what Azure AD sends the groups in. In our tests we noticed it always been "groups". To avoid hard-coding and giving the users option to change the claim name, it needs to be configurable.
- How does this change address the issue?
  - New configuration option shown in UI and user can use correct claim name

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
To test fully (with authentication) you will need to configure an application in Azure and you must use Microsoft Id for that (hotmail id works too). 
To test only the configuration, you don't need Azure at all.

### Steps to Test
1. Pull down the PR
2. Start AAP
3. Navigate to configuration of authentication methods and create one for Azure AD type.
4. (optional, when PR #682 is included as well) Perform login with Azure AD

### Expected Results
<!-- Describe what should happen after following the steps -->
Configuration of Azure AD shows new field - default is empty string which effectively means "Group".

![Screenshot_20250326_164609](https://github.com/user-attachments/assets/957c2aa1-9f5d-4348-8812-4183f87fbe12)


## Additional Context
<!-- Optional but helpful information -->

### Required Actions
- [x] Blocked by PR/MR: #682
  <!-- Reference blocking PRs/MRs with brief context -->
