### PR TITLE
[AAP-44485] fix typo in ansible_base/resource_registry/models/resource.py

### DIFF
--- a/ansible_base/resource_registry/models/resource.py
+++ b/ansible_base/resource_registry/models/resource.py
@@ -17,7 +17,7 @@ def resource_type_cache(content_type_id):
     return ContentType.objects.get_for_id(content_type_id).resource_type
 
 
-class UnamangedResourceException(Exception):
+class UnmanagedResourceException(Exception):
     pass
 
 
@@ -50,7 +50,7 @@ class ResourceType(models.Model):
         qfilter = {}
 
         if not self.can_be_managed:
-            raise UnamangedResourceException(f"Resource type {self.name} does not have a managed serializer.")
+            raise UnmanagedResourceException(f"Resource type {self.name} does not have a managed serializer.")
 
         serializer = self.serializer_class(data=resource_data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Fix typo in `ansible_base/resource_registry/models/resource.py` file

Note: As I'm working on AAP-44485, I noticed the typo in the above file. It looks like DAB DCVS check doesn't allow the NO_JIRA marker. Thus, I added AAP-44485 so that it passed the check
