### PR TITLE
[AAP-47853] Add note about openssl version for macOS libxmlsec1 installation workaround

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,6 +47,7 @@ export EDITOR=vi
 brew edit $USER/local/libxmlsec1@1.2.37
 	Change the url=" line to be:
         url "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.37.tar.gz"
+	Change any occurrences of "openssl@1.1" to "openssl@3"
 
 brew install $USER/local/libxmlsec1@1.2.37
 tox -e 311


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

Adds a note to docs/testing.md to fix errors installing `libxmlsec1` on macOS systems using `brew`. 

The documentation today describes a process for customizing the brew formula to install a specific build of `libxmlsec1`. The formula references OpenSSL 1, which is no longer available and this causes the installation to fail. 

The update advises developers to change the formula to reference OpenSSL 3, which is the current supported version and enables a successful installation of `libxmlsec1` and then the pinned  `xmlsec1` Python package.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Obtain a macOS system with Homebrew installed
2. Follow the steps in docs/testing.md
3. Confirm that `libxmlsec1` does not install with `openssl@1` but does install with `openssl@3` and enables pip installation of `xmlsec1` at the specified version.

### Expected Results
<!-- Describe what should happen after following the steps -->
`pip install xmlxec1==1.3.13` succeeds
## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
