### PR TITLE
[AAP-45287] Fix IPv6 handling for Redis

### DIFF
--- a/ansible_base/lib/redis/client.py
+++ b/ansible_base/lib/redis/client.py
@@ -12,7 +12,7 @@ from redis.cluster import ClusterNode, RedisCluster
 from redis.exceptions import NoPermissionError, RedisClusterException
 
 from ansible_base.lib.constants import STATUS_DEGRADED, STATUS_FAILED, STATUS_GOOD
-from ansible_base.lib.utils.address import AddressType, classify_and_split_address_string
+from ansible_base.lib.utils import address
 
 logger = logging.getLogger('ansible_base.lib.redis.client')
 
@@ -161,27 +161,27 @@ class RedisClientGetter:
             had_host_errors = False
             host_ports = self.redis_hosts.split(',')
             for host_port in host_ports:
-                (addr_type, node, port_string) = classify_and_split_address_string(host_port)
-                if addr_type == AddressType.UNKNOWN:
+                response = address.classify_address(host_port)
+                if response.type == address.AddressType.UNKNOWN:
                     logger.error(
                         f"Specified cluster_host {host_port} is not valid; "
                         "it is of an unknown address type and must be one of <hostname>:<port>, <ipv4>:<port> or <ipv6>:<port>"
                     )
                     had_host_errors = True
                     continue
-                if not port_string:
+                if not response.port:
                     logger.error(f"Specified cluster_host {host_port} is not valid; it needs to be in the format <host>:<port>")
                     had_host_errors = True
                     continue
                 # Make sure we have an int for the port
                 try:
-                    port = int(port_string)
+                    port = int(response.port)
                 except ValueError:
                     logger.error(f'Specified port on {host_port} is not an int')
                     had_host_errors = True
                     continue
 
-                self.connection_settings['startup_nodes'].append(ClusterNode(node, port))
+                self.connection_settings['startup_nodes'].append(ClusterNode(response.address, port))
 
             if had_host_errors:
                 raise ValueError()

--- a/ansible_base/lib/redis/client.py
+++ b/ansible_base/lib/redis/client.py
@@ -12,6 +12,7 @@ from redis.cluster import ClusterNode, RedisCluster
 from redis.exceptions import NoPermissionError, RedisClusterException
 
 from ansible_base.lib.constants import STATUS_DEGRADED, STATUS_FAILED, STATUS_GOOD
+from ansible_base.lib.utils.address import AddressType, classify_and_split_address_string
 
 logger = logging.getLogger('ansible_base.lib.redis.client')
 
@@ -160,13 +161,15 @@ class RedisClientGetter:
             had_host_errors = False
             host_ports = self.redis_hosts.split(',')
             for host_port in host_ports:
-                try:
-                    node, port_string = host_port.split(':')
-                except ValueError:
+                (addr_type, node, port_string) = classify_and_split_address_string(host_port)
+                if addr_type == AddressType.UNKNOWN:
+                    logger.error(f"Specified cluster_host {host_port} is not valid; it is of an unknown address type")
+                    had_host_errors = True
+                    continue
+                if not port_string:
                     logger.error(f"Specified cluster_host {host_port} is not valid; it needs to be in the format <host>:<port>")
                     had_host_errors = True
                     continue
-
                 # Make sure we have an int for the port
                 try:
                     port = int(port_string)

--- a/ansible_base/lib/redis/client.py
+++ b/ansible_base/lib/redis/client.py
@@ -165,7 +165,7 @@ class RedisClientGetter:
                 if response.type == address.AddressType.UNKNOWN:
                     logger.error(
                         f"Specified cluster_host {host_port} is not valid; "
-                        "it is of an unknown address type and must be one of <hostname>:<port>, <ipv4>:<port> or <ipv6>:<port>"
+                        "it is of an unknown address type and must be one of <hostname>:<port>, <ipv4>:<port> or [<ipv6>]:<port>"
                     )
                     had_host_errors = True
                     continue

--- a/ansible_base/lib/redis/client.py
+++ b/ansible_base/lib/redis/client.py
@@ -163,7 +163,10 @@ class RedisClientGetter:
             for host_port in host_ports:
                 (addr_type, node, port_string) = classify_and_split_address_string(host_port)
                 if addr_type == AddressType.UNKNOWN:
-                    logger.error(f"Specified cluster_host {host_port} is not valid; it is of an unknown address type")
+                    logger.error(
+                        f"Specified cluster_host {host_port} is not valid; "
+                        "it is of an unknown address type and must be one of <hostname>:<port>, <ipv4>:<port> or <ipv6>:<port>"
+                    )
                     had_host_errors = True
                     continue
                 if not port_string:

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -1,0 +1,113 @@
+import enum
+import ipaddress
+import re
+
+
+class AddressType(enum.Enum):
+    HOSTNAME = "hostname"
+    IPv4 = "ipv4"
+    IPv6 = "ipv6"
+    UNKNOWN = "unknown"
+
+
+def _classify_address_string(address_string) -> AddressType:
+    """
+    Categorizes a given string as IPv4, IPv6, hostname, or unknown.
+
+    Args:
+        address_string: The string to categorize.
+
+    Returns:
+        A value of AddressType indicating the category.
+    """
+    try:
+        ipaddress.IPv4Address(address_string)
+        return AddressType.IPv4
+    except ipaddress.AddressValueError:
+        pass
+
+    try:
+        ipaddress.IPv6Address(address_string)
+        return AddressType.IPv6
+    except ipaddress.AddressValueError:
+        pass
+
+    # Basic hostname check (can be expanded for more rigorous validation)
+    if re.match(
+        r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+        r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$",
+        address_string
+    ):
+        return AddressType.HOSTNAME
+
+    return AddressType.UNKNOWN
+
+
+def classify_address_string(address_string) -> AddressType:
+    """
+    Categorizes a given string as IPv4, IPv6, hostname, or unknown.
+
+    An IPv6 address wrapped in [] is considered a hostname.
+
+    Args:
+        address_string: The string to categorize.
+
+    Returns:
+        A value of AddressType indicating the category.
+    """
+    address_type = _classify_address_string(address_string)
+    if address_type != AddressType.UNKNOWN:
+        return address_type
+
+    # We could be dealing with an IPv6 address wrapped in [].
+    # If that is the case we want to identify it as a host name.
+    if (address_string[0] == "[") and (address_string[-1] == "]"):
+        address_type = _classify_address_string(address_string[1:-1])
+
+        # Only an address type of IPv6 is considered valid here.
+        # We don't want to treat any other specification as valid.
+        if address_type == AddressType.IPv6:
+            return AddressType.HOSTNAME
+
+    return AddressType.UNKNOWN
+
+
+def classify_and_split_address_string(address_string) -> tuple[AddressType, str, str]:
+    """
+    Categorizes a given string with optional ":<port>" suffix as IPv4, IPv6,
+    hostname, or unknown.
+
+    Args:
+        address_string: The string to categorize.
+
+    Returns:
+        A tuple of the form (AddressType, address string, port string) where
+        address_string and port_string are only valid (though port string may
+        be an empty string) when AddressType is not AddressType.UNKNOWN.
+    """
+    address_type = classify_address_string(address_string)
+    if address_type != AddressType.UNKNOWN:
+        # A known type with no port.
+        return (address_type, address_string, "")
+
+    # Split into potential address and port and classify the address.
+    (address_string, _, port) = address_string.rpartition(":")
+    address_type = classify_address_string(address_string)
+    if address_type != AddressType.UNKNOWN:
+        # A known type with a port.
+        return (address_type, address_string, port)
+
+    # An unknown address type.
+    return (AddressType.UNKNOWN, "", "")
+
+
+def is_hostname_address_string(address_string: str) -> bool:
+    return classify_address_string(address_string) == AddressType.HOSTNAME
+
+
+def is_ipv4_address_string(address_string: str) -> bool:
+    return classify_address_string(address_string) == AddressType.IPv4
+
+
+def is_ipv6_address_string(address_string: str) -> bool:
+    return classify_address_string(address_string) == AddressType.IPv6

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -38,17 +38,26 @@ class AddressTypeResponse(object):
     existing code to facilitate use of the classification functionality
     provided.  An empty string indicates the non-existence of that particular
     attribute as part of the classified address.
-
-    The address and port fields are not valid in any sense if the type field is
-    AddressType.UNKNOWN.
     """
 
     type: AddressType
     address: str = ""
     port: str = ""
 
+    @property
+    def ipv6_bracketed(self):
+        """
+        IPv6 addresses are stored without brackets in the address field.
+        If the type of this instance is AddressType.IPv6 the method will return
+        the address enclosed in brackets.
+        If the type is not AddressType.IPv6 it will return None.
+        """
+        if self.type != AddressType.IPv6:
+            return None
+        return f"[{self.address}]"
 
-def _classify_base_address(address: str) -> AddressType:
+
+def _classify_base_address(address: str) -> AddressTypeResponse:
     """
     Categorizes a given string as IPv4, IPv6, hostname, or unknown.
 
@@ -56,17 +65,17 @@ def _classify_base_address(address: str) -> AddressType:
         address: The string to categorize.
 
     Returns:
-        A value of AddressType indicating the category.
+        A value of AddressTypeResponse indicating the classified address.
     """
     try:
         ipaddress.IPv4Address(address)
-        return AddressType.IPv4
+        return AddressTypeResponse(AddressType.IPv4, address)
     except ipaddress.AddressValueError:
         pass
 
     try:
         ipaddress.IPv6Address(address)
-        return AddressType.IPv6
+        return AddressTypeResponse(AddressType.IPv6, address)
     except ipaddress.AddressValueError:
         pass
 
@@ -92,39 +101,33 @@ def _classify_base_address(address: str) -> AddressType:
     # It's second usage simply includes the requirement for a leading "." and
     # allows it to be specified zero or more times.
     if re.match(r"^[a-zA-Z](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", address):
-        return AddressType.HOSTNAME
+        return AddressTypeResponse(AddressType.HOSTNAME, address)
 
-    return AddressType.UNKNOWN
+    return AddressTypeResponse(AddressType.UNKNOWN, address)
 
 
-def _classify_address(address: str) -> AddressType:
+def _classify_address(address: str) -> AddressTypeResponse:
     """
     Categorizes a given string as IPv4, IPv6, hostname, or unknown.
-
-    An IPv6 address wrapped in [] is considered a hostname.
 
     Args:
         address: The string to categorize.
 
     Returns:
-        A value of AddressType indicating the category.
+        A value of AddressTypeResponse indicating the classified address.
     """
     # We could be dealing with an IPv6 address wrapped in [].
-    # If that is the case we want to identify it as a host name.
-    # The reason for this is the common use case where an IPv6 in []s is
-    # utilized in the same manner as a hostname.  Thus we eliminate special
-    # casing on the part of the client to only the situation where they have a
-    # "raw" IPv6 address.
+    # If that is the case we want to classify the address itself.
 
     # Check that the address is at least two characters long.
     if (len(address) >= 2) and (address[0] == "[") and (address[-1] == "]"):
-        address_type = _classify_base_address(address[1:-1])
+        response = _classify_base_address(address[1:-1])
 
         # Only an address type of IPv6 is considered valid here.
         # We don't want to treat any other specification as valid.
-        if address_type == AddressType.IPv6:
-            return AddressType.HOSTNAME
-        return AddressType.UNKNOWN
+        if response.type == AddressType.IPv6:
+            return response
+        return AddressTypeResponse(AddressType.UNKNOWN, address)
 
     return _classify_base_address(address)
 
@@ -138,19 +141,19 @@ def classify_address(address: str) -> AddressTypeResponse:
         address: The string to categorize.
 
     Returns:
-        An instance of AddressTypeResponse.
+        A value of AddressTypeResponse indicating the classified address.
     """
-    address_type = _classify_address(address)
-    if address_type != AddressType.UNKNOWN:
+    response = _classify_address(address)
+    if response.type != AddressType.UNKNOWN:
         # A known type with no port.
-        return AddressTypeResponse(address_type, address)
+        return response
 
     # Split into potential address and port and classify the address.
-    (address, _, port) = address.rpartition(":")
-    address_type = _classify_address(address)
-    if address_type != AddressType.UNKNOWN:
+    (split_address, _, port) = address.rpartition(":")
+    response = _classify_address(split_address)
+    if response.type != AddressType.UNKNOWN:
         # A known type with a port.
-        return AddressTypeResponse(address_type, address, port)
+        return AddressTypeResponse(response.type, response.address, port)
 
     # An unknown address type.
-    return AddressTypeResponse(AddressType.UNKNOWN)
+    return AddressTypeResponse(AddressType.UNKNOWN, address)

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -4,6 +4,22 @@ import re
 
 
 class AddressType(enum.Enum):
+    """
+    AddressType provides an abstracted identification of the determined kind of
+    an address.  The abstraction eliminates cohesion between the provided
+    address identification functionality and its clients.
+
+    The type allows a client which may be configured with any of the supported
+    types to identify which type was specified and perform necessary runtime
+    handling.
+
+    An example would be a client which uses the values from its configuration
+    to construct URLs and which is configured using raw IPv6 addreesses. The
+    client needs to be able to determine the address type to know what
+    processing (such as enclosing IPv6 addresses in []s) is needed to
+    successfully utilize it.
+    """
+
     HOSTNAME = "hostname"
     IPv4 = "ipv4"
     IPv6 = "ipv6"

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -74,6 +74,23 @@ def _classify_base_address(address: str) -> AddressType:
     # The original regex was generated via Gemini AI.
     # It was modified to require the first character be alphabetic to eliminate
     # a string composed of nothing but digits be recognized as a hostname.
+    #
+    # The regex may appear more complicated than it actually is.
+    #
+    # First you can ignore the "?:" which simply makes the group in which it
+    # appears non-capturing.
+    #
+    # Second you can conceptually collapse the portions delineated by "{" and
+    # "}" to "*". The bracketed portions simply put a limit on minimum and
+    # maximum lengths of the preceding construct.
+    #
+    # With the two above changes you'll see that there's effectively only one
+    # construct in the regex:
+    #
+    #   [a-zA-Z]([a-zA-Z0-9-]*[a-zA-Z0-9])?
+    #
+    # It's second usage simply includes the requirement for a leading "." and
+    # allows it to be specified zero or more times.
     if re.match(r"^[a-zA-Z](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", address):
         return AddressType.HOSTNAME
 

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -1,3 +1,4 @@
+import dataclasses
 import enum
 import ipaddress
 import re
@@ -26,100 +27,113 @@ class AddressType(enum.Enum):
     UNKNOWN = "unknown"
 
 
-def _classify_address_string(address_string) -> AddressType:
+@dataclasses.dataclass(frozen=True)
+class AddressTypeResponse(object):
+    """
+    AddressTypeResponse is returned from the classify address method describing
+    the detected address including splitting it into address and port parts as
+    appicable.
+
+    Strings are used for the address and port so as to minimize changes to
+    existing code to facilitate use of the classification functionality
+    provided.  An empty string indicates the non-existence of that particular
+    attribute as part of the classified address.
+
+    The address and port fields are not valid in any sense if the type field is
+    AddressType.UNKNOWN.
+    """
+
+    type: AddressType
+    address: str = ""
+    port: str = ""
+
+
+def _classify_base_address(address: str) -> AddressType:
     """
     Categorizes a given string as IPv4, IPv6, hostname, or unknown.
 
     Args:
-        address_string: The string to categorize.
+        address: The string to categorize.
 
     Returns:
         A value of AddressType indicating the category.
     """
     try:
-        ipaddress.IPv4Address(address_string)
+        ipaddress.IPv4Address(address)
         return AddressType.IPv4
     except ipaddress.AddressValueError:
         pass
 
     try:
-        ipaddress.IPv6Address(address_string)
+        ipaddress.IPv6Address(address)
         return AddressType.IPv6
     except ipaddress.AddressValueError:
         pass
 
     # Basic hostname check (can be expanded for more rigorous validation)
-    if re.match(r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", address_string):
+    # The original regex was generated via Gemini AI.
+    # It was modified to require the first character be alphabetic to eliminate
+    # a string composed of nothing but digits be recognized as a hostname.
+    if re.match(r"^[a-zA-Z](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", address):
         return AddressType.HOSTNAME
 
     return AddressType.UNKNOWN
 
 
-def classify_address_string(address_string) -> AddressType:
+def _classify_address(address: str) -> AddressType:
     """
     Categorizes a given string as IPv4, IPv6, hostname, or unknown.
 
     An IPv6 address wrapped in [] is considered a hostname.
 
     Args:
-        address_string: The string to categorize.
+        address: The string to categorize.
 
     Returns:
         A value of AddressType indicating the category.
     """
-    address_type = _classify_address_string(address_string)
-    if address_type != AddressType.UNKNOWN:
-        return address_type
-
     # We could be dealing with an IPv6 address wrapped in [].
     # If that is the case we want to identify it as a host name.
-    if (address_string[0] == "[") and (address_string[-1] == "]"):
-        address_type = _classify_address_string(address_string[1:-1])
+    # The reason for this is the common use case where an IPv6 in []s is
+    # utilized in the same manner as a hostname.  Thus we eliminate special
+    # casing on the part of the client to only the situation where they have a
+    # "raw" IPv6 address.
+
+    # Check that the address is at least two characters long.
+    if (len(address) >= 2) and (address[0] == "[") and (address[-1] == "]"):
+        address_type = _classify_base_address(address[1:-1])
 
         # Only an address type of IPv6 is considered valid here.
         # We don't want to treat any other specification as valid.
         if address_type == AddressType.IPv6:
             return AddressType.HOSTNAME
+        return AddressType.UNKNOWN
 
-    return AddressType.UNKNOWN
+    return _classify_base_address(address)
 
 
-def classify_and_split_address_string(address_string) -> tuple[AddressType, str, str]:
+def classify_address(address: str) -> AddressTypeResponse:
     """
     Categorizes a given string with optional ":<port>" suffix as IPv4, IPv6,
     hostname, or unknown.
 
     Args:
-        address_string: The string to categorize.
+        address: The string to categorize.
 
     Returns:
-        A tuple of the form (AddressType, address string, port string) where
-        address_string and port_string are only valid (though port string may
-        be an empty string) when AddressType is not AddressType.UNKNOWN.
+        An instance of AddressTypeResponse.
     """
-    address_type = classify_address_string(address_string)
+    address_type = _classify_address(address)
     if address_type != AddressType.UNKNOWN:
         # A known type with no port.
-        return (address_type, address_string, "")
+        return AddressTypeResponse(address_type, address)
 
     # Split into potential address and port and classify the address.
-    (address_string, _, port) = address_string.rpartition(":")
-    address_type = classify_address_string(address_string)
+    (address, _, port) = address.rpartition(":")
+    address_type = _classify_address(address)
     if address_type != AddressType.UNKNOWN:
         # A known type with a port.
-        return (address_type, address_string, port)
+        return AddressTypeResponse(address_type, address, port)
 
     # An unknown address type.
-    return (AddressType.UNKNOWN, "", "")
-
-
-def is_hostname_address_string(address_string: str) -> bool:
-    return classify_address_string(address_string) == AddressType.HOSTNAME
-
-
-def is_ipv4_address_string(address_string: str) -> bool:
-    return classify_address_string(address_string) == AddressType.IPv4
-
-
-def is_ipv6_address_string(address_string: str) -> bool:
-    return classify_address_string(address_string) == AddressType.IPv6
+    return AddressTypeResponse(AddressType.UNKNOWN)

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -33,11 +33,7 @@ def _classify_address_string(address_string) -> AddressType:
         pass
 
     # Basic hostname check (can be expanded for more rigorous validation)
-    if re.match(
-        r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
-        r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$",
-        address_string
-    ):
+    if re.match(r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?" r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", address_string):
         return AddressType.HOSTNAME
 
     return AddressType.UNKNOWN

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -33,7 +33,7 @@ def _classify_address_string(address_string) -> AddressType:
         pass
 
     # Basic hostname check (can be expanded for more rigorous validation)
-    if re.match(r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?" r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", address_string):
+    if re.match(r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", address_string):
         return AddressType.HOSTNAME
 
     return AddressType.UNKNOWN

--- a/ansible_base/lib/utils/address.py
+++ b/ansible_base/lib/utils/address.py
@@ -2,6 +2,7 @@ import dataclasses
 import enum
 import ipaddress
 import re
+import typing
 
 
 class AddressType(enum.Enum):
@@ -36,13 +37,12 @@ class AddressTypeResponse(object):
 
     Strings are used for the address and port so as to minimize changes to
     existing code to facilitate use of the classification functionality
-    provided.  An empty string indicates the non-existence of that particular
-    attribute as part of the classified address.
+    provided.
     """
 
     type: AddressType
-    address: str = ""
-    port: str = ""
+    address: str
+    port: typing.Optional[str] = None
 
     @property
     def ipv6_bracketed(self):
@@ -123,8 +123,9 @@ def _classify_address(address: str) -> AddressTypeResponse:
     if (len(address) >= 2) and (address[0] == "[") and (address[-1] == "]"):
         response = _classify_base_address(address[1:-1])
 
-        # Only an address type of IPv6 is considered valid here.
-        # We don't want to treat any other specification as valid.
+        # We only recognize an IPv6 address wrapped in []s as valid.
+        # Regardless of the contents being identified if it is not an IPv6
+        # address we treat it as unknown.
         if response.type == AddressType.IPv6:
             return response
         return AddressTypeResponse(AddressType.UNKNOWN, address)

--- a/test_app/tests/lib/redis/test_client.py
+++ b/test_app/tests/lib/redis/test_client.py
@@ -214,6 +214,8 @@ def test_redis_cluster_mget_raises_expected_exception():
         ('[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1', False, 1),
         ('[::1]:1,2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1', False, 2),
         ('[::1]:1,[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1', False, 2),
+        ('[::1],[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1', True, None),
+        ('[::1]:1,//////////:1', True, None),
     ],
 )
 def test_redis_client_cluster_hosts_parsing(redis_hosts, raises, expected_length):

--- a/test_app/tests/lib/redis/test_client.py
+++ b/test_app/tests/lib/redis/test_client.py
@@ -209,6 +209,11 @@ def test_redis_cluster_mget_raises_expected_exception():
         ('a:1,b:1', False, 2),
         ('a:b', True, None),
         ('a,b,c', True, None),
+        ('[::1]:1', False, 1),
+        ('2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1', False, 1),
+        ('[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1', False, 1),
+        ('[::1]:1,2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1', False, 2),
+        ('[::1]:1,[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1', False, 2),
     ],
 )
 def test_redis_client_cluster_hosts_parsing(redis_hosts, raises, expected_length):

--- a/test_app/tests/lib/utils/test_address.py
+++ b/test_app/tests/lib/utils/test_address.py
@@ -1,88 +1,32 @@
 import pytest
 
-from ansible_base.lib.utils.address import (
-    AddressType,
-    classify_address_string,
-    classify_and_split_address_string,
-    is_hostname_address_string,
-    is_ipv4_address_string,
-    is_ipv6_address_string,
-)
+from ansible_base.lib.utils.address import AddressType, AddressTypeResponse, classify_address
 
 
 @pytest.mark.parametrize(
     "address,expected",
     [
-        ("127.0.0.1", AddressType.IPv4),
-        ("[127.0.0.1]", AddressType.UNKNOWN),
-        ("10.0.1.1", AddressType.IPv4),
-        ("[10.0.1.1]", AddressType.UNKNOWN),
-        ("::1", AddressType.IPv6),
-        ("[::1]", AddressType.HOSTNAME),
-        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", AddressType.IPv6),
-        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", AddressType.HOSTNAME),
-        ("localhost", AddressType.HOSTNAME),
-        ("[localhost]", AddressType.UNKNOWN),
-        ("a-host-name", AddressType.HOSTNAME),
-        ("[a-host-name]", AddressType.UNKNOWN),
-        ("////////////", AddressType.UNKNOWN),
+        ("127.0.0.1", AddressTypeResponse(AddressType.IPv4, "127.0.0.1")),
+        ("[127.0.0.1]", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("127.0.0.1:1234", AddressTypeResponse(AddressType.IPv4, "127.0.0.1", "1234")),
+        ("10.0.1.1:1234", AddressTypeResponse(AddressType.IPv4, "10.0.1.1", "1234")),
+        ("10.0.1.1", AddressTypeResponse(AddressType.IPv4, "10.0.1.1")),
+        ("[10.0.1.1]", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("::1", AddressTypeResponse(AddressType.IPv6, "::1")),
+        ("[::1]", AddressTypeResponse(AddressType.HOSTNAME, "[::1]")),
+        ("[::1]:1234", AddressTypeResponse(AddressType.HOSTNAME, "[::1]", "1234")),
+        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", AddressTypeResponse(AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8")),
+        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", AddressTypeResponse(AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]")),
+        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1234", AddressTypeResponse(AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "1234")),
+        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1234", AddressTypeResponse(AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "1234")),
+        ("localhost", AddressTypeResponse(AddressType.HOSTNAME, "localhost")),
+        ("[localhost]", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("localhost:1234", AddressTypeResponse(AddressType.HOSTNAME, "localhost", "1234")),
+        ("a-host-name", AddressTypeResponse(AddressType.HOSTNAME, "a-host-name")),
+        ("a-host-name:1234", AddressTypeResponse(AddressType.HOSTNAME, "a-host-name", "1234")),
+        ("////////////", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("123123123123", AddressTypeResponse(AddressType.UNKNOWN)),
     ],
 )
 def test_classify_address(address, expected):
-    assert classify_address_string(address) == expected
-
-
-@pytest.mark.parametrize(
-    "address,expected",
-    [
-        ("127.0.0.1", (AddressType.IPv4, "127.0.0.1", "")),
-        ("127.0.0.1:1234", (AddressType.IPv4, "127.0.0.1", "1234")),
-        ("10.0.1.1:1234", (AddressType.IPv4, "10.0.1.1", "1234")),
-        ("::1", (AddressType.IPv6, "::1", "")),
-        ("[::1]:1234", (AddressType.HOSTNAME, "[::1]", "1234")),
-        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "")),
-        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1234", (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "1234")),
-        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "")),
-        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1234", (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "1234")),
-        ("localhost", (AddressType.HOSTNAME, "localhost", "")),
-        ("localhost:1234", (AddressType.HOSTNAME, "localhost", "1234")),
-        ("a-host-name", (AddressType.HOSTNAME, "a-host-name", "")),
-        ("a-host-name:1234", (AddressType.HOSTNAME, "a-host-name", "1234")),
-    ],
-)
-def test_classify_and_split_address(address, expected):
-    assert classify_and_split_address_string(address) == expected
-
-
-@pytest.mark.parametrize(
-    "address",
-    [
-        "localhost",
-        "a-host-name",
-        "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]",
-    ],
-)
-def test_is_hostname_address(address):
-    assert is_hostname_address_string(address)
-
-
-@pytest.mark.parametrize(
-    "address",
-    [
-        "127.0.0.1",
-        "10.0.1.1",
-    ],
-)
-def test_is_ipv4_address(address):
-    assert is_ipv4_address_string(address)
-
-
-@pytest.mark.parametrize(
-    "address",
-    [
-        "::1",
-        "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8",
-    ],
-)
-def test_is_ipv6_address(address):
-    assert is_ipv6_address_string(address)
+    assert classify_address(address) == expected

--- a/test_app/tests/lib/utils/test_address.py
+++ b/test_app/tests/lib/utils/test_address.py
@@ -39,22 +39,10 @@ def test_classify_address(address, expected):
         ("10.0.1.1:1234", (AddressType.IPv4, "10.0.1.1", "1234")),
         ("::1", (AddressType.IPv6, "::1", "")),
         ("[::1]:1234", (AddressType.HOSTNAME, "[::1]", "1234")),
-        (
-            "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8",
-            (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "")
-        ),
-        (
-            "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1234",
-            (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "1234")
-        ),
-        (
-            "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]",
-            (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "")
-        ),
-        (
-            "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1234",
-            (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "1234")
-        ),
+        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "")),
+        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1234", (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "1234")),
+        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "")),
+        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1234", (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "1234")),
         ("localhost", (AddressType.HOSTNAME, "localhost", "")),
         ("localhost:1234", (AddressType.HOSTNAME, "localhost", "1234")),
         ("a-host-name", (AddressType.HOSTNAME, "a-host-name", "")),

--- a/test_app/tests/lib/utils/test_address.py
+++ b/test_app/tests/lib/utils/test_address.py
@@ -7,26 +7,31 @@ from ansible_base.lib.utils.address import AddressType, AddressTypeResponse, cla
     "address,expected",
     [
         ("127.0.0.1", AddressTypeResponse(AddressType.IPv4, "127.0.0.1")),
-        ("[127.0.0.1]", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("[127.0.0.1]", AddressTypeResponse(AddressType.UNKNOWN, "[127.0.0.1]")),
         ("127.0.0.1:1234", AddressTypeResponse(AddressType.IPv4, "127.0.0.1", "1234")),
         ("10.0.1.1:1234", AddressTypeResponse(AddressType.IPv4, "10.0.1.1", "1234")),
         ("10.0.1.1", AddressTypeResponse(AddressType.IPv4, "10.0.1.1")),
-        ("[10.0.1.1]", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("[10.0.1.1]", AddressTypeResponse(AddressType.UNKNOWN, "[10.0.1.1]")),
         ("::1", AddressTypeResponse(AddressType.IPv6, "::1")),
-        ("[::1]", AddressTypeResponse(AddressType.HOSTNAME, "[::1]")),
-        ("[::1]:1234", AddressTypeResponse(AddressType.HOSTNAME, "[::1]", "1234")),
+        ("[::1]", AddressTypeResponse(AddressType.IPv6, "::1")),
+        ("[::1]:1234", AddressTypeResponse(AddressType.IPv6, "::1", "1234")),
         ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", AddressTypeResponse(AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8")),
-        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", AddressTypeResponse(AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]")),
+        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", AddressTypeResponse(AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8")),
         ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1234", AddressTypeResponse(AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "1234")),
-        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1234", AddressTypeResponse(AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "1234")),
+        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1234", AddressTypeResponse(AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "1234")),
         ("localhost", AddressTypeResponse(AddressType.HOSTNAME, "localhost")),
-        ("[localhost]", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("[localhost]", AddressTypeResponse(AddressType.UNKNOWN, "[localhost]")),
         ("localhost:1234", AddressTypeResponse(AddressType.HOSTNAME, "localhost", "1234")),
         ("a-host-name", AddressTypeResponse(AddressType.HOSTNAME, "a-host-name")),
         ("a-host-name:1234", AddressTypeResponse(AddressType.HOSTNAME, "a-host-name", "1234")),
-        ("////////////", AddressTypeResponse(AddressType.UNKNOWN)),
-        ("123123123123", AddressTypeResponse(AddressType.UNKNOWN)),
+        ("////////////", AddressTypeResponse(AddressType.UNKNOWN, "////////////")),
+        ("123123123123", AddressTypeResponse(AddressType.UNKNOWN, "123123123123")),
     ],
 )
 def test_classify_address(address, expected):
-    assert classify_address(address) == expected
+    response = classify_address(address)
+    assert response == expected
+    if response.type == AddressType.IPv6:
+        assert response.ipv6_bracketed == f"[{response.address}]"
+    else:
+        assert response.ipv6_bracketed is None

--- a/test_app/tests/lib/utils/test_address.py
+++ b/test_app/tests/lib/utils/test_address.py
@@ -25,6 +25,7 @@ from ansible_base.lib.utils.address import (
         ("[localhost]", AddressType.UNKNOWN),
         ("a-host-name", AddressType.HOSTNAME),
         ("[a-host-name]", AddressType.UNKNOWN),
+        ("////////////", AddressType.UNKNOWN),
     ],
 )
 def test_classify_address(address, expected):

--- a/test_app/tests/lib/utils/test_address.py
+++ b/test_app/tests/lib/utils/test_address.py
@@ -1,0 +1,99 @@
+import pytest
+
+from ansible_base.lib.utils.address import (
+    AddressType,
+    classify_address_string,
+    classify_and_split_address_string,
+    is_hostname_address_string,
+    is_ipv4_address_string,
+    is_ipv6_address_string,
+)
+
+
+@pytest.mark.parametrize(
+    "address,expected",
+    [
+        ("127.0.0.1", AddressType.IPv4),
+        ("[127.0.0.1]", AddressType.UNKNOWN),
+        ("10.0.1.1", AddressType.IPv4),
+        ("[10.0.1.1]", AddressType.UNKNOWN),
+        ("::1", AddressType.IPv6),
+        ("[::1]", AddressType.HOSTNAME),
+        ("2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", AddressType.IPv6),
+        ("[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", AddressType.HOSTNAME),
+        ("localhost", AddressType.HOSTNAME),
+        ("[localhost]", AddressType.UNKNOWN),
+        ("a-host-name", AddressType.HOSTNAME),
+        ("[a-host-name]", AddressType.UNKNOWN),
+    ],
+)
+def test_classify_address(address, expected):
+    assert classify_address_string(address) == expected
+
+
+@pytest.mark.parametrize(
+    "address,expected",
+    [
+        ("127.0.0.1", (AddressType.IPv4, "127.0.0.1", "")),
+        ("127.0.0.1:1234", (AddressType.IPv4, "127.0.0.1", "1234")),
+        ("10.0.1.1:1234", (AddressType.IPv4, "10.0.1.1", "1234")),
+        ("::1", (AddressType.IPv6, "::1", "")),
+        ("[::1]:1234", (AddressType.HOSTNAME, "[::1]", "1234")),
+        (
+            "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8",
+            (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "")
+        ),
+        (
+            "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8:1234",
+            (AddressType.IPv6, "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8", "1234")
+        ),
+        (
+            "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]",
+            (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "")
+        ),
+        (
+            "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]:1234",
+            (AddressType.HOSTNAME, "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]", "1234")
+        ),
+        ("localhost", (AddressType.HOSTNAME, "localhost", "")),
+        ("localhost:1234", (AddressType.HOSTNAME, "localhost", "1234")),
+        ("a-host-name", (AddressType.HOSTNAME, "a-host-name", "")),
+        ("a-host-name:1234", (AddressType.HOSTNAME, "a-host-name", "1234")),
+    ],
+)
+def test_classify_and_split_address(address, expected):
+    assert classify_and_split_address_string(address) == expected
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "localhost",
+        "a-host-name",
+        "[2600:1f18:218b:5902:e5d4:54de:fdc1:24b8]",
+    ],
+)
+def test_is_hostname_address(address):
+    assert is_hostname_address_string(address)
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.1.1",
+    ],
+)
+def test_is_ipv4_address(address):
+    assert is_ipv4_address_string(address)
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "::1",
+        "2600:1f18:218b:5902:e5d4:54de:fdc1:24b8",
+    ],
+)
+def test_is_ipv6_address(address):
+    assert is_ipv6_address_string(address)


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
* Extending the class of addresses supported for Redis clients to include IPv6 values.

- Why is this change needed?
* Current Redis client rejects IPv6 address as invalid.

- How does this change address the issue?
Accepts IPv6 addresses in the common forms of <addr>:<port> and [<addr>]:<port>.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Steps to Test
1. Deploy AAP environment in an IPv6-only environment *not utilizing host names for Redis client.  Installer operates as such.

### Expected Results
Redis client connections successfully instantiated.
 
