### PR TITLE
[AAP-48723] Update user.last_login_from when authenticating

### DIFF
--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -56,5 +56,8 @@ class AnsibleBaseAuth(ModelBackend):
                     return None
 
                 logger.info(f'User {user.username} logged in from authenticator with ID "{authenticator_id}"')
+                if hasattr(user, "last_login_from"):
+                    user.last_login_from = authenticator_object.database_instance
+                    user.save(update_fields=['last_login_from'])
                 return user
         return None

--- a/test_app/tests/authentication/test_backend.py
+++ b/test_app/tests/authentication/test_backend.py
@@ -172,3 +172,168 @@ def test_authentication_exception(expected_log):
         # Expect the log we emit
         with expected_log('ansible_base.authentication.backend.logger', "exception", "Exception raised while trying to authenticate with"):
             backend.AnsibleBaseAuth().authenticate(None)
+
+
+@pytest.mark.django_db
+def test_last_login_from_with_attribute(local_authenticator, random_user, expected_log):
+    """Test that last_login_from is set when user has the attribute."""
+    # Add last_login_from attribute to user
+    random_user.last_login_from = None
+
+    # Create a mock authenticator plugin object with proper structure
+    mock_authenticator_plugin = mock.MagicMock()
+    mock_authenticator_plugin.authenticate.return_value = random_user
+    mock_authenticator_plugin.database_instance = local_authenticator
+
+    # Mock the save method to track calls
+    with mock.patch.object(random_user, 'save') as mock_save:
+        with mock.patch(
+            "ansible_base.authentication.backend.get_authentication_backends",
+            return_value={local_authenticator.id: mock_authenticator_plugin},
+        ):
+            # Expected log message when user logs in
+            with expected_log(
+                'ansible_base.authentication.backend.logger',
+                "info",
+                f'User {random_user.username} logged in from authenticator with ID "{local_authenticator.id}"',
+            ):
+                auth_return = backend.AnsibleBaseAuth().authenticate(None)
+
+            # Verify the user is returned
+            assert auth_return == random_user
+
+            # Verify last_login_from was set to the authenticator database instance
+            assert random_user.last_login_from == local_authenticator
+
+            # Verify save was called with the correct update_fields
+            mock_save.assert_called_once_with(update_fields=['last_login_from'])
+
+
+@pytest.mark.django_db
+def test_last_login_from_without_attribute(local_authenticator, random_user, expected_log):
+    """Test that authentication works normally when user doesn't have last_login_from attribute."""
+    # Ensure user doesn't have last_login_from attribute
+    if hasattr(random_user, 'last_login_from'):
+        delattr(random_user, 'last_login_from')
+
+    # Create a mock authenticator plugin object with proper structure
+    mock_authenticator_plugin = mock.MagicMock()
+    mock_authenticator_plugin.authenticate.return_value = random_user
+    mock_authenticator_plugin.database_instance = local_authenticator
+
+    # Mock the save method to track calls
+    with mock.patch.object(random_user, 'save') as mock_save:
+        with mock.patch(
+            "ansible_base.authentication.backend.get_authentication_backends",
+            return_value={local_authenticator.id: mock_authenticator_plugin},
+        ):
+            with expected_log(
+                'ansible_base.authentication.backend.logger',
+                "info",
+                f'User {random_user.username} logged in from authenticator with ID "{local_authenticator.id}"',
+            ):
+                auth_return = backend.AnsibleBaseAuth().authenticate(None)
+
+            # Verify the user is returned
+            assert auth_return == random_user
+
+            # Verify save was never called since user doesn't have last_login_from
+            mock_save.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_last_login_from_multiple_authenticators(local_authenticator, github_enterprise_authenticator, random_user, expected_log):
+    """Test that last_login_from is set correctly when multiple authenticators are present."""
+    # Add last_login_from attribute to user
+    random_user.last_login_from = None
+
+    # Create mock authenticator plugin objects with proper structure
+    mock_github_plugin = mock.MagicMock()
+    mock_github_plugin.authenticate.return_value = None
+    mock_github_plugin.database_instance = github_enterprise_authenticator
+
+    mock_local_plugin = mock.MagicMock()
+    mock_local_plugin.authenticate.return_value = random_user
+    mock_local_plugin.database_instance = local_authenticator
+
+    # Mock the save method to track calls
+    with mock.patch.object(random_user, 'save') as mock_save:
+        with mock.patch(
+            "ansible_base.authentication.backend.get_authentication_backends",
+            return_value={github_enterprise_authenticator.id: mock_github_plugin, local_authenticator.id: mock_local_plugin},
+        ):
+            # Expected log message when user logs in
+            with expected_log(
+                'ansible_base.authentication.backend.logger',
+                "info",
+                f'User {random_user.username} logged in from authenticator with ID "{local_authenticator.id}"',
+            ):
+                auth_return = backend.AnsibleBaseAuth().authenticate(None)
+
+            # Verify the user is returned
+            assert auth_return == random_user
+
+            # Verify last_login_from was set to the local authenticator (the one that succeeded)
+            assert random_user.last_login_from == local_authenticator
+
+            # Verify save was called with the correct update_fields
+            mock_save.assert_called_once_with(update_fields=['last_login_from'])
+
+
+@pytest.mark.django_db
+def test_last_login_from_inactive_user(local_authenticator, random_user):
+    """Test that last_login_from is not set when user is inactive."""
+    # Add last_login_from attribute to user but make user inactive
+    random_user.last_login_from = None
+    random_user.is_active = False
+
+    # Create a mock authenticator plugin object with proper structure
+    mock_authenticator_plugin = mock.MagicMock()
+    mock_authenticator_plugin.authenticate.return_value = random_user
+    mock_authenticator_plugin.database_instance = local_authenticator
+
+    # Mock the save method to track calls
+    with mock.patch.object(random_user, 'save') as mock_save:
+        with mock.patch(
+            "ansible_base.authentication.backend.get_authentication_backends",
+            return_value={local_authenticator.id: mock_authenticator_plugin},
+        ):
+            auth_return = backend.AnsibleBaseAuth().authenticate(None)
+
+            # Verify authentication failed (returns None for inactive user)
+            assert auth_return is None
+
+            # Verify save was never called since authentication failed
+            mock_save.assert_not_called()
+
+            # Verify last_login_from was not changed
+            assert random_user.last_login_from is None
+
+
+@pytest.mark.django_db
+def test_last_login_from_social_auth_failed(local_authenticator, random_user):
+    """Test that last_login_from is not set when social auth pipeline fails."""
+    # Add last_login_from attribute to user
+    random_user.last_login_from = None
+
+    # Create a mock authenticator plugin object with proper structure
+    mock_authenticator_plugin = mock.MagicMock()
+    mock_authenticator_plugin.authenticate.return_value = SOCIAL_AUTH_PIPELINE_FAILED_STATUS
+    mock_authenticator_plugin.database_instance = local_authenticator
+
+    # Mock the save method to track calls
+    with mock.patch.object(random_user, 'save') as mock_save:
+        with mock.patch(
+            "ansible_base.authentication.backend.get_authentication_backends",
+            return_value={local_authenticator.id: mock_authenticator_plugin},
+        ):
+            auth_return = backend.AnsibleBaseAuth().authenticate(None)
+
+            # Verify authentication failed (returns None)
+            assert auth_return is None
+
+            # Verify save was never called since authentication failed
+            mock_save.assert_not_called()
+
+            # Verify last_login_from was not changed
+            assert random_user.last_login_from is None


### PR DESCRIPTION
Issue: AAP-48723
Related: https://github.com/ansible-automation-platform/aap-gateway/pull/908
Signed-off-by: Fabricio Aguiar <fabricio.aguiar@gmail.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
The `AnsibleBaseAuth` backend is modified to update the `last_login_from` attribute of the user object upon successful authentication.
- Why is this change needed?
To track which authenticator a user last used to log in. This is related to issue AAP-48723.
- How does this change address the issue?
By explicitly setting and saving the `last_login_from` field on the user model after a successful login.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Configure an authenticator.
2. Log in as a user using the configured authenticator.
3. Check the user's `last_login_from` field to see if it is set to the authenticator used.

### Expected Results
<!-- Describe what should happen after following the steps -->
The user's `last_login_from` field should be populated with the authenticator they used to log in.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
