### PR TITLE
[WIP] fix: Inject ldap implicitly to the settings loader

### DIFF
--- a/ansible_base/lib/dynamic_config/dynaconf_helpers.py
+++ b/ansible_base/lib/dynamic_config/dynaconf_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import os
 import sys
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 from warnings import warn
@@ -269,6 +270,13 @@ def load_python_file_with_injected_context(*paths: str, settings: Dynaconf, run_
         files_to_load = glob(pattern)
         for file_path in files_to_load:
             scope = settings.as_dict()
+
+            # Inject ldap module because some legacy custom config expect it on the global scope
+            with suppress(ImportError):  # ldap may not be installed on all environments
+                import ldap
+
+                scope["ldap"] = ldap
+
             file_path = os.path.abspath(file_path)
             with open(file_path, "rb") as to_compile:
                 code = compile(to_compile.read(), file_path, "exec")


### PR DESCRIPTION
```
File "/etc/tower/conf.d/ldap.py", line 2, in <module>
ldap.OPT_X_TLS_REQUIRE_CERT: True,
^^^^
NameError: name 'ldap' is not defined
```

