### PR TITLE
AAP-48726: Gateway fallback to controller authentication

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/local.py
+++ b/ansible_base/authentication/authenticator_plugins/local.py
@@ -1,16 +1,24 @@
 import logging
+from urllib.parse import urljoin
 
+import requests
+from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
+from requests.auth import HTTPBasicAuth
 
 from ansible_base.authentication.authenticator_plugins.base import AbstractAuthenticatorPlugin, BaseAuthenticatorConfiguration
 from ansible_base.authentication.utils.authentication import determine_username_from_uid, get_or_create_authenticator_user
 from ansible_base.authentication.utils.claims import update_user_claims
+from ansible_base.lib.utils.settings import get_setting
 
 logger = logging.getLogger('ansible_base.authentication.authenticator_plugins.local')
 
+
 # TODO: Change the validator to not allow it to be deleted or a second one added
+
+UserModel = get_user_model()
 
 
 class LocalConfiguration(BaseAuthenticatorConfiguration):
@@ -44,7 +52,7 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
 
         # Determine the user name for this authenticator, we have to call this so that we can "attach" to a pre-created user
         new_username = determine_username_from_uid(username, self.database_instance)
-        # However we can't really accept a different username because we are the local authenticator imageine if:
+        # However we can't really accept a different username because we are the local authenticator imagine if:
         #    User "a" is from another authenticator and has an AuthenticatorUser
         #    User "a" tried to login from local authenticator
         #    The above function will return a username of "a<hash>"
@@ -53,6 +61,24 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
             return None
 
         user = super().authenticate(request, username, password, **kwargs)
+        controller_login_results = None
+        if (
+            not user
+            and request
+            and request.path.startswith('/api/gateway/v1/login/')
+            and (controller_login_results := self._can_authenticate_from_controller(username, password))
+        ):
+            logger.warning("User has been validated by controller, updating gateway user.")
+            self.update_gateway_user(username, password)
+            user = super().authenticate(request, username, password, **kwargs)
+        elif not user:
+            logger.info(
+                "Fallback authentication condition not met: "
+                f"username={username}, "
+                f"request={'set' if request else 'None'}, "
+                f"login_path={'True' if request and request.path.startswith('/api/gateway/v1/login/') else 'False'}, "
+                f"controller_login_results={controller_login_results}"
+            )
 
         # This auth class doesn't create any new local users, but we still need to make sure
         # it has an AuthenticatorUser associated with it.
@@ -69,5 +95,126 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
                     "is_superuser": user.is_superuser,
                 },
             )
-
         return update_user_claims(user, self.database_instance, [])
+
+    def _can_authenticate_from_controller(self, username, password):
+        """
+        Check if a user exists in the AuthenticatorUser table with the local authenticator provider.
+        If the user is valid, update the gateway users credentials with the controller credentials.
+        """
+        try:
+            UserModel._default_manager.get_by_natural_key(username)
+        except UserModel.DoesNotExist:
+            logger.warning(f"User '{username}' does not exist in the database.")
+            return False
+
+        if controller_user := self._get_controller_user(username, password):
+            # Validate controller_user has a ldap_dn field, if it is not None, then the user is a local user
+            ldap_dn = controller_user.get("ldap_dn")
+            if ldap_dn is None or ldap_dn != "":
+                logger.warning(f"User '{username}' is an ldap user and can not be authenticated.")
+                return False
+            if controller_user.get('password', None) != "$encrypted$":
+                logger.warning(f"User '{username}' is an enterprise user and can not be authenticated.")
+                return False
+            return True
+        else:
+            return False
+
+    def _get_controller_user(self, username: str, password: str):
+        """
+        Get the user from the controller by making a request to the controller API /me/ endpoint.
+        If the user is not found, return None.
+        If the user is found, return the user.
+        """
+
+        controller_base_domain = get_setting('gateway_proxy_url')
+        if not controller_base_domain:
+            logger.warning("Controller authentication failed, unable to get controller base domain")
+            return None
+        controller_url = urljoin(controller_base_domain, "/api/controller/v2/me/")
+
+        timeout = get_setting('GRPC_SERVER_AUTH_SERVICE_TIMEOUT')
+        timeout = self._convert_to_seconds(timeout)
+
+        try:
+            response = requests.get(controller_url, auth=HTTPBasicAuth(username, password), timeout=int(timeout))
+            response.raise_for_status()
+            user_data = response.json()
+
+            # Check if count exists and equals 1
+            count = user_data.get("count")
+            if count != 1:
+                logger.warning(f"Unable to authenticate user '{username}' with controller.")
+                return None
+
+            # Check if results exists and is a non-empty list
+            results = user_data.get("results")
+            if not results or not isinstance(results, list) or len(results) == 0:
+                logger.info(f"Unable to authenticate user '{username}' with controller. Invalid or empty results.")
+                return None
+            if not isinstance(results[0], dict):
+                logger.warning(f"Unable to authenticate user '{username}' with controller. user was not a dictionary.")
+                return False
+
+            return results[0]
+        except requests.exceptions.HTTPError as http_err:
+            logger.warning(f"HTTP error occurred: {http_err}")
+            return None
+        except requests.exceptions.ConnectionError as conn_err:
+            logger.warning(f"Connection error occurred: {conn_err}")
+            return None
+        except requests.exceptions.Timeout as timeout_err:
+            logger.warning(f"Timeout error occurred: {timeout_err}")
+            return None
+        except requests.exceptions.RequestException as err:
+            logger.warning(f"An unexpected error occurred: {err}")
+            return None
+        except ValueError as json_err:
+            logger.warning(f"JSON decode error occurred: {json_err}")
+            return None
+        except Exception as err:
+            logger.warning(f"An unexpected error occurred: {err}")
+            return None
+
+    def update_gateway_user(self, username, password):
+        """
+        Update the gateway user with the controller credentials and set is_partially_migrated to False.
+        """
+        user = UserModel._default_manager.get_by_natural_key(username)
+        user.set_password(password)
+        user.save(update_fields=['password'])
+        logger.info(f"Updated user {username} gateway account")
+
+    def _convert_to_seconds(self, s):
+        """
+        Converts a time string like '15s', '5m', '1h', '2d', '3w' to seconds.
+        """
+        default = 10
+        try:
+            unit = s[-1].lower()
+            value = int(s[:-1])
+
+            ret_val = 0
+            # Check units
+            if unit == '-':
+                ret_val = default
+            elif unit == 's':
+                ret_val = value
+            elif unit == 'm':
+                ret_val = value * 60
+            elif unit == 'h':
+                ret_val = value * 3600  # 60 * 60
+            elif unit == 'd':
+                ret_val = value * 86400  # 60 * 60 * 24
+            elif unit == 'w':
+                ret_val = value * 604800  # 60 * 60 * 24 * 7
+            else:
+                ret_val = int(s)
+            # If less than or equal to 0, return default
+            if ret_val <= 0:
+                ret_val = default
+            return ret_val
+        except Exception:
+            logger.warning(f"Invalid duration format: '{s}'")
+            return default

--- a/test_app/tests/authentication/authenticator_plugins/test_local.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_local.py
@@ -1,6 +1,8 @@
 from unittest import mock
 
 import pytest
+import requests
+from django.contrib.auth import get_user_model
 from django.test.client import RequestFactory
 
 from ansible_base.authentication.authenticator_plugins.local import AuthenticatorPlugin
@@ -8,6 +10,16 @@ from ansible_base.authentication.session import SessionAuthentication
 from ansible_base.lib.utils.response import get_relative_url
 
 authenticated_test_page = "authenticator-list"
+
+
+def mock_get_setting(setting_name):
+    """Helper function to mock get_setting with appropriate values for different settings."""
+    if setting_name == 'gateway_proxy_url':
+        return 'http://controller.example.com'
+    elif setting_name == 'GRPC_SERVER_AUTH_SERVICE_TIMEOUT':
+        return '30s'  # Return a valid duration format
+    else:
+        return None
 
 
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
@@ -106,3 +118,895 @@ def test_local_auth_determine_username_returns_different_user(local_authenticato
     AuthenticatorUser.objects.create(uid=random_user.username, user=random_user, provider=ldap_authenticator)
     plugin = AuthenticatorPlugin(database_instance=local_authenticator)
     assert plugin.authenticate(request=RequestFactory(), username=random_user.username, password='doe') is None
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_nonexistent_user():
+    """
+    Test that _can_authenticate_from_controller returns False for a non-existent user.
+    """
+    plugin = AuthenticatorPlugin()
+    result = plugin._can_authenticate_from_controller("nonexistent_user", "password")
+    assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_success(user):
+    """
+    Test that _can_authenticate_from_controller returns True when all conditions are met.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Set user password to encrypted (indicating partial migration)
+    user.password = "$encrypted$"
+    user.save()
+
+    # Mock the controller user response - local user with encrypted password
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "", "password": "$encrypted$"}):
+        result = plugin._can_authenticate_from_controller(user.username, "password")
+        assert result is True
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_no_controller_user(user):
+    """
+    Test that _can_authenticate_from_controller returns False when controller user not found.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Mock the controller user response to return None
+    with mock.patch.object(plugin, '_get_controller_user', return_value=None):
+        result = plugin._can_authenticate_from_controller(user.username, "password")
+        assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_invalid_format(user):
+    """
+    Test that _can_authenticate_from_controller returns False when controller user format is invalid.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Mock the controller user response to return invalid format (False)
+    with mock.patch.object(plugin, '_get_controller_user', return_value=False):
+        result = plugin._can_authenticate_from_controller(user.username, "password")
+        assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_missing_ldap_dn_with_encrypted_password(user):
+    """
+    Test that _can_authenticate_from_controller returns False when ldap_dn is missing and password is encrypted.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Set user password to encrypted (indicating partial migration)
+    user.password = "$encrypted$"
+    user.save()
+
+    # Mock the controller user response without ldap_dn
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"username": "testuser"}):
+        result = plugin._can_authenticate_from_controller(user.username, "password")
+        assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_non_local_user_with_encrypted_password(user):
+    """
+    Test that _can_authenticate_from_controller returns False when user is not local and password is encrypted.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Set user password to encrypted (indicating partial migration)
+    user.password = "$encrypted$"
+    user.save()
+
+    # Mock the controller user response with non-empty ldap_dn
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "cn=testuser,ou=users,dc=example,dc=com"}):
+        result = plugin._can_authenticate_from_controller(user.username, "password")
+        assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_non_local_user_with_regular_password(user):
+    """
+    Test that _can_authenticate_from_controller returns False when user is not local (has ldap_dn).
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Set user password to regular password (not encrypted)
+    user.set_password("regular_password")
+    user.save()
+
+    # Mock the controller user response with non-empty ldap_dn (LDAP user)
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "cn=testuser,ou=users,dc=example,dc=com", "password": "regular_password"}):
+        result = plugin._can_authenticate_from_controller(user.username, "password")
+        assert result is False
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_success(user):
+    """
+    Test that _get_controller_user returns user data when successful.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 1, "results": [{"ldap_dn": ""}]}
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result == {"ldap_dn": ""}
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_no_gateway_proxy_url(user):
+    """
+    Test that _get_controller_user returns None when gateway_proxy_url is not set.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', return_value=None):
+        result = plugin._get_controller_user(user.username, "password")
+        assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_http_error(user):
+    """
+    Test that _get_controller_user returns None when HTTP error occurs.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_get.side_effect = requests.exceptions.HTTPError("HTTP Error")
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_invalid_count(user):
+    """
+    Test that _get_controller_user returns None when count is invalid.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 0}  # Invalid count
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_empty_results(user):
+    """
+    Test that _get_controller_user returns None when results are empty.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 1, "results": []}
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+def test_authenticate_with_controller_validation_success(user, local_authenticator):
+    """
+    Test that authentication works when controller validation succeeds.
+    """
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create an AuthenticatorUser entry for the user with local authenticator
+    AuthenticatorUser.objects.create(uid=user.username, user=user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    # Mock controller authentication to succeed
+    with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=True):
+        # Mock the super().authenticate to return None first (simulating initial auth failure)
+        # then return the user on the second call (after password update)
+        with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate') as mock_auth:
+            mock_auth.side_effect = [None, user]  # First call returns None, second returns user
+
+            with mock.patch.object(plugin, 'update_gateway_user') as mock_update:
+                request = RequestFactory().get('/api/gateway/v1/login/')
+                result = plugin.authenticate(request=request, username=user.username, password="password")
+
+                assert result is not None
+                assert result == user
+                mock_update.assert_called_once_with(user.username, "password")
+
+
+def test_authenticate_non_gateway_path_skips_validation(user, local_authenticator):
+    """
+    Test that controller validation is skipped when request path doesn't start with /api/gateway/v1/login/.
+    """
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create an AuthenticatorUser entry for the user with local authenticator
+    AuthenticatorUser.objects.create(uid=user.username, user=user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    # Create a request with different path
+    request = RequestFactory().get('/some/other/path/')
+
+    with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=False) as mock_check:
+        with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate', return_value=None):
+            with mock.patch.object(plugin, 'update_gateway_user') as mock_update:
+                result = plugin.authenticate(request=request, username=user.username, password="password")
+
+                # _can_authenticate_from_controller is not called because path doesn't match
+                mock_check.assert_not_called()
+                # But update_gateway_user should not be called because path doesn't match
+                mock_update.assert_not_called()
+                assert result is None
+
+
+def test_update_gateway_user(user):
+    """
+    Test that update_gateway_user correctly updates the user's password.
+    """
+    plugin = AuthenticatorPlugin()
+    original_password = user.password
+
+    plugin.update_gateway_user(user.username, "new_password")
+
+    # Refresh user from database
+    user.refresh_from_db()
+    assert user.password != original_password
+    assert user.check_password("new_password")
+
+
+def test_authenticate_logs_warning_after_controller_validation(user, local_authenticator, expected_log):
+    """
+    Test that authenticate logs a warning after successful controller validation.
+    """
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create an AuthenticatorUser entry for the user with local authenticator
+    AuthenticatorUser.objects.create(uid=user.username, user=user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    # Mock controller authentication to succeed
+    with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=True):
+        # Mock the super().authenticate to return None first, then return the user
+        with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate') as mock_auth:
+            mock_auth.side_effect = [None, user]  # First call returns None, second returns user
+
+            with mock.patch.object(plugin, 'update_gateway_user') as mock_update:
+                with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "User has been validated by controller"):
+                    # Create request with gateway login path
+                    request = RequestFactory().get('/api/gateway/v1/login/')
+                    result = plugin.authenticate(request=request, username=user.username, password="password")
+
+                    assert result is not None
+                    assert result == user
+                    mock_update.assert_called_once_with(user.username, "password")
+
+
+# Logging tests for _can_authenticate_from_controller
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_logs_warning_for_nonexistent_user(expected_log):
+    """
+    Test that _can_authenticate_from_controller logs a warning for non-existent users.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "does not exist in the database"):
+        result = plugin._can_authenticate_from_controller("nonexistent_user", "password")
+        assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_logs_warning_invalid_format(user, expected_log):
+    """
+    Test that _can_authenticate_from_controller logs a warning for invalid controller user format.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Mock the request to return invalid format (non-dict result)
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 1, "results": ["invalid_string_not_dict"]}
+            mock_get.return_value = mock_response
+
+            with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "user was not a dictionary"):
+                result = plugin._can_authenticate_from_controller(user.username, "password")
+                assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_logs_warning_not_local_user(user, expected_log):
+    """
+    Test that _can_authenticate_from_controller logs a warning when user cannot be confirmed as local.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Set user password to encrypted (indicating partial migration)
+    user.password = "$encrypted$"
+    user.save()
+
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "cn=user,dc=example,dc=com", "password": "$encrypted$"}):
+        with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "is an ldap user and can not be authenticated"):
+            result = plugin._can_authenticate_from_controller(user.username, "password")
+            assert result is False
+
+
+@pytest.mark.django_db()
+def test_authenticate_logs_fallback_condition_not_met(user, local_authenticator, expected_log):
+    """
+    Test that authenticate logs when fallback authentication condition is not met.
+    """
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create an AuthenticatorUser entry for the user with local authenticator
+    AuthenticatorUser.objects.create(uid=user.username, user=user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    # Mock regular authentication to fail
+    with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate', return_value=None):
+        # Mock _can_authenticate_from_controller to return False so condition fails
+        with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=False) as mock_check:
+            with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "info", "Fallback authentication condition not met"):
+                # Create request with gateway login path but controller auth will fail
+                request = RequestFactory().get('/api/gateway/v1/login/')
+                result = plugin.authenticate(request=request, username=user.username, password="password")
+
+                # Verify the method was called and returned None
+                mock_check.assert_called_once_with(user.username, "password")
+                assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_logs_warning_for_invalid_count(user, expected_log):
+    """
+    Test that _get_controller_user logs a warning for invalid count.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 0}
+            mock_get.return_value = mock_response
+
+            with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "Unable to authenticate user"):
+                result = plugin._get_controller_user(user.username, "password")
+                assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_logs_warning_for_empty_results(user, expected_log):
+    """
+    Test that _get_controller_user logs a warning for empty results.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 1, "results": []}
+            mock_get.return_value = mock_response
+
+            with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "info", "Invalid or empty results"):
+                result = plugin._get_controller_user(user.username, "password")
+                assert result is None
+
+
+# Comprehensive update_gateway_user tests
+@pytest.mark.django_db()
+def test_update_gateway_user_nonexistent_user():
+    """
+    Test that update_gateway_user raises exception for non-existent user.
+    """
+    plugin = AuthenticatorPlugin()
+    UserModel = get_user_model()
+
+    with pytest.raises(UserModel.DoesNotExist):
+        plugin.update_gateway_user("nonexistent_user", "password")
+
+
+@pytest.mark.django_db()
+def test_update_gateway_user_logs_success(user, expected_log):
+    """
+    Test that update_gateway_user logs success message.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "info", f"Updated user {user.username} gateway account"):
+        plugin.update_gateway_user(user.username, "new_password")
+
+    # Verify changes
+    user.refresh_from_db()
+    assert user.check_password("new_password")
+
+
+@pytest.mark.django_db()
+def test_update_gateway_user_updates_resource_flag(user):
+    """
+    Test that update_gateway_user properly updates the user password.
+    """
+    plugin = AuthenticatorPlugin()
+
+    plugin.update_gateway_user(user.username, "new_password")
+
+    # Verify password was updated
+    user.refresh_from_db()
+    assert user.check_password("new_password")
+
+
+# Authentication flow edge cases
+@pytest.mark.django_db()
+def test_authenticate_regular_auth_success_skips_controller_validation(user, local_authenticator):
+    """
+    Test that authentication skips controller validation when regular authentication succeeds.
+    """
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create an AuthenticatorUser entry for the user with local authenticator
+    AuthenticatorUser.objects.create(uid=user.username, user=user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=False) as mock_check:
+        with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate', return_value=user):
+            with mock.patch.object(plugin, 'update_gateway_user') as mock_update:
+                # Create request with gateway login path
+                request = RequestFactory().get('/api/gateway/v1/login/')
+                result = plugin.authenticate(request=request, username=user.username, password="password")
+
+                # _can_authenticate_from_controller should not be called since regular auth succeeded
+                mock_check.assert_not_called()
+                # update_gateway_user should not be called since regular auth succeeded
+                mock_update.assert_not_called()
+                assert result is not None
+
+
+# Test missing parameters and edge cases in _get_controller_user
+@pytest.mark.django_db()
+def test_get_controller_user_missing_count_field(user):
+    """
+    Test that _get_controller_user handles missing count field.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"results": [{"ldap_dn": ""}]}  # Missing count
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_non_list_results(user):
+    """
+    Test that _get_controller_user handles non-list results field.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 1, "results": "not_a_list"}
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+# Test successful authentication flow with all components
+@pytest.mark.django_db()
+def test_authenticate_successful_controller_validation_full_flow(user, local_authenticator):
+    """
+    Test complete successful authentication flow with controller validation.
+    """
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create an AuthenticatorUser entry for the user with local authenticator
+    AuthenticatorUser.objects.create(uid=user.username, user=user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    # Set user password to encrypted (indicating partial migration)
+    user.password = "$encrypted$"
+    user.save()
+
+    # Mock all the components for a successful flow
+    with (
+        mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "", "password": "$encrypted$"}),
+        mock.patch('django.contrib.auth.backends.ModelBackend.authenticate') as mock_auth,
+    ):
+        mock_auth.side_effect = [None, user]  # First call fails, second succeeds after password update
+
+        # Create request with gateway login path
+        request = RequestFactory().get('/api/gateway/v1/login/')
+        result = plugin.authenticate(request=request, username=user.username, password="password")
+
+        # Verify successful authentication
+        assert result is not None
+        assert result == user
+
+        # Verify user was updated
+        user.refresh_from_db()
+
+
+# Test connection and timeout errors
+@pytest.mark.django_db()
+def test_get_controller_user_connection_error(user):
+    """
+    Test that _get_controller_user handles connection errors gracefully.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_get.side_effect = requests.exceptions.ConnectionError("Connection failed")
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_timeout_error(user):
+    """
+    Test that _get_controller_user handles timeout errors gracefully.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_get.side_effect = requests.exceptions.Timeout("Request timed out")
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_general_request_exception(user):
+    """
+    Test that _get_controller_user handles general request exceptions gracefully.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_get.side_effect = requests.exceptions.RequestException("General request error")
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+# Test JSON parsing error handling
+@pytest.mark.django_db()
+def test_get_controller_user_json_decode_error(user):
+    """
+    Test that _get_controller_user handles JSON decode errors gracefully.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.side_effect = ValueError("Invalid JSON")
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+# Test authentication without request object
+@pytest.mark.django_db()
+def test_authenticate_without_request_object(user, local_authenticator):
+    """
+    Test authentication behavior when no request object is provided.
+    """
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create an AuthenticatorUser entry for the user with local authenticator
+    AuthenticatorUser.objects.create(uid=user.username, user=user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=False) as mock_check:
+        with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate', return_value=None):
+            with mock.patch.object(plugin, 'update_gateway_user') as mock_update:
+                result = plugin.authenticate(request=None, username=user.username, password="password")
+
+                # _can_authenticate_from_controller should not be called without request
+                mock_check.assert_not_called()
+                # But update_gateway_user should not be called without request
+                mock_update.assert_not_called()
+                assert result is None
+
+
+# Tests for _convert_to_seconds method
+@pytest.mark.django_db()
+def test_convert_to_seconds():
+    """Test _convert_to_seconds with seconds unit."""
+    plugin = AuthenticatorPlugin()
+    # Test Seconds
+    assert plugin._convert_to_seconds('15s') == 15
+    assert plugin._convert_to_seconds('1s') == 1
+    assert plugin._convert_to_seconds('0s') == 10  # Default value
+    # Test minutes
+    assert plugin._convert_to_seconds('5m') == 300  # 5 * 60
+    assert plugin._convert_to_seconds('1m') == 60
+    assert plugin._convert_to_seconds('10m') == 600
+    # Test hours
+    assert plugin._convert_to_seconds('1h') == 3600  # 1 * 3600
+    assert plugin._convert_to_seconds('2h') == 7200  # 2 * 3600
+    assert plugin._convert_to_seconds('24h') == 86400  # 24 * 3600
+    # Test days
+    assert plugin._convert_to_seconds('1d') == 86400  # 1 * 86400
+    assert plugin._convert_to_seconds('7d') == 604800  # 7 * 86400
+    assert plugin._convert_to_seconds('30d') == 2592000  # 30 * 86400
+    # Test weeks
+    assert plugin._convert_to_seconds('1w') == 604800  # 1 * 604800
+    assert plugin._convert_to_seconds('2w') == 1209600  # 2 * 604800
+    assert plugin._convert_to_seconds('4w') == 2419200  # 4 * 604800
+    # Test without unit
+    assert plugin._convert_to_seconds('30') == 30
+    assert plugin._convert_to_seconds('120') == 120
+    assert plugin._convert_to_seconds('0') == 10  # Default value
+    # Test uppercase
+    assert plugin._convert_to_seconds('15S') == 15
+    assert plugin._convert_to_seconds('5M') == 300
+    assert plugin._convert_to_seconds('1H') == 3600
+    assert plugin._convert_to_seconds('1D') == 86400
+    assert plugin._convert_to_seconds('1W') == 604800
+    # Test invalid values
+    assert plugin._convert_to_seconds('invalid') == 10  # Default value
+    assert plugin._convert_to_seconds('xs') == 10  # Default value
+    assert plugin._convert_to_seconds('') == 10  # Default value
+    assert plugin._convert_to_seconds(None) == 10  # Default value
+    assert plugin._convert_to_seconds('-5s') == 10  # Default value
+    assert plugin._convert_to_seconds('-10') == 10  # Default value
+
+
+# Test for enterprise user password check
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_enterprise_user(user, expected_log):
+    """
+    Test that _can_authenticate_from_controller returns False for enterprise users (password != "$encrypted$").
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Mock the controller user response with regular password (not encrypted)
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "", "password": "regular_password"}):
+        with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "is an enterprise user and can not be authenticated"):
+            result = plugin._can_authenticate_from_controller(user.username, "password")
+            assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_enterprise_user_missing_password(user, expected_log):
+    """
+    Test that _can_authenticate_from_controller returns False for enterprise users when password field is missing.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Mock the controller user response without password field
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "", "username": "testuser"}):
+        with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "is an enterprise user and can not be authenticated"):
+            result = plugin._can_authenticate_from_controller(user.username, "password")
+            assert result is False
+
+
+@pytest.mark.django_db()
+def test_can_authenticate_from_controller_enterprise_user_none_password(user, expected_log):
+    """
+    Test that _can_authenticate_from_controller returns False for enterprise users when password is None.
+    """
+    plugin = AuthenticatorPlugin()
+
+    # Mock the controller user response with None password
+    with mock.patch.object(plugin, '_get_controller_user', return_value={"ldap_dn": "", "password": None}):
+        with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "is an enterprise user and can not be authenticated"):
+            result = plugin._can_authenticate_from_controller(user.username, "password")
+            assert result is False
+
+
+# Test for timeout handling - if not timeout
+@pytest.mark.django_db()
+def test_get_controller_user_no_timeout_setting(user):
+    """
+    Test that _get_controller_user uses default timeout when GRPC_SERVER_AUTH_SERVICE_TIMEOUT is not set.
+    """
+    plugin = AuthenticatorPlugin()
+
+    def mock_get_setting_no_timeout(setting_name):
+        if setting_name == 'gateway_proxy_url':
+            return 'http://controller.example.com'
+        elif setting_name == 'GRPC_SERVER_AUTH_SERVICE_TIMEOUT':
+            return None  # No timeout setting
+        else:
+            return None
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting_no_timeout):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 1, "results": [{"ldap_dn": ""}]}
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+
+            # Verify that requests.get was called with the default timeout of 10
+            mock_get.assert_called_once_with('http://controller.example.com/api/controller/v2/me/', auth=mock.ANY, timeout=10)  # Default timeout should be 10
+            assert result == {"ldap_dn": ""}
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_zero_timeout_setting(user):
+    """
+    Test that _get_controller_user uses default timeout when GRPC_SERVER_AUTH_SERVICE_TIMEOUT converts to 0.
+    """
+    plugin = AuthenticatorPlugin()
+
+    def mock_get_setting_zero_timeout(setting_name):
+        if setting_name == 'gateway_proxy_url':
+            return 'http://controller.example.com'
+        elif setting_name == 'GRPC_SERVER_AUTH_SERVICE_TIMEOUT':
+            return '0s'  # Zero timeout
+        else:
+            return None
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting_zero_timeout):
+        with mock.patch('requests.get') as mock_get:
+            mock_response = mock.Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"count": 1, "results": [{"ldap_dn": ""}]}
+            mock_get.return_value = mock_response
+
+            result = plugin._get_controller_user(user.username, "password")
+
+            # Verify that requests.get was called with the default timeout of 10 (since 0 is falsy)
+            mock_get.assert_called_once_with('http://controller.example.com/api/controller/v2/me/', auth=mock.ANY, timeout=10)  # Default timeout should be 10
+            assert result == {"ldap_dn": ""}
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_invalid_timeout_format(user):
+    """
+    Test that _get_controller_user handles invalid timeout format and raises ValueError.
+    """
+    plugin = AuthenticatorPlugin()
+
+    def mock_get_setting_invalid_timeout(setting_name):
+        if setting_name == 'gateway_proxy_url':
+            return 'http://controller.example.com'
+        elif setting_name == 'GRPC_SERVER_AUTH_SERVICE_TIMEOUT':
+            return 'invalid_format'  # Invalid timeout format
+        else:
+            return None
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting_invalid_timeout):
+        # The ValueError should be raised by _convert_to_seconds, which will be caught in the generic exception handler
+        result = plugin._get_controller_user(user.username, "password")
+        assert result is None
+
+
+# Test for generic exception handling
+@pytest.mark.django_db()
+def test_get_controller_user_generic_exception(user):
+    """
+    Test that _get_controller_user handles generic exceptions gracefully.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            # Force a generic exception (not HTTP, Connection, Timeout, or JSON related)
+            mock_get.side_effect = Exception("Unexpected error")
+
+            result = plugin._get_controller_user(user.username, "password")
+            assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_generic_exception_from_conversion(user):
+    """
+    Test that _get_controller_user handles generic exceptions from _convert_to_seconds.
+    """
+    plugin = AuthenticatorPlugin()
+
+    def mock_get_setting_exception(setting_name):
+        if setting_name == 'gateway_proxy_url':
+            return 'http://controller.example.com'
+        elif setting_name == 'GRPC_SERVER_AUTH_SERVICE_TIMEOUT':
+            return 'invalid_format'  # This will cause ValueError in _convert_to_seconds
+        else:
+            return None
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting_exception):
+        result = plugin._get_controller_user(user.username, "password")
+        assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_generic_exception_during_urljoin(user):
+    """
+    Test that _get_controller_user handles generic exceptions during URL joining.
+    """
+    plugin = AuthenticatorPlugin()
+
+    def mock_get_setting_none_url(setting_name):
+        if setting_name == 'gateway_proxy_url':
+            return None  # This will cause early return
+        elif setting_name == 'GRPC_SERVER_AUTH_SERVICE_TIMEOUT':
+            return '30s'
+        else:
+            return None
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting_none_url):
+        result = plugin._get_controller_user(user.username, "password")
+        assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_generic_exception_with_logging(user, expected_log):
+    """
+    Test that _get_controller_user logs generic exceptions properly.
+    """
+    plugin = AuthenticatorPlugin()
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting):
+        with mock.patch('requests.get') as mock_get:
+            # Create a custom exception that will be caught by the generic handler
+            class CustomException(Exception):
+                pass
+
+            mock_get.side_effect = CustomException("Custom error")
+
+            with expected_log('ansible_base.authentication.authenticator_plugins.local.logger', "warning", "An unexpected error occurred"):
+                result = plugin._get_controller_user(user.username, "password")
+                assert result is None
+
+
+@pytest.mark.django_db()
+def test_get_controller_user_timeout_conversion_exception_handling(user):
+    """
+    Test that _get_controller_user handles timeout conversion exceptions correctly.
+    """
+    plugin = AuthenticatorPlugin()
+
+    def mock_get_setting_bad_timeout(setting_name):
+        if setting_name == 'gateway_proxy_url':
+            return 'http://controller.example.com'
+        elif setting_name == 'GRPC_SERVER_AUTH_SERVICE_TIMEOUT':
+            return 'not_a_valid_duration'
+        else:
+            return None
+
+    with mock.patch('ansible_base.authentication.authenticator_plugins.local.get_setting', side_effect=mock_get_setting_bad_timeout):
+        # This should handle the ValueError from _convert_to_seconds in the generic exception handler
+        result = plugin._get_controller_user(user.username, "password")
+        assert result is None


### PR DESCRIPTION
OLD PR - https://github.com/ansible/django-ansible-base/pull/767
This was closed automatically after I had merged in the feature branch.

## Description
- What is being changed?
Updates the local authenticator to fallback to controller authentication when logging in via gateway local authenticator.
- Why is this change needed?
This change is needed to support users logging in in the following case -
1. A users AAP account was migrated over from 2.4->2.6 (this causes the account to exist in both AAP and gateway, but gateway is not aware of the user password, since we can't migrate over the password).
2. When a user attempts to login via gateway the initial auth fails, we check -
    a. If the user actually exists in gateway as a local user
    b. If the user is a valid user in controller, and we check if we can authenticate successfully via the `/api/controller/v2/me/` endpoint
3. If checks pass, we update the gateway user account with the updated password.

- How does this change address the issue?
This change addresses the issue by adding the necessary fallback logic.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
4. 
5. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
