### PR TITLE
AAP-44925 Make auth map attr and group comparison case insensitive

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -181,24 +181,28 @@ def _add_rbac_role_mapping(has_permission, role_mapping, role, organization=None
 def process_groups(trigger_condition: dict, groups: list, authenticator_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
+    Group DNs are compared case-insensitively.
     """
 
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
         logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {authenticator_id} are invalid and won't be processed")
 
-    set_of_user_groups = set(groups)
+    set_of_user_groups = set([group.casefold() for group in groups])
 
     if "has_or" in trigger_condition:
-        if set_of_user_groups.intersection(set(trigger_condition["has_or"])):
+        trigger_groups = set([group.casefold() for group in trigger_condition["has_or"]])
+        if set_of_user_groups.intersection(trigger_groups):
             return TriggerResult.ALLOW
 
     elif "has_and" in trigger_condition:
-        if set(trigger_condition["has_and"]).issubset(set_of_user_groups):
+        trigger_groups = set([group.casefold() for group in trigger_condition["has_and"]])
+        if trigger_groups.issubset(set_of_user_groups):
             return TriggerResult.ALLOW
 
     elif "has_not" in trigger_condition:
-        if not set(trigger_condition["has_not"]).intersection(set_of_user_groups):
+        trigger_groups = set([group.casefold() for group in trigger_condition["has_not"]])
+        if not trigger_groups.intersection(set_of_user_groups):
             return TriggerResult.ALLOW
 
     return TriggerResult.SKIP
@@ -221,6 +225,7 @@ def has_access_with_join(current_access: Optional[bool], new_access: bool, condi
 def process_user_attributes(trigger_condition: dict, attributes: dict, authenticator_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
+    Attribute names are compared case-insensitively.
     """
 
     # Normalize user and trigger attribute keys (case insensitive compare)
@@ -270,8 +275,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
         for a_user_value in user_value:
             # We are going to do mostly string comparisons, so convert the attribute to a
             #  string just in case it came back as an int or something funky
-            # TODO Do we also want to normalize values??
-            a_user_value = f"{a_user_value}"
+            a_user_value = f"{a_user_value}".casefold()
 
             # Check for any of the valid conditions
             if "equals" in trigger_condition[attribute]:

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -227,8 +227,6 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
-
-    # Normalize user and trigger attribute keys (case insensitive compare)
     attributes = {k.casefold(): v for k, v in attributes.items()}
     trigger_condition = {k.casefold(): v for k, v in trigger_condition.items()}
 

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -183,26 +183,26 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int)
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
     Group DNs are compared case-insensitively.
     """
-
+    user_groups = [f"{group}".casefold() for group in groups]
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
         logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {authenticator_id} are invalid and won't be processed")
 
-    set_of_user_groups = set([f"{group}".casefold() for group in groups])
+    set_of_user_groups = set(user_groups)
 
     if "has_or" in trigger_condition:
-        trigger_groups = set([f"{group}".casefold() for group in trigger_condition["has_or"]])
-        if set_of_user_groups.intersection(trigger_groups):
+        trigger_groups = [f"{group}".casefold() for group in trigger_condition["has_or"]]
+        if set_of_user_groups.intersection(set(trigger_groups)):
             return TriggerResult.ALLOW
 
     elif "has_and" in trigger_condition:
-        trigger_groups = set([f"{group}".casefold() for group in trigger_condition["has_and"]])
-        if trigger_groups.issubset(set_of_user_groups):
+        trigger_groups = [f"{group}".casefold() for group in trigger_condition["has_and"]]
+        if set(trigger_groups).issubset(set_of_user_groups):
             return TriggerResult.ALLOW
 
     elif "has_not" in trigger_condition:
-        trigger_groups = set([f"{group}".casefold() for group in trigger_condition["has_not"]])
-        if not trigger_groups.intersection(set_of_user_groups):
+        trigger_groups = [f"{group}".casefold() for group in trigger_condition["has_not"]]
+        if not set(trigger_groups).intersection(set_of_user_groups):
             return TriggerResult.ALLOW
 
     return TriggerResult.SKIP

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -188,20 +188,20 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int)
     if invalid_conditions:
         logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {authenticator_id} are invalid and won't be processed")
 
-    set_of_user_groups = set([group.casefold() for group in groups])
+    set_of_user_groups = set([f"{group}".casefold() for group in groups])
 
     if "has_or" in trigger_condition:
-        trigger_groups = set([group.casefold() for group in trigger_condition["has_or"]])
+        trigger_groups = set([f"{group}".casefold() for group in trigger_condition["has_or"]])
         if set_of_user_groups.intersection(trigger_groups):
             return TriggerResult.ALLOW
 
     elif "has_and" in trigger_condition:
-        trigger_groups = set([group.casefold() for group in trigger_condition["has_and"]])
+        trigger_groups = set([f"{group}".casefold() for group in trigger_condition["has_and"]])
         if trigger_groups.issubset(set_of_user_groups):
             return TriggerResult.ALLOW
 
     elif "has_not" in trigger_condition:
-        trigger_groups = set([group.casefold() for group in trigger_condition["has_not"]])
+        trigger_groups = set([f"{group}".casefold() for group in trigger_condition["has_not"]])
         if not trigger_groups.intersection(set_of_user_groups):
             return TriggerResult.ALLOW
 
@@ -227,8 +227,8 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
-    attributes = {k.casefold(): v for k, v in attributes.items()}
-    trigger_condition = {k.casefold(): v for k, v in trigger_condition.items()}
+    attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
+    trigger_condition = {f"{k}".casefold(): v for k, v in trigger_condition.items()}
 
     has_access = None
     join_condition = trigger_condition.get('join_condition', 'or')

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -179,7 +179,11 @@ def _add_rbac_role_mapping(has_permission, role_mapping, role, organization=None
             logger.warning(f"Role mapping is not possible, organization for team '{team}' is missing")
 
 
-def _lowercase_group_names(trigger_condition: dict) -> dict:
+def _is_case_insensitivity_enabled() -> bool:
+    return flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS")
+
+
+def _lowercase_group_triggers(trigger_condition: dict) -> dict:
     """
     Lowercase all group names provided to trigger
     """
@@ -194,9 +198,9 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int)
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
     Group DNs are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS enabled.
     """
-    if flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS"):
+    if _is_case_insensitivity_enabled():
         groups = [f"{group}".casefold() for group in groups]
-        trigger_condition = _lowercase_group_names(trigger_condition)
+        trigger_condition = _lowercase_group_triggers(trigger_condition)
 
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
@@ -233,7 +237,7 @@ def has_access_with_join(current_access: Optional[bool], new_access: bool, condi
         return current_access and new_access
 
 
-def _lowercase_triggers(trigger_condition: dict) -> dict:
+def _lowercase_attr_triggers(trigger_condition: dict) -> dict:
     """
     Lower case all keys (attribute names) and contained attribute values
     """
@@ -258,9 +262,9 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
-    if flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS"):
+    if _is_case_insensitivity_enabled():
         attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
-        trigger_condition = _lowercase_triggers(trigger_condition)
+        trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
     has_access = None
     join_condition = trigger_condition.get('join_condition', 'or')
@@ -305,7 +309,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
         for a_user_value in user_value:
             # We are going to do mostly string comparisons, so convert the attribute to a
             #  string just in case it came back as an int or something funky
-            a_user_value = f"{a_user_value}".casefold() if flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS") else f"{a_user_value}"
+            a_user_value = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
 
             # Check for any of the valid conditions
             if "equals" in trigger_condition[attribute]:

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, models
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
+from flags.state import flag_enabled
 from rest_framework.serializers import DateTimeField
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap, AuthenticatorUser
@@ -191,16 +192,17 @@ def _lowercase_group_names(trigger_condition: dict) -> dict:
 def process_groups(trigger_condition: dict, groups: list, authenticator_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
-    Group DNs are compared case-insensitively.
+    Group DNs are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS enabled.
     """
-    user_groups = [f"{group}".casefold() for group in groups]
-    trigger_condition = _lowercase_group_names(trigger_condition)
+    if flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS"):
+        groups = [f"{group}".casefold() for group in groups]
+        trigger_condition = _lowercase_group_names(trigger_condition)
 
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
         logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {authenticator_id} are invalid and won't be processed")
 
-    set_of_user_groups = set(user_groups)
+    set_of_user_groups = set(groups)
 
     if "has_or" in trigger_condition:
         if set_of_user_groups.intersection(set(trigger_condition["has_or"])):
@@ -256,8 +258,9 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
-    attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
-    trigger_condition = _lowercase_triggers(trigger_condition)
+    if flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS"):
+        attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
+        trigger_condition = _lowercase_triggers(trigger_condition)
 
     has_access = None
     join_condition = trigger_condition.get('join_condition', 'or')
@@ -302,7 +305,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
         for a_user_value in user_value:
             # We are going to do mostly string comparisons, so convert the attribute to a
             #  string just in case it came back as an int or something funky
-            a_user_value = f"{a_user_value}".casefold()
+            a_user_value = f"{a_user_value}".casefold() if flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS") else f"{a_user_value}"
 
             # Check for any of the valid conditions
             if "equals" in trigger_condition[attribute]:

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -222,6 +222,11 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     """
+
+    # Normalize user and trigger attribute keys (case insensitive compare)
+    attributes = {k.casefold(): v for k, v in attributes.items()}
+    trigger_condition = {k.casefold(): v for k, v in trigger_condition.items()}
+
     has_access = None
     join_condition = trigger_condition.get('join_condition', 'or')
     if join_condition not in TRIGGER_DEFINITION['attributes']['keys']['join_condition']['choices']:
@@ -265,6 +270,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
         for a_user_value in user_value:
             # We are going to do mostly string comparisons, so convert the attribute to a
             #  string just in case it came back as an int or something funky
+            # TODO Do we also want to normalize values??
             a_user_value = f"{a_user_value}"
 
             # Check for any of the valid conditions

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -178,12 +178,24 @@ def _add_rbac_role_mapping(has_permission, role_mapping, role, organization=None
             logger.warning(f"Role mapping is not possible, organization for team '{team}' is missing")
 
 
+def _lowercase_group_names(trigger_condition: dict) -> dict:
+    """
+    Lowercase all group names provided to trigger
+    """
+    ci_trigger_condition = {}
+    for operator, grouplist in trigger_condition.items():
+        ci_trigger_condition[operator] = [f"{group}".casefold() for group in grouplist]
+    return ci_trigger_condition
+
+
 def process_groups(trigger_condition: dict, groups: list, authenticator_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
     Group DNs are compared case-insensitively.
     """
     user_groups = [f"{group}".casefold() for group in groups]
+    trigger_condition = _lowercase_group_names(trigger_condition)
+
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
         logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {authenticator_id} are invalid and won't be processed")
@@ -191,18 +203,15 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int)
     set_of_user_groups = set(user_groups)
 
     if "has_or" in trigger_condition:
-        trigger_groups = [f"{group}".casefold() for group in trigger_condition["has_or"]]
-        if set_of_user_groups.intersection(set(trigger_groups)):
+        if set_of_user_groups.intersection(set(trigger_condition["has_or"])):
             return TriggerResult.ALLOW
 
     elif "has_and" in trigger_condition:
-        trigger_groups = [f"{group}".casefold() for group in trigger_condition["has_and"]]
-        if set(trigger_groups).issubset(set_of_user_groups):
+        if set(trigger_condition["has_and"]).issubset(set_of_user_groups):
             return TriggerResult.ALLOW
 
     elif "has_not" in trigger_condition:
-        trigger_groups = [f"{group}".casefold() for group in trigger_condition["has_not"]]
-        if not set(trigger_groups).intersection(set_of_user_groups):
+        if not set(trigger_condition["has_not"]).intersection(set_of_user_groups):
             return TriggerResult.ALLOW
 
     return TriggerResult.SKIP
@@ -222,13 +231,33 @@ def has_access_with_join(current_access: Optional[bool], new_access: bool, condi
         return current_access and new_access
 
 
+def _lowercase_triggers(trigger_condition: dict) -> dict:
+    """
+    Lower case all keys (attribute names) and contained attribute values
+    """
+    ci_trigger_condition = {}
+    for attr, condition in trigger_condition.items():
+        if isinstance(condition, str):
+            updated_condition = condition.casefold()
+        elif isinstance(condition, dict):
+            if not condition:  # empty dict
+                updated_condition = {}
+            for operator, value in condition.items():
+                updated_condition = {operator: value.casefold()}
+        else:
+            updated_condition = condition
+
+        ci_trigger_condition[attr.casefold()] = updated_condition  # join_condition
+    return ci_trigger_condition
+
+
 def process_user_attributes(trigger_condition: dict, attributes: dict, authenticator_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
     attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
-    trigger_condition = {f"{k}".casefold(): v for k, v in trigger_condition.items()}
+    trigger_condition = _lowercase_triggers(trigger_condition)
 
     has_access = None
     join_condition = trigger_condition.get('join_condition', 'or')

--- a/test_app/defaults.py
+++ b/test_app/defaults.py
@@ -230,4 +230,10 @@ FLAGS = {
             "value": True,
         },
     ],
+    "FEATURE_CASE_INSENSITIVE_AUTH_MAPS": [
+        {
+            "condition": "boolean",
+            "value": False,
+        },
+    ],
 }

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -439,14 +439,14 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             id="equals, negative",
         ),
         pytest.param(
-            {"email": {"matches": ".*@ex.*"}},
+            {"EMAIL": {"matches": ".*@ex.*"}},
             {"email": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="matches, positive",
         ),
         pytest.param(
             {"email": {"matches": "^foo@.*"}},
-            {"email": "foo@example.com"},
+            {"EMAIL": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="matches, start of line, positive",
         ),
@@ -463,8 +463,8 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             id="matches, start of line, negative",
         ),
         pytest.param(
-            {"email": {"contains": "@example.com"}},
-            {"email": "foo@example.com"},
+            {"EmAiL": {"contains": "@example.com"}},
+            {"eMaIl": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="contains, positive",
         ),

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -333,12 +333,12 @@ def test_create_claims_revoke(local_authenticator_map, process_function, trigger
     "trigger_condition, groups, has_access",
     [
         # has_or
-        ({"has_or": ["foo"]}, ["FOO"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
         ({"has_or": ["foo", "bar"]}, ["foo"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["bar"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo", "bar"]}, ["Foo", "Bar"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo"]}, ["baz", "foo", "qux"], claims.TriggerResult.ALLOW),
@@ -346,7 +346,7 @@ def test_create_claims_revoke(local_authenticator_map, process_function, trigger
         ({"has_and": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
         ({"has_and": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
         ({"has_and": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo", "bar"]}, ["baR", "foO"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo", "bar"]}, ["bar", "foo"], claims.TriggerResult.ALLOW),
         ({"has_and": ["foo", "bar"]}, ["foo"], claims.TriggerResult.SKIP),
         ({"has_and": ["foo", "bar"]}, ["bar"], claims.TriggerResult.SKIP),
         ({"has_and": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
@@ -386,6 +386,13 @@ def test_create_claims_revoke(local_authenticator_map, process_function, trigger
         # None of has_or, has_and, or has_not
         ({}, ["foo"], claims.TriggerResult.SKIP),
         ({"foo": "bar"}, ["foo"], claims.TriggerResult.SKIP),
+        # Case insensitivity
+        ({"has_or": ["FOO"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["FOO"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["bAR"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["fOo", "bAr"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_not": ["FOO"]}, ["foo"], claims.TriggerResult.SKIP),
+        ({"has_and": ["fOo", "bAr"]}, ["foo", "BaZ"], claims.TriggerResult.SKIP),
     ],
 )
 def test_process_groups(trigger_condition, groups, has_access):
@@ -439,14 +446,14 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             id="equals, negative",
         ),
         pytest.param(
-            {"EMAIL": {"matches": ".*@ex.*"}},
+            {"email": {"matches": ".*@ex.*"}},
             {"email": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="matches, positive",
         ),
         pytest.param(
             {"email": {"matches": "^foo@.*"}},
-            {"EMAIL": "foo@example.com"},
+            {"email": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="matches, start of line, positive",
         ),
@@ -463,8 +470,8 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             id="matches, start of line, negative",
         ),
         pytest.param(
-            {"EmAiL": {"contains": "@example.com"}},
-            {"eMaIl": "foo@example.COM"},
+            {"email": {"contains": "@example.com"}},
+            {"email": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="contains, positive",
         ),
@@ -475,7 +482,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             id="contains, negative",
         ),
         pytest.param(
-            {"email": {"ends_with": "@EXAMPLE.com"}},
+            {"email": {"ends_with": "@example.com"}},
             {"email": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="ends_with, positive",
@@ -725,6 +732,42 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             claims.TriggerResult.SKIP,
             id="user attribute is string, condition equals, join condition or, negative",
         ),
+        pytest.param(
+            {"username": {"equals": "lowercase"}, "join_condition": "or"},
+            {"username": "LOWERCASE"},
+            claims.TriggerResult.ALLOW,
+            id="username attribute value case mismatch",
+        ),
+        pytest.param(
+            {"uSeRnAmE": {"equals": "bbelcher"}, "join_condition": "or"},
+            {"username": "bbelcher"},
+            claims.TriggerResult.ALLOW,
+            id="username attribute name/key case mismatch",
+        ),
+        pytest.param(
+            {"USERNAME": {"equals": "lowercase"}, "join_condition": "or"},
+            {"username": "LOWERCASE"},
+            claims.TriggerResult.ALLOW,
+            id="username attribute name/key and value case mismatch",
+        ),
+        pytest.param(
+            {"username": {"contains": "USER"}, "join_condition": "or"},
+            {"username": "myusername"},
+            claims.TriggerResult.ALLOW,
+            id="username attribute value case mismatch contains",
+        ),
+        pytest.param(
+            {"username": {"in": "BOB JOE JOHN TAMAR"}, "join_condition": "or"},
+            {"username": "tamar"},
+            claims.TriggerResult.ALLOW,
+            id="username attribute value case mismatch in",
+        ),
+        pytest.param(
+            {"email": {"matches": ".*@REDHAT.COM"}, "join_condition": "or"},
+            {"email": "fred@redhat.com"},
+            claims.TriggerResult.ALLOW,
+            id="email attribute value case mismatch matches",
+        ),
     ],
 )
 def test_process_user_attributes(trigger_condition, attributes, expected):
@@ -760,7 +803,7 @@ def test_update_user_claims_groups(user, local_authenticator_map):
     """
     Similar to above, but testing groups instead of attributes.
     """
-    local_authenticator_map.triggers = {"groups": {"has_or": ["Foo"]}}
+    local_authenticator_map.triggers = {"groups": {"has_or": ["foo"]}}
     local_authenticator_map.save()
     authenticator = local_authenticator_map.authenticator
     # Associate the authenticator with the user

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -838,6 +838,13 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             claims.TriggerResult.ALLOW,
             id="email attribute value case mismatch matches",
         ),
+        pytest.param(
+            {"email": {}},
+            {"email": None},
+            True,
+            claims.TriggerResult.ALLOW,
+            id="user attribute is None, exists check still works, case sensitive, negative",
+        ),
     ],
 )
 @pytest.mark.django_db

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -760,7 +760,7 @@ def test_update_user_claims_groups(user, local_authenticator_map):
     """
     Similar to above, but testing groups instead of attributes.
     """
-    local_authenticator_map.triggers = {"groups": {"has_or": ["foo"]}}
+    local_authenticator_map.triggers = {"groups": {"has_or": ["Foo"]}}
     local_authenticator_map.save()
     authenticator = local_authenticator_map.authenticator
     # Associate the authenticator with the user

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from django.conf import settings
 from django.db import connection
 
 from ansible_base.authentication.models import AuthenticatorMap, AuthenticatorUser
@@ -330,76 +331,84 @@ def test_create_claims_revoke(local_authenticator_map, process_function, trigger
 
 
 @pytest.mark.parametrize(
-    "trigger_condition, groups, has_access",
+    "trigger_condition, groups, case_insensitive, has_access",
     [
         # has_or
-        ({"has_or": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo", "bar"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["bar"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"]}, ["baz", "foo", "qux"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["foo", "bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["baz"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["foo", "bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["bar", "baz"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["baz", "foo", "qux"], False, claims.TriggerResult.ALLOW),
         # has_and
-        ({"has_and": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo", "bar"]}, ["bar", "foo"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo", "bar"]}, ["foo"], claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.SKIP),
+        ({"has_and": ["foo"]}, ["foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo", "bar"]}, ["bar", "foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo", "bar"]}, ["foo"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["baz"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["foo", "baz"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["bar", "baz"], False, claims.TriggerResult.SKIP),
         # has_not
-        ({"has_not": ["foo"]}, ["foo"], claims.TriggerResult.SKIP),
-        ({"has_not": ["foo"]}, ["bar"], claims.TriggerResult.ALLOW),
-        ({"has_not": ["foo", "bar"]}, ["foo"], claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["baz"], claims.TriggerResult.ALLOW),
-        ({"has_not": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.SKIP),
-        ({"has_not": ["foo"]}, ["baz", "foo", "qux"], claims.TriggerResult.SKIP),
+        ({"has_not": ["foo"]}, ["foo"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["foo"]}, ["bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_not": ["foo", "bar"]}, ["foo"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["baz"], False, claims.TriggerResult.ALLOW),
+        ({"has_not": ["foo", "bar"]}, ["foo", "bar"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["foo", "baz"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["bar", "baz"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["foo"]}, ["baz", "foo", "qux"], False, claims.TriggerResult.SKIP),
         # has_or and has_and (only has_or has effect)
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
         # has_or and has_not (only has_or has effect)
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
         # has_and and has_not (only has_and has effect)
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["baz", "foo"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["baz", "foo"], False, claims.TriggerResult.ALLOW),
         # has_or, has_and, and has_not (only has_or has effect)
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["bar"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["baz"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["bar"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["baz"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
         # None of has_or, has_and, or has_not
-        ({}, ["foo"], claims.TriggerResult.SKIP),
-        ({"foo": "bar"}, ["foo"], claims.TriggerResult.SKIP),
-        # Case insensitivity
-        ({"has_or": ["FOO"]}, ["foo"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"]}, ["FOO"], claims.TriggerResult.ALLOW),
-        ({"has_or": ["bAR"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["fOo", "bAr"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_not": ["FOO"]}, ["foo"], claims.TriggerResult.SKIP),
-        ({"has_and": ["fOo", "bAr"]}, ["foo", "BaZ"], claims.TriggerResult.SKIP),
+        ({}, ["foo"], False, claims.TriggerResult.SKIP),
+        ({"foo": "bar"}, ["foo"], False, claims.TriggerResult.SKIP),
+        # Case insensitivity (with and without flag enabled)
+        ({"has_or": ["FOO"]}, ["foo"], True, claims.TriggerResult.ALLOW),
+        ({"has_or": ["FOO"]}, ["foo"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"]}, ["FOO"], True, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["FOO"], False, claims.TriggerResult.SKIP),
+        ({"has_or": ["bAR"]}, ["foo", "bar"], True, claims.TriggerResult.ALLOW),
+        ({"has_or": ["bAR"]}, ["foo", "bar"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["fOo", "bAr"]}, ["foo", "bar"], True, claims.TriggerResult.ALLOW),
+        ({"has_and": ["fOo", "bAr"]}, ["foo", "bar"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["FOO"]}, ["foo"], True, claims.TriggerResult.SKIP),
+        ({"has_and": ["fOo", "bAr"]}, ["foo", "BaZ"], True, claims.TriggerResult.SKIP),
     ],
 )
-def test_process_groups(trigger_condition, groups, has_access):
+@pytest.mark.django_db
+def test_process_groups(trigger_condition, groups, case_insensitive, has_access, settings_override_mutable):
     """
     Test the process_groups function.
     """
-    res = claims.process_groups(trigger_condition, groups, authenticator_id=1337)
+    with settings_override_mutable("FLAGS"):
+        settings.FLAGS["FEATURE_CASE_INSENSITIVE_AUTH_MAPS"][0]["value"] = case_insensitive
+        res = claims.process_groups(trigger_condition, groups, authenticator_id=1337)
+
     assert res is has_access
 
 
@@ -431,77 +440,89 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
 
 
 @pytest.mark.parametrize(
-    "trigger_condition, attributes, expected",
+    "trigger_condition, attributes, case_insensitive, expected",
     [
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": "foo@example.com"},
+            False,
             claims.TriggerResult.ALLOW,
             id="equals, positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": "foo@example.org"},
+            False,
             claims.TriggerResult.SKIP,
             id="equals, negative",
         ),
         pytest.param(
             {"email": {"matches": ".*@ex.*"}},
             {"email": "foo@example.com"},
+            False,
             claims.TriggerResult.ALLOW,
             id="matches, positive",
         ),
         pytest.param(
             {"email": {"matches": "^foo@.*"}},
             {"email": "foo@example.com"},
+            False,
             claims.TriggerResult.ALLOW,
             id="matches, start of line, positive",
         ),
         pytest.param(
             {"email": {"matches": "foo@.*"}},
             {"email": "bar@example.com"},
+            False,
             claims.TriggerResult.SKIP,
             id="matches, negative",
         ),
         pytest.param(
             {"email": {"matches": "^foo@.*"}},
             {"email": "bar@example.com"},
+            False,
             claims.TriggerResult.SKIP,
             id="matches, start of line, negative",
         ),
         pytest.param(
             {"email": {"contains": "@example.com"}},
             {"email": "foo@example.com"},
+            False,
             claims.TriggerResult.ALLOW,
             id="contains, positive",
         ),
         pytest.param(
             {"email": {"contains": "@example.com"}},
             {"email": "foo@example.org"},
+            False,
             claims.TriggerResult.SKIP,
             id="contains, negative",
         ),
         pytest.param(
             {"email": {"ends_with": "@example.com"}},
             {"email": "foo@example.com"},
+            False,
             claims.TriggerResult.ALLOW,
             id="ends_with, positive",
         ),
         pytest.param(
             {"email": {"ends_with": "@example.com"}},
             {"email": "foo@example.org"},
+            False,
             claims.TriggerResult.SKIP,
             id="ends_with, negative",
         ),
         pytest.param(
             {"email": {"in": "omg hey foo@example.com bye"}},
             {"email": "foo@example.com"},
+            False,
             claims.TriggerResult.ALLOW,
             id="in, positive",
         ),
         pytest.param(
             {"email": {"in": "omg hey foo@example.com bye"}},
             {"email": "foo@example.org"},
+            False,
             claims.TriggerResult.SKIP,
             id="in, negative",
         ),
@@ -514,6 +535,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org"},
+            False,
             claims.TriggerResult.SKIP,
             id="'and' join_condition, missing one attribute, negative",
         ),
@@ -526,6 +548,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org", "favorite_color": "red"},
+            False,
             claims.TriggerResult.SKIP,
             id="'and' join_condition, two false conditions, negative",
         ),
@@ -538,6 +561,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org", "favorite_color": "teal"},
+            False,
             claims.TriggerResult.SKIP,
             id="'and' join_condition, one false condition, negative",
         ),
@@ -550,6 +574,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "teal"},
+            False,
             claims.TriggerResult.ALLOW,
             id="'and' join_condition, positive",
         ),
@@ -562,6 +587,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "teal"},
+            False,
             claims.TriggerResult.ALLOW,
             id="'or' join_condition, both conditions true, positive",
         ),
@@ -574,6 +600,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "red"},
+            False,
             claims.TriggerResult.ALLOW,
             id="'or' join_condition, one condition true, positive",
         ),
@@ -585,6 +612,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "red"},
+            False,
             claims.TriggerResult.ALLOW,
             id="implicit 'or' join_condition, one condition true, positive",
         ),
@@ -596,6 +624,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org", "favorite_color": "red"},
+            False,
             claims.TriggerResult.SKIP,
             id="implicit 'or' join_condition, both conditions false, negative",
         ),
@@ -608,66 +637,77 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org", "favorite_color": "red"},
+            False,
             claims.TriggerResult.SKIP,
             id="'or' join_condition, both conditions false, negative",
         ),
         pytest.param(
             {"email": {"invalid": "omg hey foo@example.com bye"}},
             {"email": "foo@example.org"},
+            False,
             claims.TriggerResult.SKIP,
             id="invalid predicate in trigger conditions returns None",
         ),
         pytest.param(
             {"email": {}},
             {"email": "foo@example.org"},
+            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attribute has empty dict, becomes 'exists', positive",
         ),
         pytest.param(
             {"email": {}},
             {"favorite_color": "teal"},
+            False,
             claims.TriggerResult.SKIP,
             id="trigger dict attribute has empty dict, becomes 'exists', negative",
         ),
         pytest.param(
             {"email": {}},
             {},
+            False,
             claims.TriggerResult.SKIP,
             id="trigger dict attribute has empty dict, becomes 'exists', empty attributes, negative",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}},
             {"favorite_color": "teal"},
+            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attributes have empty dicts, becomes 'exists', implicit 'or', positive",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}, "join_condition": "or"},
             {"favorite_color": "teal"},
+            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attributes have empty dicts, becomes 'exists', explicit 'or', positive",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}, "join_condition": "and"},
             {"favorite_color": "teal"},
+            False,
             claims.TriggerResult.SKIP,
             id="trigger dict attributes have empty dicts, becomes 'exists', explicit 'and', negative",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}, "join_condition": "and"},
             {"favorite_color": "teal", "email": "foo@example.com"},
+            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attributes have empty dicts, becomes 'exists', explicit 'and', positive",
         ),
         pytest.param(
             {"email": {"contains": "example"}},
             {"email": None},
+            False,
             claims.TriggerResult.SKIP,
             id="user attribute is None, no predicate checks, returns None",
         ),
         pytest.param(
             {"email": {}},
             {"email": None},
+            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is None, exists check still works, negative",
         ),
@@ -675,103 +715,137 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": ["bar@example.com", "baz@example.com"]},
+            False,
             claims.TriggerResult.SKIP,
             id="user attribute is list, no matches, negative",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": ["bar@example.com", "foo@example.com"]},
+            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, one match, implicit 'or', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": ["bar@example.com", "foo@example.com"]},
+            False,
             claims.TriggerResult.SKIP,
             id="user attribute is list, one match, explicit 'and', negative",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": ["foo@example.com", "foo@example.com"]},
+            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, all matches, explicit 'and', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "or"},
             {"email": ["foo@example.com", "foo@example.com"]},
+            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, all matches, explicit 'or', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": []},
+            False,
             claims.TriggerResult.SKIP,
             id="user attribute is empty list, explicit 'and', returns None",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "or"},
             {"email": []},
+            False,
             claims.TriggerResult.SKIP,
             id="user attribute is empty list, explicit 'or', returns None",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "or"},
             {"email": ["foo@example.com", "bar@example.com"]},
+            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, explicit 'or', second match is false, positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "invalid"},
             {"email": ["foo@example.com", "bar@example.com"]},
+            False,
             claims.TriggerResult.ALLOW,
             id="join condition is invalid, defaults to or",
         ),
         pytest.param(
             {"username": {"equals": "alice"}, "join_condition": "or"},
             {"username": "bob", "email": ""},
+            False,
             claims.TriggerResult.SKIP,
             id="user attribute is string, condition equals, join condition or, negative",
         ),
         pytest.param(
             {"username": {"equals": "lowercase"}, "join_condition": "or"},
             {"username": "LOWERCASE"},
+            True,
             claims.TriggerResult.ALLOW,
+            id="username attribute value case mismatch",
+        ),
+        pytest.param(
+            {"username": {"equals": "lowercase"}, "join_condition": "or"},
+            {"username": "LOWERCASE"},
+            False,
+            claims.TriggerResult.SKIP,
             id="username attribute value case mismatch",
         ),
         pytest.param(
             {"uSeRnAmE": {"equals": "bbelcher"}, "join_condition": "or"},
             {"username": "bbelcher"},
+            True,
             claims.TriggerResult.ALLOW,
+            id="username attribute name/key case mismatch",
+        ),
+        pytest.param(
+            {"uSeRnAmE": {"equals": "bbelcher"}, "join_condition": "or"},
+            {"username": "bbelcher"},
+            False,
+            claims.TriggerResult.SKIP,
             id="username attribute name/key case mismatch",
         ),
         pytest.param(
             {"USERNAME": {"equals": "lowercase"}, "join_condition": "or"},
             {"username": "LOWERCASE"},
+            True,
             claims.TriggerResult.ALLOW,
             id="username attribute name/key and value case mismatch",
         ),
         pytest.param(
             {"username": {"contains": "USER"}, "join_condition": "or"},
             {"username": "myusername"},
+            True,
             claims.TriggerResult.ALLOW,
             id="username attribute value case mismatch contains",
         ),
         pytest.param(
             {"username": {"in": "BOB JOE JOHN TAMAR"}, "join_condition": "or"},
             {"username": "tamar"},
+            True,
             claims.TriggerResult.ALLOW,
             id="username attribute value case mismatch in",
         ),
         pytest.param(
             {"email": {"matches": ".*@REDHAT.COM"}, "join_condition": "or"},
             {"email": "fred@redhat.com"},
+            True,
             claims.TriggerResult.ALLOW,
             id="email attribute value case mismatch matches",
         ),
     ],
 )
-def test_process_user_attributes(trigger_condition, attributes, expected):
-    res = claims.process_user_attributes(trigger_condition, attributes, authenticator_id=1337)
+@pytest.mark.django_db
+def test_process_user_attributes(trigger_condition, attributes, expected, case_insensitive, settings_override_mutable):
+    with settings_override_mutable("FLAGS"):
+        settings.FLAGS["FEATURE_CASE_INSENSITIVE_AUTH_MAPS"][0]["value"] = case_insensitive
+        res = claims.process_user_attributes(trigger_condition, attributes, authenticator_id=1337)
+
     assert res is expected
 
 

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -333,12 +333,12 @@ def test_create_claims_revoke(local_authenticator_map, process_function, trigger
     "trigger_condition, groups, has_access",
     [
         # has_or
-        ({"has_or": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["FOO"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
         ({"has_or": ["foo", "bar"]}, ["foo"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["bar"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
-        ({"has_or": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["Foo", "Bar"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.ALLOW),
         ({"has_or": ["foo"]}, ["baz", "foo", "qux"], claims.TriggerResult.ALLOW),
@@ -346,7 +346,7 @@ def test_create_claims_revoke(local_authenticator_map, process_function, trigger
         ({"has_and": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
         ({"has_and": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
         ({"has_and": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo", "bar"]}, ["bar", "foo"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo", "bar"]}, ["baR", "foO"], claims.TriggerResult.ALLOW),
         ({"has_and": ["foo", "bar"]}, ["foo"], claims.TriggerResult.SKIP),
         ({"has_and": ["foo", "bar"]}, ["bar"], claims.TriggerResult.SKIP),
         ({"has_and": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
@@ -464,7 +464,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
         ),
         pytest.param(
             {"EmAiL": {"contains": "@example.com"}},
-            {"eMaIl": "foo@example.com"},
+            {"eMaIl": "foo@example.COM"},
             claims.TriggerResult.ALLOW,
             id="contains, positive",
         ),
@@ -475,7 +475,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             id="contains, negative",
         ),
         pytest.param(
-            {"email": {"ends_with": "@example.com"}},
+            {"email": {"ends_with": "@EXAMPLE.com"}},
             {"email": "foo@example.com"},
             claims.TriggerResult.ALLOW,
             id="ends_with, positive",


### PR DESCRIPTION
## Description

Does case insensitive comparison for authenticator map attributes, values, and group names:

```
"attributes": {
    "InSenSiTiVe_Attr_nAme": {
        "contains": "value"
    }
}

"groups": {
  "has_or": [
    "cN=auDitors,Ou=GroupS,DC=example,dc=ORG"
  ]
}
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
Start gateway w/ LDAP sidecar.

### Steps to Test
1. Create an auth map using random case for a known user attribute and with a noticeable result (adds user to org for instance).  givenName for instance in the LDAP server arrives as "givenname", but create a map for attribute "GIVENnAME"
2. Log in with user matching attribute value and ensure user is added to org (or whichever effect you configured).
3. Repeat the above, but with another authenticator map targeting an LDAP group with mixed case.

### Expected Results
Maps use case insensitive comparison for attribute names and group DNs

