### PR TITLE
AAP-49479  Fix RoleTeamAssignmentSerializer team_ansible_id allow_null

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -323,6 +323,7 @@ class RoleTeamAssignmentSerializer(BaseAssignmentSerializer):
     team_ansible_id = serializers.UUIDField(
         required=False,
         help_text=_('The resource ID of the team who will receive permissions from this assignment. An alternative to team field.'),
+        allow_null=True,
     )
 
     class Meta:


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? `allow_null field being added to `team_ansible_id` for RoleTeamAssignmentSerializer
- Why is this change needed? Align `RoleTeamAssignmentSerializer` with `RoleUserAssignmentSerializer` for proper API schema generation
- How does this change address the issue? Changing the serializer corrects schema generation by indicating to the introspection tools that None is a potential value for the field coming from the API

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
test_app up and running

### Steps to Test

1. Generate openAPI spec file /api/v1/docs/schema
2. Read the spec file to ensure expected results
 

### Expected Results
RoleTeamAssignment:

```yaml
        team_ansible_id:
          type: string
          format: uuid
          nullable: true
          description: The resource ID of the team who will receive permissions from
            this assignment. An alternative to team field.
``` 


