### PR TITLE
AAP-49479 Fix BaseAssignmentSerializer to allow null content_type

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -158,7 +158,7 @@ class RoleDefinitionDetailSerializer(RoleDefinitionSerializer):
 
 
 class BaseAssignmentSerializer(CommonModelSerializer):
-    content_type = ContentTypeField(read_only=True)
+    content_type = ContentTypeField(read_only=True, allow_null=True)
     object_ansible_id = serializers.UUIDField(
         required=False,
         help_text=_('The resource id of the object this role applies to. An alternative to the object_id field.'),


### PR DESCRIPTION

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? `allow_null` field being added to content_type for BaseAssignmentSerializer
- Why is this change needed? For proper API schema generation for RoleUserAssignment's
- How does this change address the issue? Changing the serializer corrects schema generation by indicating to the introspection tools that `None` is a potential value for the field coming from the API

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
test_app up and running

### Steps to Test
1. Generate openAPI spec file `/api/v1/docs/schema`
2. Read the spec file to ensure expected results

### Expected Results
RoleUserAssignment is both read_only and nullable
```
    RoleUserAssignment:
      type: object
      properties:
        id:
          type: integer
          readOnly: true
        url:
          type: string
          readOnly: true
        related:
          type: object
          additionalProperties:
            type: string
          readOnly: true
        summary_fields:
          type: object
          additionalProperties:
            type: object
            additionalProperties: {}
          readOnly: true
        created:
          type: string
          format: date-time
          readOnly: true
          description: The date/time this resource was created.
        created_by:
          type: integer
          readOnly: true
          nullable: true
          description: The user who created this resource.
        content_type:
          readOnly: true
          nullable: true
          description: |-
            The type of resource this applies to.

            * `shared.organization` - Organization
            * `shared.team` - Team
          oneOf:
          - $ref: '#/components/schemas/ContentTypeEnum'
          - $ref: '#/components/schemas/NullEnum'
        object_id:
          type: string
          nullable: true
          description: The primary key of the object this assignment applies to; null
            value indicates system-wide assignment.
        object_ansible_id:
          type: string
          format: uuid
          nullable: true
          description: The resource id of the object this role applies to. An alternative
            to the object_id field.
        role_definition:
          type: integer
          description: The role definition which defines permissions conveyed by this
            assignment.
        user:
          type: integer
        user_ansible_id:
          type: string
          format: uuid
          nullable: true
          description: The resource ID of the user who will receive permissions from
            this assignment. An alternative to user field.
      required:
      - role_definition
 ```