### PR TITLE
AAP-43587 Additionally check for prefixed user prior to legacy_auth

### DIFF
--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -200,7 +200,9 @@ class ValidateLocalUserView(AnsibleBaseDjangoAppApiView):
         serializer.is_valid(raise_exception=True)
 
         # Ensure the users exists before authenticating
-        if not get_user_model().objects.filter(username=serializer.validated_data["username"]).exists():
+        PREFIX = getattr(settings, "RENAMED_USERNAME_PREFIX", "")
+        viable_usernames = [serializer.validated_data["username"], PREFIX + serializer.validated_data["username"]]
+        if not get_user_model().objects.filter(username__in=viable_usernames).exists():
             logger.debug(f"User {serializer.validated_data['username']} does not exist, not validating authentication")
             return Response(status=401)
 


### PR DESCRIPTION
AAP-43587

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? Checking for PREFIX_user and user when checking if a user exists during legacy auth
- Why is this change needed? Users can exist, but as PREFIX user, we do not want to break these cases during legacy authentication
- How does this change address the issue? Check a list of `PREFIX_user` and `user` when checking if the user exists prior to attempting authentication.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment
