### PR TITLE
AAP-50411: Avoid email fallback auth for local authenticator

### DIFF
--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -170,7 +170,8 @@ def _handle_email_fallback_strategy(uid: str, email: Union[str, list[str], None]
     normalized_email = normalize_and_get_email(email)
 
     # PROPOSAL FLOW: Authenticator No Email provided
-    if not normalized_email:
+    # If local authenticator, no need to use email fallback strategy
+    if not normalized_email or authenticator.type == "ansible_base.authentication.authenticator_plugins.local":
         return _handle_no_merge_strategy(uid, authenticator)  # Logic is identical to the no-merge strategy
 
     # PROPOSAL FLOW: Authenticator provides email


### PR DESCRIPTION
## Description
- What is being changed? Avoid email fallback authentication, when signing in via local authenticator. If signing in via local authenticator, just validate based off of previous authentication mechanism, just using username/password.
- Why is this change needed? In some cases, multiple admin users may have the same email account, which can complicate sign in when signing in locally.
- How does this change address the issue? This change addresses the issue by ensuring that when signing in via local authenticator, we just our existing authentication mechanism, validating only user/pass, and not checking email.

[Jira ticket](https://issues.redhat.com/browse/AAP-50411)

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Deploy aap-dev off of devel
2. Before signing in, create another user with shared email in gateway - 
```bash
User.objects.create_user(username='aap-operator-service-account', email='test@example.com', password='test', first_name='test', last_name='test')
```
4. Also update the `admin` user to have the same email - 
```bash
u = User.objects.get(username='admin')
u.email='test@example.com'
u.save()
```
5. Delete all the AuthenticatorUsers to mimic a fresh env - 
```bash
au = AuthenticatorUser.objects.all()
au.delete()
```
7. Attempt to sign in via admin, sign in should fail.
8. checkout this branch, wait for redeploy
9. Attempt to sign in via admin, sign in should succeed.

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
