### PR TITLE
[AAP-48066] Allow login from multiple active authenticators

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -554,7 +554,13 @@ class AuthenticatorPlugin(LDAPBackend, AbstractAuthenticatorPlugin):
             # In unit testing there were cases where the function we are in was being called before get_or_build_user.
             # Its unclear if that was just a byproduct of mocking or a real scenario.
             # Since this call is idempotent we are just going to call it again to ensure the AuthenticatorUser is created for update_user_claims
-            get_or_create_authenticator_user(username.lower(), self.database_instance, user_details={}, extra_data=user_from_ldap.ldap_user.attrs.data)
+            get_or_create_authenticator_user(
+                uid=username.lower(),
+                email=user_from_ldap.email,
+                authenticator=self.database_instance,
+                user_details={},
+                extra_data=user_from_ldap.ldap_user.attrs.data,
+            )
             return update_user_claims(user_from_ldap, self.database_instance, users_groups)
         except Exception:
             logger.exception(f"Encountered an error authenticating to LDAP {self.database_instance.name}")
@@ -582,8 +588,9 @@ class AuthenticatorPlugin(LDAPBackend, AbstractAuthenticatorPlugin):
         This gets called by _LDAPUser to create the user in the database.
         """
         user, _authenticator_user, created = get_or_create_authenticator_user(
-            username.lower(),
-            self.database_instance,
+            uid=username.lower(),
+            email=ldap_user.attrs.data.get(ldap_user.settings.USER_ATTR_MAP['email'], ""),
+            authenticator=self.database_instance,
             user_details={
                 "username": username,
             },

--- a/ansible_base/authentication/authenticator_plugins/local.py
+++ b/ansible_base/authentication/authenticator_plugins/local.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from requests.auth import HTTPBasicAuth
 
 from ansible_base.authentication.authenticator_plugins.base import AbstractAuthenticatorPlugin, BaseAuthenticatorConfiguration
-from ansible_base.authentication.utils.authentication import determine_username_from_uid, get_or_create_authenticator_user
+from ansible_base.authentication.utils.authentication import get_or_create_authenticator_user
 from ansible_base.authentication.utils.claims import update_user_claims
 from ansible_base.lib.utils.settings import get_setting
 
@@ -50,16 +50,6 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
             logger.info(f"Local authenticator {self.database_instance.name} is disabled, skipping")
             return None
 
-        # Determine the user name for this authenticator, we have to call this so that we can "attach" to a pre-created user
-        new_username = determine_username_from_uid(username, self.database_instance)
-        # However we can't really accept a different username because we are the local authenticator imagine if:
-        #    User "a" is from another authenticator and has an AuthenticatorUser
-        #    User "a" tried to login from local authenticator
-        #    The above function will return a username of "a<hash>"
-        #    We then try to do local authentication with the database from a different username that will not exist in the database, so it would never work
-        if new_username != username:
-            return None
-
         user = super().authenticate(request, username, password, **kwargs)
         controller_login_results = None
         if (
@@ -84,7 +74,8 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
         # it has an AuthenticatorUser associated with it.
         if user:
             get_or_create_authenticator_user(
-                username,
+                uid=username,
+                email=user.email,
                 authenticator=self.database_instance,
                 user_details={},
                 extra_data={

--- a/ansible_base/authentication/authenticator_plugins/radius.py
+++ b/ansible_base/authentication/authenticator_plugins/radius.py
@@ -87,7 +87,8 @@ class AuthenticatorPlugin(AbstractAuthenticatorPlugin):
             return None
 
         user, _authenticator_user, _is_created = get_or_create_authenticator_user(
-            username,
+            uid=username,
+            email="",
             authenticator=self.database_instance,
             user_details={},
             extra_data={"username": username},

--- a/ansible_base/authentication/authenticator_plugins/tacacs.py
+++ b/ansible_base/authentication/authenticator_plugins/tacacs.py
@@ -119,8 +119,9 @@ class AuthenticatorPlugin(SocialAuthMixin, AbstractAuthenticatorPlugin, ModelBac
 
             if reply.valid:
                 user, _authenticator_user, _created = get_or_create_authenticator_user(
-                    username,
-                    self.database_instance,
+                    uid=username,
+                    email="",
+                    authenticator=self.database_instance,
                     user_details={},
                     extra_data={'username': username},
                 )

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -13,6 +13,7 @@ from social_django.strategy import DjangoStrategy
 
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_class, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
+from ansible_base.authentication.utils.user import normalize_and_get_email
 from ansible_base.lib.utils.response import get_fully_qualified_url
 
 logger = logging.getLogger('ansible_base.authentication.social_auth')
@@ -187,6 +188,41 @@ class SocialAuthValidateCallbackMixin:
             configuration['CALLBACK_URL'] = get_fully_qualified_url('social:complete', kwargs={'backend': slug})
 
         return data
+
+
+def capture_oauth_email_pipeline(*args, backend, details, **kwargs):
+    """
+    Pipeline function to capture and store OAuth provider email in AuthenticatorUser.
+    """
+    if not backend or not hasattr(backend, 'database_instance') or not backend.database_instance:
+        logger.warning("No backend or database_instance found in OAuth email pipeline")
+        return
+
+    user = kwargs.get('user')
+    if not user:
+        return
+
+    uid = kwargs.get('uid')
+    if not uid:
+        logger.warning("No uid found in OAuth email pipeline")
+        return
+
+    email = normalize_and_get_email(details.get('email', ''))
+    if not email:
+        email = ''
+
+    logger.debug(f"Capturing OAuth email for user {user.username}: {email}")
+
+    # Get or update the AuthenticatorUser with the email
+    try:
+        from ansible_base.authentication.utils.authentication import get_or_create_authenticator_user
+
+        get_or_create_authenticator_user(
+            uid=uid, email=email, authenticator=backend.database_instance, user_details=details, extra_data=kwargs.get('response', {})
+        )
+        logger.info(f"Stored OAuth email {email} for user {user.username} from {backend.database_instance.name}")
+    except Exception as e:
+        logger.warning(f"Failed to store OAuth email for user {user.username}: {e}")
 
 
 def create_user_claims_pipeline(*args, backend, response, **kwargs):

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -12,8 +12,11 @@ from social_core.pipeline.user import get_username
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 from ansible_base.authentication.social_auth import AuthenticatorStorage, AuthenticatorStrategy
+from ansible_base.authentication.utils.user import normalize_and_get_email
 
 logger = logging.getLogger('ansible_base.authentication.utils.authentication')
+
+merge_strategy = "Email fallback"
 
 
 class FakeBackend:
@@ -125,18 +128,105 @@ def determine_username_from_uid_social(**kwargs) -> dict:
         )
 
     alt_uid = authenticator.get_alternative_uid(**kwargs)
+    email = kwargs.get('details', {}).get('email', None)
 
     if migrated_username := migrate_from_existing_authenticator(
         uid=kwargs.get("uid"), alt_uid=alt_uid, authenticator=authenticator.database_instance, preferred_username=selected_username
     ):
         username = migrated_username
     else:
-        username = determine_username_from_uid(selected_username, authenticator.database_instance)
+        username = determine_username_from_uid(selected_username, email, authenticator.database_instance)
 
     return {"username": username}
 
 
-def determine_username_from_uid(uid: str = None, authenticator: Authenticator = None, alt_uid: Optional[str] = None) -> str:
+def _handle_no_merge_strategy(uid: str, authenticator: Authenticator) -> str:
+    """Handles the merge strategy where users are unique for each authenticator."""
+    if AuthenticatorUser.objects.filter(Q(uid=uid) | Q(user__username=uid)).exists():
+        # Some other provider is providing this username so we need to create our own username
+        new_username = get_local_username({'username': uid})
+        logger.info(
+            f'Authenticator {authenticator.name} wants to authenticate {uid} but that'
+            f' username is already in use by another authenticator,'
+            f' the user from this authenticator will be {new_username}'
+        )
+        return new_username
+    else:
+        # We didn't have an exact match but no other provider is servicing this uid so lets return that for usage
+        logger.info(f"Authenticator {authenticator.name} is able to authenticate user {uid} as {uid}")
+        return uid
+
+
+def _handle_email_fallback_strategy(uid: str, email: Union[str, list[str], None], authenticator: Authenticator) -> str:
+    """Handles the merge strategy where AAP users are matched by email."""
+    ###
+    # AUTHENTICATION STRATEGY OVERVIEW
+    # For more detailed information, see the following proposal
+    # https://handbook.eng.ansible.com/proposals/0082-Handling-Sign-In-Via-Multiple-Authenticators#how
+    #
+    # The logic below maps to the proposal flowchart, indicated by comments starting with "PROPOSAL FLOW"
+    ###
+    user_model = get_user_model()
+    normalized_email = normalize_and_get_email(email)
+
+    # PROPOSAL FLOW: Authenticator No Email provided
+    if not normalized_email:
+        return _handle_no_merge_strategy(uid, authenticator)  # Logic is identical to the no-merge strategy
+
+    # PROPOSAL FLOW: Authenticator provides email
+    existing_user_match = user_model.objects.filter(email__iexact=normalized_email)
+    user_count = existing_user_match.count()
+
+    # PROPOSAL FLOW: Are there multiple AAP users with this Email? Yes
+    if user_count > 1:
+        logger.warning(f"Found more than 1 user matching {uid}/{email}, unable to determine which user to merge with!")
+        raise AuthException(f"Found more than 1 user matching {uid}/{email}, unable to determine which user to merge with!")
+    # PROPOSAL FLOW: Are there multiple AAP users with this Email? No only 1
+    elif user_count == 1:
+        return existing_user_match.first().username
+    # PROPOSAL FLOW: Does an AAP User with this email exist? No
+    else:
+        new_username = get_local_username({'username': uid})
+        logger.warning(
+            f"Authenticator {authenticator.name} wants to authenticate {uid}/{email} "
+            "but that username is already in use by another authenticator, "
+            f"the user from this authenticator will be {new_username}"
+        )
+        return new_username
+
+
+# def _handle_email_username_fallback_strategy(uid: str, email: Union[str, list[str], None], authenticator: Authenticator) -> str:
+#     """Handles the unused 'Email and Username fallback' strategy."""
+#     # This code is not used anywhere, but is kept here for reference, in case we later want to enable it.
+#     normalized_email = normalize_and_get_email(email)
+
+#     # Note: The original code uses .get(), which will raise an exception if zero or multiple
+#     # objects are found, and then tries to call .count() on the result, which will fail.
+#     # The logic is preserved here as-is.
+#     if not normalized_email:
+#         existing_user_match = Authenticator.objects.get(user__username=uid)
+#     else:
+#         existing_user_match = Authenticator.objects.get(user__email=normalized_email)
+
+#     if existing_user_match.count() == 1:
+#         existing_user = existing_user_match[0].user
+#         new_username = existing_user.username
+#         logger.info(f"Authenticator {authenticator.name} matched {uid}/{email} from provider {existing_user_match[0].provider.name}, combining users")
+#         return new_username
+#     elif existing_user_match.count() > 1:
+#         raise AuthException(f"Found more than 1 user matching {uid}/{email}, unable to determine which user to merge with!")
+#     else:
+#         # Some other provider is providing this username so we need to create our own username
+#         new_username = get_local_username({'username': uid})
+#         logger.info(
+#             f'Authenticator {authenticator.name} wants to authenticate {uid}/{email} but that'
+#             f' username is already in use by another authenticator,'
+#             f' the user from this authenticator will be {new_username}'
+#         )
+#         return new_username
+
+
+def determine_username_from_uid(uid: str = None, email: Union[str, list[str], None] = None, authenticator: Authenticator = None) -> str:
     """
     Determine what the username for the User object will be from the given uid and authenticator
     This will take uid like "bella" and search for an AuthenticatorUser and return:
@@ -157,30 +247,43 @@ def determine_username_from_uid(uid: str = None, authenticator: Authenticator = 
         raise
 
     # If we have an AuthenticatorUser with the exact uid and provider than we have a match
-    exact_match = AuthenticatorUser.objects.filter(uid=uid, provider=authenticator)
-    if exact_match.count() == 1:
-        new_username = exact_match[0].user.username
+    if (exact_match := AuthenticatorUser.objects.filter(uid=uid, provider=authenticator)).exists():
+        new_username = exact_match.first().user.username
         logger.info(f"Authenticator {authenticator.name} already authenticated {uid} as {new_username}")
         return new_username
 
-    # We didn't get an exact match. If any other provider is using this uid our id will be uid<hash>
-    if AuthenticatorUser.objects.filter(Q(uid=uid) | Q(user__username=uid)).count() != 0:
-        # Some other provider is providing this username so we need to create our own username
-        new_username = get_local_username({'username': uid})
-        logger.info(
-            f'Authenticator {authenticator.name} wants to authenticate {uid} but that'
-            f' username is already in use by another authenticator,'
-            f' the user from this authenticator will be {new_username}'
-        )
-        return new_username
+    logger.debug(f"Authentication merge strategy is {merge_strategy}")
 
-    # We didn't have an exact match but no other provider is servicing this uid so lets return that for usage
-    logger.info(f"Authenticator {authenticator.name} is able to authenticate user {uid} as {uid}")
-    return uid
+    # Dispatch to the correct handler based on the merge strategy
+    # if merge_strategy == "": # AAP 2.5 Merge Strategy
+    #     return _handle_no_merge_strategy(uid, authenticator)
+    if merge_strategy == "Email fallback":  # AAP 2.6 Default Merge Strategy
+        return _handle_email_fallback_strategy(uid, email, authenticator)
+    # elif merge_strategy == "Email and Username fallback": # In the future, we may want to enable this
+    #     return _handle_email_username_fallback_strategy(uid, email, authenticator)
+    else:
+        raise AuthException(f"Got an invalid merge_strategy {merge_strategy}")
+
+
+def _validate_username_for_new_user(username: str, authenticator: Authenticator):
+    """
+    Prevents creating a user if the username is already tied to another authenticator.
+    Returns True if the username is available, False otherwise.
+
+    Note: This assumes `merge_strategy` is available in the scope, as in the original code.
+    """
+    if merge_strategy is None:
+        if conflicting_user := AuthenticatorUser.objects.filter(user__username=username).first():
+            logger.error(
+                f'Authenticator {authenticator.name} attempted to create an AuthenticatorUser for {username}'
+                f' but that id is already tied to authenticator {conflicting_user.provider.name}'
+            )
+            return False  # Validation failed
+    return True  # Validation passed
 
 
 def get_or_create_authenticator_user(
-    uid: str, authenticator: Authenticator, user_details: dict = dict, extra_data: dict = dict
+    uid: str, email: str, authenticator: Authenticator, user_details: dict = dict, extra_data: dict = dict
 ) -> Tuple[Optional[AbstractUser], Optional[AuthenticatorUser], Optional[bool]]:
     """
     Create the user object in the database along with it's associated AuthenticatorUser class.
@@ -200,47 +303,45 @@ def get_or_create_authenticator_user(
         logger.warning(f"AuthException: {e}")
         raise
 
+    # Step 1: Determine the username, running the migration logic FIRST. This is the key fix.
     if migrated_username := migrate_from_existing_authenticator(uid=uid, alt_uid=None, authenticator=authenticator, preferred_username=uid):
         username = migrated_username
     else:
-        username = determine_username_from_uid(uid, authenticator)
+        username = determine_username_from_uid(uid, email, authenticator)
 
+    # Step 2: Now that the username is finalized, try to find the AuthenticatorUser.
+    auth_user = None
     created = None
     try:
-        # First see if we have an auth user and if so update it
         auth_user = AuthenticatorUser.objects.get(uid=uid, provider=authenticator)
         auth_user.extra_data = extra_data
+        auth_user.email = email
         auth_user.save()
         created = False
     except AuthenticatorUser.DoesNotExist:
-        # Ensure that this username is not already tied to another authenticator
-        auth_user = AuthenticatorUser.objects.filter(user__username=username).first()
-        if auth_user is not None:
-            logger.error(
-                f'Authenticator {authenticator.name} attempted to create an AuthenticatorUser for {username}'
-                f' but that id is already tied to authenticator {auth_user.provider.name}'
-            )
+        # If the AuthenticatorUser doesn't exist, validate the username before creating a new one.
+        if not _validate_username_for_new_user(username, authenticator):
             return None, None, None
 
-    # ensure the authenticator isn't trying to pass along a cheeky is_superuser in user_details
+    # Step 3: Get or create the main User model instance.
     details = {k: user_details.get(k, "") for k in ["first_name", "last_name", "email"]}
-    # Create or get our user object
     local_user, user_created = get_user_model().objects.get_or_create(username=username, defaults=details)
     if user_created:
         logger.info(f"Authenticator {authenticator.name} created User {username}")
 
+    # Step 4: If the AuthenticatorUser was not found in Step 2, create it now.
     if created is None:
-        # Create or get the user object. The get shouldn't happen but just incase something snuck in on us
         auth_user, created = AuthenticatorUser.objects.get_or_create(
             user=local_user,
+            email=email,
             uid=uid,
             provider=authenticator,
             defaults={'extra_data': extra_data},
         )
         if created:
-            extra = ''
-            if not user_created:
-                extra = ' attaching to existing user'
+            extra = ' attaching to existing user' if not user_created else ''
             logger.debug(f"Authenticator {authenticator.name} created AuthenticatorUser for {username}{extra}")
 
-    return local_user, auth_user, created
+    # Ensure the returned user object is the one linked to the auth_user.
+    final_user = auth_user.user if auth_user else local_user
+    return final_user, auth_user, created

--- a/ansible_base/authentication/utils/user.py
+++ b/ansible_base/authentication/utils/user.py
@@ -1,10 +1,29 @@
-from typing import Optional
+from typing import Any, Optional
 
 from django.contrib.auth.models import AbstractUser
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.lib.utils.models import is_system_user
+
+
+# This helper centralizes the logic for handling and cleaning the email input.
+def normalize_and_get_email(email: Any) -> Optional[str]:
+    """Handles list or string email input, validates type, and normalizes it."""
+    if not email:  # Covers None, empty string, or empty list
+        return None
+
+    if isinstance(email, list):
+        first_email = email[0]
+        if not isinstance(first_email, str) or not first_email.strip():
+            return None
+        return first_email.strip().lower()
+
+    if isinstance(email, str):
+        return email.strip().lower()
+
+    # For any other type (int, dict, etc.), treat as empty
+    return None
 
 
 def can_user_change_password(user: Optional[AbstractUser]) -> bool:

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -170,6 +170,7 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
             'social_core.pipeline.social_auth.social_user',
             'ansible_base.authentication.utils.authentication.determine_username_from_uid_social',
             'social_core.pipeline.user.create_user',
+            'ansible_base.authentication.social_auth.capture_oauth_email_pipeline',
             'social_core.pipeline.social_auth.associate_user',
             'social_core.pipeline.social_auth.load_extra_data',
             'social_core.pipeline.user.user_details',

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap_get_or_build_user.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap_get_or_build_user.py
@@ -32,5 +32,5 @@ def test_get_or_build_user(username, ldap_authenticator):
         ldap_object = MagicMock()
         plugin.get_or_build_user(username, ldap_object)
         assert get_or_create_authenticator_user.called
-        assert username.lower() in get_or_create_authenticator_user.call_args[0]
-        assert username not in get_or_create_authenticator_user.call_args[0]
+        assert username.lower() in get_or_create_authenticator_user.call_args.kwargs['uid']
+        assert username not in get_or_create_authenticator_user.call_args.kwargs['uid']

--- a/test_app/tests/authentication/authenticator_plugins/test_local.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_local.py
@@ -111,15 +111,6 @@ def test_local_auth_no_db_instance():
     assert plugin.authenticate(request=RequestFactory(), username='jane', password='doe') is None
 
 
-def test_local_auth_determine_username_returns_different_user(local_authenticator, ldap_authenticator, random_user):
-    from ansible_base.authentication.models import AuthenticatorUser
-
-    # Tie the random user to another authenticator, this will force determine_username_from_uid to return something different
-    AuthenticatorUser.objects.create(uid=random_user.username, user=random_user, provider=ldap_authenticator)
-    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
-    assert plugin.authenticate(request=RequestFactory(), username=random_user.username, password='doe') is None
-
-
 @pytest.mark.django_db()
 def test_can_authenticate_from_controller_nonexistent_user():
     """

--- a/test_app/tests/authentication/test_merge_strategy_email_fallback.py
+++ b/test_app/tests/authentication/test_merge_strategy_email_fallback.py
@@ -1,0 +1,181 @@
+import pytest
+from django.contrib.auth import get_user_model
+from social_core.exceptions import AuthException
+
+from ansible_base.authentication.models import AuthenticatorUser
+from ansible_base.authentication.utils.authentication import determine_username_from_uid
+
+User = get_user_model()
+
+
+@pytest.fixture
+def existing_user():
+    """Create an existing user with an email."""
+    return User.objects.create(username='john', email='john@example.com', first_name='John', last_name='Doe')
+
+
+@pytest.fixture
+def existing_user_with_github_auth(existing_user, github_authenticator):
+    """Create an existing user linked to GitHub authenticator."""
+    AuthenticatorUser.objects.create(user=existing_user, uid='john', provider=github_authenticator, extra_data={'github_id': 12345})
+    return existing_user
+
+
+@pytest.mark.django_db
+class TestEmailFallbackMergeStrategy:
+    """Test the Email fallback merge strategy logic."""
+
+    def test_email_fallback_merge_same_email_different_authenticators(self, existing_user_with_github_auth, ldap_authenticator):
+        """Test that users with same email are merged regardless of authenticator."""
+        # User already exists with GitHub auth and email john@example.com
+        # Now try to authenticate with LDAP using different uid but same email
+
+        username = determine_username_from_uid(uid='john_ldap', email='john@example.com', authenticator=ldap_authenticator)
+
+        # Should return the existing user's username (merge accounts)
+        assert username == 'john'
+
+    def test_email_fallback_merge_email_as_list(self, existing_user_with_github_auth, saml_authenticator):
+        """Test that email as list is handled correctly."""
+        # Email provided as list (common in SAML)
+        username = determine_username_from_uid(uid='john_saml', email=['john@example.com', 'john.doe@example.com'], authenticator=saml_authenticator)
+
+        # Should use first email and merge with existing user
+        assert username == 'john'
+
+    def test_email_fallback_no_existing_user_with_email(self, ldap_authenticator):
+        """Test creating new user when no existing user has the email."""
+        username = determine_username_from_uid(uid='newuser', email='newuser@example.com', authenticator=ldap_authenticator)
+
+        # Should create a unique username since no existing user has this email
+        # and no other authenticator is using this uid
+        assert username == 'newuser'
+
+    def test_email_fallback_multiple_users_same_email_raises_exception(self, ldap_authenticator):
+        """Test that multiple users with same email raises an exception."""
+        # Create two users with same email
+        User.objects.create(username='user1', email='duplicate@example.com')
+        User.objects.create(username='user2', email='duplicate@example.com')
+
+        with pytest.raises(AuthException) as exc_info:
+            determine_username_from_uid(uid='conflicting_user', email='duplicate@example.com', authenticator=ldap_authenticator)
+            assert "Found more than 1 user matching" in str(exc_info.value)
+
+    def test_email_fallback_no_email_provided_username_available(self, ldap_authenticator):
+        """Test behavior when no email is provided and username is available."""
+        username = determine_username_from_uid(uid='available_username', email=None, authenticator=ldap_authenticator)
+
+        # Should use the uid as username since no conflicts
+        assert username == 'available_username'
+
+    def test_email_fallback_no_email_provided_username_taken(self, existing_user_with_github_auth, ldap_authenticator):
+        """Test behavior when no email is provided and username is taken by another authenticator."""
+        # Try to use 'john' which is already taken by GitHub authenticator
+        username = determine_username_from_uid(uid='john', email=None, authenticator=ldap_authenticator)
+
+        # Should create a unique username since 'john' is already used
+        assert username != 'john'
+        assert 'john' in username  # Should be based on original username
+
+    def test_email_fallback_no_email_provided_username_taken_by_same_authenticator(self, existing_user_with_github_auth, github_authenticator):
+        """Test behavior when user already exists for same authenticator."""
+        # User 'john' already exists with GitHub authenticator
+        username = determine_username_from_uid(uid='john', email=None, authenticator=github_authenticator)
+
+        # Should return the existing username since it's the same authenticator
+        assert username == 'john'
+
+    def test_email_fallback_empty_email_string(self, ldap_authenticator):
+        """Test behavior with empty email string."""
+        username = determine_username_from_uid(uid='testuser', email='', authenticator=ldap_authenticator)
+
+        # Empty email should be treated same as None
+        assert username == 'testuser'
+
+    def test_email_fallback_empty_email_list(self, ldap_authenticator):
+        """Test behavior with empty email list."""
+        username = determine_username_from_uid(uid='testuser', email=[], authenticator=ldap_authenticator)
+
+        # Empty email list should be treated same as None
+        assert username == 'testuser'
+
+    def test_email_fallback_cross_authenticator_merge(self, github_authenticator, ldap_authenticator, saml_authenticator):
+        """Test merging users across multiple different authenticators."""
+        # Create user via GitHub
+        github_user = User.objects.create(username='multiauth_user', email='multi@example.com')
+        AuthenticatorUser.objects.create(user=github_user, uid='github_user', provider=github_authenticator, extra_data={'github_id': 12345})
+
+        # Try to authenticate same email via LDAP
+        ldap_username = determine_username_from_uid(uid='ldap_user', email='multi@example.com', authenticator=ldap_authenticator)
+
+        # Should merge with existing user
+        assert ldap_username == 'multiauth_user'
+
+        # Try to authenticate same email via SAML
+        saml_username = determine_username_from_uid(uid='saml_user', email='multi@example.com', authenticator=saml_authenticator)
+
+        # Should also merge with existing user
+        assert saml_username == 'multiauth_user'
+
+    def test_email_fallback_case_insensitive_email_merge(self, existing_user_with_github_auth, ldap_authenticator):
+        """Test that email comparison is case insensitive."""
+        # existing_user_with_github_auth has email 'john@example.com'
+
+        username = determine_username_from_uid(uid='john_ldap', email='JOHN@EXAMPLE.COM', authenticator=ldap_authenticator)  # Different case
+
+        # Should still merge with existing user (case insensitive)
+        assert username == 'john'
+
+    def test_email_fallback_merge_preserves_original_username(self, github_authenticator, ldap_authenticator):
+        """Test that merging preserves the original user's username."""
+        # Create user with specific username and email
+        original_user = User.objects.create(username='original_name', email='merge@example.com')
+        AuthenticatorUser.objects.create(user=original_user, uid='github_original', provider=github_authenticator, extra_data={})
+
+        # Try to authenticate with different uid but same email
+        username = determine_username_from_uid(uid='completely_different_name', email='merge@example.com', authenticator=ldap_authenticator)
+
+        # Should return the original username, not the new uid
+        assert username == 'original_name'
+
+    def test_email_fallback_with_whitespace_email(self, existing_user_with_github_auth, ldap_authenticator):
+        """Test that email with whitespace is handled correctly."""
+        # Note: This test depends on how Django handles email normalization
+        username = determine_username_from_uid(uid='john_ldap', email='  john@example.com  ', authenticator=ldap_authenticator)  # Email with whitespace
+
+        # Should still find and merge with existing user
+        # (This may need adjustment based on actual email handling)
+        assert username == 'john'
+
+    def test_email_fallback_uid_conflicts_with_existing_username(self, ldap_authenticator):
+        """Test when uid conflicts with existing username but different email."""
+        # Create user with username 'conflict' and different email
+        User.objects.create(username='conflict', email='other@example.com')
+
+        username = determine_username_from_uid(uid='conflict', email='new@example.com', authenticator=ldap_authenticator)
+
+        # Should create unique username since emails don't match
+        assert username != 'conflict'
+        assert 'conflict' in username  # Should be based on original uid
+
+    def test_email_fallback_complex_scenario(self, github_authenticator, ldap_authenticator, saml_authenticator):
+        """Test a complex scenario with multiple authenticators and email merging."""
+        # Create initial user via GitHub
+        github_user = User.objects.create(username='complex_user', email='complex@example.com')
+        AuthenticatorUser.objects.create(user=github_user, uid='github_complex', provider=github_authenticator, extra_data={'github_id': 12345})
+
+        # Create another user with different email
+        other_user = User.objects.create(username='other_user', email='other@example.com')
+        AuthenticatorUser.objects.create(user=other_user, uid='ldap_other', provider=ldap_authenticator, extra_data={})
+
+        # Try to authenticate with SAML using same email as first user
+        saml_username = determine_username_from_uid(uid='saml_complex', email='complex@example.com', authenticator=saml_authenticator)
+
+        # Should merge with first user
+        assert saml_username == 'complex_user'
+
+        # Try to authenticate with LDAP using different uid but same email as first user
+        ldap_username = determine_username_from_uid(uid='ldap_complex', email='complex@example.com', authenticator=ldap_authenticator)
+
+        # Should also merge with first user
+        assert ldap_username == 'complex_user'

--- a/test_app/tests/authentication/test_migrate_user_to_authenticator.py
+++ b/test_app/tests/authentication/test_migrate_user_to_authenticator.py
@@ -322,6 +322,7 @@ def test_password_based_authenticators_existing_user(ldap_authenticator, saml_au
 
     get_or_create_authenticator_user(
         uid="my_user_id",
+        email="my_user_id@example.com",
         authenticator=ldap_authenticator,
         user_details={},
         extra_data={},
@@ -354,6 +355,7 @@ def test_password_based_authenticators_new_user(ldap_authenticator, saml_authent
 
     user, _, _ = get_or_create_authenticator_user(
         uid="my_user_id",
+        email="my_user_id@example.com",
         authenticator=ldap_authenticator,
         user_details={},
         extra_data={},

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -9,6 +9,7 @@ from ansible_base.authentication.social_auth import (
     AuthenticatorStrategy,
     SocialAuthMixin,
     SocialAuthValidateCallbackMixin,
+    capture_oauth_email_pipeline,
     create_user_claims_pipeline,
 )
 
@@ -109,6 +110,179 @@ id_token_no_groups = {
 id_token = {**id_token_no_groups, "groups": ["myidtokengroup"]}
 
 id_token_duplicate_group = {**id_token_no_groups, "groups": ["mygroup", "myidtokengroup"]}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "backend_has_instance,user_exists,uid_exists,email_value,expected_calls",
+    [
+        # Happy path - all parameters valid
+        (True, True, True, "user@example.com", {"get_or_create": True, "debug": True, "info": True}),
+        # Email as list (SAML case)
+        (True, True, True, ["user@example.com", "backup@example.com"], {"get_or_create": True, "debug": True, "info": True}),
+        # Empty email
+        (True, True, True, "", {"get_or_create": True, "debug": True, "info": True}),
+        # Email as non-string (gets normalized to empty)
+        (True, True, True, 123, {"get_or_create": True, "debug": True, "info": True}),
+        # No backend database_instance attribute
+        (False, True, True, "user@example.com", {"warning_backend": True}),
+        # Backend database_instance is None
+        ("none", True, True, "user@example.com", {"warning_backend": True}),
+        # No user in kwargs
+        (True, False, True, "user@example.com", {}),
+        # No uid in kwargs
+        (True, True, False, "user@example.com", {"warning_uid": True}),
+    ],
+)
+@mock.patch("ansible_base.authentication.social_auth.logger")
+@mock.patch("ansible_base.authentication.utils.authentication.get_or_create_authenticator_user")
+def test_capture_oauth_email_pipeline(mock_get_or_create, mock_logger, backend_has_instance, user_exists, uid_exists, email_value, expected_calls):
+    """Test the capture_oauth_email_pipeline function with various scenarios."""
+
+    # Create mock objects
+    mock_user = mock.Mock()
+    mock_user.username = "testuser"
+
+    if backend_has_instance is True:
+        mock_backend = mock.Mock()
+        mock_backend.database_instance = mock.Mock()
+        mock_backend.database_instance.name = "Test Authenticator"
+    elif backend_has_instance == "none":
+        # Test case where backend has database_instance attribute but it's None
+        mock_backend = mock.Mock()
+        mock_backend.database_instance = None
+    else:
+        # Test case where backend doesn't have database_instance attribute
+        mock_backend = mock.Mock(spec=[])  # Backend without database_instance attribute
+
+    # Setup kwargs and details
+    kwargs = {}
+    if user_exists:
+        kwargs['user'] = mock_user
+    if uid_exists:
+        kwargs['uid'] = "test_uid"
+    kwargs['response'] = {"extra": "data"}
+
+    details = {'email': email_value, 'first_name': 'Test', 'last_name': 'User'}
+
+    # Call the function
+    capture_oauth_email_pipeline(backend=mock_backend, details=details, **kwargs)
+
+    # Verify expected calls
+    if expected_calls.get("warning_backend"):
+        mock_logger.warning.assert_called_with("No backend or database_instance found in OAuth email pipeline")
+
+    if expected_calls.get("warning_uid"):
+        mock_logger.warning.assert_called_with("No uid found in OAuth email pipeline")
+
+    if expected_calls.get("debug"):
+        # Normalize email for assertion
+        expected_email = email_value
+        if isinstance(email_value, list) and email_value:
+            expected_email = email_value[0]
+        elif not isinstance(email_value, str):
+            expected_email = ""
+
+        mock_logger.debug.assert_called_with(f"Capturing OAuth email for user testuser: {expected_email}")
+
+    if expected_calls.get("get_or_create"):
+        # Verify get_or_create_authenticator_user was called with correct parameters
+        assert mock_get_or_create.called
+        call_args = mock_get_or_create.call_args
+
+        # Check uid
+        assert call_args[1]['uid'] == 'test_uid'
+
+        # Check normalized email
+        expected_email = email_value
+        if isinstance(email_value, list) and email_value:
+            expected_email = email_value[0]
+        elif not isinstance(email_value, str):
+            expected_email = ""
+        assert call_args[1]['email'] == expected_email
+
+        # Check other parameters
+        assert call_args[1]['authenticator'] == mock_backend.database_instance
+        assert call_args[1]['user_details'] == details
+        assert call_args[1]['extra_data'] == {"extra": "data"}
+
+    if expected_calls.get("info"):
+        expected_email = email_value
+        if isinstance(email_value, list) and email_value:
+            expected_email = email_value[0]
+        elif not isinstance(email_value, str):
+            expected_email = ""
+        mock_logger.info.assert_called_with(f"Stored OAuth email {expected_email} for user testuser from Test Authenticator")
+
+    # If no expected calls, verify nothing was called
+    if not expected_calls:
+        assert not mock_get_or_create.called
+
+
+@mock.patch("ansible_base.authentication.social_auth.logger")
+@mock.patch("ansible_base.authentication.utils.authentication.get_or_create_authenticator_user")
+def test_capture_oauth_email_pipeline_exception_handling(mock_get_or_create, mock_logger):
+    """Test exception handling in capture_oauth_email_pipeline."""
+
+    # Setup mocks to raise exception
+    mock_get_or_create.side_effect = Exception("Database error")
+
+    mock_user = mock.Mock()
+    mock_user.username = "testuser"
+
+    mock_backend = mock.Mock()
+    mock_backend.database_instance = mock.Mock()
+    mock_backend.database_instance.name = "Test Authenticator"
+
+    kwargs = {'user': mock_user, 'uid': 'test_uid', 'response': {}}
+    details = {'email': 'user@example.com'}
+
+    # Call the function
+    capture_oauth_email_pipeline(backend=mock_backend, details=details, **kwargs)
+
+    # Verify exception was caught and logged
+    mock_logger.warning.assert_called_with("Failed to store OAuth email for user testuser: Database error")
+
+
+@mock.patch("ansible_base.authentication.social_auth.logger")
+@mock.patch("ansible_base.authentication.utils.authentication.get_or_create_authenticator_user")
+def test_capture_oauth_email_pipeline_edge_cases(mock_get_or_create, mock_logger):
+    """Test edge cases for email normalization in capture_oauth_email_pipeline."""
+
+    mock_user = mock.Mock()
+    mock_user.username = "testuser"
+
+    mock_backend = mock.Mock()
+    mock_backend.database_instance = mock.Mock()
+    mock_backend.database_instance.name = "Test Authenticator"
+
+    test_cases = [
+        # Empty list
+        ([], ""),
+        # None value
+        (None, ""),
+        # List with empty string
+        ([""], ""),
+        # List with None as first element
+        ([None, "backup@example.com"], ""),
+        # Multiple valid emails in list
+        (["primary@example.com", "backup@example.com"], "primary@example.com"),
+    ]
+
+    for email_input, expected_email in test_cases:
+        # Reset mocks
+        mock_get_or_create.reset_mock()
+        mock_logger.reset_mock()
+
+        kwargs = {'user': mock_user, 'uid': 'test_uid', 'response': {}}
+        details = {'email': email_input}
+
+        # Call the function
+        capture_oauth_email_pipeline(backend=mock_backend, details=details, **kwargs)
+
+        # Verify the email was normalized correctly
+        call_args = mock_get_or_create.call_args
+        assert call_args[1]['email'] == expected_email, f"Failed for input {email_input}, got {call_args[1]['email']}, expected {expected_email}"
 
 
 @pytest.mark.parametrize(

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -44,7 +44,7 @@ class TestAuthenticationUtilsAuthentication:
         elif related_authenticator in ['ldap', 'multiple']:
             AuthenticatorUser.objects.create(uid=random_user.username, user=random_user, provider=ldap_authenticator)
         with expected_log(self.logger, 'info', info_message):
-            new_username = authentication.determine_username_from_uid(uid, local_authenticator)
+            new_username = authentication.determine_username_from_uid(uid, "", local_authenticator)
             if expected_username:
                 assert new_username == random_user.username
             else:
@@ -52,7 +52,7 @@ class TestAuthenticationUtilsAuthentication:
 
     def test_determine_username_from_uid_behavior(self, local_authenticator, saml_authenticator):
         # Test when there's no collision
-        new_username = authentication.determine_username_from_uid(uid="new-user", authenticator=saml_authenticator)
+        new_username = authentication.determine_username_from_uid(uid="new-user", email="", authenticator=saml_authenticator)
         assert new_username == "new-user"
 
         # Create a different user tied to the same authenticator to force a collision
@@ -60,11 +60,11 @@ class TestAuthenticationUtilsAuthentication:
         AuthenticatorUser.objects.create(user=existing_user, provider=saml_authenticator, uid="existing-user")
 
         # Test when there is a match (same uid and authenticator)
-        new_username = authentication.determine_username_from_uid(uid="existing-user", authenticator=saml_authenticator)
+        new_username = authentication.determine_username_from_uid(uid="existing-user", email="", authenticator=saml_authenticator)
         assert new_username == "existing-user", "There should not have been a collision "
 
         # Test with a different authenticator (should return a new username)
-        new_username = authentication.determine_username_from_uid(uid="existing-user", authenticator=local_authenticator)
+        new_username = authentication.determine_username_from_uid(uid="existing-user", email="", authenticator=local_authenticator)
         assert new_username != "existing-user"
         assert new_username.startswith("existing-user")  # It should be "existing-user" followed by a hash
 
@@ -74,7 +74,9 @@ class TestAuthenticationUtilsAuthentication:
         user2_uid = "user-2"
 
         # Step 1: Create an external user with username 'user-1' through the API
-        user1, _, user1_created = authentication.get_or_create_authenticator_user(user1_uid, saml_authenticator, {}, {})
+        user1, _, user1_created = authentication.get_or_create_authenticator_user(
+            uid=user1_uid, email="", authenticator=saml_authenticator, user_details={}, extra_data={}
+        )
         # This should now succeed because we're using a unique username
         assert user1.get_authenticator_uids() == [user1_uid]
         assert user1_created is True
@@ -92,7 +94,7 @@ class TestAuthenticationUtilsAuthentication:
         # Step 3: Get the ID of a new user whose uid is "user-2"
         # We want to end up with: uid: user-1, username: user2<hash>, authenticator: local
         # The function should now return a different username due to collision
-        throw_away_user2_username = authentication.determine_username_from_uid(uid=user2_uid, authenticator=saml_authenticator)
+        throw_away_user2_username = authentication.determine_username_from_uid(uid=user2_uid, email="", authenticator=saml_authenticator)
         assert throw_away_user2_username != user2_uid, "Newly selected username matches conflicting username"
         assert throw_away_user2_username.startswith(user2_uid)  # It should be "user-2" followed by a hash
         # We have not changed the AuthenticatorUser table here, just confirmed that if we try
@@ -100,7 +102,9 @@ class TestAuthenticationUtilsAuthentication:
         #    there is already a user in the system with username user-2
 
         # Attempt to create the new user
-        user2_user, _, user2_created = authentication.get_or_create_authenticator_user(user2_uid, saml_authenticator, {}, {})
+        user2_user, _, user2_created = authentication.get_or_create_authenticator_user(
+            uid=user2_uid, email="", authenticator=saml_authenticator, user_details={}, extra_data={}
+        )
         assert user2_user.username != user2_uid
         assert user2_user.get_authenticator_uids() == [user2_uid]
         assert user2_created is True
@@ -128,9 +132,9 @@ class TestAuthenticationUtilsAuthentication:
         uid = settings.SYSTEM_USERNAME
         authenticator = request.getfixturevalue(auth_fixture)
         with pytest.raises(AuthException):
-            authentication.determine_username_from_uid(uid, authenticator)
+            authentication.determine_username_from_uid(uid, "", authenticator)
         with pytest.raises(AuthException):
-            authentication.get_or_create_authenticator_user(uid, authenticator, {}, {})
+            authentication.get_or_create_authenticator_user(uid=uid, email="", authenticator=authenticator, user_details={}, extra_data={})
 
     #
     # Tests for get_or_create_authenticator_user (gocau)
@@ -138,7 +142,9 @@ class TestAuthenticationUtilsAuthentication:
 
     def test_gocau_auth_user_exists(self, random_user, local_authenticator):
         au = AuthenticatorUser.objects.create(uid=random_user.username, provider=local_authenticator, user=random_user)
-        local_user, auth_user, created = authentication.get_or_create_authenticator_user(random_user.username, local_authenticator, {}, {})
+        local_user, auth_user, created = authentication.get_or_create_authenticator_user(
+            uid=random_user.username, email="", authenticator=local_authenticator, user_details={}, extra_data={}
+        )
         assert created is False
         assert local_user == random_user
         assert auth_user == au
@@ -146,7 +152,7 @@ class TestAuthenticationUtilsAuthentication:
     def test_gocau_auth_user_exists_from_another_provider(self, random_user, local_authenticator, ldap_authenticator):
         orig_au = AuthenticatorUser.objects.create(uid=random_user.username, provider=ldap_authenticator, user=random_user)
         local_user, auth_user, created = authentication.get_or_create_authenticator_user(
-            random_user.username, local_authenticator, {'username': random_user.username}, {}
+            uid=random_user.username, email="", authenticator=local_authenticator, user_details={'username': random_user.username}, extra_data={}
         )
         assert created is True, "New AuthenticatorUser should have been created"
         assert local_user != random_user, "A new user should have been created"
@@ -164,11 +170,15 @@ class TestAuthenticationUtilsAuthentication:
         if user_exists:
             User.objects.create(username=username)
             with expected_log(self.logger, 'debug', f'created AuthenticatorUser for {username} attaching to existing user'):
-                local_user, auth_user, created = authentication.get_or_create_authenticator_user(username, ldap_authenticator, {}, {})
+                local_user, auth_user, created = authentication.get_or_create_authenticator_user(
+                    uid=username, email="", authenticator=ldap_authenticator, user_details={}, extra_data={}
+                )
         else:
             with expected_log(self.logger, 'info', 'created User'):
                 with expected_log(self.logger, 'debug', f'created AuthenticatorUser for {username}'):
-                    local_user, auth_user, created = authentication.get_or_create_authenticator_user(username, ldap_authenticator, {}, {})
+                    local_user, auth_user, created = authentication.get_or_create_authenticator_user(
+                        uid=username, email="", authenticator=ldap_authenticator, user_details={}, extra_data={}
+                    )
 
         assert local_user is not None
         assert auth_user is not None
@@ -211,6 +221,8 @@ class TestAuthenticationUtilsAuthentication:
             'AuthException: System user is not allowed to log in from external authentication sources.',
         ):
             try:
-                authentication.get_or_create_authenticator_user(settings.SYSTEM_USERNAME, local_authenticator, user_details={}, extra_data={})
+                authentication.get_or_create_authenticator_user(
+                    uid=settings.SYSTEM_USERNAME, email="", authenticator=local_authenticator, user_details={}, extra_data={}
+                )
             except AuthException:
                 pass


### PR DESCRIPTION
## Description

This PR is based off of the following [PoC](https://github.com/ansible/django-ansible-base/pull/751).

[Jira](https://issues.redhat.com/browse/AAP-48066)

- What is being changed? This PR allows for multiple authenticators to match to a given AAP user, based on the email as the unifying key. When attempting to sign in via any authenticator with email - `user@example.com`, we will sign you into the AAP user associated with that email, provided only 1 AAP user exists with that email address.
- Why is this change needed? This change is needed to standardize our users, and provide clear expectations about how users are signed in. With this change, we will no longer have unique users for each authenticator, and will instead be able to link multiple authenticators to a given AAP user.
- How does this change address the issue?
This change addresses the issue by adjusting the logic used to match users to usernames as described in the [proposal](https://handbook.eng.ansible.com/proposals/0082-Handling-Sign-In-Via-Multiple-Authenticators).


Note -
This change allows users to log into existing AAP accounts if one associated with their email exists. However in this flow -
1. Local AAP account created
2. Sign in via LDAP
The user will sign in successfully, but due to how django-auth-ldap works, it will automatically unset the users local password preventing them from then signing in via the local password. We may be able to circumvent this. In my testing so far I have not yet been able too, but upon thinking about it further, it may be best to avoid circumventing it, to avoid messing with how django-auth-ldap handles its security.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test (using aap-dev)
1. `make configure-sources`, use this DAB PR
4. `make aap`
5. Configure multiple authenticators such as LDAP, GitHub, SAML, etc in your AAP environment
6. (Optional) Create a local user, with same email address another authenticator users, and sign in as local user. Sign in succeeds
7. Check the /api/gateway/v1/users/<ID> endpoint, we should see associated_authenticators updated with this authenticator reference
8. Sign in via another authenticator (such as github), you should be signed into the same AAP Account, and now associated_authenticators should have multiple entries.
9. (Optional) Keep signing in with other authenticators, you should continue to sign into the same AAP account as long as the same email address is provided by authenticator

Next test -
1. Create a new local user, without an email
2. Sign in via local, see the user is created and linked to local authenticator
3. Sign in via authenticator, a new AAP user should be created (Since no email was available to match on)
4. Sign in via another authenticator (which provides email). We should link to the AAP account created by the step 3 authenticator.

### Expected Results

User can sign into AAP using any authenticator, and expect to sign into their existing AAP account, so long as it is associated with a matching email.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
