### PR TITLE
AAP-41842: Fix pagination

### DIFF
--- a/ansible_base/activitystream/views.py
+++ b/ansible_base/activitystream/views.py
@@ -37,9 +37,10 @@ class EntryReadOnlyViewSet(ReadOnlyModelViewSet, AnsibleBaseDjangoAppApiView):
     API endpoint that allows for read-only access to activity stream entries.
     """
 
-    queryset = Entry.objects.order_by('-id')
+    queryset = Entry.objects.all()
     serializer_class = EntrySerializer
     filter_backends = calculate_filter_backends()
+    ordering = ['-id']
 
     def get_permissions(self):
         """

--- a/ansible_base/lib/utils/views/ansible_base.py
+++ b/ansible_base/lib/utils/views/ansible_base.py
@@ -11,6 +11,8 @@ logger = logging.getLogger('ansible_base.lib.utils.views.ansible_base')
 
 class AnsibleBaseView(APIView):
 
+    ordering = ['pk']
+
     # pulp openapi generator compatibility
     endpoint_name = ''
 


### PR DESCRIPTION
## Description
Provide a base ordering via rest filter such that all queries are returned in order of pk (if no other ordering is specified).  This ensures that paginated returns are complete and no records are duplicated.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Create enough records (users or organizations for example) to exceed one page.  (the page size can also be reduced via setting DEFAULT_PAGE_SIZE if desired), ideally at least 3 pages.
2. Fetch API endpoint (this issue was discovered on service-index/resources/ so that would be a good one to verify)
3. Ensure the content has no missing or duplicated items

### Expected Results
No records are missing and/or duplicated.

## Additional Context
