### PR TITLE
AAP-36381: Make SAML username/permid required

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -128,8 +128,6 @@ class SAMLConfiguration(BaseAuthenticatorConfiguration):
         ui_field_label=_('User Email'),
     )
     IDP_ATTR_USERNAME = CharField(
-        allow_null=True,
-        required=False,
         help_text=_("The field in the assertion which represents the user's username."),
         ui_field_label=_('Username'),
     )
@@ -144,9 +142,7 @@ class SAMLConfiguration(BaseAuthenticatorConfiguration):
         ui_field_label=_('User First Name'),
     )
     IDP_ATTR_USER_PERMANENT_ID = CharField(
-        allow_null=True,
-        required=False,
-        help_text=_("The field in the assertion which represents the user's permanent id (overrides IDP_ATTR_USERNAME)"),
+        help_text=_("The field in the assertion which represents the user's permanent id."),
         ui_field_label=_('User Permanent ID'),
     )
     CALLBACK_URL = URLField(

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -189,10 +189,6 @@ class SAMLConfiguration(BaseAuthenticatorConfiguration):
         except ValidationError as e:
             errors['SP_PRIVATE_KEY'] = e
 
-        idp_data = attrs.get('ENABLED_IDPS', {}).get(idp_string, {})
-        if not idp_data.get('attr_user_permanent_id', None) and not idp_data.get('attr_username'):
-            errors['IDP_ATTR_USERNAME'] = "Either IDP_ATTR_USERNAME or IDP_ATTR_USER_PERMANENT_ID needs to be set"
-
         if errors:
             raise ValidationError(errors)
 

--- a/test_app/tests/authentication/authenticator_plugins/test_saml.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_saml.py
@@ -40,7 +40,7 @@ def test_saml_auth_successful(authenticate, unauthenticated_api_client, saml_aut
         pytest.param({"SP_PRIVATE_KEY": "really invalid"}, {"SP_PRIVATE_KEY": "Unable to load as PEM data"}, id="SP_PRIVATE_KEY is utterly invalid"),
         pytest.param(
             {"IDP_ATTR_USERNAME": None, "IDP_ATTR_USER_PERMANENT_ID": None},
-            {"IDP_ATTR_USERNAME": "Either IDP_ATTR_USERNAME or IDP_ATTR_USER_PERMANENT_ID needs to be set"},
+            {"IDP_ATTR_USERNAME": "This field may not be null.", "IDP_ATTR_USER_PERMANENT_ID": "This field may not be null."},
             id="null IDP_ATTR_USERNAME and IDP_ATTR_USER_PERMANENT_ID",
         ),
         pytest.param(
@@ -55,7 +55,7 @@ def test_saml_auth_successful(authenticate, unauthenticated_api_client, saml_aut
         ),
         pytest.param(
             {"-IDP_ATTR_USERNAME": None, "-IDP_ATTR_USER_PERMANENT_ID": None},
-            {"IDP_ATTR_USERNAME": "Either IDP_ATTR_USERNAME or IDP_ATTR_USER_PERMANENT_ID needs to be set"},
+            {"IDP_ATTR_USERNAME": "This field is required.", "IDP_ATTR_USER_PERMANENT_ID": "This field is required."},
             id="missing IDP_ATTR_USERNAME and IDP_ATTR_USER_PERMANENT_ID",
         ),
     ],


### PR DESCRIPTION
## Description
Some time back, attr_user_permanent_id and attr_username were made nullable/not-required since the docs make it seem like that is acceptable.  It however is not and authentication fails without either of them.  The docs have already been updated to state they are required, but the UI still shows them as optional.  This just makes them required in the UI.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Try to create a SAML authenticator without specifying one or both of these params.
2. See that it's not accepted.
3. 

### Expected Results
Impossible to create SAML authenticator without username and permanent ID fields.

## Additional Context
N/A

