### PR TITLE
AAP-47896 Improve auth map application debug output

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -306,10 +306,10 @@ def _lowercase_attr_triggers(trigger_condition: dict) -> dict:
 def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: int, tracking_id: str) -> TriggerResult:
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
-    Attribute names are compared case-insensitively.
+    Attribute names are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS is enabled.
     """
     if _is_case_insensitivity_enabled():
-        _prefixed_debug(map_id, tracking_id, "Case insensitivity enabled, converting attributes and values to lowercase")
+        _prefixed_debug(map_id, tracking_id, f"[{tracking_id}] Case insensitivity enabled, converting attributes and values to lowercase")
         attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
         trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
@@ -329,7 +329,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: i
         if invalid_conditions:
             logger.warning(
                 f"[{tracking_id}] The conditions {', '.join(invalid_conditions)} for attribute {attribute} "
-                "in authenticator map {auth_id} are invalid and won't be processed"
+                f"in authenticator map {map_id} are invalid and won't be processed"
             )
 
         # The attribute is an empty dict we just need to see if the user has the attribute or not

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -3,7 +3,7 @@ import importlib
 import logging
 import re
 from enum import Enum, auto
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -351,50 +351,54 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, auth_id: 
             # If the value is a string then convert it to a list
             user_value = [user_value]
 
-        for a_user_value in user_value:
-            # We are going to do mostly string comparisons, so convert the attribute to a
-            #  string just in case it came back as an int or something funky
-            a_user_value = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
-
-            # Check for any of the valid conditions
-            header = f"Attr [{attribute}] value [{a_user_value}]"
-            if "equals" in trigger_condition[attribute]:
-                trigger_value = trigger_condition[attribute]["equals"]
-                is_equal = a_user_value == trigger_value
-                has_access = has_access_with_join(has_access, is_equal, join_condition)
-                _prefixed_debug(auth_id, map_id, f"{header} is {'equal' if is_equal else 'not equal'} to [{trigger_value}], {_result_suffix(is_equal)}")
-
-            elif "matches" in trigger_condition[attribute]:
-                trigger_value = trigger_condition[attribute]["matches"]
-                is_match = re.match(trigger_value, a_user_value, re.IGNORECASE) is not None
-                has_access = has_access_with_join(has_access, is_match, join_condition)
-                _prefixed_debug(auth_id, map_id, f"{header} {'matches' if is_match else 'does not match'} [{trigger_value}], {_result_suffix(is_match)}")
-
-            elif "contains" in trigger_condition[attribute]:
-                trigger_value = trigger_condition[attribute]['contains']
-                does_contain = trigger_value in a_user_value
-                has_access = has_access_with_join(has_access, does_contain, join_condition)
-                _prefixed_debug(
-                    auth_id, map_id, f"{header} {'contains' if does_contain else 'does not contain'} [{trigger_value}], {_result_suffix(does_contain)}"
-                )
-
-            elif "ends_with" in trigger_condition[attribute]:
-                trigger_value = trigger_condition[attribute]['ends_with']
-                does_end_with = a_user_value.endswith(trigger_value)
-                has_access = has_access_with_join(has_access, does_end_with, join_condition)
-                _prefixed_debug(
-                    auth_id,
-                    map_id,
-                    f"{header} {'ends with' if does_end_with else 'does not end with'} [{trigger_value}], {_result_suffix(does_end_with)}",
-                )
-
-            elif "in" in trigger_condition[attribute]:
-                trigger_value = trigger_condition[attribute]['in']
-                is_in = a_user_value in trigger_value
-                has_access = has_access_with_join(has_access, is_in, join_condition)
-                _prefixed_debug(auth_id, map_id, f"{header} {'is in' if is_in else 'is not in'} [{trigger_value}], {_result_suffix(is_in)}")
+        has_access = _process_user_value(has_access, trigger_condition, user_value, join_condition, attribute, auth_id, map_id)
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
+
+
+def _process_user_value(
+    has_access: Optional[bool], trigger_condition: dict, user_value: List[str], join_condition: str, attribute: str, auth_id: int, map_id: int
+) -> str:
+    for a_user_value in user_value:
+        # We are going to do mostly string comparisons, so convert the attribute to a
+        #  string just in case it came back as an int or something funky
+        a_user_value = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
+
+        # Check for any of the valid conditions
+        header = f"Attr [{attribute}] value [{a_user_value}]"
+        if "equals" in trigger_condition[attribute]:
+            trigger_value = trigger_condition[attribute]["equals"]
+            is_equal = a_user_value == trigger_value
+            has_access = has_access_with_join(has_access, is_equal, join_condition)
+            _prefixed_debug(auth_id, map_id, f"{header} is {'equal' if is_equal else 'not equal'} to [{trigger_value}], {_result_suffix(is_equal)}")
+
+        elif "matches" in trigger_condition[attribute]:
+            trigger_value = trigger_condition[attribute]["matches"]
+            is_match = re.match(trigger_value, a_user_value, re.IGNORECASE) is not None
+            has_access = has_access_with_join(has_access, is_match, join_condition)
+            _prefixed_debug(auth_id, map_id, f"{header} {'matches' if is_match else 'does not match'} [{trigger_value}], {_result_suffix(is_match)}")
+
+        elif "contains" in trigger_condition[attribute]:
+            trigger_value = trigger_condition[attribute]['contains']
+            does_contain = trigger_value in a_user_value
+            has_access = has_access_with_join(has_access, does_contain, join_condition)
+            _prefixed_debug(auth_id, map_id, f"{header} {'contains' if does_contain else 'does not contain'} [{trigger_value}], {_result_suffix(does_contain)}")
+
+        elif "ends_with" in trigger_condition[attribute]:
+            trigger_value = trigger_condition[attribute]['ends_with']
+            does_end_with = a_user_value.endswith(trigger_value)
+            has_access = has_access_with_join(has_access, does_end_with, join_condition)
+            _prefixed_debug(
+                auth_id,
+                map_id,
+                f"{header} {'ends with' if does_end_with else 'does not end with'} [{trigger_value}], {_result_suffix(does_end_with)}",
+            )
+
+        elif "in" in trigger_condition[attribute]:
+            trigger_value = trigger_condition[attribute]['in']
+            is_in = a_user_value in trigger_value
+            has_access = has_access_with_join(has_access, is_in, join_condition)
+            _prefixed_debug(auth_id, map_id, f"{header} {'is in' if is_in else 'is not in'} [{trigger_value}], {_result_suffix(is_in)}")
 
 
 def _result_suffix(result: bool) -> str:

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -358,7 +358,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, auth_id: 
 
 def _process_user_value(
     has_access: Optional[bool], trigger_condition: dict, user_value: List[str], join_condition: str, attribute: str, auth_id: int, map_id: int
-) -> str:
+) -> Optional[bool]:
     for a_user_value in user_value:
         # We are going to do mostly string comparisons, so convert the attribute to a
         #  string just in case it came back as an int or something funky
@@ -399,6 +399,8 @@ def _process_user_value(
             is_in = a_user_value in trigger_value
             has_access = has_access_with_join(has_access, is_in, join_condition)
             _prefixed_debug(auth_id, map_id, f"{header} {'is in' if is_in else 'is not in'} [{trigger_value}], {_result_suffix(is_in)}")
+
+    return has_access
 
 
 def _result_suffix(result: bool) -> str:

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -4,6 +4,7 @@ import logging
 import re
 from enum import Enum, auto
 from typing import List, Optional, Union
+from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -57,10 +58,12 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
     logger.debug(f"{username}'s groups: {groups}")
     logger.debug(f"{username}'s attrs: {attrs}")
 
+    # debug tracking ID
+    tracking_id = str(uuid4())
+
     # load the maps
-    apk = authenticator.pk
-    maps = AuthenticatorMap.objects.filter(authenticator=apk).order_by("order")
-    logger.debug(f"Processing {maps.count()} map(s) for Authenticator ID [{apk}]")
+    maps = AuthenticatorMap.objects.filter(authenticator=authenticator.pk).order_by("order")
+    logger.debug(f"Processing {maps.count()} map(s) for Authenticator ID [{authenticator.pk}] ID [{tracking_id}]")
 
     for auth_map in maps:
         mpk = auth_map.pk
@@ -70,46 +73,46 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
         invalid_keys = set(auth_map.triggers.keys()) - set(allowed_keys)
 
         if auth_map.enabled is False:
-            logger.info(f"Skipping AuthenticatorMap {mpk} because it is disabled")
+            logger.info(f"[{tracking_id}] Skipping AuthenticatorMap {mpk} because it is disabled")
             rule_responses.append({mpk: 'skipped', 'enabled': auth_map.enabled})
             continue
 
         if invalid_keys:
-            logger.warning(f"In AuthenticatorMap {mpk} the following trigger keys are invalid: {', '.join(invalid_keys)}, rule will be ignored")
+            logger.warning(f"[{tracking_id}] In AuthenticatorMap {mpk} the following trigger keys are invalid: {', '.join(invalid_keys)}, rule will be ignored")
             rule_responses.append({mpk: 'invalid', 'enabled': auth_map.enabled})
             continue
 
         for trigger_type, trigger in auth_map.triggers.items():
             if trigger_type == 'groups':
-                _prefixed_debug(apk, mpk, "Groups trigger, comparing user groups to trigger groups")
-                trigger_result = process_groups(trigger, groups, apk, mpk)
+                _prefixed_debug(mpk, tracking_id, "Groups trigger, comparing user groups to trigger groups")
+                trigger_result = process_groups(trigger, groups, mpk, tracking_id)
             elif trigger_type == 'attributes':
-                _prefixed_debug(apk, mpk, "Attributes trigger, comparing user attrs to trigger attrs")
-                trigger_result = process_user_attributes(trigger, attrs, apk, mpk)
+                _prefixed_debug(mpk, tracking_id, "Attributes trigger, comparing user attrs to trigger attrs")
+                trigger_result = process_user_attributes(trigger, attrs, mpk, tracking_id)
             elif trigger_type == 'always':
-                _prefixed_debug(apk, mpk, "Always trigger, allowing")
+                _prefixed_debug(mpk, tracking_id, "Always trigger, allowing")
                 trigger_result = TriggerResult.ALLOW
             elif trigger_type == 'never':
-                _prefixed_debug(apk, mpk, "Never trigger, denying")
+                _prefixed_debug(mpk, tracking_id, "Never trigger, denying")
                 trigger_result = TriggerResult.DENY
 
         # If the trigger result is SKIP, auth map is not defined for this user.
         # Together with "revoke" flag => change permission to DENY
         if auth_map.revoke and trigger_result is TriggerResult.SKIP:
-            _prefixed_debug(apk, mpk, "Revoke flag is set for map, denying and revoking permission")
+            _prefixed_debug(mpk, tracking_id, "Revoke flag is set for map, denying and revoking permission")
             trigger_result = TriggerResult.DENY
 
         # If the trigger result is still SKIP, this auth map is not applicable to this user => no action needed
         if trigger_result is TriggerResult.SKIP:
-            _prefixed_debug(apk, mpk, "Trigger result is SKIP, skipping map, no action needed")
+            _prefixed_debug(mpk, tracking_id, "Trigger result is SKIP, skipping map, no action needed")
             rule_responses.append({mpk: 'skipped', 'enabled': auth_map.enabled})
             continue
 
         if trigger_result is TriggerResult.ALLOW:
-            _prefixed_debug(apk, mpk, "Trigger result is ALLOW, allowing map, applying permission")
+            _prefixed_debug(mpk, tracking_id, "Trigger result is ALLOW, allowing map, applying permission")
             has_permission = True
         elif trigger_result is TriggerResult.DENY:
-            _prefixed_debug(apk, mpk, "Trigger result is DENY, denying map, revoking permission")
+            _prefixed_debug(mpk, tracking_id, "Trigger result is DENY, denying map, revoking permission")
             has_permission = False
 
         rule_responses.append({mpk: has_permission, 'enabled': auth_map.enabled})
@@ -130,7 +133,9 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
                 expanded_role = expanded_values.get('role', None)
 
                 if (role_errors := check_role_type(map_type=auth_map.map_type, role=expanded_role, team=expanded_team, org=expanded_organization)) != {}:
-                    logger.info(f"Map type {auth_map.map_type} of rule {auth_map.name} had an invalid role type and will be skipped {role_errors}")
+                    logger.info(
+                        f"[{tracking_id}] Map type {auth_map.map_type} of rule {auth_map.name} had an invalid role type and will be skipped {role_errors}"
+                    )
                 elif (
                     auth_map.map_type in ['team', 'role']
                     and not is_empty(expanded_organization)
@@ -151,7 +156,7 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
                     understood_map = True
 
         if not understood_map:
-            logger.error(f"Map type {auth_map.map_type} of rule {auth_map.name} does not know how to be processed")
+            logger.error(f"[{tracking_id}] Map type {auth_map.map_type} of rule {auth_map.name} does not know how to be processed")
 
     return {
         "access_allowed": access_allowed,
@@ -165,8 +170,8 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
     }
 
 
-def _prefixed_debug(authenticator_pk: int, auth_map_pk: int, message: str):
-    prefix = f"Authenticator [{authenticator_pk}] Map [{auth_map_pk}]"
+def _prefixed_debug(auth_map_pk: int, tracking_id: str, message: str):
+    prefix = f"[{tracking_id}] Map [{auth_map_pk}]"
     logger.debug(f"{prefix} {message}")
 
 
@@ -224,7 +229,7 @@ def _lowercase_group_triggers(trigger_condition: dict) -> dict:
     return ci_trigger_condition
 
 
-def process_groups(trigger_condition: dict, groups: list, auth_id: int, map_id: int) -> TriggerResult:
+def process_groups(trigger_condition: dict, groups: list, map_id: int, tracking_id: str) -> TriggerResult:
     """
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
     Group DNs are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS enabled.
@@ -235,32 +240,32 @@ def process_groups(trigger_condition: dict, groups: list, auth_id: int, map_id: 
 
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
-        logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {auth_id} are invalid and won't be processed")
+        logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {map_id} are invalid and won't be processed")
 
     set_of_user_groups = set(groups)
 
     if "has_or" in trigger_condition:
         matching_groups = set_of_user_groups.intersection(set(trigger_condition["has_or"]))
         if matching_groups:
-            _prefixed_debug(auth_id, map_id, f"User has at least one trigger group [{matching_groups}], allowing")
+            _prefixed_debug(map_id, tracking_id, f"User has at least one trigger group [{matching_groups}], allowing")
             return TriggerResult.ALLOW
         else:
-            _prefixed_debug(auth_id, map_id, "User does not have any trigger groups, skipping")
+            _prefixed_debug(map_id, tracking_id, "User does not have any trigger groups, skipping")
 
     elif "has_and" in trigger_condition:
         if set(trigger_condition["has_and"]).issubset(set_of_user_groups):
-            _prefixed_debug(auth_id, map_id, "User has all groups in trigger, allowing")
+            _prefixed_debug(map_id, tracking_id, "User has all groups in trigger, allowing")
             return TriggerResult.ALLOW
         else:
-            _prefixed_debug(auth_id, map_id, "User does not have all trigger groups, skipping")
+            _prefixed_debug(map_id, tracking_id, "User does not have all trigger groups, skipping")
 
     elif "has_not" in trigger_condition:
         unwanted_groups = set(trigger_condition["has_not"]).intersection(set_of_user_groups)
         if not unwanted_groups:
-            _prefixed_debug(auth_id, map_id, "User does not have disallowed groups, allowing")
+            _prefixed_debug(map_id, tracking_id, "User does not have disallowed groups, allowing")
             return TriggerResult.ALLOW
         else:
-            _prefixed_debug(auth_id, map_id, f"User has one or more disallowed groups [{unwanted_groups}], skipping")
+            _prefixed_debug(map_id, tracking_id, f"User has one or more disallowed groups [{unwanted_groups}], skipping")
     return TriggerResult.SKIP
 
 
@@ -298,30 +303,30 @@ def _lowercase_attr_triggers(trigger_condition: dict) -> dict:
     return ci_trigger_condition
 
 
-def process_user_attributes(trigger_condition: dict, attributes: dict, auth_id: int, map_id: int) -> TriggerResult:
+def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: int, tracking_id: str) -> TriggerResult:
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
     if _is_case_insensitivity_enabled():
-        _prefixed_debug(auth_id, map_id, "Case insensitivity enabled, converting attributes and values to lowercase")
+        _prefixed_debug(map_id, tracking_id, "Case insensitivity enabled, converting attributes and values to lowercase")
         attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
         trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
     has_access = None
     join_condition = trigger_condition.get('join_condition', 'or')
     if join_condition not in TRIGGER_DEFINITION['attributes']['keys']['join_condition']['choices']:
-        logger.warning("Trigger join_condition {join_condition} on authenticator map {auth_id} is invalid and will be set to 'or'")
+        logger.warning(f"[{tracking_id}] Trigger join_condition {join_condition} on authenticator map {map_id} is invalid and will be set to 'or'")
         join_condition = 'or'
 
     for attribute in trigger_condition.keys():
         if has_access and join_condition == 'or':
             # If we are an or condition and we already have a positive we can break out and return
-            _prefixed_debug(auth_id, map_id, "At least one attribute match with OR join, allowing")
+            _prefixed_debug(map_id, tracking_id, "At least one attribute match with OR join, allowing")
             break
         elif has_access is False and join_condition == 'and':
             # If we are an and and already have a False we can give up
-            _prefixed_debug(auth_id, map_id, "At least one attribute mismatch with AND join, skipping")
+            _prefixed_debug(map_id, tracking_id, "At least one attribute mismatch with AND join, skipping")
             break
 
         # We can skip the join_condition since we already processed that.
@@ -332,73 +337,111 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, auth_id: 
         invalid_conditions = set(trigger_condition[attribute].keys()) - set(TRIGGER_DEFINITION['attributes']['keys']['*']['keys'].keys())
         if invalid_conditions:
             logger.warning(
-                f"The conditions {', '.join(invalid_conditions)} for attribute {attribute} " "in authenticator map {auth_id} are invalid and won't be processed"
+                f"[{tracking_id}] The conditions {', '.join(invalid_conditions)} for attribute {attribute} "
+                "in authenticator map {auth_id} are invalid and won't be processed"
             )
 
         # The attribute is an empty dict we just need to see if the user has the attribute or not
         if trigger_condition[attribute] == {}:
             has_access = has_access_with_join(has_access, attribute in attributes, join_condition)
-            _prefixed_debug(auth_id, map_id, f"Attr [{attribute}] without value constraint {'is' if attribute in attributes else 'is not'} present, allowing")
+            _prefixed_debug(
+                map_id, tracking_id, f"Attr [{attribute}] without value constraint {'is' if attribute in attributes else 'is not'} present, allowing"
+            )
             continue
 
         user_value = attributes.get(attribute, None)
         # If the user does not contain the attribute then we can't check any further, don't set has_access and just continue
         if user_value is None:
-            _prefixed_debug(auth_id, map_id, f"Attr [{attribute}] is not present in user attributes, skipping")
+            _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] is not present in user attributes, skipping")
             continue
 
         if type(user_value) is not list:
             # If the value is a string then convert it to a list
             user_value = [user_value]
 
-        has_access = _process_user_value(has_access, trigger_condition, user_value, join_condition, attribute, auth_id, map_id)
+        has_access = _process_user_value(has_access, trigger_condition, user_value, join_condition, attribute, map_id, tracking_id)
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
 
 
+def _evaluate_equals(user_value: str, trigger_value: str) -> bool:
+    """Check if user value equals trigger value."""
+    return user_value == trigger_value
+
+
+def _evaluate_matches(user_value: str, trigger_value: str) -> bool:
+    """Check if user value matches regex pattern."""
+    return re.match(trigger_value, user_value, re.IGNORECASE) is not None
+
+
+def _evaluate_contains(user_value: str, trigger_value: str) -> bool:
+    """Check if user value contains trigger value."""
+    return trigger_value in user_value
+
+
+def _evaluate_ends_with(user_value: str, trigger_value: str) -> bool:
+    """Check if user value ends with trigger value."""
+    return user_value.endswith(trigger_value)
+
+
+def _evaluate_in(user_value: str, trigger_value: List[str]) -> bool:
+    """Check if user value is in trigger value list."""
+    return user_value in trigger_value
+
+
+def _get_operator_messages(operator: str, result: bool) -> str:
+    """Get appropriate message text for operator and result."""
+    messages = {
+        "equals": ("is equal", "is not equal"),
+        "matches": ("matches", "does not match"),
+        "contains": ("contains", "does not contain"),
+        "ends_with": ("ends with", "does not end with"),
+        "in": ("is in", "is not in"),
+    }
+    true_msg, false_msg = messages.get(operator, ("", ""))
+    return true_msg if result else false_msg
+
+
 def _process_user_value(
-    has_access: Optional[bool], trigger_condition: dict, user_value: List[str], join_condition: str, attribute: str, auth_id: int, map_id: int
+    has_access: Optional[bool], trigger_condition: dict, user_value: List[str], join_condition: str, attribute: str, map_id: int, tracking_id: str
 ) -> Optional[bool]:
+    # Operator dispatch table
+    operators = {
+        "equals": _evaluate_equals,
+        "matches": _evaluate_matches,
+        "contains": _evaluate_contains,
+        "ends_with": _evaluate_ends_with,
+        "in": _evaluate_in,
+    }
+
+    condition = trigger_condition[attribute]
+
+    # Find which operator is present (preserve original priority order)
+    operator = None
+    trigger_value = None
+    for op in ["equals", "matches", "contains", "ends_with", "in"]:
+        if op in condition:
+            operator = op
+            trigger_value = condition[op]
+            break
+
+    if not operator:
+        return has_access
+
+    evaluate_fn = operators[operator]
+
     for a_user_value in user_value:
-        # We are going to do mostly string comparisons, so convert the attribute to a
-        #  string just in case it came back as an int or something funky
-        a_user_value = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
+        # Normalize user value for comparison
+        user_str = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
 
-        # Check for any of the valid conditions
-        header = f"Attr [{attribute}] value [{a_user_value}]"
-        if "equals" in trigger_condition[attribute]:
-            trigger_value = trigger_condition[attribute]["equals"]
-            is_equal = a_user_value == trigger_value
-            has_access = has_access_with_join(has_access, is_equal, join_condition)
-            _prefixed_debug(auth_id, map_id, f"{header} is {'equal' if is_equal else 'not equal'} to [{trigger_value}], {_result_suffix(is_equal)}")
+        # Evaluate condition
+        result = evaluate_fn(user_str, trigger_value)
+        has_access = has_access_with_join(has_access, result, join_condition)
 
-        elif "matches" in trigger_condition[attribute]:
-            trigger_value = trigger_condition[attribute]["matches"]
-            is_match = re.match(trigger_value, a_user_value, re.IGNORECASE) is not None
-            has_access = has_access_with_join(has_access, is_match, join_condition)
-            _prefixed_debug(auth_id, map_id, f"{header} {'matches' if is_match else 'does not match'} [{trigger_value}], {_result_suffix(is_match)}")
-
-        elif "contains" in trigger_condition[attribute]:
-            trigger_value = trigger_condition[attribute]['contains']
-            does_contain = trigger_value in a_user_value
-            has_access = has_access_with_join(has_access, does_contain, join_condition)
-            _prefixed_debug(auth_id, map_id, f"{header} {'contains' if does_contain else 'does not contain'} [{trigger_value}], {_result_suffix(does_contain)}")
-
-        elif "ends_with" in trigger_condition[attribute]:
-            trigger_value = trigger_condition[attribute]['ends_with']
-            does_end_with = a_user_value.endswith(trigger_value)
-            has_access = has_access_with_join(has_access, does_end_with, join_condition)
-            _prefixed_debug(
-                auth_id,
-                map_id,
-                f"{header} {'ends with' if does_end_with else 'does not end with'} [{trigger_value}], {_result_suffix(does_end_with)}",
-            )
-
-        elif "in" in trigger_condition[attribute]:
-            trigger_value = trigger_condition[attribute]['in']
-            is_in = a_user_value in trigger_value
-            has_access = has_access_with_join(has_access, is_in, join_condition)
-            _prefixed_debug(auth_id, map_id, f"{header} {'is in' if is_in else 'is not in'} [{trigger_value}], {_result_suffix(is_in)}")
+        # Log result
+        header = f"Attr [{attribute}] value [{user_str}]"
+        message = _get_operator_messages(operator, result)
+        _prefixed_debug(map_id, tracking_id, f"{header} {message} to [{trigger_value}], {_result_suffix(result)}")
 
     return has_access
 

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -334,10 +334,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: i
 
         # The attribute is an empty dict we just need to see if the user has the attribute or not
         if trigger_condition[attribute] == {}:
-            has_access = has_access_with_join(has_access, attribute in attributes, join_condition)
-            _prefixed_debug(
-                map_id, tracking_id, f"Attr [{attribute}] without value constraint {'is' if attribute in attributes else 'is not'} present, allowing"
-            )
+            has_access = has_access_with_join(has_access, _check_empty_attribute(attribute, attributes, map_id, tracking_id), join_condition)
             continue
 
         user_value = attributes.get(attribute, None)
@@ -353,6 +350,15 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: i
         has_access = _process_user_value(has_access, trigger_condition, user_value, join_condition, attribute, map_id, tracking_id)
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
+
+
+def _check_empty_attribute(attribute: str, attributes: dict, map_id: int, tracking_id: str) -> bool:
+    _prefixed_debug(
+        map_id,
+        tracking_id,
+        f"Attr [{attribute}] without value constraint {'is' if attribute in attributes else 'is not'} present, {_result_suffix(attribute in attributes)}",
+    )
+    return attribute in attributes
 
 
 def _check_early_exit(has_access: Optional[bool], join_condition: str, map_id: int, tracking_id: str) -> bool:
@@ -393,7 +399,7 @@ def _evaluate_in(user_value: str, trigger_value: str) -> bool:
 def _get_operator_messages(operator: str, result: bool) -> str:
     """Get appropriate message text for operator and result."""
     messages = {
-        "equals": ("is equal", "is not equal"),
+        "equals": ("equals", "does not equal"),
         "matches": ("matches", "does not match"),
         "contains": ("contains", "does not contain"),
         "ends_with": ("ends with", "does not end with"),
@@ -442,7 +448,7 @@ def _process_user_value(
         # Log result
         header = f"Attr [{attribute}] value [{user_str}]"
         message = _get_operator_messages(operator, result)
-        _prefixed_debug(map_id, tracking_id, f"{header} {message} to [{trigger_value}], {_result_suffix(result)}")
+        _prefixed_debug(map_id, tracking_id, f"{header} {message} [{trigger_value}], {_result_suffix(result)}")
 
     return has_access
 

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -58,62 +58,61 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
     logger.debug(f"{username}'s attrs: {attrs}")
 
     # load the maps
-    logger.debug(f"Authenticator ID: {authenticator.id}")
-    maps = AuthenticatorMap.objects.filter(authenticator=authenticator.id).order_by("order")
-    logger.debug("==============================================================")
-    logger.debug(f"Processing {maps.count()} map(s) for this authenticator")
+    apk = authenticator.pk
+    maps = AuthenticatorMap.objects.filter(authenticator=apk).order_by("order")
+    logger.debug(f"Processing {maps.count()} map(s) for Authenticator ID [{apk}]")
 
     for auth_map in maps:
-        logger.debug(f"Processing map {auth_map.name} {auth_map.id}")
+        mpk = auth_map.pk
         has_permission = None
         trigger_result = TriggerResult.SKIP
         allowed_keys = TRIGGER_DEFINITION.keys()
         invalid_keys = set(auth_map.triggers.keys()) - set(allowed_keys)
 
         if auth_map.enabled is False:
-            logger.info(f"Skipping AuthenticatorMap {auth_map.id} because it is disabled")
-            rule_responses.append({auth_map.id: 'skipped', 'enabled': auth_map.enabled})
+            logger.info(f"Skipping AuthenticatorMap {mpk} because it is disabled")
+            rule_responses.append({mpk: 'skipped', 'enabled': auth_map.enabled})
             continue
 
         if invalid_keys:
-            logger.warning(f"In AuthenticatorMap {auth_map.id} the following trigger keys are invalid: {', '.join(invalid_keys)}, rule will be ignored")
-            rule_responses.append({auth_map.id: 'invalid', 'enabled': auth_map.enabled})
+            logger.warning(f"In AuthenticatorMap {mpk} the following trigger keys are invalid: {', '.join(invalid_keys)}, rule will be ignored")
+            rule_responses.append({mpk: 'invalid', 'enabled': auth_map.enabled})
             continue
 
         for trigger_type, trigger in auth_map.triggers.items():
             if trigger_type == 'groups':
-                logger.debug("Groups trigger, comparing user groups to trigger groups")
-                trigger_result = process_groups(trigger, groups, authenticator.pk)
+                _prefixed_debug(apk, mpk, "Groups trigger, comparing user groups to trigger groups")
+                trigger_result = process_groups(trigger, groups, apk, mpk)
             elif trigger_type == 'attributes':
-                logger.debug("Attributes trigger, comparing user attrs to trigger attrs")
-                trigger_result = process_user_attributes(trigger, attrs, authenticator.pk)
+                _prefixed_debug(apk, mpk, "Attributes trigger, comparing user attrs to trigger attrs")
+                trigger_result = process_user_attributes(trigger, attrs, apk, mpk)
             elif trigger_type == 'always':
-                logger.debug("Always trigger, allowing")
+                _prefixed_debug(apk, mpk, "Always trigger, allowing")
                 trigger_result = TriggerResult.ALLOW
             elif trigger_type == 'never':
-                logger.debug("Never trigger, denying")
+                _prefixed_debug(apk, mpk, "Never trigger, denying")
                 trigger_result = TriggerResult.DENY
 
         # If the trigger result is SKIP, auth map is not defined for this user.
         # Together with "revoke" flag => change permission to DENY
         if auth_map.revoke and trigger_result is TriggerResult.SKIP:
-            logger.debug(f"Revoke flag is set for map {auth_map.id}, denying and revoking permission")
+            _prefixed_debug(apk, mpk, "Revoke flag is set for map, denying and revoking permission")
             trigger_result = TriggerResult.DENY
 
         # If the trigger result is still SKIP, this auth map is not applicable to this user => no action needed
         if trigger_result is TriggerResult.SKIP:
-            logger.debug(f"Trigger result is SKIP, skipping map {auth_map.id}, no action needed")
-            rule_responses.append({auth_map.id: 'skipped', 'enabled': auth_map.enabled})
+            _prefixed_debug(apk, mpk, "Trigger result is SKIP, skipping map, no action needed")
+            rule_responses.append({mpk: 'skipped', 'enabled': auth_map.enabled})
             continue
 
         if trigger_result is TriggerResult.ALLOW:
-            logger.debug(f"Trigger result is ALLOW, allowing map {auth_map.id}, applying permission")
+            _prefixed_debug(apk, mpk, "Trigger result is ALLOW, allowing map, applying permission")
             has_permission = True
         elif trigger_result is TriggerResult.DENY:
-            logger.debug(f"Trigger result is DENY, denying map {auth_map.id}, revoking permission")
+            _prefixed_debug(apk, mpk, "Trigger result is DENY, denying map, revoking permission")
             has_permission = False
 
-        rule_responses.append({auth_map.id: has_permission, 'enabled': auth_map.enabled})
+        rule_responses.append({mpk: has_permission, 'enabled': auth_map.enabled})
 
         understood_map = False
         if auth_map.map_type == 'allow' and not has_permission:
@@ -164,6 +163,11 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
         },
         "last_login_map_results": rule_responses,
     }
+
+
+def _prefixed_debug(authenticator_pk: int, auth_map_pk: int, message: str):
+    prefix = f"Authenticator [{authenticator_pk}] Map [{auth_map_pk}]"
+    logger.debug(f"{prefix} {message}")
 
 
 def _add_rbac_role_mapping(has_permission, role_mapping, role, organization=None, team=None):
@@ -220,7 +224,7 @@ def _lowercase_group_triggers(trigger_condition: dict) -> dict:
     return ci_trigger_condition
 
 
-def process_groups(trigger_condition: dict, groups: list, authenticator_id: int) -> TriggerResult:
+def process_groups(trigger_condition: dict, groups: list, authenticator_id: int, map_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
     Group DNs are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS enabled.
@@ -238,25 +242,25 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int)
     if "has_or" in trigger_condition:
         matching_groups = set_of_user_groups.intersection(set(trigger_condition["has_or"]))
         if matching_groups:
-            logger.debug(f"User has at least one trigger group [{matching_groups}], allowing")
+            _prefixed_debug(authenticator_id, map_id, f"User has at least one trigger group [{matching_groups}], allowing")
             return TriggerResult.ALLOW
         else:
-            logger.debug("User does not have any trigger groups, skipping")
+            _prefixed_debug(authenticator_id, map_id, "User does not have any trigger groups, skipping")
 
     elif "has_and" in trigger_condition:
         if set(trigger_condition["has_and"]).issubset(set_of_user_groups):
-            logger.debug("User has all groups in trigger, allowing")
+            _prefixed_debug(authenticator_id, map_id, "User has all groups in trigger, allowing")
             return TriggerResult.ALLOW
         else:
-            logger.debug("User does not have all trigger groups, skipping")
+            _prefixed_debug(authenticator_id, map_id, "User does not have all trigger groups, skipping")
 
     elif "has_not" in trigger_condition:
         unwanted_groups = set(trigger_condition["has_not"]).intersection(set_of_user_groups)
         if not unwanted_groups:
-            logger.debug("User does not have disallowed groups, allowing")
+            _prefixed_debug(authenticator_id, map_id, "User does not have disallowed groups, allowing")
             return TriggerResult.ALLOW
         else:
-            logger.debug(f"User has one or more disallowed groups [{unwanted_groups}], skipping")
+            _prefixed_debug(authenticator_id, map_id, f"User has one or more disallowed groups [{unwanted_groups}], skipping")
     return TriggerResult.SKIP
 
 
@@ -294,13 +298,13 @@ def _lowercase_attr_triggers(trigger_condition: dict) -> dict:
     return ci_trigger_condition
 
 
-def process_user_attributes(trigger_condition: dict, attributes: dict, authenticator_id: int) -> TriggerResult:
+def process_user_attributes(trigger_condition: dict, attributes: dict, authenticator_id: int, map_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
     if _is_case_insensitivity_enabled():
-        logger.debug("Case insensitivity enabled, converting attributes and values to lowercase")
+        _prefixed_debug(authenticator_id, map_id, "Case insensitivity enabled, converting attributes and values to lowercase")
         attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
         trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
@@ -313,11 +317,11 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     for attribute in trigger_condition.keys():
         if has_access and join_condition == 'or':
             # If we are an or condition and we already have a positive we can break out and return
-            logger.debug("At least one attribute match with OR join, allowing")
+            _prefixed_debug(authenticator_id, map_id, "At least one attribute match with OR join, allowing")
             break
         elif has_access is False and join_condition == 'and':
             # If we are an and and already have a False we can give up
-            logger.debug("At least one attribute mismatch with AND join, skipping")
+            _prefixed_debug(authenticator_id, map_id, "At least one attribute mismatch with AND join, skipping")
             break
 
         # We can skip the join_condition since we already processed that.
@@ -335,13 +339,15 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
         # The attribute is an empty dict we just need to see if the user has the attribute or not
         if trigger_condition[attribute] == {}:
             has_access = has_access_with_join(has_access, attribute in attributes, join_condition)
-            logger.debug(f"Attr {attribute} without value constraint {'is' if attribute in attributes else 'is not'} present, allowing")
+            _prefixed_debug(
+                authenticator_id, map_id, f"Attr {attribute} without value constraint {'is' if attribute in attributes else 'is not'} present, allowing"
+            )
             continue
 
         user_value = attributes.get(attribute, None)
         # If the user does not contain the attribute then we can't check any further, don't set has_access and just continue
         if user_value is None:
-            logger.debug(f"Attr {attribute} is not present in user attributes, skipping")
+            _prefixed_debug(authenticator_id, map_id, f"Attr {attribute} is not present in user attributes, skipping")
             continue
 
         if type(user_value) is not list:
@@ -354,36 +360,42 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
             a_user_value = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
 
             # Check for any of the valid conditions
-            prefix = f"Attr {attribute} value {a_user_value}"
+            header = f"Attr [{attribute}] value [{a_user_value}]"
             if "equals" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]["equals"]
                 is_equal = a_user_value == trigger_value
                 has_access = has_access_with_join(has_access, is_equal, join_condition)
-                logger.debug(f"{prefix} is {'equal' if is_equal else 'not equal'} to {trigger_value}, {_result_suffix(is_equal)}")
+                _prefixed_debug(authenticator_id, map_id, f"{header} is {'equal' if is_equal else 'not equal'} to {trigger_value}, {_result_suffix(is_equal)}")
 
             elif "matches" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]["matches"]
                 is_match = re.match(trigger_value, a_user_value, re.IGNORECASE) is not None
                 has_access = has_access_with_join(has_access, is_match, join_condition)
-                logger.debug(f"{prefix} {'matches' if is_match else 'does not match'} {trigger_value}, {_result_suffix(is_match)}")
+                _prefixed_debug(authenticator_id, map_id, f"{header} {'matches' if is_match else 'does not match'} {trigger_value}, {_result_suffix(is_match)}")
 
             elif "contains" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]['contains']
                 does_contain = trigger_value in a_user_value
                 has_access = has_access_with_join(has_access, does_contain, join_condition)
-                logger.debug(f"{prefix} {'contains' if does_contain else 'does not contain'} {trigger_value}, {_result_suffix(does_contain)}")
+                _prefixed_debug(
+                    authenticator_id, map_id, f"{header} {'contains' if does_contain else 'does not contain'} {trigger_value}, {_result_suffix(does_contain)}"
+                )
 
             elif "ends_with" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]['ends_with']
                 does_end_with = a_user_value.endswith(trigger_value)
                 has_access = has_access_with_join(has_access, does_end_with, join_condition)
-                logger.debug(f"{prefix} {'ends with' if does_end_with else 'does not end with'} {trigger_value}, {_result_suffix(does_end_with)}")
+                _prefixed_debug(
+                    authenticator_id,
+                    map_id,
+                    f"{header} {'ends with' if does_end_with else 'does not end with'} {trigger_value}, {_result_suffix(does_end_with)}",
+                )
 
             elif "in" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]['in']
                 is_in = a_user_value in trigger_value
                 has_access = has_access_with_join(has_access, is_in, join_condition)
-                logger.debug(f"{prefix} {'is in' if is_in else 'is not in'} {trigger_value}, {_result_suffix(is_in)}")
+                _prefixed_debug(authenticator_id, map_id, f"{header} {'is in' if is_in else 'is not in'} {trigger_value}, {_result_suffix(is_in)}")
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
 

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -384,7 +384,7 @@ def _evaluate_ends_with(user_value: str, trigger_value: str) -> bool:
     return user_value.endswith(trigger_value)
 
 
-def _evaluate_in(user_value: str, trigger_value: List[str]) -> bool:
+def _evaluate_in(user_value: str, trigger_value: str) -> bool:
     """Check if user value is in trigger value list."""
     return user_value in trigger_value
 

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -224,7 +224,7 @@ def _lowercase_group_triggers(trigger_condition: dict) -> dict:
     return ci_trigger_condition
 
 
-def process_groups(trigger_condition: dict, groups: list, authenticator_id: int, map_id: int) -> TriggerResult:
+def process_groups(trigger_condition: dict, groups: list, auth_id: int, map_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
     Group DNs are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS enabled.
@@ -235,32 +235,32 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int,
 
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
-        logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {authenticator_id} are invalid and won't be processed")
+        logger.warning(f"The conditions {', '.join(invalid_conditions)} for groups in mapping {auth_id} are invalid and won't be processed")
 
     set_of_user_groups = set(groups)
 
     if "has_or" in trigger_condition:
         matching_groups = set_of_user_groups.intersection(set(trigger_condition["has_or"]))
         if matching_groups:
-            _prefixed_debug(authenticator_id, map_id, f"User has at least one trigger group [{matching_groups}], allowing")
+            _prefixed_debug(auth_id, map_id, f"User has at least one trigger group [{matching_groups}], allowing")
             return TriggerResult.ALLOW
         else:
-            _prefixed_debug(authenticator_id, map_id, "User does not have any trigger groups, skipping")
+            _prefixed_debug(auth_id, map_id, "User does not have any trigger groups, skipping")
 
     elif "has_and" in trigger_condition:
         if set(trigger_condition["has_and"]).issubset(set_of_user_groups):
-            _prefixed_debug(authenticator_id, map_id, "User has all groups in trigger, allowing")
+            _prefixed_debug(auth_id, map_id, "User has all groups in trigger, allowing")
             return TriggerResult.ALLOW
         else:
-            _prefixed_debug(authenticator_id, map_id, "User does not have all trigger groups, skipping")
+            _prefixed_debug(auth_id, map_id, "User does not have all trigger groups, skipping")
 
     elif "has_not" in trigger_condition:
         unwanted_groups = set(trigger_condition["has_not"]).intersection(set_of_user_groups)
         if not unwanted_groups:
-            _prefixed_debug(authenticator_id, map_id, "User does not have disallowed groups, allowing")
+            _prefixed_debug(auth_id, map_id, "User does not have disallowed groups, allowing")
             return TriggerResult.ALLOW
         else:
-            _prefixed_debug(authenticator_id, map_id, f"User has one or more disallowed groups [{unwanted_groups}], skipping")
+            _prefixed_debug(auth_id, map_id, f"User has one or more disallowed groups [{unwanted_groups}], skipping")
     return TriggerResult.SKIP
 
 
@@ -298,30 +298,30 @@ def _lowercase_attr_triggers(trigger_condition: dict) -> dict:
     return ci_trigger_condition
 
 
-def process_user_attributes(trigger_condition: dict, attributes: dict, authenticator_id: int, map_id: int) -> TriggerResult:
+def process_user_attributes(trigger_condition: dict, attributes: dict, auth_id: int, map_id: int) -> TriggerResult:
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
     Attribute names are compared case-insensitively.
     """
     if _is_case_insensitivity_enabled():
-        _prefixed_debug(authenticator_id, map_id, "Case insensitivity enabled, converting attributes and values to lowercase")
+        _prefixed_debug(auth_id, map_id, "Case insensitivity enabled, converting attributes and values to lowercase")
         attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
         trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
     has_access = None
     join_condition = trigger_condition.get('join_condition', 'or')
     if join_condition not in TRIGGER_DEFINITION['attributes']['keys']['join_condition']['choices']:
-        logger.warning("Trigger join_condition {join_condition} on authenticator map {authenticator_id} is invalid and will be set to 'or'")
+        logger.warning("Trigger join_condition {join_condition} on authenticator map {auth_id} is invalid and will be set to 'or'")
         join_condition = 'or'
 
     for attribute in trigger_condition.keys():
         if has_access and join_condition == 'or':
             # If we are an or condition and we already have a positive we can break out and return
-            _prefixed_debug(authenticator_id, map_id, "At least one attribute match with OR join, allowing")
+            _prefixed_debug(auth_id, map_id, "At least one attribute match with OR join, allowing")
             break
         elif has_access is False and join_condition == 'and':
             # If we are an and and already have a False we can give up
-            _prefixed_debug(authenticator_id, map_id, "At least one attribute mismatch with AND join, skipping")
+            _prefixed_debug(auth_id, map_id, "At least one attribute mismatch with AND join, skipping")
             break
 
         # We can skip the join_condition since we already processed that.
@@ -332,22 +332,19 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
         invalid_conditions = set(trigger_condition[attribute].keys()) - set(TRIGGER_DEFINITION['attributes']['keys']['*']['keys'].keys())
         if invalid_conditions:
             logger.warning(
-                f"The conditions {', '.join(invalid_conditions)} for attribute {attribute} "
-                "in authenticator map {authenticator_id} are invalid and won't be processed"
+                f"The conditions {', '.join(invalid_conditions)} for attribute {attribute} " "in authenticator map {auth_id} are invalid and won't be processed"
             )
 
         # The attribute is an empty dict we just need to see if the user has the attribute or not
         if trigger_condition[attribute] == {}:
             has_access = has_access_with_join(has_access, attribute in attributes, join_condition)
-            _prefixed_debug(
-                authenticator_id, map_id, f"Attr {attribute} without value constraint {'is' if attribute in attributes else 'is not'} present, allowing"
-            )
+            _prefixed_debug(auth_id, map_id, f"Attr [{attribute}] without value constraint {'is' if attribute in attributes else 'is not'} present, allowing")
             continue
 
         user_value = attributes.get(attribute, None)
         # If the user does not contain the attribute then we can't check any further, don't set has_access and just continue
         if user_value is None:
-            _prefixed_debug(authenticator_id, map_id, f"Attr {attribute} is not present in user attributes, skipping")
+            _prefixed_debug(auth_id, map_id, f"Attr [{attribute}] is not present in user attributes, skipping")
             continue
 
         if type(user_value) is not list:
@@ -365,20 +362,20 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
                 trigger_value = trigger_condition[attribute]["equals"]
                 is_equal = a_user_value == trigger_value
                 has_access = has_access_with_join(has_access, is_equal, join_condition)
-                _prefixed_debug(authenticator_id, map_id, f"{header} is {'equal' if is_equal else 'not equal'} to {trigger_value}, {_result_suffix(is_equal)}")
+                _prefixed_debug(auth_id, map_id, f"{header} is {'equal' if is_equal else 'not equal'} to [{trigger_value}], {_result_suffix(is_equal)}")
 
             elif "matches" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]["matches"]
                 is_match = re.match(trigger_value, a_user_value, re.IGNORECASE) is not None
                 has_access = has_access_with_join(has_access, is_match, join_condition)
-                _prefixed_debug(authenticator_id, map_id, f"{header} {'matches' if is_match else 'does not match'} {trigger_value}, {_result_suffix(is_match)}")
+                _prefixed_debug(auth_id, map_id, f"{header} {'matches' if is_match else 'does not match'} [{trigger_value}], {_result_suffix(is_match)}")
 
             elif "contains" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]['contains']
                 does_contain = trigger_value in a_user_value
                 has_access = has_access_with_join(has_access, does_contain, join_condition)
                 _prefixed_debug(
-                    authenticator_id, map_id, f"{header} {'contains' if does_contain else 'does not contain'} {trigger_value}, {_result_suffix(does_contain)}"
+                    auth_id, map_id, f"{header} {'contains' if does_contain else 'does not contain'} [{trigger_value}], {_result_suffix(does_contain)}"
                 )
 
             elif "ends_with" in trigger_condition[attribute]:
@@ -386,16 +383,16 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
                 does_end_with = a_user_value.endswith(trigger_value)
                 has_access = has_access_with_join(has_access, does_end_with, join_condition)
                 _prefixed_debug(
-                    authenticator_id,
+                    auth_id,
                     map_id,
-                    f"{header} {'ends with' if does_end_with else 'does not end with'} {trigger_value}, {_result_suffix(does_end_with)}",
+                    f"{header} {'ends with' if does_end_with else 'does not end with'} [{trigger_value}], {_result_suffix(does_end_with)}",
                 )
 
             elif "in" in trigger_condition[attribute]:
                 trigger_value = trigger_condition[attribute]['in']
                 is_in = a_user_value in trigger_value
                 has_access = has_access_with_join(has_access, is_in, join_condition)
-                _prefixed_debug(authenticator_id, map_id, f"{header} {'is in' if is_in else 'is not in'} {trigger_value}, {_result_suffix(is_in)}")
+                _prefixed_debug(auth_id, map_id, f"{header} {'is in' if is_in else 'is not in'} [{trigger_value}], {_result_suffix(is_in)}")
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
 

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -314,24 +314,15 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: i
         trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
     has_access = None
-    join_condition = trigger_condition.get('join_condition', 'or')
+    join_condition = trigger_condition.pop('join_condition', 'or')
     if join_condition not in TRIGGER_DEFINITION['attributes']['keys']['join_condition']['choices']:
         logger.warning(f"[{tracking_id}] Trigger join_condition {join_condition} on authenticator map {map_id} is invalid and will be set to 'or'")
         join_condition = 'or'
 
     for attribute in trigger_condition.keys():
-        if has_access and join_condition == 'or':
-            # If we are an or condition and we already have a positive we can break out and return
-            _prefixed_debug(map_id, tracking_id, "At least one attribute match with OR join, allowing")
+        # If we have already determined the result, we can break out and return
+        if _check_early_exit(has_access, join_condition, map_id, tracking_id):
             break
-        elif has_access is False and join_condition == 'and':
-            # If we are an and and already have a False we can give up
-            _prefixed_debug(map_id, tracking_id, "At least one attribute mismatch with AND join, skipping")
-            break
-
-        # We can skip the join_condition since we already processed that.
-        if attribute == 'join_condition':
-            continue
 
         # Warn if there are any invalid conditions, we are just going to ignore them
         invalid_conditions = set(trigger_condition[attribute].keys()) - set(TRIGGER_DEFINITION['attributes']['keys']['*']['keys'].keys())
@@ -362,6 +353,16 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: i
         has_access = _process_user_value(has_access, trigger_condition, user_value, join_condition, attribute, map_id, tracking_id)
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
+
+
+def _check_early_exit(has_access: Optional[bool], join_condition: str, map_id: int, tracking_id: str) -> bool:
+    if has_access and join_condition == 'or':
+        _prefixed_debug(map_id, tracking_id, "At least one attribute match with OR join, allowing")
+        return True
+    elif has_access is False and join_condition == 'and':
+        _prefixed_debug(map_id, tracking_id, "At least one attribute mismatch with AND join, skipping")
+        return True
+    return False
 
 
 def _evaluate_equals(user_value: str, trigger_value: str) -> bool:

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -354,42 +354,42 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
             a_user_value = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
 
             # Check for any of the valid conditions
+            prefix = f"Attr {attribute} value {a_user_value}"
             if "equals" in trigger_condition[attribute]:
-                is_equal = a_user_value == trigger_condition[attribute]["equals"]
+                trigger_value = trigger_condition[attribute]["equals"]
+                is_equal = a_user_value == trigger_value
                 has_access = has_access_with_join(has_access, is_equal, join_condition)
-                logger.debug(
-                    f"Attr {attribute} value {a_user_value} is {'equal' if is_equal else 'not equal'} to {trigger_condition[attribute]['equals']}, {'allowing' if is_equal else 'skipping'}"
-                )
+                logger.debug(f"{prefix} is {'equal' if is_equal else 'not equal'} to {trigger_value}, {_result_suffix(is_equal)}")
 
             elif "matches" in trigger_condition[attribute]:
-                is_match = re.match(trigger_condition[attribute]["matches"], a_user_value, re.IGNORECASE) is not None
+                trigger_value = trigger_condition[attribute]["matches"]
+                is_match = re.match(trigger_value, a_user_value, re.IGNORECASE) is not None
                 has_access = has_access_with_join(has_access, is_match, join_condition)
-                logger.debug(
-                    f"Attr {attribute} value {a_user_value} {'matches' if is_match else 'does not match'} {trigger_condition[attribute]['matches']}, {'allowing' if is_match else 'skipping'}"
-                )
+                logger.debug(f"{prefix} {'matches' if is_match else 'does not match'} {trigger_value}, {_result_suffix(is_match)}")
 
             elif "contains" in trigger_condition[attribute]:
-                does_contain = trigger_condition[attribute]['contains'] in a_user_value
+                trigger_value = trigger_condition[attribute]['contains']
+                does_contain = trigger_value in a_user_value
                 has_access = has_access_with_join(has_access, does_contain, join_condition)
-                logger.debug(
-                    f"Attr {attribute} value {a_user_value} {'contains' if does_contain else 'does not contain'} {trigger_condition[attribute]['contains']}, {'allowing' if does_contain else 'skipping'}"
-                )
+                logger.debug(f"{prefix} {'contains' if does_contain else 'does not contain'} {trigger_value}, {_result_suffix(does_contain)}")
 
             elif "ends_with" in trigger_condition[attribute]:
-                does_end_with = a_user_value.endswith(trigger_condition[attribute]['ends_with'])
+                trigger_value = trigger_condition[attribute]['ends_with']
+                does_end_with = a_user_value.endswith(trigger_value)
                 has_access = has_access_with_join(has_access, does_end_with, join_condition)
-                logger.debug(
-                    f"Attr {attribute} value {a_user_value} {'ends with' if does_end_with else 'does not end with'} {trigger_condition[attribute]['ends_with']}, {'allowing' if does_end_with else 'skipping'}"
-                )
+                logger.debug(f"{prefix} {'ends with' if does_end_with else 'does not end with'} {trigger_value}, {_result_suffix(does_end_with)}")
 
             elif "in" in trigger_condition[attribute]:
-                is_in = a_user_value in trigger_condition[attribute]['in']
+                trigger_value = trigger_condition[attribute]['in']
+                is_in = a_user_value in trigger_value
                 has_access = has_access_with_join(has_access, is_in, join_condition)
-                logger.debug(
-                    f"Attr {attribute} value {a_user_value} {'is in' if is_in else 'is not in'} {trigger_condition[attribute]['in']}, {'allowing' if is_in else 'skipping'}"
-                )
+                logger.debug(f"{prefix} {'is in' if is_in else 'is not in'} {trigger_value}, {_result_suffix(is_in)}")
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
+
+
+def _result_suffix(result: bool) -> str:
+    return "allowing" if result else "skipping"
 
 
 def update_user_claims(user: Optional[AbstractUser], database_authenticator: Authenticator, groups: list[str]) -> Optional[AbstractUser]:

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -61,7 +61,7 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
     logger.debug(f"Authenticator ID: {authenticator.id}")
     maps = AuthenticatorMap.objects.filter(authenticator=authenticator.id).order_by("order")
     logger.debug("==============================================================")
-    logger.debug("Processing {maps.count()} map(s) for this authenticator")
+    logger.debug(f"Processing {maps.count()} map(s) for this authenticator")
 
     for auth_map in maps:
         logger.debug(f"Processing map {auth_map.name} {auth_map.id}")
@@ -82,27 +82,35 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
 
         for trigger_type, trigger in auth_map.triggers.items():
             if trigger_type == 'groups':
+                logger.debug("Groups trigger, comparing user groups to trigger groups")
                 trigger_result = process_groups(trigger, groups, authenticator.pk)
             elif trigger_type == 'attributes':
+                logger.debug("Attributes trigger, comparing user attrs to trigger attrs")
                 trigger_result = process_user_attributes(trigger, attrs, authenticator.pk)
             elif trigger_type == 'always':
+                logger.debug("Always trigger, allowing")
                 trigger_result = TriggerResult.ALLOW
             elif trigger_type == 'never':
+                logger.debug("Never trigger, denying")
                 trigger_result = TriggerResult.DENY
 
         # If the trigger result is SKIP, auth map is not defined for this user.
         # Together with "revoke" flag => change permission to DENY
         if auth_map.revoke and trigger_result is TriggerResult.SKIP:
+            logger.debug(f"Revoke flag is set for map {auth_map.id}, denying and revoking permission")
             trigger_result = TriggerResult.DENY
 
         # If the trigger result is still SKIP, this auth map is not applicable to this user => no action needed
         if trigger_result is TriggerResult.SKIP:
+            logger.debug(f"Trigger result is SKIP, skipping map {auth_map.id}, no action needed")
             rule_responses.append({auth_map.id: 'skipped', 'enabled': auth_map.enabled})
             continue
 
         if trigger_result is TriggerResult.ALLOW:
+            logger.debug(f"Trigger result is ALLOW, allowing map {auth_map.id}, applying permission")
             has_permission = True
         elif trigger_result is TriggerResult.DENY:
+            logger.debug(f"Trigger result is DENY, denying map {auth_map.id}, revoking permission")
             has_permission = False
 
         rule_responses.append({auth_map.id: has_permission, 'enabled': auth_map.enabled})
@@ -228,17 +236,27 @@ def process_groups(trigger_condition: dict, groups: list, authenticator_id: int)
     set_of_user_groups = set(groups)
 
     if "has_or" in trigger_condition:
-        if set_of_user_groups.intersection(set(trigger_condition["has_or"])):
+        matching_groups = set_of_user_groups.intersection(set(trigger_condition["has_or"]))
+        if matching_groups:
+            logger.debug(f"User has at least one trigger group [{matching_groups}], allowing")
             return TriggerResult.ALLOW
+        else:
+            logger.debug("User does not have any trigger groups, skipping")
 
     elif "has_and" in trigger_condition:
         if set(trigger_condition["has_and"]).issubset(set_of_user_groups):
+            logger.debug("User has all groups in trigger, allowing")
             return TriggerResult.ALLOW
+        else:
+            logger.debug("User does not have all trigger groups, skipping")
 
     elif "has_not" in trigger_condition:
-        if not set(trigger_condition["has_not"]).intersection(set_of_user_groups):
+        unwanted_groups = set(trigger_condition["has_not"]).intersection(set_of_user_groups)
+        if not unwanted_groups:
+            logger.debug("User does not have disallowed groups, allowing")
             return TriggerResult.ALLOW
-
+        else:
+            logger.debug(f"User has one or more disallowed groups [{unwanted_groups}], skipping")
     return TriggerResult.SKIP
 
 
@@ -282,6 +300,7 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     Attribute names are compared case-insensitively.
     """
     if _is_case_insensitivity_enabled():
+        logger.debug("Case insensitivity enabled, converting attributes and values to lowercase")
         attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
         trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
@@ -294,9 +313,11 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
     for attribute in trigger_condition.keys():
         if has_access and join_condition == 'or':
             # If we are an or condition and we already have a positive we can break out and return
+            logger.debug("At least one attribute match with OR join, allowing")
             break
         elif has_access is False and join_condition == 'and':
             # If we are an and and already have a False we can give up
+            logger.debug("At least one attribute mismatch with AND join, skipping")
             break
 
         # We can skip the join_condition since we already processed that.
@@ -314,11 +335,13 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
         # The attribute is an empty dict we just need to see if the user has the attribute or not
         if trigger_condition[attribute] == {}:
             has_access = has_access_with_join(has_access, attribute in attributes, join_condition)
+            logger.debug(f"Attr {attribute} without value constraint {'is' if attribute in attributes else 'is not'} present, allowing")
             continue
 
         user_value = attributes.get(attribute, None)
         # If the user does not contain the attribute then we can't check any further, don't set has_access and just continue
         if user_value is None:
+            logger.debug(f"Attr {attribute} is not present in user attributes, skipping")
             continue
 
         if type(user_value) is not list:
@@ -332,21 +355,39 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, authentic
 
             # Check for any of the valid conditions
             if "equals" in trigger_condition[attribute]:
-                has_access = has_access_with_join(has_access, a_user_value == trigger_condition[attribute]["equals"], join_condition)
+                is_equal = a_user_value == trigger_condition[attribute]["equals"]
+                has_access = has_access_with_join(has_access, is_equal, join_condition)
+                logger.debug(
+                    f"Attr {attribute} value {a_user_value} is {'equal' if is_equal else 'not equal'} to {trigger_condition[attribute]['equals']}, {'allowing' if is_equal else 'skipping'}"
+                )
 
             elif "matches" in trigger_condition[attribute]:
-                has_access = has_access_with_join(
-                    has_access, re.match(trigger_condition[attribute]["matches"], a_user_value, re.IGNORECASE) is not None, join_condition
+                is_match = re.match(trigger_condition[attribute]["matches"], a_user_value, re.IGNORECASE) is not None
+                has_access = has_access_with_join(has_access, is_match, join_condition)
+                logger.debug(
+                    f"Attr {attribute} value {a_user_value} {'matches' if is_match else 'does not match'} {trigger_condition[attribute]['matches']}, {'allowing' if is_match else 'skipping'}"
                 )
 
             elif "contains" in trigger_condition[attribute]:
-                has_access = has_access_with_join(has_access, trigger_condition[attribute]['contains'] in a_user_value, join_condition)
+                does_contain = trigger_condition[attribute]['contains'] in a_user_value
+                has_access = has_access_with_join(has_access, does_contain, join_condition)
+                logger.debug(
+                    f"Attr {attribute} value {a_user_value} {'contains' if does_contain else 'does not contain'} {trigger_condition[attribute]['contains']}, {'allowing' if does_contain else 'skipping'}"
+                )
 
             elif "ends_with" in trigger_condition[attribute]:
-                has_access = has_access_with_join(has_access, a_user_value.endswith(trigger_condition[attribute]['ends_with']), join_condition)
+                does_end_with = a_user_value.endswith(trigger_condition[attribute]['ends_with'])
+                has_access = has_access_with_join(has_access, does_end_with, join_condition)
+                logger.debug(
+                    f"Attr {attribute} value {a_user_value} {'ends with' if does_end_with else 'does not end with'} {trigger_condition[attribute]['ends_with']}, {'allowing' if does_end_with else 'skipping'}"
+                )
 
             elif "in" in trigger_condition[attribute]:
-                has_access = has_access_with_join(has_access, a_user_value in trigger_condition[attribute]['in'], join_condition)
+                is_in = a_user_value in trigger_condition[attribute]['in']
+                has_access = has_access_with_join(has_access, is_in, join_condition)
+                logger.debug(
+                    f"Attr {attribute} value {a_user_value} {'is in' if is_in else 'is not in'} {trigger_condition[attribute]['in']}, {'allowing' if is_in else 'skipping'}"
+                )
 
     return TriggerResult.ALLOW if has_access else TriggerResult.SKIP
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ skip_glob = [ "ansible_base/*/migrations" ]
 [tool.flake8]
 max-line-length = 160
 extend-ignore = [ "E203" ]
-exclude = [ 'ansible_base/*/migrations/*', 'test_app/migrations/*', '.tox', 'build']
+exclude = [ 'ansible_base/*/migrations/*', 'test_app/migrations/*', '.tox', 'build', '.venv', 'venv']
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "test_app.settings"

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -274,6 +274,7 @@ def test_create_claims_bad_map_type_logged(
     logger.error.assert_called_once()
     f"Map type bad_map_type of rule {local_authenticator_map.name} does not know how to be processed" in logger.error.call_args
 
+
 def test_create_claims_multiple_same_org(
     local_authenticator_map,
     local_authenticator_map_1,

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -271,8 +271,8 @@ def test_create_claims_bad_map_type_logged(
 
     # Most of the actual logic is tested in the above test case, so we just
     # check that the log message is correct here.
-    logger.error.assert_called_once_with(f"Map type bad_map_type of rule {local_authenticator_map.name} does not know how to be processed")
-
+    logger.error.assert_called_once()
+    f"Map type bad_map_type of rule {local_authenticator_map.name} does not know how to be processed" in logger.error.call_args
 
 def test_create_claims_multiple_same_org(
     local_authenticator_map,
@@ -423,7 +423,7 @@ def test_process_groups(trigger_condition, groups, case_insensitive, has_access,
     """
     with settings_override_mutable("FLAGS"):
         settings.FLAGS["FEATURE_CASE_INSENSITIVE_AUTH_MAPS"][0]["value"] = case_insensitive
-        res = claims.process_groups(trigger_condition, groups, auth_id=1337, map_id=1)
+        res = claims.process_groups(trigger_condition, groups, map_id=1, tracking_id="xxx")
 
     assert res is has_access
 
@@ -867,7 +867,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
 def test_process_user_attributes(trigger_condition, attributes, expected, case_insensitive, settings_override_mutable):
     with settings_override_mutable("FLAGS"):
         settings.FLAGS["FEATURE_CASE_INSENSITIVE_AUTH_MAPS"][0]["value"] = case_insensitive
-        res = claims.process_user_attributes(trigger_condition, attributes, auth_id=1337, map_id=1)
+        res = claims.process_user_attributes(trigger_condition, attributes, map_id=1, tracking_id="xxx")
 
     assert res is expected
 

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -423,7 +423,7 @@ def test_process_groups(trigger_condition, groups, case_insensitive, has_access,
     """
     with settings_override_mutable("FLAGS"):
         settings.FLAGS["FEATURE_CASE_INSENSITIVE_AUTH_MAPS"][0]["value"] = case_insensitive
-        res = claims.process_groups(trigger_condition, groups, authenticator_id=1337)
+        res = claims.process_groups(trigger_condition, groups, auth_id=1337, map_id=1)
 
     assert res is has_access
 
@@ -867,7 +867,7 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
 def test_process_user_attributes(trigger_condition, attributes, expected, case_insensitive, settings_override_mutable):
     with settings_override_mutable("FLAGS"):
         settings.FLAGS["FEATURE_CASE_INSENSITIVE_AUTH_MAPS"][0]["value"] = case_insensitive
-        res = claims.process_user_attributes(trigger_condition, attributes, authenticator_id=1337)
+        res = claims.process_user_attributes(trigger_condition, attributes, auth_id=1337, map_id=1)
 
     assert res is expected
 


### PR DESCRIPTION
## Description

This bug was not a bug, but requested improved debug output w/ explanation of how auth maps are being processed/results.  Example:

(updated again)
utils.claims Processing 6 map(s) for Authenticator ID [2] ID [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1]
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [1] Attributes trigger, comparing user attrs to trigger attrs
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [1] Attr [is_superuser] without value constraint is present, allowing
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [1] Trigger result is ALLOW, allowing map, applying permission

utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [2] Attributes trigger, comparing user attrs to trigger attrs
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [2] Attr [is_system_auditor] without value constraint is not present, skipping 
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [2] Trigger result is SKIP, skipping map, no action needed

utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [3] Always trigger, allowing
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [3] Trigger result is ALLOW, allowing map, applying permission

utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [7] Groups trigger, comparing user groups to trigger groups
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [7] User has at least one trigger group [{'admins'}], allowing
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [7] Trigger result is ALLOW, allowing map, applying permission

utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [8] Attributes trigger, comparing user attrs to trigger attrs
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [8] Attr [aud] value [gateway_oidc_client] does not contain [account2], skipping
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [8] Attr [aud] value [account] does not contain [account2], skipping
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [8] Revoke flag is set for map, denying and revoking permission
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [8] Trigger result is DENY, denying map, revoking permission

utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [9] Attributes trigger, comparing user attrs to trigger attrs
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [9] Attr [given_name] value [Gateway] does not match [ateway], skipping
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [9] Attr [family_name] value [Admin] ends with [dmin], allowing
utils.claims [0933d14c-27d5-4f0e-ac5f-fd1e1d60b5f1] Map [9] Trigger result is ALLOW, allowing map, applying permission



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [x] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Enable ansible_base debug level
2. Log in with some auth maps
3. See improved logging

### Expected Results
More descriptive debug log entries to clarify how auth maps are applied and reasons why they are applied, skipped, or denied/revoked.

