### PR TITLE
AAP-49728 Allow absolute paths for LOGIN_REDIRECT_OVERRIDE

### DIFF
--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Union
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
@@ -39,6 +40,24 @@ class UIAuth(AnsibleBaseDjangoAppApiView):
             return self._get()
 
 
+def _validate_and_get_login_redirect_override() -> Union[str, None]:
+
+    try:
+        login_redirect_override = get_setting('LOGIN_REDIRECT_OVERRIDE', '')
+        # ignore validation if login_redirect_override is None or empty string
+        if login_redirect_override is not None and login_redirect_override != '':
+            validate_url(url=login_redirect_override, allow_plain_hostname=True)
+            return login_redirect_override
+    except ValidationError:
+        # login_redirect_override can also be an absolute path
+        try:
+            validate_absolute_path(path=login_redirect_override)
+            return login_redirect_override
+        except ValidationError:
+            logger.error('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL or absolute path, ignoring')
+    return None
+
+
 def generate_ui_auth_data():
     authenticators = Authenticator.objects.filter(enabled=True)
     response = {
@@ -68,19 +87,9 @@ def generate_ui_auth_data():
         else:
             logger.error(f"Don't know how to handle authenticator of type {authenticator.type}")
 
-    try:
-        login_redirect_override = get_setting('LOGIN_REDIRECT_OVERRIDE', '')
-        # ignore validation if login_redirect_override is None or empty string
-        if login_redirect_override is not None and login_redirect_override != '':
-            validate_url(url=login_redirect_override, allow_plain_hostname=True)
-            response['login_redirect_override'] = login_redirect_override
-    except ValidationError:
-        # login_redirect_override can also be an absolute path
-        try:
-            validate_absolute_path(path=login_redirect_override)
-            response['login_redirect_override'] = login_redirect_override
-        except ValidationError:
-            logger.error('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL or absolute path, ignoring')
+    login_redirect_override = _validate_and_get_login_redirect_override()
+    if login_redirect_override:
+        response['login_redirect_override'] = login_redirect_override
 
     custom_login_info = get_setting('custom_login_info', '')
     if isinstance(custom_login_info, str):

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -41,12 +41,11 @@ class UIAuth(AnsibleBaseDjangoAppApiView):
 
 
 def _validate_and_get_login_redirect_override() -> Union[str, None]:
-
     try:
         login_redirect_override = get_setting('LOGIN_REDIRECT_OVERRIDE', '')
         # ignore validation if login_redirect_override is None or empty string
         if login_redirect_override is not None and login_redirect_override != '':
-            validate_url(url=login_redirect_override, allow_plain_hostname=True)
+            validate_url(url=login_redirect_override, schemes=['https', 'http'], allow_plain_hostname=True)
             return login_redirect_override
     except ValidationError:
         # login_redirect_override can also be an absolute path

--- a/ansible_base/authentication/views/ui_auth.py
+++ b/ansible_base/authentication/views/ui_auth.py
@@ -8,7 +8,7 @@ from rest_framework.serializers import ValidationError
 from ansible_base.authentication.models import Authenticator
 from ansible_base.authentication.serializers import UIAuthResponseSerializer
 from ansible_base.lib.utils.settings import get_setting, is_aoc_instance
-from ansible_base.lib.utils.validation import validate_image_data, validate_url
+from ansible_base.lib.utils.validation import validate_absolute_path, validate_image_data, validate_url
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 logger = logging.getLogger('ansible_base.authentication.views.ui_auth')
@@ -75,7 +75,12 @@ def generate_ui_auth_data():
             validate_url(url=login_redirect_override, allow_plain_hostname=True)
             response['login_redirect_override'] = login_redirect_override
     except ValidationError:
-        logger.error('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
+        # login_redirect_override can also be an absolute path
+        try:
+            validate_absolute_path(path=login_redirect_override)
+            response['login_redirect_override'] = login_redirect_override
+        except ValidationError:
+            logger.error('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL or absolute path, ignoring')
 
     custom_login_info = get_setting('custom_login_info', '')
     if isinstance(custom_login_info, str):

--- a/ansible_base/lib/utils/validation.py
+++ b/ansible_base/lib/utils/validation.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import re
 import secrets
+from pathlib import Path
 from urllib.parse import urlparse, urlunsplit
 
 from cryptography.exceptions import InvalidSignature
@@ -30,6 +31,12 @@ def validate_url_list(urls: list, schemes: list = ['https'], allow_plain_hostnam
             errors.append(f"{a_url} is invalid")
     if errors:
         raise ValidationError(', '.join(errors))
+
+
+def validate_absolute_path(path: str) -> None:
+    path = Path(path)
+    if not path.is_absolute():
+        raise ValidationError(f"{path} is not an absolute path")
 
 
 def validate_url(url: str, schemes: list = ['https'], allow_plain_hostname: bool = False) -> None:

--- a/test_app/tests/authentication/views/test_ui_auth.py
+++ b/test_app/tests/authentication/views/test_ui_auth.py
@@ -24,7 +24,14 @@ def test_generate_ui_auth_data_no_authenticators_or_settings():
 
 @override_settings(LOGIN_REDIRECT_OVERRIDE='https://example.com')
 @pytest.mark.django_db
-def test_generate_ui_auth_data_valid_login_redirect():
+def test_generate_ui_auth_data_valid_login_redirect_url():
+    response = generate_ui_auth_data()
+    assert response['login_redirect_override'] == settings.LOGIN_REDIRECT_OVERRIDE
+
+
+@override_settings(LOGIN_REDIRECT_OVERRIDE='/an/absolute/path')
+@pytest.mark.django_db
+def test_generate_ui_auth_data_valid_login_redirect_path():
     response = generate_ui_auth_data()
     assert response['login_redirect_override'] == settings.LOGIN_REDIRECT_OVERRIDE
 
@@ -34,7 +41,15 @@ def test_generate_ui_auth_data_valid_login_redirect():
 @pytest.mark.django_db
 def test_generate_ui_auth_data_invalid_login_redirect_function(logger):
     generate_ui_auth_data()
-    logger.error.assert_called_with('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL, ignoring')
+    logger.error.assert_called_with('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL or absolute path, ignoring')
+
+
+@mock.patch("ansible_base.authentication.views.ui_auth.logger")
+@override_settings(LOGIN_REDIRECT_OVERRIDE='a/relative/path')
+@pytest.mark.django_db
+def test_generate_ui_auth_invalid_path_login_redirect_function(logger):
+    generate_ui_auth_data()
+    logger.error.assert_called_with('LOGIN_REDIRECT_OVERRIDE was set but was not a valid URL or absolute path, ignoring')
 
 
 @override_settings(custom_login_info='Login with your username and password')


### PR DESCRIPTION
## Description

LOGIN_REDIRECT_OVERRIDE can be an absolute path or a URL.

## Type of Change
- [sigh] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1.  Deploy gateway with partner PR #926
2. Test according to steps listed in above PR
3. 

### Expected Results
LOGIN_REDIRECT_OVERRIDE accepts absolute paths (and URLs)

