### PR TITLE
[WIP] Allow customizing settings module from get_setting

### DIFF
--- a/ansible_base/lib/utils/requests.py
+++ b/ansible_base/lib/utils/requests.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from crum import get_current_request
+from django.conf import LazySettings, settings
 from django.http import HttpRequest
 
 from ansible_base.jwt_consumer.common.util import validate_x_trusted_proxy_header
@@ -24,7 +25,7 @@ def split_header(value: str) -> list[str]:
     return values
 
 
-def get_remote_hosts(request: HttpRequest, get_first_only: bool = False) -> list[str]:
+def get_remote_hosts(request: HttpRequest, get_first_only: bool = False, settings_module: LazySettings = settings) -> list[str]:
     '''
     Get all IPs from the allowed headers
     NOTE: this function does not unique the hosts to preserve the order of hosts found in the variables
@@ -34,7 +35,7 @@ def get_remote_hosts(request: HttpRequest, get_first_only: bool = False) -> list
     if not request or not hasattr(request, 'META'):
         return remote_hosts
 
-    headers = get_setting('REMOTE_HOST_HEADERS', ['REMOTE_ADDR', 'REMOTE_HOST'])
+    headers = get_setting('REMOTE_HOST_HEADERS', ['REMOTE_ADDR', 'REMOTE_HOST'], settings_module=settings_module)
 
     for header in headers:
         for value in split_header(request.META.get(header, '')):

--- a/ansible_base/lib/utils/settings.py
+++ b/ansible_base/lib/utils/settings.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 from typing import Any
 
-from django.conf import settings
+from django.conf import LazySettings, settings
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.utils.validation import to_python_boolean
@@ -14,9 +14,9 @@ class SettingNotSetException(Exception):
     pass
 
 
-def get_setting(name: str, default: Any = None, log_exception: bool = True) -> Any:
+def get_setting(name: str, default: Any = None, log_exception: bool = True, settings_module: LazySettings = settings) -> Any:
     try:
-        the_function = get_function_from_setting('ANSIBLE_BASE_SETTINGS_FUNCTION')
+        the_function = get_function_from_setting('ANSIBLE_BASE_SETTINGS_FUNCTION', settings_module=settings_module)
         if the_function:
             setting = the_function(name)
             return setting
@@ -32,11 +32,11 @@ def get_setting(name: str, default: Any = None, log_exception: bool = True) -> A
                 )
             )
 
-    return getattr(settings, name, default)
+    return getattr(settings_module, name, default)
 
 
-def get_function_from_setting(setting_name: str) -> Any:
-    setting = getattr(settings, setting_name, None)
+def get_function_from_setting(setting_name: str, settings_module: LazySettings = settings) -> Any:
+    setting = getattr(settings_module, setting_name, None)
     if not setting:
         return None
 

--- a/ansible_base/rbac/policies.py
+++ b/ansible_base/rbac/policies.py
@@ -1,5 +1,5 @@
 from django.apps import apps
-from django.conf import settings
+from django.conf import LazySettings, settings
 from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
@@ -12,12 +12,12 @@ from ansible_base.rbac.permission_registry import permission_registry
 from ansible_base.rbac.validators import permissions_allowed_for_role
 
 
-def visible_users(request_user, queryset=None, always_show_superusers=True, always_show_self=True) -> QuerySet:
+def visible_users(request_user, queryset=None, always_show_superusers=True, always_show_self=True, settings_module: LazySettings = settings) -> QuerySet:
     """Gives a queryset of users that another user should be able to view"""
     user_cls = permission_registry.user_model
     org_cls = apps.get_model(settings.ANSIBLE_BASE_ORGANIZATION_MODEL)
 
-    if can_view_all_users(request_user):
+    if can_view_all_users(request_user, settings_module=settings_module):
         if queryset is not None:
             return queryset
         else:
@@ -38,22 +38,22 @@ def visible_users(request_user, queryset=None, always_show_superusers=True, alwa
     return queryset.distinct()
 
 
-def can_view_all_users(request_user):
+def can_view_all_users(request_user, settings_module: LazySettings = settings):
     org_cls = apps.get_model(settings.ANSIBLE_BASE_ORGANIZATION_MODEL)
 
     return has_super_permission(request_user, 'view') or (
-        get_setting('ORG_ADMINS_CAN_SEE_ALL_USERS', False) and org_cls.access_ids_qs(request_user, 'change').exists()
+        get_setting('ORG_ADMINS_CAN_SEE_ALL_USERS', False, settings_module=settings_module) and org_cls.access_ids_qs(request_user, 'change').exists()
     )
 
 
-def can_change_user(request_user, target_user) -> bool:
+def can_change_user(request_user, target_user, settings_module: LazySettings = settings) -> bool:
     """Tells if the request user can modify details of the target user"""
     if request_user.is_superuser:
         return True
     elif target_user.is_superuser:
         return False  # target is a superuser and request user is not
 
-    if not get_setting('MANAGE_ORGANIZATION_AUTH', False):
+    if not get_setting('MANAGE_ORGANIZATION_AUTH', False, settings_module=settings_module):
         return False
 
     # All users can change their own password and other details

--- a/test_app/tests/lib/utils/test_settings.py
+++ b/test_app/tests/lib/utils/test_settings.py
@@ -1,5 +1,5 @@
-from unittest import mock
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 from django.test import override_settings

--- a/test_app/tests/lib/utils/test_settings.py
+++ b/test_app/tests/lib/utils/test_settings.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from types import SimpleNamespace
 
 import pytest
 from django.test import override_settings
@@ -48,6 +49,11 @@ def setting_getter_function(setting_name):
 def test_settings_from_function(setting_name, default, expected_value):
     value = get_setting(setting_name, default)
     assert value == expected_value
+
+
+def test_get_setting_custom_module():
+    fake_settings = SimpleNamespace(FOO_SETTING_TEST='fooz')
+    assert get_setting('FOO_SETTING_TEST', settings_module=fake_settings) == 'fooz'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
For dynamic settings, we may not save all settings in the same settings module

Practically, I countered this with the AWX job template callback view. Somehow, the code from that made it into DAB, which referenced `django.conf.settings`, but I need `awx.conf.db_settings`

## Type of Change
- [x] Test update
- [x] Refactoring (no functional changes)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
Can only be functional combined with changes elsewhere

### Prerequisites
none

### Steps to Test
Needs dynamic settings patches in other components

### Expected Results
Unblocks that other work

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
- [ ] Requires documentation updates
- [x] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [x] Requires coordination with other teams
- [x] Blocked by PR/MR: https://github.com/ansible/awx/pull/15997

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
