### PR TITLE
AAP-39645 Allow non-admin admin

### DIFF
--- a/ansible_base/authentication/management/commands/authenticators.py
+++ b/ansible_base/authentication/management/commands/authenticators.py
@@ -17,10 +17,10 @@ class Command(BaseCommand):
     help = "Initialize service configuration with an admin user and a local authenticator"
 
     def add_arguments(self, parser):
-        parser.add_argument("--list", action="store_true", help="list the authenticators", required=False)
+        parser.add_argument("--list", action="store_true", help="List the authenticators", required=False)
         parser.add_argument("--initialize", action="store_true", help="Initialize an admin user and local db authenticator", required=False)
-        parser.add_argument("--enable", type=int, help="Initialize an admin user and local db authenticator", required=False)
-        parser.add_argument("--disable", type=int, help="Initialize an admin user and local db authenticator", required=False)
+        parser.add_argument("--enable", type=int, help="Enable the authenticator with provided ID", required=False)
+        parser.add_argument("--disable", type=int, help="Disable the authenticator with provided ID", required=False)
 
     def handle(self, *args, **options):
         took_action = False
@@ -31,16 +31,19 @@ class Command(BaseCommand):
             for id, state in [(options['enable'], True), (options['disable'], False)]:
                 if not id:
                     continue
-                try:
-                    authenticator = Authenticator.objects.get(id=id)
-                except Authenticator.DoesNotExist:
-                    raise CommandError(_("Authenticator %(id)s does not exist") % {"id": id})
-                if authenticator.enabled is not state:
-                    authenticator.enabled = state
-                    authenticator.save()
+                self._update_authenticator(id, state)
             took_action = True
         if options["list"] or not took_action:
             self.list_authenticators()
+
+    def _update_authenticator(self, id: int, state: bool):
+        try:
+            authenticator = Authenticator.objects.get(id=id)
+        except Authenticator.DoesNotExist:
+            raise CommandError(_("Authenticator %(id)s does not exist") % {"id": id})
+        if authenticator.enabled is not state:
+            authenticator.enabled = state
+            authenticator.save()
 
     def list_authenticators(self):
         authenticators = []
@@ -59,6 +62,10 @@ class Command(BaseCommand):
         self.stdout.write('')
 
     def initialize_authenticators(self):
+        if Authenticator.objects.filter(type="ansible_base.authentication.authenticator_plugins.local").exists():
+            self.stdout.write("Local authenticator already exists, skipping")
+            return
+
         # First try to get the system user
         system_user = get_system_user()
         admin_user = None
@@ -74,23 +81,22 @@ class Command(BaseCommand):
         else:
             creator = None
             self.stderr.write("Neither system user nor admin user were defined, local authenticator will be created without created_by set")
-        existing_authenticator = Authenticator.objects.filter(type="ansible_base.authentication.authenticator_plugins.local").first()
-        if not existing_authenticator:
-            existing_authenticator = Authenticator.objects.create(
-                name='Local Database Authenticator',
-                enabled=True,
-                create_objects=True,
-                configuration={},
-                created_by=creator,
-                modified_by=creator,
-                remove_users=False,
-                type='ansible_base.authentication.authenticator_plugins.local',
+
+        new_authenticator = Authenticator.objects.create(
+            name='Local Database Authenticator',
+            enabled=True,
+            create_objects=True,
+            configuration={},
+            created_by=creator,
+            modified_by=creator,
+            remove_users=False,
+            type='ansible_base.authentication.authenticator_plugins.local',
+        )
+        self.stdout.write("Created default local authenticator")
+        if admin_user is not None:
+            self.stdout.write("Binding admin user to the local authenticator")
+            AuthenticatorUser.objects.get_or_create(
+                uid=admin_user.username,
+                user=admin_user,
+                provider=new_authenticator,
             )
-            self.stdout.write("Created default local authenticator")
-            if admin_user is not None:
-                self.stdout.write("Binding admin user to the local authenticator")
-                AuthenticatorUser.objects.get_or_create(
-                    uid=admin_user.username,
-                    user=admin_user,
-                    provider=existing_authenticator,
-                )

--- a/ansible_base/authentication/management/commands/authenticators.py
+++ b/ansible_base/authentication/management/commands/authenticators.py
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext_lazy as _
 
-from ansible_base.authentication.models import Authenticator, AuthenticatorUser
+from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.utils.models import get_system_user
 
 
@@ -82,7 +82,7 @@ class Command(BaseCommand):
             creator = None
             self.stderr.write("Neither system user nor admin user were defined, local authenticator will be created without created_by set")
 
-        new_authenticator = Authenticator.objects.create(
+        Authenticator.objects.create(
             name='Local Database Authenticator',
             enabled=True,
             create_objects=True,
@@ -93,10 +93,3 @@ class Command(BaseCommand):
             type='ansible_base.authentication.authenticator_plugins.local',
         )
         self.stdout.write("Created default local authenticator")
-        if admin_user is not None:
-            self.stdout.write("Binding admin user to the local authenticator")
-            AuthenticatorUser.objects.get_or_create(
-                uid=admin_user.username,
-                user=admin_user,
-                provider=new_authenticator,
-            )

--- a/ansible_base/authentication/management/commands/authenticators.py
+++ b/ansible_base/authentication/management/commands/authenticators.py
@@ -10,6 +10,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
+from ansible_base.lib.utils.models import get_system_user
 
 
 class Command(BaseCommand):
@@ -58,10 +59,21 @@ class Command(BaseCommand):
         self.stdout.write('')
 
     def initialize_authenticators(self):
-        admin_user = get_user_model().objects.filter(username="admin").first()
-        if not admin_user:
-            raise CommandError("Admin user with username 'admin' not defined.")
-
+        # First try to get the system user
+        system_user = get_system_user()
+        admin_user = None
+        try:
+            admin_user = get_user_model().objects.filter(username="admin").first()
+        except get_user_model().DoesNotExist:
+            pass
+        creator = None
+        if system_user is not None:
+            creator = system_user
+        elif admin_user is not None:
+            creator = admin_user
+        else:
+            creator = None
+            self.stderr.write("Neither system user nor admin user were defined, local authenticator will be created without created_by set")
         existing_authenticator = Authenticator.objects.filter(type="ansible_base.authentication.authenticator_plugins.local").first()
         if not existing_authenticator:
             existing_authenticator = Authenticator.objects.create(
@@ -69,15 +81,16 @@ class Command(BaseCommand):
                 enabled=True,
                 create_objects=True,
                 configuration={},
-                created_by=admin_user,
-                modified_by=admin_user,
+                created_by=creator,
+                modified_by=creator,
                 remove_users=False,
                 type='ansible_base.authentication.authenticator_plugins.local',
             )
             self.stdout.write("Created default local authenticator")
-
-            AuthenticatorUser.objects.get_or_create(
-                uid=admin_user.username,
-                user=admin_user,
-                provider=existing_authenticator,
-            )
+            if admin_user is not None:
+                self.stdout.write("Binding admin user to the local authenticator")
+                AuthenticatorUser.objects.get_or_create(
+                    uid=admin_user.username,
+                    user=admin_user,
+                    provider=existing_authenticator,
+                )

--- a/test_app/tests/authentication/management/test_authenticators.py
+++ b/test_app/tests/authentication/management/test_authenticators.py
@@ -5,7 +5,6 @@ import pytest
 from django.core.management import CommandError, call_command
 from django.test.utils import override_settings
 
-from ansible_base.authentication.management.commands.authenticators import Command
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 
 
@@ -79,10 +78,20 @@ def test_authenticators_cli_list_without_tabulate(command_args, local_authentica
         assert order.strip() == str(authenticator.order)
 
 
-def test_authenticators_cli_initialize(django_user_model):
+@pytest.mark.parametrize(
+    "system_user_exists,admin_user_exists,log_location,expected_log_entry,expected_authenticator_creator",
+    [
+        (True, True, "stdout", "Binding admin user to the local authenticator", "_system"),
+        (True, False, "stdout", "Created default local authenticator", "_system"),
+        (False, True, "stdout", "Binding admin user to the local authenticator", "admin"),
+        (False, False, "stderr", "Neither system user nor admin user were defined", None),
+    ],
+)
+def test_authenticators_cli_initialize(
+    django_user_model, system_user_exists, admin_user_exists, log_location, expected_log_entry, expected_authenticator_creator
+):
     """
-    Calling with --initialize will create:
-    - An authenticator if there is an admin user
+    Tests the different options for --initialize on authenticators.
     """
     out = StringIO()
     err = StringIO()
@@ -90,39 +99,25 @@ def test_authenticators_cli_initialize(django_user_model):
     # Sanity check:
     assert django_user_model.objects.count() == 0
 
-    call_command('authenticators', "--initialize", stdout=out, stderr=err)
-    assert "Created default local authenticator" in out.getvalue()
+    # Optionally create admin user
+    if admin_user_exists:
+        django_user_model.objects.create(username="admin")
 
-    assert Authenticator.objects.count() == 1
-    assert Authenticator.objects.first().created_by.username == "_system"
+    # Set system user
+    system_username = "_system" if system_user_exists else None
+    with override_settings(SYSTEM_USERNAME=system_username):
+        call_command('authenticators', "--initialize", stdout=out, stderr=err)
 
-    # Delete authenticator for next round
-    Authenticator.objects.all().delete()
-
-    # Create admin user
-    django_user_model.objects.create(username="admin")
-    call_command('authenticators', "--initialize", stdout=out, stderr=err)
-    assert "Binding admin user to the local authenticator" in out.getvalue()
-
-    assert Authenticator.objects.count() == 1
-    assert AuthenticatorUser.objects.first().user.username == "admin"
-
-
-@pytest.mark.django_db
-def test_authenticators_cli_initialize_no_system_user():
-
-    # Hide system user
-    with override_settings(SYSTEM_USERNAME=None):
-        assert Authenticator.objects.count() == 0
-        command = Command()
-        command.stderr = StringIO()
-        command.initialize_authenticators()
-
-        assert "Neither system user nor admin user were defined" in command.stderr.getvalue()
+        if log_location == "stdout":
+            assert expected_log_entry in out.getvalue()
+        else:
+            assert expected_log_entry in err.getvalue()
 
         assert Authenticator.objects.count() == 1
-        assert Authenticator.objects.first().created_by is None
-        assert AuthenticatorUser.objects.count() == 0
+        if admin_user_exists or system_user_exists:
+            assert Authenticator.objects.first().created_by.username == expected_authenticator_creator
+        else:
+            assert Authenticator.objects.first().created_by is None
 
 
 def test_authenticators_cli_initialize_pre_existing(django_user_model, local_authenticator, admin_user):

--- a/test_app/tests/authentication/management/test_authenticators.py
+++ b/test_app/tests/authentication/management/test_authenticators.py
@@ -81,9 +81,9 @@ def test_authenticators_cli_list_without_tabulate(command_args, local_authentica
 @pytest.mark.parametrize(
     "system_user_exists,admin_user_exists,log_location,expected_log_entry,expected_authenticator_creator",
     [
-        (True, True, "stdout", "Binding admin user to the local authenticator", "_system"),
+        (True, True, "stdout", "Created default local authenticator", "_system"),
         (True, False, "stdout", "Created default local authenticator", "_system"),
-        (False, True, "stdout", "Binding admin user to the local authenticator", "admin"),
+        (False, True, "stdout", "Created default local authenticator", "admin"),
         (False, False, "stderr", "Neither system user nor admin user were defined", None),
     ],
 )
@@ -120,7 +120,7 @@ def test_authenticators_cli_initialize(
             assert Authenticator.objects.first().created_by is None
 
 
-def test_authenticators_cli_initialize_pre_existing(django_user_model, local_authenticator, admin_user):
+def test_authenticators_cli_initialize_pre_existing(django_user_model, local_authenticator, admin_user, unauthenticated_api_client):
     """
     What if we already have an admin user?
 
@@ -149,6 +149,11 @@ def test_authenticators_cli_initialize_pre_existing(django_user_model, local_aut
 
     # No AuthenticatorUser should get created in this case
     assert AuthenticatorUser.objects.count() == 0
+
+    # Log in to auto-create AuthenticatorUser
+    unauthenticated_api_client.login(username="admin", password="password")
+    assert AuthenticatorUser.objects.count() == 1
+    assert AuthenticatorUser.objects.first().user == admin_user
 
 
 @pytest.mark.parametrize(

--- a/test_app/tests/authentication/management/test_authenticators.py
+++ b/test_app/tests/authentication/management/test_authenticators.py
@@ -3,7 +3,9 @@ from unittest import mock
 
 import pytest
 from django.core.management import CommandError, call_command
+from django.test.utils import override_settings
 
+from ansible_base.authentication.management.commands.authenticators import Command
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 
 
@@ -88,13 +90,39 @@ def test_authenticators_cli_initialize(django_user_model):
     # Sanity check:
     assert django_user_model.objects.count() == 0
 
-    with pytest.raises(CommandError) as e:
-        call_command('authenticators', "--initialize", stdout=out, stderr=err)
-    assert "Admin user with username 'admin' not defined." in str(e.value)
-
-    django_user_model.objects.create(username="admin")
     call_command('authenticators', "--initialize", stdout=out, stderr=err)
     assert "Created default local authenticator" in out.getvalue()
+
+    assert Authenticator.objects.count() == 1
+    assert Authenticator.objects.first().created_by.username == "_system"
+
+    # Delete authenticator for next round
+    Authenticator.objects.all().delete()
+
+    # Create admin user
+    django_user_model.objects.create(username="admin")
+    call_command('authenticators', "--initialize", stdout=out, stderr=err)
+    assert "Binding admin user to the local authenticator" in out.getvalue()
+
+    assert Authenticator.objects.count() == 1
+    assert AuthenticatorUser.objects.first().user.username == "admin"
+
+
+@pytest.mark.django_db
+def test_authenticators_cli_initialize_no_system_user():
+
+    # Hide system user
+    with override_settings(SYSTEM_USERNAME=None):
+        assert Authenticator.objects.count() == 0
+        command = Command()
+        command.stderr = StringIO()
+        command.initialize_authenticators()
+
+        assert "Neither system user nor admin user were defined" in command.stderr.getvalue()
+
+        assert Authenticator.objects.count() == 1
+        assert Authenticator.objects.first().created_by is None
+        assert AuthenticatorUser.objects.count() == 0
 
 
 def test_authenticators_cli_initialize_pre_existing(django_user_model, local_authenticator, admin_user):

--- a/test_app/tests/authentication/management/test_authenticators.py
+++ b/test_app/tests/authentication/management/test_authenticators.py
@@ -144,7 +144,7 @@ def test_authenticators_cli_initialize_pre_existing(django_user_model, local_aut
     # Nothing should have changed
     assert existing_user == new_user
     assert existing_user.date_joined == new_user.date_joined
-    assert out.getvalue() == ""
+    assert "Local authenticator already exists, skipping" in out.getvalue()
     assert err.getvalue() == ""
 
     # No AuthenticatorUser should get created in this case


### PR DESCRIPTION
## Description

Fixes issues blocking a user not named "admin" from being the admin user.  The issue in this case was creation of the db authenticator via "aap-gateway-manage authenticators --initialize" was hard coded to the user "admin" but this PR allows it to be created by the system user or by no user if there is no "admin" user or system user defined.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Start gateway (with PR for AAP-39645 + this PR) after modifying gateway_admin_username in container-startup.yml to something other than admin.
2. See that everything works OK (there were errors in the log and didn't start before).  Log in as the specified user and see they have system administrator role.
3. It's not really possible to unset SYSTEM_USER for gateway or for test_app, both are not happy without one.  This situation could be tested with awx (since apparently it does not use a system user) but that is a challenge to set up.  Unit tests cover this scenario.

### Expected Results
See above.

## Additional Context
N/A

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

### Screenshots/Logs
N/A