### PR TITLE
AAP-47841 authenticator and authenticator map view permission updates to allow service token access

### DIFF
--- a/ansible_base/authentication/views/authenticator.py
+++ b/ansible_base/authentication/views/authenticator.py
@@ -18,6 +18,7 @@ class AuthenticatorViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
 
     queryset = Authenticator.objects.all()
     serializer_class = AuthenticatorSerializer
+    allow_service_token = True
 
     def get_serializer(self, *args, **kwargs):
         # Return an instanced serializer if one exists for OPTIONS requests.

--- a/ansible_base/authentication/views/authenticator_map.py
+++ b/ansible_base/authentication/views/authenticator_map.py
@@ -12,3 +12,4 @@ class AuthenticatorMapViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
 
     queryset = AuthenticatorMap.objects.all().order_by("id")
     serializer_class = AuthenticatorMapSerializer
+    allow_service_token = True


### PR DESCRIPTION
## Description

- What is being changed?  Added `allow_service_token = True` to authenticator and autenticator_map view.
- Why is this change needed?  The management command in controller needs this to allow service tokens to be used between controller and gateway.
- How does this change address the issue?  Enables service tokens to be used.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] New feature (non-breaking change which adds functionality)
- [X] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment
