### PR TITLE
AAP-50626 AAP-50627 Use ansible_id references in access lists

### DIFF
--- a/ansible_base/rbac/api/fields.py
+++ b/ansible_base/rbac/api/fields.py
@@ -1,0 +1,41 @@
+from django.apps import apps
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import serializers
+
+
+class ActorAnsibleIdField(serializers.UUIDField):
+    """
+    UUID field that serializes actor objects to their ansible_id and accepts ansible_id for deserialization.
+
+    Always resolves ansible_id input to the corresponding actor object.
+    Uses the source parameter to determine which field to populate.
+    """
+
+    def to_representation(self, actor):
+        """Convert actor object to its ansible_id UUID"""
+        if actor is None:
+            return None
+        try:
+            if hasattr(actor, 'resource') and actor.resource:
+                return super().to_representation(actor.resource.ansible_id)
+        except ObjectDoesNotExist:
+            # Resource doesn't exist, return None
+            pass
+        return None
+
+    def to_internal_value(self, data):
+        """Convert ansible_id UUID to actor object"""
+        if data is None:
+            return None
+
+        # Let UUIDField handle validation and conversion
+        uuid_value = super().to_internal_value(data)
+
+        # Always resolve to actor object
+        resource_cls = apps.get_model('dab_resource_registry', 'Resource')
+        try:
+            resource = resource_cls.objects.get(ansible_id=uuid_value)
+        except resource_cls.DoesNotExist:
+            source_name = getattr(self, 'source', 'actor')
+            raise serializers.ValidationError(f"No {source_name} found with ansible_id={uuid_value}")
+        return resource.content_object

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -132,15 +132,6 @@ class BaseAssignmentSerializer(CommonModelSerializer):
 
         return super().validate(attrs)
 
-    def get_actor_from_data(self, validated_data, requesting_user):
-        actor_aid_field = f'{self.actor_field}_ansible_id'
-        if validated_data.get(self.actor_field):
-            actor = validated_data[self.actor_field]
-        else:
-            # Actor is already resolved by ActorAnsibleIdField and validated
-            actor = validated_data[self.actor_field]
-        return actor
-
     def get_object_from_data(self, validated_data, role_definition, requesting_user):
         obj = None
         if validated_data.get('object_id') and validated_data.get('object_ansible_id'):
@@ -175,7 +166,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         requesting_user = self.context['view'].request.user
 
         # Resolve actor - team or user
-        actor = self.get_actor_from_data(validated_data, requesting_user)
+        actor = validated_data[self.actor_field]
 
         # Resolve object
         obj = self.get_object_from_data(validated_data, rd, requesting_user)
@@ -285,7 +276,6 @@ class AccessListMixin:
         except ObjectDoesNotExist:
             # Resource doesn't exist, stick with pk
             logger.error(f"Resource does not exist for {self.Meta.model} {obj.pk}")
-            pass
 
         related_fields['details'] = get_relative_url(
             f'role-{actor_cls._meta.model_name}-access-assignments',

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -125,9 +125,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         has_actor_in_request = self.actor_field in self.initial_data
         has_actor_aid_in_request = actor_aid_field in self.initial_data
 
-        if has_actor_in_request and has_actor_aid_in_request:
-            self.raise_id_fields_error(self.actor_field, actor_aid_field)
-        elif not has_actor_in_request and not has_actor_aid_in_request:
+        if (has_actor_in_request and has_actor_aid_in_request) or (not has_actor_in_request and not has_actor_aid_in_request):
             self.raise_id_fields_error(self.actor_field, actor_aid_field)
 
         return super().validate(attrs)
@@ -153,10 +151,11 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         elif validated_data.get('object_ansible_id'):
             obj = self.get_by_ansible_id(validated_data.get('object_ansible_id'), requesting_user, for_field='object_ansible_id')
             if permission_registry.content_type_model.objects.get_for_model(obj) != role_definition.content_type:
+                model_name = getattr(role_definition.content_type, 'model', 'global')
                 raise ValidationError(
                     {
                         'object_ansible_id': _('Object type of %(model_name)s does not match role type of %(role_definition)s')
-                        % {'model_name': obj._meta.model_name, 'role_definition': role_definition.content_type.model}
+                        % {'model_name': obj._meta.model_name, 'role_definition': model_name}
                     }
                 )
         return obj

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -20,6 +20,7 @@ from ansible_base.rbac.validators import check_locally_managed, validate_permiss
 
 from ..models import DABContentType, DABPermission
 from ..remote import RemoteObject
+from .fields import ActorAnsibleIdField
 from .queries import assignment_qs_user_to_obj, assignment_qs_user_to_obj_perm
 
 logger = logging.getLogger(__name__)
@@ -116,16 +117,28 @@ class BaseAssignmentSerializer(CommonModelSerializer):
             raise ValidationError({for_field: msg.format(pk_value=ansible_id)})
         return resource.content_object
 
+    def validate(self, attrs):
+        """Validate that exactly one of actor or actor_ansible_id is provided"""
+        actor_aid_field = f'{self.actor_field}_ansible_id'
+
+        # Check what was actually provided in the request
+        has_actor_in_request = self.actor_field in self.initial_data
+        has_actor_aid_in_request = actor_aid_field in self.initial_data
+
+        if has_actor_in_request and has_actor_aid_in_request:
+            self.raise_id_fields_error(self.actor_field, actor_aid_field)
+        elif not has_actor_in_request and not has_actor_aid_in_request:
+            self.raise_id_fields_error(self.actor_field, actor_aid_field)
+
+        return super().validate(attrs)
+
     def get_actor_from_data(self, validated_data, requesting_user):
         actor_aid_field = f'{self.actor_field}_ansible_id'
-        if validated_data.get(self.actor_field) and validated_data.get(actor_aid_field):
-            self.raise_id_fields_error(self.actor_field, actor_aid_field)
-        elif validated_data.get(self.actor_field):
+        if validated_data.get(self.actor_field):
             actor = validated_data[self.actor_field]
-        elif ansible_id := validated_data.get(actor_aid_field):
-            actor = self.get_by_ansible_id(ansible_id, requesting_user, for_field=actor_aid_field)
         else:
-            self.raise_id_fields_error(self.actor_field, f'{self.actor_field}_ansible_id')
+            # Actor is already resolved by ActorAnsibleIdField and validated
+            actor = validated_data[self.actor_field]
         return actor
 
     def get_object_from_data(self, validated_data, role_definition, requesting_user):
@@ -220,7 +233,8 @@ ASSIGNMENT_FIELDS = ImmutableCommonModelSerializer.Meta.fields + ['content_type'
 
 class RoleUserAssignmentSerializer(BaseAssignmentSerializer):
     actor_field = 'user'
-    user_ansible_id = serializers.UUIDField(
+    user_ansible_id = ActorAnsibleIdField(
+        source='user',
         required=False,
         help_text=_('The resource ID of the user who will receive permissions from this assignment. An alternative to user field.'),
         allow_null=True,  # for ease of use of the browseable API
@@ -236,7 +250,8 @@ class RoleUserAssignmentSerializer(BaseAssignmentSerializer):
 
 class RoleTeamAssignmentSerializer(BaseAssignmentSerializer):
     actor_field = 'team'
-    team_ansible_id = serializers.UUIDField(
+    team_ansible_id = ActorAnsibleIdField(
+        source='team',
         required=False,
         help_text=_('The resource ID of the team who will receive permissions from this assignment. An alternative to team field.'),
         allow_null=True,

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
@@ -19,6 +21,8 @@ from ansible_base.rbac.validators import check_locally_managed, validate_permiss
 from ..models import DABContentType, DABPermission
 from ..remote import RemoteObject
 from .queries import assignment_qs_user_to_obj, assignment_qs_user_to_obj_perm
+
+logger = logging.getLogger(__name__)
 
 
 class RoleDefinitionSerializer(CommonModelSerializer):
@@ -257,9 +261,20 @@ class AccessListMixin:
             return {}
         related_fields = {}
         actor_cls = self.Meta.model
+
+        # Use ansible_id if available, otherwise fall back to pk
+        actor_identifier = obj.pk
+        try:
+            if hasattr(obj, 'resource') and obj.resource:
+                actor_identifier = str(obj.resource.ansible_id)
+        except ObjectDoesNotExist:
+            # Resource doesn't exist, stick with pk
+            logger.error(f"Resource does not exist for {self.Meta.model} {obj.pk}")
+            pass
+
         related_fields['details'] = get_relative_url(
             f'role-{actor_cls._meta.model_name}-access-assignments',
-            kwargs={'model_name': self.context.get("content_type").api_slug, 'pk': self.context.get("related_object").pk, 'actor_pk': obj.pk},
+            kwargs={'model_name': self.context.get("content_type").api_slug, 'pk': self.context.get("related_object").pk, 'actor_pk': actor_identifier},
         )
         return related_fields
 

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -274,7 +274,9 @@ class AccessListMixin:
                 actor_identifier = str(obj.resource.ansible_id)
         except ObjectDoesNotExist:
             # Resource doesn't exist, stick with pk
-            logger.warning(f"No resource for {self.Meta.model} {obj.pk} due to internal error. Linking role-{actor_cls._meta.model_name}-access-assignments as pk.")
+            logger.warning(
+                f"No resource for {self.Meta.model} {obj.pk} due to internal error. Linking role-{actor_cls._meta.model_name}-access-assignments as pk."
+            )
 
         related_fields['details'] = get_relative_url(
             f'role-{actor_cls._meta.model_name}-access-assignments',

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -274,7 +274,7 @@ class AccessListMixin:
                 actor_identifier = str(obj.resource.ansible_id)
         except ObjectDoesNotExist:
             # Resource doesn't exist, stick with pk
-            logger.error(f"Resource does not exist for {self.Meta.model} {obj.pk}")
+            logger.warning(f"No resource for {self.Meta.model} {obj.pk} due to internal error. Linking role-{actor_cls._meta.model_name}-access-assignments as pk.")
 
         related_fields['details'] = get_relative_url(
             f'role-{actor_cls._meta.model_name}-access-assignments',

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -125,7 +125,8 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         has_actor_in_request = self.actor_field in self.initial_data
         has_actor_aid_in_request = actor_aid_field in self.initial_data
 
-        if (has_actor_in_request and has_actor_aid_in_request) or (not has_actor_in_request and not has_actor_aid_in_request):
+        # If both actor and actor_ansible_id are present or both not present than we error out
+        if has_actor_in_request == has_actor_aid_in_request:
             self.raise_id_fields_error(self.actor_field, actor_aid_field)
 
         return super().validate(attrs)

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -1,6 +1,9 @@
+import uuid
 from collections import OrderedDict
 from typing import Type
 
+from django.apps import apps
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Model
 from django.utils.translation import gettext_lazy as _
@@ -379,6 +382,28 @@ class UserAccessAssignmentViewSet(
     def get_url_actor(self):
         actor_pk = self.kwargs.get("actor_pk")
         actor_cls = self.get_actor_model()
+
+        # First, try to parse as UUID for ansible_id lookup
+        try:
+            parsed_uuid = uuid.UUID(actor_pk)
+            # It's a valid UUID, try resource lookup first
+            try:
+                resource_cls = apps.get_model('dab_resource_registry', 'Resource')
+                resource = resource_cls.objects.get(ansible_id=parsed_uuid)
+                actor = resource.content_object
+                # Verify the content object is the correct type
+                if isinstance(actor, actor_cls):
+                    return actor
+                else:
+                    raise NotFound(f'Resource with ansible_id {parsed_uuid} is not a {actor_cls._meta.model_name}')
+            except (LookupError, ObjectDoesNotExist):
+                # Resource registry not available or resource not found with this UUID
+                raise NotFound(f'The {actor_cls._meta.model_name} with ansible_id={actor_pk} can not be found')
+        except ValueError:
+            # Not a valid UUID, continue with primary key lookup
+            pass
+
+        # Fallback to primary key lookup (only for non-UUID values)
         try:
             return actor_cls.objects.get(pk=actor_pk)
         except actor_cls.DoesNotExist:

--- a/ansible_base/rbac/service_api/serializers.py
+++ b/ansible_base/rbac/service_api/serializers.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from ..api.fields import ActorAnsibleIdField
 from ..models import DABContentType, DABPermission, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ..remote import RemoteObject
 
@@ -22,25 +23,6 @@ class DABPermissionSerializer(serializers.ModelSerializer):
     class Meta:
         model = DABPermission
         fields = ['api_slug', 'codename', 'content_type', 'name']
-
-
-class ActorAnsibleIDField(serializers.Field):
-    def to_representation(self, actor):
-        if actor is None:
-            return None
-        resource = actor.resource
-        if resource is None:
-            return None
-        return str(resource.ansible_id)
-
-    def to_internal_value(self, data):
-        resource_cls = apps.get_model('dab_resource_registry', 'Resource')
-        try:
-            resource = resource_cls.objects.get(ansible_id=data)
-        except resource_cls.DoesNotExist:
-            raise serializers.ValidationError(f"No {self.source} found with ansible_id={data}")
-
-        return resource.content_object
 
 
 class ObjectIDAnsibleIDField(serializers.Field):
@@ -71,7 +53,7 @@ assignment_common_fields = ('created', 'created_by_ansible_id', 'object_id', 'ob
 class BaseAssignmentSerializer(serializers.ModelSerializer):
     content_type = serializers.SlugRelatedField(read_only=True, slug_field='api_slug')
     role_definition = serializers.SlugRelatedField(slug_field='name', queryset=RoleDefinition.objects.all())
-    created_by_ansible_id = ActorAnsibleIDField(source='created_by', required=False)
+    created_by_ansible_id = ActorAnsibleIdField(source='created_by', required=False)
     object_ansible_id = ObjectIDAnsibleIDField(source='object_id', required=False, allow_null=True)
     object_id = serializers.CharField(allow_blank=True, required=False, allow_null=True)
     from_service = serializers.CharField(write_only=True)
@@ -158,7 +140,7 @@ class BaseAssignmentSerializer(serializers.ModelSerializer):
 
 
 class ServiceRoleUserAssignmentSerializer(BaseAssignmentSerializer):
-    user_ansible_id = ActorAnsibleIDField(source='user', required=True)
+    user_ansible_id = ActorAnsibleIdField(source='user', required=True)
     actor_field = 'user'
 
     class Meta:
@@ -167,7 +149,7 @@ class ServiceRoleUserAssignmentSerializer(BaseAssignmentSerializer):
 
 
 class ServiceRoleTeamAssignmentSerializer(BaseAssignmentSerializer):
-    team_ansible_id = ActorAnsibleIDField(source='team', required=True)
+    team_ansible_id = ActorAnsibleIdField(source='team', required=True)
     actor_field = 'team'
 
     class Meta:

--- a/test_app/management/commands/create_demo_data.py
+++ b/test_app/management/commands/create_demo_data.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 from ansible_base.oauth2_provider.models import OAuth2Application
+from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import DABContentType, RoleDefinition
 from test_app.models import EncryptionModel, InstanceGroup, Inventory, Organization, Team, User
 
@@ -41,6 +42,7 @@ class Command(BaseCommand):
         (galaxy, _) = Organization.objects.get_or_create(name='Galaxy_community')
 
         (spud, _) = User.objects.get_or_create(username='angry_spud')
+        (team_member, _) = User.objects.get_or_create(username='team_member')
         (bull_bot, _) = User.objects.get_or_create(username='ansibullbot')
         (admin, _) = User.objects.get_or_create(username='admin')
         spud.set_password('password')
@@ -72,8 +74,8 @@ class Command(BaseCommand):
 
             # Inventory objects exist inside of an organization
             Inventory.objects.create(name='K8S clusters', organization=operator_stuff)
-            Inventory.objects.create(name='Galaxy Host', organization=galaxy)
-            Inventory.objects.create(name='AWX deployment', organization=awx)
+            galaxy_inv = Inventory.objects.create(name='Galaxy Host', organization=galaxy)
+            awx_inv = Inventory.objects.create(name='AWX deployment', organization=awx)
             # Objects that have no associated organization
             InstanceGroup.objects.create(name='Default')
             isolated_group = InstanceGroup.objects.create(name='Isolated Network')
@@ -95,7 +97,18 @@ class Command(BaseCommand):
             user.set_password('password')
             user.save()
 
-        RoleDefinition.objects.managed.team_member.give_permission(spud, awx_devs)
+        # Give some users team member and give that team some inventory object permissions
+        for user in (spud, team_member):
+            RoleDefinition.objects.managed.team_member.give_permission(spud, awx_devs)
+
+        with impersonate(bull_bot):
+            inv_admin = RoleDefinition.objects.create_from_permissions(
+                permissions=['change_inventory', 'view_inventory'],
+                name='Inventory Admin',
+                content_type=permission_registry.content_type_model.objects.get_for_model(Inventory),
+            )
+        for inv in (awx_inv, galaxy_inv):
+            inv_admin.give_permission(awx_devs, inv)
 
         OAuth2Application.objects.get_or_create(
             name="Demo OAuth2 Application",

--- a/test_app/management/commands/create_demo_data.py
+++ b/test_app/management/commands/create_demo_data.py
@@ -105,9 +105,7 @@ class Command(BaseCommand):
             inv_admin, _ = RoleDefinition.objects.get_or_create(
                 name='Inventory Admin',
                 permissions=['change_inventory', 'view_inventory'],
-                defaults={
-                    'content_type': permission_registry.content_type_model.objects.get_for_model(Inventory)
-                }
+                defaults={'content_type': permission_registry.content_type_model.objects.get_for_model(Inventory)},
             )
         for inv in (awx_inv, galaxy_inv):
             inv_admin.give_permission(awx_devs, inv)

--- a/test_app/management/commands/create_demo_data.py
+++ b/test_app/management/commands/create_demo_data.py
@@ -102,10 +102,12 @@ class Command(BaseCommand):
             RoleDefinition.objects.managed.team_member.give_permission(spud, awx_devs)
 
         with impersonate(bull_bot):
-            inv_admin = RoleDefinition.objects.create_from_permissions(
-                permissions=['change_inventory', 'view_inventory'],
+            inv_admin, _ = RoleDefinition.objects.get_or_create(
                 name='Inventory Admin',
-                content_type=permission_registry.content_type_model.objects.get_for_model(Inventory),
+                permissions=['change_inventory', 'view_inventory'],
+                defaults={
+                    'content_type': permission_registry.content_type_model.objects.get_for_model(Inventory)
+                }
             )
         for inv in (awx_inv, galaxy_inv):
             inv_admin.give_permission(awx_devs, inv)

--- a/test_app/tests/rbac/api/test_access_assignment_uuid_lookup.py
+++ b/test_app/tests/rbac/api/test_access_assignment_uuid_lookup.py
@@ -1,0 +1,183 @@
+import uuid
+
+import pytest
+
+from ansible_base.lib.utils.response import get_relative_url
+from test_app.models import Team, User
+
+
+@pytest.mark.django_db
+class TestUserAccessAssignmentUUIDLookup:
+    """Test UUID-based lookup for UserAccessAssignmentViewSet"""
+
+    def test_get_url_actor_with_primary_key(self, admin_api_client, inventory, inv_rd):
+        """Test existing functionality - lookup by primary key should still work"""
+        user = User.objects.create(username='test-user')
+        inv_rd.give_permission(user, inventory)
+
+        url = get_relative_url('role-user-access-assignments', kwargs={'model_name': 'aap.inventory', 'pk': inventory.pk, 'actor_pk': str(user.pk)})
+
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+        assert response.data['count'] >= 1
+
+    def test_get_url_actor_with_ansible_id(self, admin_api_client, inventory, inv_rd):
+        """Test new functionality - lookup by ansible_id (UUID)"""
+        user = User.objects.create(username='test-user')
+        inv_rd.give_permission(user, inventory)
+
+        # Get the user's ansible_id from their resource
+        user_ansible_id = user.resource.ansible_id
+
+        url = get_relative_url('role-user-access-assignments', kwargs={'model_name': 'aap.inventory', 'pk': inventory.pk, 'actor_pk': str(user_ansible_id)})
+
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+        assert response.data['count'] >= 1
+
+    def test_get_url_actor_with_invalid_uuid(self, admin_api_client, inventory):
+        """Test error handling for invalid UUID"""
+        invalid_uuid = str(uuid.uuid4())
+
+        url = get_relative_url('role-user-access-assignments', kwargs={'model_name': 'aap.inventory', 'pk': inventory.pk, 'actor_pk': invalid_uuid})
+
+        response = admin_api_client.get(url)
+        assert response.status_code == 404
+        assert 'can not be found' in response.data['detail']
+
+    def test_get_url_actor_with_nonexistent_pk(self, admin_api_client, inventory):
+        """Test error handling for non-existent primary key"""
+        nonexistent_pk = '99999'
+
+        url = get_relative_url('role-user-access-assignments', kwargs={'model_name': 'aap.inventory', 'pk': inventory.pk, 'actor_pk': nonexistent_pk})
+
+        response = admin_api_client.get(url)
+        assert response.status_code == 404
+        assert 'can not be found' in response.data['detail']
+
+
+@pytest.mark.django_db
+class TestTeamAccessAssignmentUUIDLookup:
+    """Test UUID-based lookup for TeamAccessAssignmentViewSet"""
+
+    def test_get_url_actor_with_primary_key(self, admin_api_client, inventory, inv_rd, organization):
+        """Test existing functionality - lookup by primary key should still work"""
+        team = Team.objects.create(name='test-team', organization=organization)
+        inv_rd.give_permission(team, inventory)
+
+        url = get_relative_url('role-team-access-assignments', kwargs={'model_name': 'aap.inventory', 'pk': inventory.pk, 'actor_pk': str(team.pk)})
+
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+        assert response.data['count'] >= 1
+
+    def test_get_url_actor_with_ansible_id(self, admin_api_client, inventory, inv_rd, organization):
+        """Test new functionality - lookup by ansible_id (UUID)"""
+        team = Team.objects.create(name='test-team', organization=organization)
+        inv_rd.give_permission(team, inventory)
+
+        # Get the team's ansible_id from their resource
+        team_ansible_id = team.resource.ansible_id
+
+        url = get_relative_url('role-team-access-assignments', kwargs={'model_name': 'aap.inventory', 'pk': inventory.pk, 'actor_pk': str(team_ansible_id)})
+
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+        assert response.data['count'] >= 1
+
+    def test_get_url_actor_with_invalid_uuid(self, admin_api_client, inventory):
+        """Test error handling for invalid UUID"""
+        invalid_uuid = str(uuid.uuid4())
+
+        url = get_relative_url('role-team-access-assignments', kwargs={'model_name': 'aap.inventory', 'pk': inventory.pk, 'actor_pk': invalid_uuid})
+
+        response = admin_api_client.get(url)
+        assert response.status_code == 404
+        assert 'can not be found' in response.data['detail']
+
+
+@pytest.mark.django_db
+class TestAccessListRelatedLinksWithAnsibleID:
+    """Test that related links in access list serializers use ansible_id when available"""
+
+    def test_user_access_list_related_links_use_ansible_id(self, admin_api_client, inventory, inv_rd):
+        """Test that user access list provides related links with ansible_id"""
+        user = User.objects.create(username='test-user')
+        inv_rd.give_permission(user, inventory)
+
+        url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'})
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+
+        # Find our test user in the results
+        user_data = None
+        for user_detail in response.data['results']:
+            if user_detail['username'] == 'test-user':
+                user_data = user_detail
+                break
+
+        assert user_data is not None
+        assert 'related' in user_data
+        assert 'details' in user_data['related']
+
+        # The details URL should use ansible_id instead of primary key
+        expected_ansible_id = str(user.resource.ansible_id)
+        assert expected_ansible_id in user_data['related']['details']
+        # Check that the URL ends with the ansible_id, not the primary key
+        assert user_data['related']['details'].endswith(f'{expected_ansible_id}/')
+        assert not user_data['related']['details'].endswith(f'{user.pk}/')
+
+    def test_team_access_list_related_links_use_ansible_id(self, admin_api_client, inventory, inv_rd, organization):
+        """Test that team access list provides related links with ansible_id"""
+        team = Team.objects.create(name='test-team', organization=organization)
+        inv_rd.give_permission(team, inventory)
+
+        url = get_relative_url('role-team-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'})
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+
+        # Find our test team in the results
+        team_data = None
+        for team_detail in response.data['results']:
+            if team_detail['name'] == 'test-team':
+                team_data = team_detail
+                break
+
+        assert team_data is not None
+        assert 'related' in team_data
+        assert 'details' in team_data['related']
+
+        # The details URL should use ansible_id instead of primary key
+        expected_ansible_id = str(team.resource.ansible_id)
+        assert expected_ansible_id in team_data['related']['details']
+        # Check that the URL ends with the ansible_id, not the primary key
+        assert team_data['related']['details'].endswith(f'{expected_ansible_id}/')
+        assert not team_data['related']['details'].endswith(f'{team.pk}/')
+
+    def test_user_access_list_fallback_to_pk_when_no_resource(self, admin_api_client, inventory, inv_rd):
+        """Test fallback to primary key when user has no resource (edge case)"""
+        user = User.objects.create(username='test-user-no-resource')
+
+        # Manually delete the resource to simulate edge case
+        if hasattr(user, 'resource') and user.resource:
+            user.resource.delete()
+
+        inv_rd.give_permission(user, inventory)
+
+        url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'})
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+
+        # Find our test user in the results
+        user_data = None
+        for user_detail in response.data['results']:
+            if user_detail['username'] == 'test-user-no-resource':
+                user_data = user_detail
+                break
+
+        assert user_data is not None
+        assert 'related' in user_data
+        assert 'details' in user_data['related']
+
+        # Should fall back to primary key when no resource available
+        assert str(user.pk) in user_data['related']['details']

--- a/test_app/tests/rbac/api/test_access_assignment_uuid_lookup.py
+++ b/test_app/tests/rbac/api/test_access_assignment_uuid_lookup.py
@@ -152,7 +152,7 @@ class TestAccessListRelatedLinksWithAnsibleID:
         assert expected_ansible_id in team_data['related']['details']
         # Check that the URL ends with the ansible_id, not the primary key
         assert team_data['related']['details'].endswith(f'{expected_ansible_id}/')
-        assert not team_data['related']['details'].endswith(f'{team.pk}/')
+        assert not team_data['related']['details'].endswith(f'/{team.pk}/')
 
     def test_user_access_list_fallback_to_pk_when_no_resource(self, admin_api_client, inventory, inv_rd):
         """Test fallback to primary key when user has no resource (edge case)"""

--- a/test_app/tests/rbac/api/test_role_assignment_ansible_id_serialization.py
+++ b/test_app/tests/rbac/api/test_role_assignment_ansible_id_serialization.py
@@ -1,0 +1,99 @@
+import pytest
+
+from ansible_base.lib.utils.response import get_relative_url
+from test_app.models import Team, User
+
+
+@pytest.mark.django_db
+class TestRoleAssignmentAnsibleIdSerialization:
+    """Test serialization of ansible_id fields in role assignment endpoints"""
+
+    def test_role_user_assignment_serializes_user_ansible_id(self, admin_api_client, inventory, inv_rd):
+        """Test that RoleUserAssignment API returns user_ansible_id instead of null"""
+        user = User.objects.create(username='test-user')
+        assignment = inv_rd.give_permission(user, inventory)
+
+        # Verify user has a resource and ansible_id
+        assert hasattr(user, 'resource')
+        assert user.resource is not None
+        assert user.resource.ansible_id is not None
+        expected_ansible_id = str(user.resource.ansible_id)
+
+        # Get the assignment via API
+        url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+
+        # The user_ansible_id field should be populated, not null
+        assert response.data['user_ansible_id'] is not None
+        assert response.data['user_ansible_id'] == expected_ansible_id
+
+        # Also verify the user field contains the primary key for backward compatibility
+        assert response.data['user'] == user.pk
+
+    def test_role_team_assignment_serializes_team_ansible_id(self, admin_api_client, inventory, inv_rd, organization):
+        """Test that RoleTeamAssignment API returns team_ansible_id instead of null"""
+        team = Team.objects.create(name='test-team', organization=organization)
+        assignment = inv_rd.give_permission(team, inventory)
+
+        # Verify team has a resource and ansible_id
+        assert hasattr(team, 'resource')
+        assert team.resource is not None
+        assert team.resource.ansible_id is not None
+        expected_ansible_id = str(team.resource.ansible_id)
+
+        # Get the assignment via API
+        url = get_relative_url('roleteamassignment-detail', kwargs={'pk': assignment.pk})
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+
+        # The team_ansible_id field should be populated, not null
+        assert response.data['team_ansible_id'] is not None
+        assert response.data['team_ansible_id'] == expected_ansible_id
+
+        # Also verify the team field contains the primary key for backward compatibility
+        assert response.data['team'] == team.pk
+
+    def test_role_user_assignment_list_includes_ansible_id(self, admin_api_client, inventory, inv_rd):
+        """Test that RoleUserAssignment list endpoint includes user_ansible_id"""
+        user = User.objects.create(username='test-user-list')
+        assignment = inv_rd.give_permission(user, inventory)
+        expected_ansible_id = str(user.resource.ansible_id)
+
+        # Get assignments list via API
+        url = get_relative_url('roleuserassignment-list')
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+
+        # Find our assignment in the results
+        assignment_data = None
+        for item in response.data['results']:
+            if item['id'] == assignment.pk:
+                assignment_data = item
+                break
+
+        assert assignment_data is not None
+        assert assignment_data['user_ansible_id'] is not None
+        assert assignment_data['user_ansible_id'] == expected_ansible_id
+
+    def test_role_team_assignment_list_includes_ansible_id(self, admin_api_client, inventory, inv_rd, organization):
+        """Test that RoleTeamAssignment list endpoint includes team_ansible_id"""
+        team = Team.objects.create(name='test-team-list', organization=organization)
+        assignment = inv_rd.give_permission(team, inventory)
+        expected_ansible_id = str(team.resource.ansible_id)
+
+        # Get assignments list via API
+        url = get_relative_url('roleteamassignment-list')
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+
+        # Find our assignment in the results
+        assignment_data = None
+        for item in response.data['results']:
+            if item['id'] == assignment.pk:
+                assignment_data = item
+                break
+
+        assert assignment_data is not None
+        assert assignment_data['team_ansible_id'] is not None
+        assert assignment_data['team_ansible_id'] == expected_ansible_id


### PR DESCRIPTION
This is needed to complete the UI connection of the access lists.

Background:

Due to technical issues, we have asked the UI to use the component-based access list for resources owned by a certain component. So if there's an AWX resource, get the access list served from AWX for that item, like an inventory or job template.

However, our endpoints were still using the local team or user id. This is a problem, because all other RBAC management is centralized around the resource server. So a translation is needed, and right now there's no easy way to do that translation. So the solution (this) is to formulate all the access list related endpoints around the ansible_id of the actor, that being the user or the team.

Corresponding to this, we need a fix for the bug https://github.com/ansible/django-ansible-base/issues/534, so that the client has the ansible_id as a starting point when navigating to the component endpoints