### PR TITLE
[AAP-50642] memoize pem private key to avoid openssl slowdown

### DIFF
--- a/ansible_base/jwt_consumer/common/util.py
+++ b/ansible_base/jwt_consumer/common/util.py
@@ -22,7 +22,7 @@ def _load_pem_private_key(key: str):
     return serialization.load_pem_private_key(bytes(key, 'utf-8'), password=None)
 
 def generate_x_trusted_proxy_header(key: str) -> str:
-    private_key = _load_private_key(key)
+    private_key = _load_pem_private_key(key)
     timestamp = time.time_ns()
     message = f'{_SHARED_SECRET}-{timestamp}'
     signature = private_key.sign(bytes(message, 'utf-8'), padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())

--- a/ansible_base/jwt_consumer/common/util.py
+++ b/ansible_base/jwt_consumer/common/util.py
@@ -14,12 +14,14 @@ logger = logging.getLogger('ansible_base.jwt_consumer.common.util')
 
 _SHARED_SECRET = 'trusted_proxy'
 
+
 @lru_cache
 def _load_pem_private_key(key: str):
     # Loading and validating the private key is more expensive in OpenSSL 3.2 (from RHEL9) than in Openssl 1.1 (from RHEL8)
     # For that reason, we will memoize the result of this function, and only re-execute it if the key changes
     # This is stored in memory local to the process
     return serialization.load_pem_private_key(bytes(key, 'utf-8'), password=None)
+
 
 def generate_x_trusted_proxy_header(key: str) -> str:
     private_key = _load_pem_private_key(key)

--- a/ansible_base/jwt_consumer/common/util.py
+++ b/ansible_base/jwt_consumer/common/util.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from base64 import b64encode
+from functools import lru_cache
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
@@ -13,9 +14,15 @@ logger = logging.getLogger('ansible_base.jwt_consumer.common.util')
 
 _SHARED_SECRET = 'trusted_proxy'
 
+@lru_cache(maxsize=None)
+def _load_pem_private_key(key: str):
+    # Loading and validating the private key is more expensive in OpenSSL 3.2 (from RHEL9) than in Openssl 1.1 (from RHEL8)
+    # For that reason, we will memoize the result of this function, and only re-execute it if the key changes
+    # This is stored in memory local to the process
+    return serialization.load_pem_private_key(bytes(key, 'utf-8'), password=None)
 
 def generate_x_trusted_proxy_header(key: str) -> str:
-    private_key = serialization.load_pem_private_key(bytes(key, 'utf-8'), password=None)
+    private_key = _load_private_key(key)
     timestamp = time.time_ns()
     message = f'{_SHARED_SECRET}-{timestamp}'
     signature = private_key.sign(bytes(message, 'utf-8'), padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())

--- a/ansible_base/jwt_consumer/common/util.py
+++ b/ansible_base/jwt_consumer/common/util.py
@@ -14,7 +14,7 @@ logger = logging.getLogger('ansible_base.jwt_consumer.common.util')
 
 _SHARED_SECRET = 'trusted_proxy'
 
-@lru_cache(maxsize=None)
+@lru_cache
 def _load_pem_private_key(key: str):
     # Loading and validating the private key is more expensive in OpenSSL 3.2 (from RHEL9) than in Openssl 1.1 (from RHEL8)
     # For that reason, we will memoize the result of this function, and only re-execute it if the key changes


### PR DESCRIPTION
For 2.6, we've moved to RHEL9 for the base container, which has openssl 3.2 in it. Apparently , its is a known issue that the RSA key validation is more secure and more slow in this version vs. Openssl 1 that RHEL8 uses. We were loading and validating the same jwt private key on every request, at a cost of ~ 38 ms, vs previously this took ~ 3 ms. We noticed this slowdown in the benchmarks and after deep dive/profiling we found this was the difference and memoizing the validated private key saves us from this broad slowdown. See https://issues.redhat.com/browse/AAP-50642 for more details

https://github.com/pyca/cryptography/issues/7236#issuecomment-1131908472 <--- report that details Openssl 3 slowdown

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
The speedup is visible running hte benchmark tests in the test-suite
```
pytest tests/perf/benchmark/test_api_benchmark.py -k 'test_benchmark_controller_endpoint_list_response[notifications]' --tsd=../tsd.json
```

### Expected Results
<!-- Describe what should happen after following the steps -->
~ 30ms speedup, which brings us back in line with 2.5 results on containerized and OCP
Note: we didn't see the slow down comparing AAP 2.5 and AAP 2.6 on RHEL9, because they BOTH use same openssl version. The difference between containerized and OCP AAP 2.5 and AAP 2.6 is the base image (we moved from RHEL8 to RHEL9)

## Additional Context
<!-- Optional but helpful information -->
For the return value type of the function, I did try importing the class that this returns `from cryptography.hazmat.bindings._rust.openssl.rsa import RSAPrivateKey` but that caused the gRPC service to not be able to start 

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
