### PR TITLE
[AAP-50320] Add missing api schema for /ui_auth endpoint

### DIFF
--- a/ansible_base/authentication/serializers/__init__.py
+++ b/ansible_base/authentication/serializers/__init__.py
@@ -1,2 +1,3 @@
 from .authenticator import AuthenticatorSerializer  # noqa: 401
 from .authenticator_map import AuthenticatorMapSerializer  # noqa: 401
+from .ui_auth import PasswordAuthenticatorSerializer, SSOAuthenticatorSerializer, UIAuthResponseSerializer  # noqa: 401

--- a/ansible_base/authentication/serializers/ui_auth.py
+++ b/ansible_base/authentication/serializers/ui_auth.py
@@ -1,0 +1,27 @@
+from rest_framework import serializers
+
+
+class PasswordAuthenticatorSerializer(serializers.Serializer):
+    """Serializer for password authenticator items in UI auth response."""
+
+    name = serializers.CharField()
+
+
+class SSOAuthenticatorSerializer(serializers.Serializer):
+    """Serializer for SSO authenticator items in UI auth response."""
+
+    name = serializers.CharField()
+    login_url = serializers.URLField()
+    type = serializers.CharField()
+
+
+class UIAuthResponseSerializer(serializers.Serializer):
+    """Serializer for UI authentication configuration response."""
+
+    passwords = PasswordAuthenticatorSerializer(many=True)
+    ssos = SSOAuthenticatorSerializer(many=True)
+    show_login_form = serializers.BooleanField()
+    login_redirect_override = serializers.CharField(allow_blank=True)
+    custom_login_info = serializers.CharField(allow_blank=True)
+    custom_logo = serializers.CharField(allow_blank=True)
+    managed_cloud_install = serializers.BooleanField()

--- a/ansible_base/authentication/serializers/ui_auth.py
+++ b/ansible_base/authentication/serializers/ui_auth.py
@@ -4,24 +4,24 @@ from rest_framework import serializers
 class PasswordAuthenticatorSerializer(serializers.Serializer):
     """Serializer for password authenticator items in UI auth response."""
 
-    name = serializers.CharField()
+    name = serializers.CharField(read_only=True)
 
 
 class SSOAuthenticatorSerializer(serializers.Serializer):
     """Serializer for SSO authenticator items in UI auth response."""
 
-    name = serializers.CharField()
-    login_url = serializers.URLField()
-    type = serializers.CharField()
+    name = serializers.CharField(read_only=True)
+    login_url = serializers.URLField(read_only=True)
+    type = serializers.CharField(read_only=True)
 
 
 class UIAuthResponseSerializer(serializers.Serializer):
     """Serializer for UI authentication configuration response."""
 
-    passwords = PasswordAuthenticatorSerializer(many=True)
-    ssos = SSOAuthenticatorSerializer(many=True)
-    show_login_form = serializers.BooleanField()
-    login_redirect_override = serializers.CharField(allow_blank=True)
-    custom_login_info = serializers.CharField(allow_blank=True)
-    custom_logo = serializers.CharField(allow_blank=True)
-    managed_cloud_install = serializers.BooleanField()
+    passwords = PasswordAuthenticatorSerializer(many=True, read_only=True)
+    ssos = SSOAuthenticatorSerializer(many=True, read_only=True)
+    show_login_form = serializers.BooleanField(read_only=True)
+    login_redirect_override = serializers.CharField(allow_blank=True, read_only=True)
+    custom_login_info = serializers.CharField(allow_blank=True, read_only=True)
+    custom_logo = serializers.CharField(allow_blank=True, read_only=True)
+    managed_cloud_install = serializers.BooleanField(read_only=True)

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -1,10 +1,12 @@
 import logging
 
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.models import Authenticator
+from ansible_base.authentication.serializers import UIAuthResponseSerializer
 from ansible_base.lib.utils.settings import get_setting, is_aoc_instance
 from ansible_base.lib.utils.validation import validate_image_data, validate_url
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
@@ -15,11 +17,26 @@ logger = logging.getLogger('ansible_base.authentication.views.ui_auth')
 class UIAuth(AnsibleBaseDjangoAppApiView):
     authentication_classes = []
     permission_classes = []
+    serializer_class = UIAuthResponseSerializer
 
-    def get(self, request, format=None):
+    def _get(self):
         response = generate_ui_auth_data()
-
         return Response(response)
+
+    # Conditionally add openapi documentation
+    if 'ansible_base.api_documentation' in settings.INSTALLED_APPS:
+        from drf_spectacular.utils import extend_schema
+
+        @extend_schema(
+            request=None, responses=UIAuthResponseSerializer, description="Get UI authentication configuration including available authenticators and settings."
+        )
+        def get(self, request, format=None):
+            return self._get()
+
+    else:
+
+        def get(self, request, format=None):
+            return self._get()
 
 
 def generate_ui_auth_data():

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -35,7 +35,7 @@ class UIAuth(AnsibleBaseDjangoAppApiView):
 
     else:
 
-        def get(self, request, format=None):
+        def get(self):
             return self._get()
 
 

--- a/test_app/tests/authentication/serializers/test_ui_auth.py
+++ b/test_app/tests/authentication/serializers/test_ui_auth.py
@@ -6,91 +6,41 @@ from ansible_base.authentication.serializers.ui_auth import (
 
 
 class TestPasswordAuthenticatorSerializer:
-    def test_valid_data(self):
-        """Test PasswordAuthenticatorSerializer with valid data"""
+    def test_serializes_password_authenticator_data(self):
+        """Test PasswordAuthenticatorSerializer serializes data correctly"""
         data = {'name': 'password_auth'}
-        serializer = PasswordAuthenticatorSerializer(data=data)
-        assert serializer.is_valid()
-        assert serializer.validated_data == data
+        serializer = PasswordAuthenticatorSerializer(data)
+        assert serializer.data == data
 
-    def test_missing_name(self):
-        """Test PasswordAuthenticatorSerializer requires name field"""
-        data = {}
-        serializer = PasswordAuthenticatorSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'name' in serializer.errors
-
-    def test_empty_name(self):
-        """Test PasswordAuthenticatorSerializer handles empty name"""
-        data = {'name': ''}
-        serializer = PasswordAuthenticatorSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'name' in serializer.errors
-
-    def test_name_type_coercion(self):
-        """Test PasswordAuthenticatorSerializer coerces types to string"""
-        data = {'name': 123}
-        serializer = PasswordAuthenticatorSerializer(data=data)
-        assert serializer.is_valid()
-        assert serializer.validated_data['name'] == '123'
-
-    def test_name_invalid_type(self):
-        """Test PasswordAuthenticatorSerializer with truly invalid type"""
-        data = {'name': {'invalid': 'object'}}
-        serializer = PasswordAuthenticatorSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'name' in serializer.errors
+    def test_serializes_with_different_name(self):
+        """Test PasswordAuthenticatorSerializer with different name"""
+        data = {'name': 'local_password'}
+        serializer = PasswordAuthenticatorSerializer(data)
+        assert serializer.data == data
 
 
 class TestSSOAuthenticatorSerializer:
-    def test_valid_data(self):
-        """Test SSOAuthenticatorSerializer with valid data"""
+    def test_serializes_sso_authenticator_data(self):
+        """Test SSOAuthenticatorSerializer serializes data correctly"""
         data = {'name': 'sso_auth', 'login_url': 'https://example.com/login', 'type': 'saml'}
-        serializer = SSOAuthenticatorSerializer(data=data)
-        assert serializer.is_valid()
-        assert serializer.validated_data == data
+        serializer = SSOAuthenticatorSerializer(data)
+        assert serializer.data == data
 
-    def test_missing_required_fields(self):
-        """Test SSOAuthenticatorSerializer requires all fields"""
-        data = {}
-        serializer = SSOAuthenticatorSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'name' in serializer.errors
-        assert 'login_url' in serializer.errors
-        assert 'type' in serializer.errors
+    def test_serializes_different_sso_types(self):
+        """Test SSOAuthenticatorSerializer with different SSO types"""
+        saml_data = {'name': 'saml_auth', 'login_url': 'https://example.com/saml', 'type': 'saml'}
+        oidc_data = {'name': 'oidc_auth', 'login_url': 'https://example.com/oidc', 'type': 'oidc'}
 
-    def test_invalid_url(self):
-        """Test SSOAuthenticatorSerializer validates URL format"""
-        data = {'name': 'sso_auth', 'login_url': 'not_a_url', 'type': 'saml'}
-        serializer = SSOAuthenticatorSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'login_url' in serializer.errors
+        saml_serializer = SSOAuthenticatorSerializer(saml_data)
+        oidc_serializer = SSOAuthenticatorSerializer(oidc_data)
 
-    def test_empty_fields(self):
-        """Test SSOAuthenticatorSerializer handles empty fields"""
-        data = {'name': '', 'login_url': '', 'type': ''}
-        serializer = SSOAuthenticatorSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'name' in serializer.errors
-        assert 'login_url' in serializer.errors
-
-    def test_valid_url_formats(self):
-        """Test various valid URL formats"""
-        valid_urls = [
-            'https://example.com/login',
-            'http://localhost:8080/auth',
-            'https://auth.company.com/saml/login?param=value',
-        ]
-
-        for url in valid_urls:
-            data = {'name': 'sso_auth', 'login_url': url, 'type': 'saml'}
-            serializer = SSOAuthenticatorSerializer(data=data)
-            assert serializer.is_valid(), f"URL should be valid: {url}"
+        assert saml_serializer.data == saml_data
+        assert oidc_serializer.data == oidc_data
 
 
 class TestUIAuthResponseSerializer:
-    def test_valid_complete_data(self):
-        """Test UIAuthResponseSerializer with complete valid data"""
+    def test_serializes_complete_auth_response(self):
+        """Test UIAuthResponseSerializer serializes complete data correctly"""
         data = {
             'passwords': [{'name': 'password_auth'}],
             'ssos': [{'name': 'sso_auth', 'login_url': 'https://example.com/login', 'type': 'saml'}],
@@ -100,12 +50,11 @@ class TestUIAuthResponseSerializer:
             'custom_logo': 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=',
             'managed_cloud_install': False,
         }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert serializer.is_valid()
-        assert serializer.validated_data == data
+        serializer = UIAuthResponseSerializer(data)
+        assert serializer.data == data
 
-    def test_valid_minimal_data(self):
-        """Test UIAuthResponseSerializer with minimal required data"""
+    def test_serializes_minimal_auth_response(self):
+        """Test UIAuthResponseSerializer serializes minimal data correctly"""
         data = {
             'passwords': [],
             'ssos': [],
@@ -115,21 +64,10 @@ class TestUIAuthResponseSerializer:
             'custom_logo': '',
             'managed_cloud_install': False,
         }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert serializer.is_valid()
-        assert serializer.validated_data == data
+        serializer = UIAuthResponseSerializer(data)
+        assert serializer.data == data
 
-    def test_missing_required_fields(self):
-        """Test UIAuthResponseSerializer requires all fields"""
-        data = {}
-        serializer = UIAuthResponseSerializer(data=data)
-        assert not serializer.is_valid()
-
-        required_fields = ['passwords', 'ssos', 'show_login_form', 'login_redirect_override', 'custom_login_info', 'custom_logo', 'managed_cloud_install']
-        for field in required_fields:
-            assert field in serializer.errors
-
-    def test_multiple_password_authenticators(self):
+    def test_serializes_multiple_password_authenticators(self):
         """Test UIAuthResponseSerializer with multiple password authenticators"""
         data = {
             'passwords': [{'name': 'password_auth_1'}, {'name': 'password_auth_2'}],
@@ -140,11 +78,13 @@ class TestUIAuthResponseSerializer:
             'custom_logo': '',
             'managed_cloud_install': False,
         }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert serializer.is_valid()
-        assert len(serializer.validated_data['passwords']) == 2
+        serializer = UIAuthResponseSerializer(data)
+        result = serializer.data
+        assert len(result['passwords']) == 2
+        assert result['passwords'][0] == {'name': 'password_auth_1'}
+        assert result['passwords'][1] == {'name': 'password_auth_2'}
 
-    def test_multiple_sso_authenticators(self):
+    def test_serializes_multiple_sso_authenticators(self):
         """Test UIAuthResponseSerializer with multiple SSO authenticators"""
         data = {
             'passwords': [],
@@ -158,14 +98,42 @@ class TestUIAuthResponseSerializer:
             'custom_logo': '',
             'managed_cloud_install': False,
         }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert serializer.is_valid()
-        assert len(serializer.validated_data['ssos']) == 2
+        serializer = UIAuthResponseSerializer(data)
+        result = serializer.data
+        assert len(result['ssos']) == 2
+        assert result['ssos'][0] == {'name': 'saml_auth', 'login_url': 'https://example.com/saml', 'type': 'saml'}
+        assert result['ssos'][1] == {'name': 'oidc_auth', 'login_url': 'https://example.com/oidc', 'type': 'oidc'}
 
-    def test_invalid_nested_password_authenticator(self):
-        """Test UIAuthResponseSerializer with invalid password authenticator"""
+    def test_serializes_nested_authenticator_data(self):
+        """Test UIAuthResponseSerializer correctly serializes nested authenticator data"""
         data = {
-            'passwords': [{'name': ''}],  # Invalid: empty name
+            'passwords': [{'name': 'local_auth'}, {'name': 'ldap_auth'}],
+            'ssos': [
+                {'name': 'google_sso', 'login_url': 'https://accounts.google.com/oauth', 'type': 'oidc'},
+                {'name': 'okta_sso', 'login_url': 'https://company.okta.com/saml', 'type': 'saml'},
+            ],
+            'show_login_form': True,
+            'login_redirect_override': '/dashboard',
+            'custom_login_info': 'Use your company credentials',
+            'custom_logo': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+            'managed_cloud_install': True,
+        }
+        serializer = UIAuthResponseSerializer(data)
+        result = serializer.data
+
+        # Verify top-level structure
+        assert result == data
+
+        # Verify nested data is properly serialized
+        assert len(result['passwords']) == 2
+        assert len(result['ssos']) == 2
+        assert result['show_login_form'] is True
+        assert result['managed_cloud_install'] is True
+
+    def test_serializes_empty_authenticator_lists(self):
+        """Test UIAuthResponseSerializer with empty authenticator lists"""
+        data = {
+            'passwords': [],
             'ssos': [],
             'show_login_form': False,
             'login_redirect_override': '',
@@ -173,88 +141,80 @@ class TestUIAuthResponseSerializer:
             'custom_logo': '',
             'managed_cloud_install': False,
         }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'passwords' in serializer.errors
+        serializer = UIAuthResponseSerializer(data)
+        result = serializer.data
+        assert result['passwords'] == []
+        assert result['ssos'] == []
+        assert result['show_login_form'] is False
 
-    def test_invalid_nested_sso_authenticator(self):
-        """Test UIAuthResponseSerializer with invalid SSO authenticator"""
-        data = {
+    def test_serializes_boolean_fields_correctly(self):
+        """Test UIAuthResponseSerializer handles boolean fields correctly"""
+        true_data = {
             'passwords': [],
-            'ssos': [{'name': 'sso_auth', 'login_url': 'invalid_url', 'type': 'saml'}],
+            'ssos': [],
+            'show_login_form': True,
+            'login_redirect_override': '',
+            'custom_login_info': '',
+            'custom_logo': '',
+            'managed_cloud_install': True,
+        }
+        false_data = {
+            'passwords': [],
+            'ssos': [],
             'show_login_form': False,
             'login_redirect_override': '',
             'custom_login_info': '',
             'custom_logo': '',
             'managed_cloud_install': False,
         }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'ssos' in serializer.errors
 
-    def test_boolean_field_validation(self):
-        """Test boolean field validation"""
+        true_serializer = UIAuthResponseSerializer(true_data)
+        false_serializer = UIAuthResponseSerializer(false_data)
+
+        assert true_serializer.data['show_login_form'] is True
+        assert true_serializer.data['managed_cloud_install'] is True
+        assert false_serializer.data['show_login_form'] is False
+        assert false_serializer.data['managed_cloud_install'] is False
+
+    def test_serializes_string_fields_correctly(self):
+        """Test UIAuthResponseSerializer handles string fields correctly"""
         data = {
             'passwords': [],
             'ssos': [],
-            'show_login_form': 'not_boolean',  # Invalid boolean
+            'show_login_form': False,
+            'login_redirect_override': 'https://example.com/custom-redirect',
+            'custom_login_info': 'Welcome! Please sign in with your credentials.',
+            'custom_logo': 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iYmx1ZSIvPjwvc3ZnPg==',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data)
+        result = serializer.data
+
+        assert result['login_redirect_override'] == 'https://example.com/custom-redirect'
+        assert result['custom_login_info'] == 'Welcome! Please sign in with your credentials.'
+        assert result['custom_logo'].startswith('data:image/svg+xml;base64,')
+
+    def test_read_only_serializer_behavior(self):
+        """Test that the serializer behaves as read-only (for documentation purposes)"""
+        # This test documents that the serializer is read-only
+        # Input validation is not performed since all fields are read_only=True
+        data = {
+            'passwords': [],
+            'ssos': [],
+            'show_login_form': False,
             'login_redirect_override': '',
             'custom_login_info': '',
             'custom_logo': '',
             'managed_cloud_install': False,
         }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert not serializer.is_valid()
-        assert 'show_login_form' in serializer.errors
 
-    def test_string_field_allow_blank(self):
-        """Test that string fields allow blank values"""
-        data = {
-            'passwords': [],
-            'ssos': [],
-            'show_login_form': False,
-            'login_redirect_override': '',  # Should be allowed
-            'custom_login_info': '',  # Should be allowed
-            'custom_logo': '',  # Should be allowed
-            'managed_cloud_install': False,
-        }
-        serializer = UIAuthResponseSerializer(data=data)
-        assert serializer.is_valid()
+        # When used as a response serializer (the intended use case)
+        serializer = UIAuthResponseSerializer(data)
+        assert serializer.data == data
 
-    def test_field_types_validation(self):
-        """Test field type validation for fields that don't allow coercion"""
-        invalid_data = {
-            'passwords': 'not_a_list',
-            'ssos': 'not_a_list',
-            'show_login_form': 'not_boolean',
-            'login_redirect_override': '123',  # String that gets coerced
-            'custom_login_info': '123',  # String that gets coerced
-            'custom_logo': '123',  # String that gets coerced
-            'managed_cloud_install': 'not_boolean',
-        }
-        serializer = UIAuthResponseSerializer(data=invalid_data)
-        assert not serializer.is_valid()
-
-        # Only list and boolean fields should have validation errors
-        # String fields accept coerced values
-        expected_errors = ['passwords', 'ssos', 'show_login_form', 'managed_cloud_install']
-        for field in expected_errors:
-            assert field in serializer.errors
-
-    def test_incompatible_types_validation(self):
-        """Test field validation with truly incompatible types"""
-        invalid_data = {
-            'passwords': {'not': 'a_list'},
-            'ssos': {'not': 'a_list'},
-            'show_login_form': {'not': 'boolean'},
-            'login_redirect_override': {'not': 'string'},
-            'custom_login_info': {'not': 'string'},
-            'custom_logo': {'not': 'string'},
-            'managed_cloud_install': {'not': 'boolean'},
-        }
-        serializer = UIAuthResponseSerializer(data=invalid_data)
-        assert not serializer.is_valid()
-
-        # All fields should have validation errors with dict inputs
-        for field in invalid_data.keys():
-            assert field in serializer.errors
+        # When used with invalid input data (which would normally fail validation)
+        # it still works because read_only fields are ignored during validation
+        invalid_input = {'invalid_field': 'invalid_value'}
+        input_serializer = UIAuthResponseSerializer(data=invalid_input)
+        assert input_serializer.is_valid()  # Always valid since all fields are read_only
+        assert input_serializer.validated_data == {}  # Empty since fields are read_only

--- a/test_app/tests/authentication/serializers/test_ui_auth.py
+++ b/test_app/tests/authentication/serializers/test_ui_auth.py
@@ -1,0 +1,260 @@
+from ansible_base.authentication.serializers.ui_auth import (
+    PasswordAuthenticatorSerializer,
+    SSOAuthenticatorSerializer,
+    UIAuthResponseSerializer,
+)
+
+
+class TestPasswordAuthenticatorSerializer:
+    def test_valid_data(self):
+        """Test PasswordAuthenticatorSerializer with valid data"""
+        data = {'name': 'password_auth'}
+        serializer = PasswordAuthenticatorSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == data
+
+    def test_missing_name(self):
+        """Test PasswordAuthenticatorSerializer requires name field"""
+        data = {}
+        serializer = PasswordAuthenticatorSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'name' in serializer.errors
+
+    def test_empty_name(self):
+        """Test PasswordAuthenticatorSerializer handles empty name"""
+        data = {'name': ''}
+        serializer = PasswordAuthenticatorSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'name' in serializer.errors
+
+    def test_name_type_coercion(self):
+        """Test PasswordAuthenticatorSerializer coerces types to string"""
+        data = {'name': 123}
+        serializer = PasswordAuthenticatorSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data['name'] == '123'
+
+    def test_name_invalid_type(self):
+        """Test PasswordAuthenticatorSerializer with truly invalid type"""
+        data = {'name': {'invalid': 'object'}}
+        serializer = PasswordAuthenticatorSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'name' in serializer.errors
+
+
+class TestSSOAuthenticatorSerializer:
+    def test_valid_data(self):
+        """Test SSOAuthenticatorSerializer with valid data"""
+        data = {'name': 'sso_auth', 'login_url': 'https://example.com/login', 'type': 'saml'}
+        serializer = SSOAuthenticatorSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == data
+
+    def test_missing_required_fields(self):
+        """Test SSOAuthenticatorSerializer requires all fields"""
+        data = {}
+        serializer = SSOAuthenticatorSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'name' in serializer.errors
+        assert 'login_url' in serializer.errors
+        assert 'type' in serializer.errors
+
+    def test_invalid_url(self):
+        """Test SSOAuthenticatorSerializer validates URL format"""
+        data = {'name': 'sso_auth', 'login_url': 'not_a_url', 'type': 'saml'}
+        serializer = SSOAuthenticatorSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'login_url' in serializer.errors
+
+    def test_empty_fields(self):
+        """Test SSOAuthenticatorSerializer handles empty fields"""
+        data = {'name': '', 'login_url': '', 'type': ''}
+        serializer = SSOAuthenticatorSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'name' in serializer.errors
+        assert 'login_url' in serializer.errors
+
+    def test_valid_url_formats(self):
+        """Test various valid URL formats"""
+        valid_urls = [
+            'https://example.com/login',
+            'http://localhost:8080/auth',
+            'https://auth.company.com/saml/login?param=value',
+        ]
+
+        for url in valid_urls:
+            data = {'name': 'sso_auth', 'login_url': url, 'type': 'saml'}
+            serializer = SSOAuthenticatorSerializer(data=data)
+            assert serializer.is_valid(), f"URL should be valid: {url}"
+
+
+class TestUIAuthResponseSerializer:
+    def test_valid_complete_data(self):
+        """Test UIAuthResponseSerializer with complete valid data"""
+        data = {
+            'passwords': [{'name': 'password_auth'}],
+            'ssos': [{'name': 'sso_auth', 'login_url': 'https://example.com/login', 'type': 'saml'}],
+            'show_login_form': True,
+            'login_redirect_override': 'https://example.com/redirect',
+            'custom_login_info': 'Please login with your credentials',
+            'custom_logo': 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == data
+
+    def test_valid_minimal_data(self):
+        """Test UIAuthResponseSerializer with minimal required data"""
+        data = {
+            'passwords': [],
+            'ssos': [],
+            'show_login_form': False,
+            'login_redirect_override': '',
+            'custom_login_info': '',
+            'custom_logo': '',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == data
+
+    def test_missing_required_fields(self):
+        """Test UIAuthResponseSerializer requires all fields"""
+        data = {}
+        serializer = UIAuthResponseSerializer(data=data)
+        assert not serializer.is_valid()
+
+        required_fields = ['passwords', 'ssos', 'show_login_form', 'login_redirect_override', 'custom_login_info', 'custom_logo', 'managed_cloud_install']
+        for field in required_fields:
+            assert field in serializer.errors
+
+    def test_multiple_password_authenticators(self):
+        """Test UIAuthResponseSerializer with multiple password authenticators"""
+        data = {
+            'passwords': [{'name': 'password_auth_1'}, {'name': 'password_auth_2'}],
+            'ssos': [],
+            'show_login_form': True,
+            'login_redirect_override': '',
+            'custom_login_info': '',
+            'custom_logo': '',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert serializer.is_valid()
+        assert len(serializer.validated_data['passwords']) == 2
+
+    def test_multiple_sso_authenticators(self):
+        """Test UIAuthResponseSerializer with multiple SSO authenticators"""
+        data = {
+            'passwords': [],
+            'ssos': [
+                {'name': 'saml_auth', 'login_url': 'https://example.com/saml', 'type': 'saml'},
+                {'name': 'oidc_auth', 'login_url': 'https://example.com/oidc', 'type': 'oidc'},
+            ],
+            'show_login_form': True,
+            'login_redirect_override': '',
+            'custom_login_info': '',
+            'custom_logo': '',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert serializer.is_valid()
+        assert len(serializer.validated_data['ssos']) == 2
+
+    def test_invalid_nested_password_authenticator(self):
+        """Test UIAuthResponseSerializer with invalid password authenticator"""
+        data = {
+            'passwords': [{'name': ''}],  # Invalid: empty name
+            'ssos': [],
+            'show_login_form': False,
+            'login_redirect_override': '',
+            'custom_login_info': '',
+            'custom_logo': '',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'passwords' in serializer.errors
+
+    def test_invalid_nested_sso_authenticator(self):
+        """Test UIAuthResponseSerializer with invalid SSO authenticator"""
+        data = {
+            'passwords': [],
+            'ssos': [{'name': 'sso_auth', 'login_url': 'invalid_url', 'type': 'saml'}],
+            'show_login_form': False,
+            'login_redirect_override': '',
+            'custom_login_info': '',
+            'custom_logo': '',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'ssos' in serializer.errors
+
+    def test_boolean_field_validation(self):
+        """Test boolean field validation"""
+        data = {
+            'passwords': [],
+            'ssos': [],
+            'show_login_form': 'not_boolean',  # Invalid boolean
+            'login_redirect_override': '',
+            'custom_login_info': '',
+            'custom_logo': '',
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert not serializer.is_valid()
+        assert 'show_login_form' in serializer.errors
+
+    def test_string_field_allow_blank(self):
+        """Test that string fields allow blank values"""
+        data = {
+            'passwords': [],
+            'ssos': [],
+            'show_login_form': False,
+            'login_redirect_override': '',  # Should be allowed
+            'custom_login_info': '',  # Should be allowed
+            'custom_logo': '',  # Should be allowed
+            'managed_cloud_install': False,
+        }
+        serializer = UIAuthResponseSerializer(data=data)
+        assert serializer.is_valid()
+
+    def test_field_types_validation(self):
+        """Test field type validation for fields that don't allow coercion"""
+        invalid_data = {
+            'passwords': 'not_a_list',
+            'ssos': 'not_a_list',
+            'show_login_form': 'not_boolean',
+            'login_redirect_override': '123',  # String that gets coerced
+            'custom_login_info': '123',  # String that gets coerced
+            'custom_logo': '123',  # String that gets coerced
+            'managed_cloud_install': 'not_boolean',
+        }
+        serializer = UIAuthResponseSerializer(data=invalid_data)
+        assert not serializer.is_valid()
+
+        # Only list and boolean fields should have validation errors
+        # String fields accept coerced values
+        expected_errors = ['passwords', 'ssos', 'show_login_form', 'managed_cloud_install']
+        for field in expected_errors:
+            assert field in serializer.errors
+
+    def test_incompatible_types_validation(self):
+        """Test field validation with truly incompatible types"""
+        invalid_data = {
+            'passwords': {'not': 'a_list'},
+            'ssos': {'not': 'a_list'},
+            'show_login_form': {'not': 'boolean'},
+            'login_redirect_override': {'not': 'string'},
+            'custom_login_info': {'not': 'string'},
+            'custom_logo': {'not': 'string'},
+            'managed_cloud_install': {'not': 'boolean'},
+        }
+        serializer = UIAuthResponseSerializer(data=invalid_data)
+        assert not serializer.is_valid()
+
+        # All fields should have validation errors with dict inputs
+        for field in invalid_data.keys():
+            assert field in serializer.errors


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Add new serializers for /ui_auth endpoint.
- Why is this change needed?
So that api schema for /ui_auth endpoint can be correctly generated to be used by testing.
- How does this change address the issue?
By creating a serializer class for the endpoint and 2 serializers for 2 object fields of the endpoint.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
`/ui_auth` endpoint documentation schema spec
```
  /api/gateway/v1/ui_auth/:
    get:
      operationId: ui_auth_retrieve
      description: Get UI authentication configuration including available authenticators
        and settings.
      tags:
      - ui_auth
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/UIAuthResponse'
          description: ''
```

Serializer for `/ui_auth` endpoint response
```
    UIAuthResponse:
      type: object
      description: Serializer for UI authentication configuration response.
      properties:
        passwords:
          type: array
          items:
            $ref: '#/components/schemas/PasswordAuthenticator'
        ssos:
          type: array
          items:
            $ref: '#/components/schemas/SSOAuthenticator'
        show_login_form:
          type: boolean
        login_redirect_override:
          type: string
        custom_login_info:
          type: string
        custom_logo:
          type: string
        managed_cloud_install:
          type: boolean
      required:
      - custom_login_info
      - custom_logo
      - login_redirect_override
      - managed_cloud_install
      - passwords
      - show_login_form
      - ssos
```

Serializer for `passwords` field
```
    PasswordAuthenticator:
      type: object
      description: Serializer for password authenticator items in UI auth response.
      properties:
        name:
          type: string
      required:
      - name
```
Serializer for `ssos` field
```
    SSOAuthenticator:
      type: object
      description: Serializer for SSO authenticator items in UI auth response.
      properties:
        name:
          type: string
        login_url:
          type: string
          format: uri
        type:
          type: string
      required:
      - login_url
      - name
      - type
```