### PR TITLE
Disable LDAP referrals by default, AAP-48822

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -246,7 +246,7 @@ class LDAPConfiguration(BaseAuthenticatorConfiguration):
             'https://www.python-ldap.org/doc/html/ldap.html#options for '
             'possible options and values that can be set.'
         ),
-        default={},
+        default={'OPT_REFERRALS': 0},
         allow_null=False,
         required=False,
         ui_field_label=_('LDAP Connection Options'),


### PR DESCRIPTION
## Description

This is expected to fix AAP-48822.

The ldap.py authentication plugin states in the help text that LDAP referrals are disabled by default, but they do not behave this way.
This PR sets `CONNECTION_OPTIONS.default = {"OPT_REFERRALS": 0}` so as to effectively disable LDAP referrals.

This change will silently add `"OPT_REFERRALS": 0` to the LDAP Connection Options box, i.e.:
The user will leave the box empty and will save the LDAP authenticator settings. This by itself will add `"OPT_REFERRALS": 0` to the LDAP Connection Options box, so the next time this authenticator is viewed on the web UI it will display the new option added.
Since this behavior of silently adding an option may cause user confusion, **I welcome suggestions on how to make this non-silent and non-surprising to users.**


## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist

- [X] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Configure AAP Gateway to authenticate with LDAP against an Active Directory server that responds with LDAP referrals by default.
2. Do not add `"OPT_REFERRALS": 0` to the LDAP connection options box.
3. Confirm that LDAP authentication works and that referrals were not followed.

### Expected Results
LDAP authentication would work and LDAP referrals would not be followed.

## Additional Context
None.

### Required Actions
None.

### Screenshots/Logs
None.