### PR TITLE
[WIP] Emit logs for authentication failures and successes (local and oidc authenticator plugins

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/local.py
+++ b/ansible_base/authentication/authenticator_plugins/local.py
@@ -52,6 +52,15 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
         if new_username != username:
             return None
 
+        auth_log_headers = (
+            f"HTTP_USER_AGENT: {request.META['HTTP_USER_AGENT'] if 'HTTP_USER_AGENT' in request.META else 'UNKNOWN'} "
+            f"HTTP_X_FORWARDED_FOR: {request.META['HTTP_X_FORWARDED_FOR'] if 'HTTP_X_FORWARDED_FOR' in request.META else 'UNKNOWN'} "
+            f"REMOTE_ADDR: {request.META['REMOTE_ADDR'] if 'REMOTE_ADDR' in request.META else 'UNKNOWN'} "
+            f"REMOTE_HOST: {request.META['REMOTE_HOST'] if 'REMOTE_HOST' in request.META else 'UNKNOWN'}"
+        )
+
+        logger.info(f"Login attempt for user: {username} {auth_log_headers}")
+
         user = super().authenticate(request, username, password, **kwargs)
 
         # This auth class doesn't create any new local users, but we still need to make sure
@@ -69,5 +78,8 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
                     "is_superuser": user.is_superuser,
                 },
             )
+            logger.info(f"Successful login for user: {username} {auth_log_headers}")
+        else:
+            logger.info(f"Failed login for user: {username} {auth_log_headers}")
 
         return update_user_claims(user, self.database_instance, [])

--- a/ansible_base/authentication/authenticator_plugins/oidc.py
+++ b/ansible_base/authentication/authenticator_plugins/oidc.py
@@ -221,6 +221,29 @@ class AuthenticatorPlugin(SocialAuthMixin, OpenIdConnectAuth, AbstractAuthentica
     def groups_claim(self):
         return self.setting('GROUPS_CLAIM')
 
+    def authenticate(self, *args, **kwargs):
+        request = args[0]
+
+        auth_log_headers = (
+            f"HTTP_USER_AGENT: {request.META['HTTP_USER_AGENT'] if 'HTTP_USER_AGENT' in request.META else 'UNKNOWN'} "
+            f"HTTP_X_FORWARDED_FOR: {request.META['HTTP_X_FORWARDED_FOR'] if 'HTTP_X_FORWARDED_FOR' in request.META else 'UNKNOWN'} "
+            f"REMOTE_ADDR: {request.META['REMOTE_ADDR'] if 'REMOTE_ADDR' in request.META else 'UNKNOWN'} "
+            f"REMOTE_HOST: {request.META['REMOTE_HOST'] if 'REMOTE_HOST' in request.META else 'UNKNOWN'}"
+        )
+
+        if "backend" in kwargs and kwargs["backend"].name == self.name:
+            logger.info(f"Login attempt for {auth_log_headers}")
+
+        user = super().authenticate(*args, **kwargs)
+
+        if "backend" in kwargs and kwargs["backend"].name == self.name:
+            if user:
+                logger.info(f"Successful login for {user} {auth_log_headers}")
+            else:
+                logger.info(f"Failed login {auth_log_headers}")
+
+        return user
+
     def extra_data(self, user, backend, response, *args, **kwargs):
         for perm in ["is_superuser", get_setting('ANSIBLE_BASE_SOCIAL_AUDITOR_FLAG')]:
             if perm in response:


### PR DESCRIPTION
## Description
- What is being changed?
Modifes the local and oidc authentication plugins so that logs are emitted for:
  - Login attempts
  - Login Successes
  - Login Failures
- Why is this change needed?
This assist with audit user accesses
- How does this change address the issue?
Logs are emitted that can be inspected to audit what users are logging in and if any failed login attempts are occurring


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
Login using either local or oidc and check logs for emitted logs

### Prerequisites
N/A

### Steps to Test
1. Login successfully using local user
2. Confirm logs contain expected logs
3. Attempt to login using local user with incorrect credentials
4. Confirm logs contain expected logs
5. Login using oidc
6. Confirm logs contain expected logs

### Expected Results
#### Failed local login
```
2025-05-15 03:47:07,597 WARNING  898d5f6b-45a9-4388-bdb7-afbc43ad77a3 ansible_base.authentication.authenticator_plugins.local Login attempt for user: asdf HTTP_USER_AGENT: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0 HTTP_X_FORWARDED_FOR: 10.111.0.10,100.73.10.4 REMOTE_ADDR: 127.0.0.1 REMOTE_HOST: UNKNOWN
2025-05-15 03:47:07,695 WARNING  898d5f6b-45a9-4388-bdb7-afbc43ad77a3 ansible_base.authentication.authenticator_plugins.local Failed login for user: asdf HTTP_USER_AGENT: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0 HTTP_X_FORWARDED_FOR: 10.111.0.10,100.73.10.4 REMOTE_ADDR: 127.0.0.1 REMOTE_HOST: UNKNOWN
```

#### Successful oidc login
```
2025-05-15 03:48:20,859 WARNING  caea1e96-239d-4af1-ad1e-0f74a4ffbb72 ansible_base.authentication.authenticator_plugins.oidc Login attempt for HTTP_USER_AGENT: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0 HTTP_X_FORWARDED_FOR: 10.111.0.10,100.73.10.4 REMOTE_ADDR: 127.0.0.1 REMOTE_HOST: UNKNOWN
2025-05-15 03:48:21,299 WARNING  caea1e96-239d-4af1-ad1e-0f74a4ffbb72 ansible_base.authentication.authenticator_plugins.oidc Successful login for Mark Farrell HTTP_USER_AGENT: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0 HTTP_X_FORWARDED_FOR: 10.111.0.10,100.73.10.4 REMOTE_ADDR: 127.0.0.1 REMOTE_HOST: UNKNOWN
```

#### Successful local login
```
2025-05-15 03:50:12,925 WARNING  90d1301d-6646-4e95-bb17-10950d9eaed2 ansible_base.authentication.authenticator_plugins.local Login attempt for user: admin HTTP_USER_AGENT: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0 HTTP_X_FORWARDED_FOR: 10.111.0.10,100.73.10.4 REMOTE_ADDR: 127.0.0.1 REMOTE_HOST: UNKNOWN
2025-05-15 03:50:13,052 WARNING  90d1301d-6646-4e95-bb17-10950d9eaed2 ansible_base.authentication.authenticator_plugins.local Successful login for user: admin HTTP_USER_AGENT: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0 HTTP_X_FORWARDED_FOR: 10.111.0.10,100.73.10.4 REMOTE_ADDR: 127.0.0.1 REMOTE_HOST: UNKNOWN
```

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
