### PR TITLE
[AAP-46508] rename feature_flag_state view for uniform reverse lookup

### DIFF
--- a/ansible_base/feature_flags/urls.py
+++ b/ansible_base/feature_flags/urls.py
@@ -6,7 +6,7 @@ from ansible_base.feature_flags.apps import FeatureFlagsConfig
 app_name = FeatureFlagsConfig.label
 
 api_version_urls = [
-    path('feature_flags_state/', views.FeatureFlagsStateListView.as_view(), name='featureflags-list'),
+    path('feature_flags_state/', views.FeatureFlagsStateListView.as_view(), name='feature-flags-state-list'),
 ]
 api_urls = []
 root_urls = []

--- a/test_app/tests/feature_flags/test_api.py
+++ b/test_app/tests/feature_flags/test_api.py
@@ -8,7 +8,7 @@ def test_feature_flags_state_api_list(admin_api_client: APIClient):
     """
     Test that we can list all feature flags
     """
-    url = get_relative_url("featureflags-list")
+    url = get_relative_url("feature-flags-state-list")
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert 'FEATURE_SOME_PLATFORM_FLAG_ENABLED' in response.data
@@ -34,7 +34,7 @@ def test_feature_flags_state_api_list_settings_override(admin_api_client: APICli
     """
     Test that we can list all feature flags
     """
-    url = get_relative_url("featureflags-list")
+    url = get_relative_url("feature-flags-state-list")
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert 'FEATURE_SOME_PLATFORM_FLAG_ENABLED' not in response.data
@@ -51,7 +51,7 @@ def test_feature_flags_state_api_list_settings_override_empty(admin_api_client: 
     """
     Test that we can list all feature flags
     """
-    url = get_relative_url("featureflags-list")
+    url = get_relative_url("feature-flags-state-list")
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert response.data == {}


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
This change is part of the work in [AAP-46508](https://issues.redhat.com/browse/AAP-46508)
django view name for endpoint `'feature_flags_state/'` is renamed from `featureflags-list` to `feature-flags-state-list`.
- Why is this change needed?
This will make the view name standard-conforming and simplify the logic in reverse URL look up
 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Steps to Test
1. all tests in `test_app/tests/feature_flags/test_api.py` should pass
2. 
3. 


