### PR TITLE
AAP-49736 Fix SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -583,6 +583,9 @@ class AuthenticatorPlugin(LDAPBackend, AbstractAuthenticatorPlugin):
     def update_settings(self, database_authenticator: Authenticator) -> None:
         self.settings = LDAPSettings(defaults=database_authenticator.configuration)
 
+    def setting(self, name, default=None):
+        return getattr(self.settings, name, default)
+
     def get_or_build_user(self, username, ldap_user):
         """
         This gets called by _LDAPUser to create the user in the database.

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 from typing import Optional, Tuple, Union
 
@@ -20,8 +21,28 @@ merge_strategy = "Email fallback"
 
 
 class FakeBackend:
-    def setting(self, *args, **kwargs):
-        return ["username", "email"]
+    def __init__(self):
+        self.settings = {}
+        fq_function_name = getattr(settings, 'ANSIBLE_BASE_SOCIAL_AUTH_STRATEGY_SETTINGS_FUNCTION', None)
+        if fq_function_name:
+            try:
+                module_name, _, function_name = fq_function_name.rpartition('.')
+                the_function = getattr(importlib.import_module(module_name), function_name)
+                self.settings = the_function()
+            except Exception as e:
+                logger.error(f"FakeBackend: Failed to run {fq_function_name} to get additional settings: {e}")
+
+        self.settings["USER_FIELDS"] = ["username", "email"]
+
+    def setting(self, name, default=None):
+        if name in self.settings:
+            return self.settings[name]
+
+        social_auth_key = f"SOCIAL_AUTH_{name}"
+        if social_auth_key in self.settings:
+            return self.settings[social_auth_key]
+
+        return default
 
 
 def raise_auth_exception(message: str, backend: Optional[Authenticator] = None):
@@ -87,7 +108,6 @@ def get_local_username(user_details: dict) -> str:
     from other auth backends.
     """
     username = get_username(strategy=AuthenticatorStrategy(AuthenticatorStorage()), details=user_details, backend=FakeBackend())
-
     return username['username']
 
 
@@ -118,8 +138,10 @@ def determine_username_from_uid_social(**kwargs) -> dict:
     authenticator = kwargs.get('backend')
     if not authenticator:
         raise_auth_exception(_('Unable to get backend from kwargs'))
-
-    selected_username = kwargs.get('details', {}).get('username', None)
+    if authenticator.setting('USERNAME_IS_FULL_EMAIL', False):
+        selected_username = kwargs.get('details', {}).get('email', None)
+    else:
+        selected_username = kwargs.get('details', {}).get('username', None)
     if not selected_username:
         raise_auth_exception(
             _('Unable to get associated username from details, expected entry "username". Full user details: %(details)s')

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -35,13 +35,9 @@ class FakeBackend:
         self.settings["USER_FIELDS"] = ["username", "email"]
 
     def setting(self, name, default=None):
-        if name in self.settings:
-            return self.settings[name]
-
-        social_auth_key = f"SOCIAL_AUTH_{name}"
-        if social_auth_key in self.settings:
-            return self.settings[social_auth_key]
-
+        for name in [name, f"SOCIAL_AUTH_{name}"]:
+            if name in self.settings:
+                return self.settings[name]
         return default
 
 

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -1,5 +1,6 @@
 import pytest
 from django.conf import settings
+from django.test import override_settings
 from social_core.exceptions import AuthException
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_class
@@ -9,14 +10,36 @@ from ansible_base.lib.utils.response import get_relative_url
 from test_app.models import User
 
 
+def load_social_auth_settings():
+    return {"SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL": settings.SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL}
+
+
 @pytest.mark.django_db
 class TestAuthenticationUtilsAuthentication:
     logger = 'ansible_base.authentication.utils.authentication.logger'
 
-    def test_fake_backend_settings(self):
+    @pytest.mark.parametrize(
+        "name, exp_val, username_is_full_email_setting",
+        [
+            ("USER_FIELDS", ["username", "email"], False),
+            ("SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL", True, True),
+            ("SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL", False, False),
+            ("BOGUS", None, False),
+        ],
+    )
+    def test_fake_backend_settings(self, name, exp_val, username_is_full_email_setting):
+        with override_settings(SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL=username_is_full_email_setting):
+            with override_settings(
+                ANSIBLE_BASE_SOCIAL_AUTH_STRATEGY_SETTINGS_FUNCTION="test_app.tests.authentication.utils.test_authentication.load_social_auth_settings"
+            ):
+                backend = authentication.FakeBackend()
+                response = backend.setting(name)
+                assert response == exp_val
+
+    def test_fake_backend_settings_with_default(self):
         backend = authentication.FakeBackend()
-        response = backend.setting()
-        assert response == ["username", "email"]
+        response = backend.setting("BOGUS", "bogus_default")
+        assert response == "bogus_default"
 
     def test_get_local_username_no_input(self):
         response = authentication.get_local_username({})

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -50,6 +50,22 @@ class TestAuthenticationUtilsAuthentication:
         assert len(response) > len(random_user.username)
 
     @pytest.mark.parametrize(
+        "username_is_full_email_setting, expected_username",
+        [
+            (True, "new-user@example.com"),
+            (False, "new-user"),
+        ],
+    )
+    def test_get_local_username_with_email(self, username_is_full_email_setting, expected_username):
+        user_details = {'username': 'new-user', 'email': 'new-user@example.com'}
+        with override_settings(SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL=username_is_full_email_setting):
+            with override_settings(
+                ANSIBLE_BASE_SOCIAL_AUTH_STRATEGY_SETTINGS_FUNCTION="test_app.tests.authentication.utils.test_authentication.load_social_auth_settings"
+            ):
+                response = authentication.get_local_username(user_details)
+                assert response == expected_username
+
+    @pytest.mark.parametrize(
         "related_authenticator,info_message,expected_username",
         [
             (None, 'is able to authenticate user', True),


### PR DESCRIPTION
## Description

This setting causes social auth to use the user's email as their username if set to True.  GW implements this as a dynamic preference and supplies a function that returns the value to the social auth pipeline to select username vs email.  Our social auth pipeline replaces the entry that takes care of this with our own version, which did not respect this value.  Fixed here along w/ unit tests.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Run GW dev environment w/ keycloak enabled.
2. Log in with OIDC or SAML (gateway_admin/admin123 perhaps)
3. Check username and see that it is "gateway_admin" (or whatever)
4. Log in again as admin and delete the user
5. Enable "Social auth username is full email" in gateway settings
6. Log back in as the same user
7. See that the username is now the email

### Expected Results
The setting functions properly allowing username to be username/uid or email address

