### PR TITLE
AAP-45589 set the default timeout of OPT_NETWORK_TIMEOUT from 30 to 20

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -380,7 +380,7 @@ class LDAPSettings(BaseLDAPSettings):
         # If a DB-backed setting is specified that wipes out the
         # OPT_NETWORK_TIMEOUT, fall back to a sane default
         if ldap.OPT_NETWORK_TIMEOUT not in internal_data:
-            internal_data[ldap.OPT_NETWORK_TIMEOUT] = 30
+            internal_data[ldap.OPT_NETWORK_TIMEOUT] = 20
 
         # when specifying `.set_option()` calls for TLS in python-ldap, the
         # *order* in which you invoke them *matters*, particularly in Python3,


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
set the default timeout of OPT_NETWORK_TIMEOUT from 30 to 20
- Why is this change needed?
As an AAP user using LDAP for authentication I want to get a 401 if my LDAP request times out instead of a 504 error code.
- How does this change address the issue?
The default LDAP timeout is 30 seconds in the authenticator. This happens to be the same time for envoy. Since LDAP doesn't start until just a bit after the request goes through envoy, if the LDAP server times out we end up with a 504 proxy error instead of a 401.

We should alter the default timeout to be 20 seconds and write an ATF test to validate that a time out returns the correct code instead of a 504. 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
We need the code to get merged first to test this on ATF. 
Then we can have a test in ATF and check the change in the pipelines

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
