### PR TITLE
AAP-50130: No fallback auth for 'admin' user

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/local.py
+++ b/ansible_base/authentication/authenticator_plugins/local.py
@@ -63,7 +63,8 @@ class AuthenticatorPlugin(ModelBackend, AbstractAuthenticatorPlugin):
         user = super().authenticate(request, username, password, **kwargs)
         controller_login_results = None
         if (
-            not user
+            username.lower() != "admin"  # Avoid fallback authentication for admin user. We don't want to overwrite the admin password.
+            and not user
             and request
             and request.path.startswith('/api/gateway/v1/login/')
             and (controller_login_results := self._can_authenticate_from_controller(username, password))

--- a/test_app/tests/authentication/authenticator_plugins/test_local.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_local.py
@@ -1010,3 +1010,85 @@ def test_get_controller_user_timeout_conversion_exception_handling(user):
         # This should handle the ValueError from _convert_to_seconds in the generic exception handler
         result = plugin._get_controller_user(user.username, "password")
         assert result is None
+
+
+@pytest.mark.django_db()
+def test_authenticate_admin_user_skips_controller_fallback(local_authenticator):
+    """
+    Test that controller fallback authentication is skipped for 'admin' user,
+    even when all other conditions are met (non-admin users would trigger fallback).
+    """
+    from django.contrib.auth import get_user_model
+
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create admin user
+    UserModel = get_user_model()
+    admin_user = UserModel.objects.create_user(username='admin', password='admin_password')
+
+    # Create an AuthenticatorUser entry for the admin user with local authenticator
+    AuthenticatorUser.objects.create(uid=admin_user.username, user=admin_user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    # Mock regular authentication to fail (this would normally trigger controller fallback for non-admin users)
+    with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate', return_value=None):
+        # Mock controller authentication methods that would be called for non-admin users
+        with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=True) as mock_check:
+            with mock.patch.object(plugin, 'update_gateway_user') as mock_update:
+                # Create request with gateway login path (condition for fallback)
+                request = RequestFactory().get('/api/gateway/v1/login/')
+
+                # Attempt authentication with admin user
+                result = plugin.authenticate(request=request, username='admin', password='wrong_password')
+
+                # Verify that authentication failed
+                assert result is None
+
+                # Verify that controller fallback authentication was NOT triggered for admin user
+                # _can_authenticate_from_controller should NOT be called because username is 'admin'
+                mock_check.assert_not_called()
+
+                # update_gateway_user should NOT be called because controller fallback was skipped
+                mock_update.assert_not_called()
+
+
+@pytest.mark.django_db()
+def test_authenticate_admin_user_case_insensitive_skips_controller_fallback(local_authenticator):
+    """
+    Test that controller fallback authentication is skipped for 'ADMIN' user (case insensitive),
+    even when all other conditions are met.
+    """
+    from django.contrib.auth import get_user_model
+
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    # Create ADMIN user (uppercase)
+    UserModel = get_user_model()
+    admin_user = UserModel.objects.create_user(username='ADMIN', password='admin_password')
+
+    # Create an AuthenticatorUser entry for the admin user with local authenticator
+    AuthenticatorUser.objects.create(uid=admin_user.username, user=admin_user, provider=local_authenticator)
+
+    plugin = AuthenticatorPlugin(database_instance=local_authenticator)
+
+    # Mock regular authentication to fail
+    with mock.patch('django.contrib.auth.backends.ModelBackend.authenticate', return_value=None):
+        # Mock controller authentication methods that would be called for non-admin users
+        with mock.patch.object(plugin, '_can_authenticate_from_controller', return_value=True) as mock_check:
+            with mock.patch.object(plugin, 'update_gateway_user') as mock_update:
+                # Create request with gateway login path (condition for fallback)
+                request = RequestFactory().get('/api/gateway/v1/login/')
+
+                # Attempt authentication with ADMIN user (uppercase)
+                result = plugin.authenticate(request=request, username='ADMIN', password='wrong_password')
+
+                # Verify that authentication failed
+                assert result is None
+
+                # Verify that controller fallback authentication was NOT triggered for ADMIN user
+                # _can_authenticate_from_controller should NOT be called because username.lower() == 'admin'
+                mock_check.assert_not_called()
+
+                # update_gateway_user should NOT be called because controller fallback was skipped
+                mock_update.assert_not_called()


### PR DESCRIPTION
## Description
- What is being changed? Update the conditionals which handle fallback authentication, so we explicitly do not attempt to fallback to controller authentication for the 'admin' user
- Why is this change needed? This change is needed, as we don't want to override the admin users password, with the controller password accidentally. The admin user account should be excluded from the fallback authentication
- How does this change address the issue? This change addresses the issue by explicitly disallowing the fallback auth to be triggered if the username == 'admin'

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Deploy aap-dev with these changes
2. Try to sign in with gateway admin password (login succeeds)
3. Try and sign in with controller admin password (login fails, avoiding the password update)

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
