### PR TITLE
AAP-36738: enhance ldap filter validation

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from typing import Any
 
 import ldap
+from ldap_filter import Filter, ParseError
 from django.utils.translation import gettext_lazy as _
 from django_auth_ldap import config
 from django_auth_ldap.backend import LDAPBackend
@@ -183,14 +184,14 @@ def validate_ldap_filter(value: Any, with_user: bool = False) -> None:
 
         dn_value = value.replace(user_search_string, 'USER')
 
-    if re.match(r'^\([A-Za-z0-9-]+?=[^()]+?\)$', dn_value):
-        return
-    elif re.match(r'^\([&|!]\(.*?\)\)$', dn_value):
+    if re.match(r'^\([&|!]\(.*?\)\)$', dn_value):
         for sub_filter in dn_value[3:-2].split(')('):
             # We only need to check with_user at the top of the recursion stack
             validate_ldap_filter(f'({sub_filter})', with_user=False)
-        return
-    raise ValidationError(_('Invalid filter: %s') % value)
+    try:
+        Filter.parse(dn_value)
+    except ParseError:
+        raise ValidationError(_('Invalid filter: %s') % value)
 
 
 def get_all_sub_classes(cls):

--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -184,6 +184,7 @@ def validate_ldap_filter(value: Any, with_user: bool = False) -> None:
 
         dn_value = value.replace(user_search_string, 'USER')
 
+    # Check if this is an and/or filter with multiple subfilters
     if re.match(r'^\([&|!]\(.*?\)\)$', dn_value):
         for sub_filter in dn_value[3:-2].split(')('):
             # We only need to check with_user at the top of the recursion stack

--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -5,12 +5,12 @@ from collections import OrderedDict
 from typing import Any
 
 import ldap
-from ldap_filter import Filter, ParseError
 from django.utils.translation import gettext_lazy as _
 from django_auth_ldap import config
 from django_auth_ldap.backend import LDAPBackend
 from django_auth_ldap.backend import LDAPSettings as BaseLDAPSettings
 from django_auth_ldap.config import LDAPGroupType, LDAPSearchUnion
+from ldap_filter import Filter, ParseError
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.authenticator_plugins.base import AbstractAuthenticatorPlugin, Authenticator, BaseAuthenticatorConfiguration

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -71,6 +71,8 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 jwcrypto==1.5.6
     # via django-oauth-toolkit
+ldap-filter==1.0.1
+    # via -r requirements/requirements_authentication.in
 lxml==5.3.0
     # via
     #   python3-saml
@@ -145,7 +147,9 @@ six==1.17.0
 social-auth-app-django==5.4.1
     # via -r requirements/requirements_authentication.in
 social-auth-core==4.5.4
-    # via social-auth-app-django
+    # via
+    #   -r requirements/requirements_authentication.in
+    #   social-auth-app-django
 sqlparse==0.5.2
     # via
     #   -r requirements/requirements.in

--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -7,6 +7,7 @@ tabulate
 # LDAP Authenticator Plugins
 django-auth-ldap
 python-ldap
+ldap-filter
 
 # Social Authenticator Plugins
 python3-saml

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -479,6 +479,10 @@ def test_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
         validate_ldap_filter(invalid_filter, True)
     assert e.value.args[0] == 'Invalid filter: (invalid)'
 
+    # From AAP-36738
+    customer_filter = "(&(sAMAccountName=%(user)s)(memberOf:1.2.840.113556.1.4.1941:=CN=pasta,CN=Users,DC=mcanuwin2022,DC=local))"
+    validate_ldap_filter(customer_filter, True)
+
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.logger")

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -480,7 +480,7 @@ def test_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
     assert e.value.args[0] == 'Invalid filter: (invalid)'
 
     # From AAP-36738
-    customer_filter = "(&(sAMAccountName=%(user)s)(memberOf:1.2.840.113556.1.4.1941:=CN=pasta,CN=Users,DC=mcanuwin2022,DC=local))"
+    customer_filter = "(&(sAMAccountName=%(user)s)(memberOf:1.3.850.114256.1.4.1241:=CN=ravioli,CN=Users,DC=username2024,DC=local))"
     validate_ldap_filter(customer_filter, True)
 
 


### PR DESCRIPTION
## Description

Please review/approve as desired, but DO NOT MERGE until https://issues.redhat.com/browse/AAP-46053 is closed (will break PDE builds before that point).

Use ldap-filter package to do LDAP filter validation rather than the regex we had before.

A customer had a problem where we were declaring a valid filter invalid.  Their filter is added to the unit test and now validates OK.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Create ldap authenticator with filter like customer's filter (or whatever you like).  See bug.
2. Log in and see that it works OK.
3. 

### Expected Results
All valid filters should be declared valid.

