### PR TITLE
[AAP-47811] Update jwt_consumer to load user claims from gateway, if needed

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from datetime import datetime
 from typing import Optional, Tuple
 
@@ -18,7 +19,9 @@ from ansible_base.jwt_consumer.common.exceptions import HTTP_498_INVALID_TOKEN, 
 from ansible_base.lib.logging.runtime import log_excess_runtime
 from ansible_base.lib.utils.auth import get_user_by_ansible_id
 from ansible_base.lib.utils.translations import translatableConditionally as _
+from ansible_base.rbac.claims import get_claims_hash, get_user_claims, get_user_claims_hashable_form
 from ansible_base.resource_registry.models import Resource, ResourceType
+from ansible_base.resource_registry.rest_client import get_resource_server_client
 from ansible_base.resource_registry.signals.handlers import no_reverse_sync
 
 logger = logging.getLogger("ansible_base.jwt_consumer.common.auth")
@@ -226,7 +229,7 @@ class JWTCommonAuth:
         return validated_body
 
     def decode_jwt_token(self, unencrypted_token, decryption_key, additional_options={}):
-        local_required_field = ["sub", "user_data", "exp", "objects", "object_roles", "global_roles", "version"]
+        local_required_field = ["sub", "user_data", "exp", "claims_hash", "version"]
         options = {"require": local_required_field}
         options.update(additional_options)
         return jwt.decode(
@@ -258,17 +261,98 @@ class JWTCommonAuth:
 
     def process_rbac_permissions(self):
         """
-        This is a default process_permissions which should be usable if you are using RBAC from DAB
+        Process RBAC permissions using claims hash logic
         """
         if self.token is None or self.user is None:
-            logger.error("Unable to process rbac permissions because user or token is not defined, please call authenticate first")
+            logger.error("Unable to process rbac permissions because user or token is not defined")
             return
 
+        jwt_claims_hash = self.token.get("claims_hash")
+        if not jwt_claims_hash:
+            logger.error("No claims_hash found in JWT token")
+            return
+
+        user_ansible_id = self.token.get("sub")
+        if not user_ansible_id:
+            logger.error("No subject (sub) found in JWT token")
+            return
+
+        # Validate UUID format (consistent with rest of codebase)
+        try:
+            uuid.UUID(user_ansible_id)
+        except (ValueError, TypeError):
+            logger.error(f"Invalid UUID format for user_ansible_id: {user_ansible_id}")
+            return
+
+        # Check cached claims hash
+        cached_claims_hash = self.cache.get_cached_claims_hash(user_ansible_id)
+
+        if cached_claims_hash == jwt_claims_hash:
+            logger.debug(f"Claims hash matches cached value for user {user_ansible_id}")
+            return
+
+        # Calculate local claims hash
+        local_claims = get_user_claims(self.user)
+        local_hashable_claims = get_user_claims_hashable_form(local_claims)
+        local_claims_hash = get_claims_hash(local_hashable_claims)
+
+        if local_claims_hash == jwt_claims_hash:
+            logger.debug(f"Claims hash matches local calculation for user {user_ansible_id}")
+            # Update cache with the correct hash
+            self.cache.cache_claims_hash(user_ansible_id, jwt_claims_hash)
+            return
+
+        # Claims hash mismatch - fetch from gateway
+        logger.info(f"Claims hash mismatch for user {user_ansible_id}. JWT: {jwt_claims_hash}, Local: {local_claims_hash}. Fetching from gateway.")
+        gateway_claims = self._fetch_jwt_claims_from_gateway(user_ansible_id)
+
+        if gateway_claims:
+            # Extract claims structure from gateway response
+            objects = gateway_claims.get('objects', {})
+            object_roles = gateway_claims.get('object_roles', {})
+            global_roles = gateway_claims.get('global_roles', [])
+
+            # Process the RBAC permissions with the gateway claims
+            self._apply_rbac_permissions(objects, object_roles, global_roles)
+
+            # Update cache with the new hash
+            self.cache.cache_claims_hash(user_ansible_id, jwt_claims_hash)
+        else:
+            self.log_and_raise(
+                _("Unable to validate user permissions - gateway claims fetch failed for user %(user_ansible_id)s"), {"user_ansible_id": user_ansible_id}
+            )
+
+    def _fetch_jwt_claims_from_gateway(self, user_ansible_id: str) -> Optional[dict]:
+        """
+        Fetch JWT claims from the gateway endpoint using resource server client
+        """
+        try:
+            # Use the resource server client to make the request
+            client = get_resource_server_client(service_path="api/gateway/v1")
+
+            logger.debug(f"Fetching claims from gateway for user {user_ansible_id}")
+            response = client._make_request("GET", f"jwt_claims/{user_ansible_id}/")
+
+            if response.status_code == 200:
+                claims_data = response.json()
+                return claims_data
+            else:
+                logger.error(f"Gateway request failed with status {response.status_code}")
+                return None
+
+        except Exception as e:
+            logger.error(f"Error fetching claims from gateway: {e}")
+            return None
+
+    def _apply_rbac_permissions(self, objects, object_roles, global_roles):
+        """
+        Apply RBAC permissions from claims data
+        """
         from ansible_base.rbac.models import RoleUserAssignment
 
         role_diff = RoleUserAssignment.objects.filter(user=self.user, role_definition__name__in=settings.ANSIBLE_BASE_JWT_MANAGED_ROLES)
 
-        for system_role_name in self.token.get("global_roles", []):
+        for system_role_name in global_roles:
             logger.debug(f"Processing system role {system_role_name} for {self.user.username}")
             rd = self.get_role_definition(system_role_name)
             if rd:
@@ -282,7 +366,7 @@ class JWTCommonAuth:
                 logger.error(f"Unable to grant {self.user.username} system level role {system_role_name} because it does not exist")
                 continue
 
-        for object_role_name in self.token.get('object_roles', {}).keys():
+        for object_role_name in object_roles.keys():
             rd = self.get_role_definition(object_role_name)
             if rd is None:
                 logger.error(f"Unable to grant {self.user.username} object role {object_role_name} because it does not exist")
@@ -291,11 +375,11 @@ class JWTCommonAuth:
                 logger.error(f"Unable to grant {self.user.username} object role {object_role_name} because it is not a JWT managed role")
                 continue
 
-            object_type = self.token['object_roles'][object_role_name]['content_type']
-            object_indexes = self.token['object_roles'][object_role_name]['objects']
+            object_type = object_roles[object_role_name]['content_type']
+            object_indexes = object_roles[object_role_name]['objects']
 
             for index in object_indexes:
-                object_data = self.token['objects'][object_type][index]
+                object_data = objects[object_type][index]
                 try:
                     resource, obj = self.get_or_create_resource(object_type, object_data)
                 except IntegrityError as e:

--- a/ansible_base/jwt_consumer/common/cache.py
+++ b/ansible_base/jwt_consumer/common/cache.py
@@ -38,6 +38,19 @@ class JWTCache:
         cache.set(validated_body["sub"], expected_cache_value, timeout=self.get_cache_timeout())
         return False, expected_cache_value
 
+    def cache_claims_hash(self, user_ansible_id: str, claims_hash: str) -> None:
+        """Cache the claims hash for a user"""
+        cache_key = f"claims_hash_{user_ansible_id}"
+        cache.set(cache_key, claims_hash, timeout=self.get_cache_timeout())
+        logger.debug(f"Cached claims hash for user {user_ansible_id}: {claims_hash}")
+
+    def get_cached_claims_hash(self, user_ansible_id: str) -> Optional[str]:
+        """Get cached claims hash for a user"""
+        cache_key = f"claims_hash_{user_ansible_id}"
+        cached_hash = cache.get(cache_key, None)
+        logger.debug(f"Retrieved cached claims hash for user {user_ansible_id}: {cached_hash}")
+        return cached_hash
+
     def get_key_from_cache(self) -> Optional[str]:
         # If we are not ignoring the cache (forcing a reload of the key), check it
         key = cache.get(cache_key, None)

--- a/ansible_base/jwt_consumer/hub/auth.py
+++ b/ansible_base/jwt_consumer/hub/auth.py
@@ -22,7 +22,7 @@ class HubJWTAuth(JWTAuthentication):
 
         return Organization, Team
 
-    def process_permissions(self):
+    def _apply_rbac_permissions(self, objects, object_roles, global_roles):
         # Map teams in the JWT to Automation Hub groups.
         Organization, Team = self.get_galaxy_models()
         self.team_content_type = ContentType.objects.get_for_model(Team)
@@ -40,10 +40,10 @@ class HubJWTAuth(JWTAuthentication):
         # the teams this user should have a "shared" [!local] assignment to
         member_teams = []
 
-        for role_name in self.common_auth.token.get('object_roles', {}).keys():
+        for role_name in object_roles.keys():
             if role_name.startswith('Team'):
-                for object_index in self.common_auth.token['object_roles'][role_name]['objects']:
-                    team_data = self.common_auth.token['objects']['team'][object_index]
+                for object_index in object_roles[role_name]['objects']:
+                    team_data = objects['team'][object_index]
                     ansible_id = team_data['ansible_id']
                     try:
                         team = Resource.objects.get(ansible_id=ansible_id).content_object
@@ -83,7 +83,7 @@ class HubJWTAuth(JWTAuthentication):
                 roledef.give_permission(self.common_auth.user, team)
 
         auditor_roledef = RoleDefinition.objects.get(name='Platform Auditor')
-        if "Platform Auditor" in self.common_auth.token.get('global_roles', []):
+        if "Platform Auditor" in global_roles:
             auditor_roledef.give_global_permission(self.common_auth.user)
         else:
             auditor_roledef.remove_global_permission(self.common_auth.user)

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -542,9 +542,7 @@ def jwt_token(test_encryption_private_key):
                     "email": "noone@redhat.com",
                     "is_superuser": False,
                 },
-                "objects": {},
-                "object_roles": {},
-                "global_roles": [],
+                "claims_hash": "abc123def456",
             }
 
         def encrypt_token(self):

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -152,9 +152,7 @@ class TestJWTCommonAuth:
             ("iss", False),
             ("exp", False),
             ("aud", False),
-            ("objects", False),
-            ("object_roles", False),
-            ("global_roles", False),
+            ("claims_hash", False),
         ],
     )
     def test_validate_token_missing_default_items(self, remove, is_user_data_entry, jwt_token, test_encryption_public_key):
@@ -287,24 +285,23 @@ class TestJWTCommonAuth:
                         common_auth.parse_jwt_token(request)
 
     @pytest.mark.parametrize(
-        "token,logs_error",
+        "global_roles,logs_error",
         [
-            ({}, None),
-            ({"global_roles": ['System Auditor']}, False),
-            ({"global_roles": ['Ext Auditor']}, False),  # must dynamically create
-            ({"global_roles": ['Unmanaged Auditor']}, True),  # must dynamically create
-            ({"global_roles": ['Junk']}, True),
+            ([], None),
+            (['System Auditor'], False),
+            (['Ext Auditor'], False),  # must dynamically create
+            (['Unmanaged Auditor'], True),  # must dynamically create
+            (['Junk'], True),
         ],
     )
-    def test_process_rbac_permissions_system_roles(
-        self, token, logs_error, admin_user, expected_log, external_auditor_constructor, unmanaged_external_auditor_constructor
+    def test_apply_rbac_permissions_system_roles(
+        self, global_roles, logs_error, admin_user, expected_log, external_auditor_constructor, unmanaged_external_auditor_constructor
     ):
         authentication = JWTCommonAuth()
         authentication.user = admin_user
-        authentication.token = token
         if logs_error:
             with expected_log(default_logger, 'error', 'Unable to grant'):
-                authentication.process_rbac_permissions()
+                authentication._apply_rbac_permissions({}, {}, global_roles)
         elif logs_error is not None:
             # Make sure we have a System Auditor role
             RoleDefinition.objects.get_or_create(
@@ -315,16 +312,16 @@ class TestJWTCommonAuth:
                 },
             )
             with expected_log(default_logger, 'info', 'Granted user'):
-                authentication.process_rbac_permissions()
+                authentication._apply_rbac_permissions({}, {}, global_roles)
         else:
-            authentication.process_rbac_permissions()
+            authentication._apply_rbac_permissions({}, {}, global_roles)
 
-    def test_process_rbac_permissions_object_roles_role_dne(self, expected_log, admin_user):
+    def test_apply_rbac_permissions_object_roles_role_dne(self, expected_log, admin_user):
         authentication = JWTCommonAuth()
         authentication.user = admin_user
-        authentication.token = {'object_roles': {'Junk': ['a']}}
+        object_roles = {'Junk': ['a']}
         with expected_log(default_logger, 'error', 'Unable to grant'):
-            authentication.process_rbac_permissions()
+            authentication._apply_rbac_permissions({}, object_roles, [])
 
     @pytest.mark.parametrize(
         "object_roles,log_level,log_substring",
@@ -333,30 +330,25 @@ class TestJWTCommonAuth:
             ({"Cow Admin": {'content_type': 'organization', 'objects': [0]}}, "error", "Unable to grant"),
         ],
     )
-    def test_process_rbac_permissions_object_role_exists_object_exists(
+    def test_apply_rbac_permissions_object_role_exists_object_exists(
         self, object_roles, log_level, log_substring, expected_log, admin_user, organization, organization_admin_role
     ):
         authentication = JWTCommonAuth()
         authentication.user = admin_user
-        authentication.token = {
-            'objects': {'organization': [{'ansible_id': organization.resource.ansible_id, 'name': organization.name}]},
-            'object_roles': object_roles,
-        }
+        objects = {'organization': [{'ansible_id': organization.resource.ansible_id, 'name': organization.name}]}
         if log_level:
             with expected_log(default_logger, log_level, log_substring):
-                authentication.process_rbac_permissions()
+                authentication._apply_rbac_permissions(objects, object_roles, [])
 
-    def test_process_rbac_permissions_org_duplicate_name_error(self, expected_log, admin_user, organization, organization_admin_role):
+    def test_apply_rbac_permissions_org_duplicate_name_error(self, expected_log, admin_user, organization, organization_admin_role):
         authentication = JWTCommonAuth()
         authentication.user = admin_user
-        authentication.token = {
-            'objects': {'organization': [{'ansible_id': str(uuid4()), 'name': organization.name}]},
-            'object_roles': {"Organization Admin": {'content_type': 'organization', 'objects': [0]}},
-        }
+        objects = {'organization': [{'ansible_id': str(uuid4()), 'name': organization.name}]}
+        object_roles = {"Organization Admin": {'content_type': 'organization', 'objects': [0]}}
         with expected_log(default_logger, "warning", "Got integrity error"):
-            authentication.process_rbac_permissions()
+            authentication._apply_rbac_permissions(objects, object_roles, [])
 
-    def test_process_rbac_permissions_removed_when_removed_from_jwt(self, admin_user, organization, organization_admin_role):
+    def test_apply_rbac_permissions_removed_when_removed_from_jwt(self, admin_user, organization, organization_admin_role):
         # Make sure we have a System Auditor role
         RoleDefinition.objects.get_or_create(
             name='System Auditor',
@@ -368,19 +360,16 @@ class TestJWTCommonAuth:
 
         authentication = JWTCommonAuth()
         authentication.user = admin_user
-        authentication.token = {
-            'objects': {'organization': [{'ansible_id': organization.resource.ansible_id, 'name': organization.name}]},
-            'object_roles': {organization_admin_role.name: {'content_type': 'organization', 'objects': [0]}},
-            'global_roles': ["Platform Auditor"],
-        }
+        objects = {'organization': [{'ansible_id': organization.resource.ansible_id, 'name': organization.name}]}
+        object_roles = {organization_admin_role.name: {'content_type': 'organization', 'objects': [0]}}
+        global_roles = ["Platform Auditor"]
 
-        authentication.process_rbac_permissions()
+        authentication._apply_rbac_permissions(objects, object_roles, global_roles)
 
         assert RoleUserAssignment.objects.filter(user=admin_user).count() == 2
 
-        authentication.token = {}
-
-        authentication.process_rbac_permissions()
+        # Test removing all roles
+        authentication._apply_rbac_permissions({}, {}, [])
 
         assert RoleUserAssignment.objects.filter(user=admin_user).count() == 0
 
@@ -427,6 +416,158 @@ class TestJWTCommonAuth:
         assert Organization.objects.filter(name=org_name).exists()
         assert Resource.objects.filter(ansible_id=data['ansible_id']).exists()
         assert Team.objects.filter(name=data['name']).exists()
+
+    @pytest.mark.parametrize(
+        "cache_hit,local_match,gateway_success,expected_cache_update,expected_gateway_call,expected_rbac_call",
+        [
+            # Cache hit - should return early without processing
+            (True, True, True, False, False, False),
+            # Cache miss but local match - should update cache and return
+            (False, True, True, True, False, False),
+            # Cache miss and local mismatch, gateway success - should fetch and apply
+            (False, False, True, True, True, True),
+            # Cache miss and local mismatch, gateway failure - should not apply
+            (False, False, False, False, True, False),
+        ],
+    )
+    def test_process_rbac_permissions_cache_scenarios(
+        self,
+        cache_hit,
+        local_match,
+        gateway_success,
+        expected_cache_update,
+        expected_gateway_call,
+        expected_rbac_call,
+        admin_user,
+    ):
+        """Test process_rbac_permissions cache hit/miss scenarios"""
+
+        # Setup authentication object
+        authentication = JWTCommonAuth()
+        authentication.user = admin_user
+        user_ansible_id = "12345678-1234-5678-9abc-123456789012"
+        jwt_claims_hash = "a1b2c3d4"
+        local_claims_hash = jwt_claims_hash if local_match else "e5f6g7h8"
+        cached_claims_hash = jwt_claims_hash if cache_hit else "x9y8z7w6"
+
+        authentication.token = {
+            "sub": user_ansible_id,
+            "claims_hash": jwt_claims_hash,
+        }
+
+        # Mock gateway response with realistic data structure matching get_user_claims format
+        gateway_response = (
+            {
+                'claims_hash': jwt_claims_hash,  # Gateway should return the matching hash
+                'objects': {
+                    'organization': [
+                        {'ansible_id': '11111111-1111-1111-1111-111111111111', 'name': 'Engineering Org'},
+                        {'ansible_id': '22222222-2222-2222-2222-222222222222', 'name': 'DevOps Team Org'},
+                    ],
+                    'team': [{'ansible_id': '33333333-3333-3333-3333-333333333333', 'name': 'Backend Team', 'org': 0}],
+                },
+                'object_roles': {
+                    'Organization Admin': {'content_type': 'organization', 'objects': [0, 1]},
+                    'Team Member': {'content_type': 'team', 'objects': [0]},
+                },
+                'global_roles': ['Platform Auditor'],
+            }
+            if gateway_success
+            else None
+        )
+
+        with (
+            mock.patch.object(authentication.cache, 'get_cached_claims_hash') as mock_get_cache,
+            mock.patch.object(authentication.cache, 'cache_claims_hash') as mock_set_cache,
+            mock.patch('ansible_base.jwt_consumer.common.auth.get_user_claims') as mock_get_claims,
+            mock.patch('ansible_base.jwt_consumer.common.auth.get_user_claims_hashable_form') as mock_get_hashable,
+            mock.patch('ansible_base.jwt_consumer.common.auth.get_claims_hash') as mock_get_hash,
+            mock.patch.object(authentication, '_fetch_jwt_claims_from_gateway') as mock_gateway,
+            mock.patch.object(authentication, '_apply_rbac_permissions') as mock_apply,
+        ):
+
+            # Setup mocks
+            mock_get_cache.return_value = cached_claims_hash if cache_hit else None
+            mock_get_claims.return_value = {}
+            mock_get_hashable.return_value = {}
+            mock_get_hash.return_value = local_claims_hash
+            mock_gateway.return_value = gateway_response
+
+            # Execute the method
+            if not gateway_success and not cache_hit and not local_match:
+                # Gateway failure case should raise AuthenticationFailed
+                with pytest.raises(AuthenticationFailed, match="Unable to validate user permissions"):
+                    authentication.process_rbac_permissions()
+                # Early return - no further assertions needed for this case
+                return
+            else:
+                authentication.process_rbac_permissions()
+
+            # Verify cache lookup happened
+            mock_get_cache.assert_called_once_with(user_ansible_id)
+
+            # Verify local claims calculation - only called when cache miss occurs
+            if cache_hit:
+                # Cache hit - no local claims calculation needed
+                mock_get_claims.assert_not_called()
+                mock_get_hashable.assert_not_called()
+                mock_get_hash.assert_not_called()
+            else:
+                # Cache miss - local claims calculation should happen
+                mock_get_claims.assert_called_once_with(admin_user)
+                mock_get_hashable.assert_called_once_with({})  # mock_get_claims returns {}
+                mock_get_hash.assert_called_once_with({})  # mock_get_hashable returns {}
+
+            # Verify cache update behavior
+            if expected_cache_update:
+                mock_set_cache.assert_called_once_with(user_ansible_id, jwt_claims_hash)
+            else:
+                mock_set_cache.assert_not_called()
+
+            # Verify gateway call behavior
+            if expected_gateway_call:
+                mock_gateway.assert_called_once_with(user_ansible_id)
+            else:
+                mock_gateway.assert_not_called()
+
+            # Verify RBAC application behavior
+            if expected_rbac_call:
+                mock_apply.assert_called_once()
+            else:
+                mock_apply.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_process_rbac_permissions_missing_token_data(self):
+        """Test process_rbac_permissions with missing required token data"""
+        authentication = JWTCommonAuth()
+        authentication.user = None
+        authentication.token = None
+
+        with mock.patch('ansible_base.jwt_consumer.common.auth.logger') as mock_logger:
+            authentication.process_rbac_permissions()
+            mock_logger.error.assert_called_with("Unable to process rbac permissions because user or token is not defined")
+
+    @pytest.mark.django_db
+    def test_process_rbac_permissions_missing_claims_hash(self, admin_user):
+        """Test process_rbac_permissions with missing claims_hash in token"""
+        authentication = JWTCommonAuth()
+        authentication.user = admin_user
+        authentication.token = {"sub": "f47ac10b-58cc-4372-a567-0e02b2c3d479"}  # Missing claims_hash
+
+        with mock.patch('ansible_base.jwt_consumer.common.auth.logger') as mock_logger:
+            authentication.process_rbac_permissions()
+            mock_logger.error.assert_called_with("No claims_hash found in JWT token")
+
+    @pytest.mark.django_db
+    def test_process_rbac_permissions_missing_subject(self, admin_user):
+        """Test process_rbac_permissions with missing subject in token"""
+        authentication = JWTCommonAuth()
+        authentication.user = admin_user
+        authentication.token = {"claims_hash": "a1b2c3d4"}  # Missing sub
+
+        with mock.patch('ansible_base.jwt_consumer.common.auth.logger') as mock_logger:
+            authentication.process_rbac_permissions()
+            mock_logger.error.assert_called_with("No subject (sub) found in JWT token")
 
 
 class TestJWTAuthentication:
@@ -594,3 +735,48 @@ class TestJWTAuthentication:
             authentication.use_rbac_permissions = True
             authentication.process_permissions()
             mp.assert_called_once()
+
+    def test__fetch_jwt_claims_from_gateway_success(self):
+        authentication = JWTCommonAuth()
+        user_ansible_id = '12345678-1234-5678-9abc-123456789012'
+
+        with mock.patch('ansible_base.jwt_consumer.common.auth.get_resource_server_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_response = mock.Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {'objects': {}, 'object_roles': {}, 'global_roles': []}
+            mock_client._make_request.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            result = authentication._fetch_jwt_claims_from_gateway(user_ansible_id)
+
+            assert result == {'objects': {}, 'object_roles': {}, 'global_roles': []}
+            mock_get_client.assert_called_once_with(service_path='api/gateway/v1')
+            mock_client._make_request.assert_called_once_with('GET', f'jwt_claims/{user_ansible_id}/')
+
+    def test__fetch_jwt_claims_from_gateway_non_200(self):
+        authentication = JWTCommonAuth()
+        user_ansible_id = '12345678-1234-5678-9abc-123456789012'
+
+        with mock.patch('ansible_base.jwt_consumer.common.auth.get_resource_server_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_response = mock.Mock()
+            mock_response.status_code = 404
+            mock_client._make_request.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            result = authentication._fetch_jwt_claims_from_gateway(user_ansible_id)
+
+            assert result is None
+            mock_get_client.assert_called_once_with(service_path='api/gateway/v1')
+            mock_client._make_request.assert_called_once_with('GET', f'jwt_claims/{user_ansible_id}/')
+
+    def test__fetch_jwt_claims_from_gateway_exception(self):
+        authentication = JWTCommonAuth()
+        user_ansible_id = '12345678-1234-5678-9abc-123456789012'
+
+        with mock.patch('ansible_base.jwt_consumer.common.auth.get_resource_server_client', side_effect=Exception('boom')) as mock_get_client:
+            result = authentication._fetch_jwt_claims_from_gateway(user_ansible_id)
+
+            assert result is None
+            mock_get_client.assert_called_once_with(service_path='api/gateway/v1')

--- a/test_app/tests/jwt_consumer/common/test_cache.py
+++ b/test_app/tests/jwt_consumer/common/test_cache.py
@@ -1,1 +1,8 @@
-# The cache is tested by test_auth and test_cert
+# The cache is also tested by test_auth and test_cert
+from ansible_base.jwt_consumer.common.cache import JWTCache
+
+
+def test_cache_claims_hash():
+    cache = JWTCache()
+    cache.cache_claims_hash('12345678-1234-5678-9abc-123456789012', 'a1b2c3d4')
+    assert cache.get_cached_claims_hash('12345678-1234-5678-9abc-123456789012') == 'a1b2c3d4'

--- a/test_app/tests/jwt_consumer/hub/test_auth.py
+++ b/test_app/tests/jwt_consumer/hub/test_auth.py
@@ -12,7 +12,8 @@ from test_app.models import Organization, Team, User
 def test_hub_import_error(user):
     authenticator = HubJWTAuth()
     with pytest.raises(InvalidService):
-        authenticator.process_permissions()
+        # Test that InvalidService is raised when trying to apply RBAC permissions
+        authenticator._apply_rbac_permissions({}, {}, [])
 
 
 @pytest.mark.parametrize(
@@ -102,43 +103,38 @@ def test_hub_jwt_orgs_teams_groups_memberships(mock_contenttype, mock_resource):
 
     # Add the user to the org and the team. Galaxy doesn't have
     # a concept of org&team admin yet so we don't care about those.
-    auth.common_auth.token = {
-        "global_roles": {
-            'Platform Auditor': {},
-        },
-        "object_roles": {
-            'Organization Admin': {'content_type': 'organization', 'objects': [0]},
-            'Organization Member': {'content_type': 'organization', 'objects': [0]},
-            'Team Admin': {'content_type': 'team', 'objects': [0]},
-            'Team Member': {'content_type': 'team', 'objects': [0]},
-        },
-        "objects": {
-            "organization": [
-                {
-                    "ansible_id": str(testorg.resource.ansible_id),
-                    "id": testorg.id,
-                    "name": testorg.name,
-                }
-            ],
-            "team": [
-                {
-                    "ansible_id": str(testteam.resource.ansible_id),
-                    "name": testteam.name,
-                    "org": 0,
-                }
-            ],
-        },
+    objects = {
+        "organization": [
+            {
+                "ansible_id": str(testorg.resource.ansible_id),
+                "id": testorg.id,
+                "name": testorg.name,
+            }
+        ],
+        "team": [
+            {
+                "ansible_id": str(testteam.resource.ansible_id),
+                "name": testteam.name,
+                "org": 0,
+            }
+        ],
     }
+    object_roles = {
+        'Organization Admin': {'content_type': 'organization', 'objects': [0]},
+        'Organization Member': {'content_type': 'organization', 'objects': [0]},
+        'Team Admin': {'content_type': 'team', 'objects': [0]},
+        'Team Member': {'content_type': 'team', 'objects': [0]},
+    }
+    global_roles = ['Platform Auditor']
 
-    # PROCSSS THE CLAIMS AND CHECK THE SIDE EFFECTS ...
-    auth.process_permissions()
+    # PROCESS THE CLAIMS AND CHECK THE SIDE EFFECTS ...
+    auth._apply_rbac_permissions(objects, object_roles, global_roles)
     assert RoleUserAssignment.objects.filter(user=testuser, role_definition=team_member_role, object_id=testteam.pk).count() == 1
     assert RoleUserAssignment.objects.filter(user=testuser, role_definition=team_admin_role, object_id=testteam.pk).count() == 1
     assert RoleUserAssignment.objects.filter(user=testuser, role_definition=platform_auditor_role).count() == 1
 
     # REVOKE EVERYTHING AND RECHECK ...
-    auth.common_auth.token = {}
-    auth.process_permissions()
+    auth._apply_rbac_permissions({}, {}, [])
     assert RoleUserAssignment.objects.filter(user=testuser, role_definition=team_member_role, object_id=testteam.pk).count() == 0
     assert RoleUserAssignment.objects.filter(user=testuser, role_definition=team_admin_role, object_id=testteam.pk).count() == 0
     assert RoleUserAssignment.objects.filter(user=testuser, role_definition=platform_auditor_role).count() == 0


### PR DESCRIPTION
#  [AAP-47811](https://issues.redhat.com/browse/AAP-47811) Update jwt_consumer to load user claims from gateway, if needed
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- **What is being changed?** Refactored JWT RBAC permission processing to use claims hash validation and caching
- **Why is this change needed?** To improve performance by avoiding unnecessary gateway calls and ensure RBAC permissions are properly validated
- **How does this change address the issue?** Implements a claims hash mechanism that caches permission data and only fetches from the gateway when the hash changes, reducing redundant API calls while maintaining data consistency

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

### Prerequisites
- Use aap-dev build from sources for all components
- Deploy with the corresponding gateway changes from https://github.com/ansible-automation-platform/aap-gateway/pull/930
- Full AAP environment with JWT authentication enabled

### Steps to Test
1. Run the existing JWT authentication test suite: `tox -e py311`
2. Verify all RBAC permission tests pass: `pytest test_app/tests/jwt_consumer/ -v`
3. Deploy aap-dev with all components built from source (including gateway PR changes)
4. Login to the platform as various users with different permission levels (admin, org admin, regular users)
5. Perform actions across different services (Controller, EDA, Hub) as these users
6. Validate that RBAC permissions are correctly enforced and nothing breaks
7. Verify that users can successfully authenticate and perform authorized actions

### Expected Results
- All existing JWT authentication functionality continues to work
- RBAC permissions are correctly applied based on claims hash validation
- Users can successfully authenticate and perform authorized actions
- Performance improvement due to reduced gateway calls when claims haven't changed
- Test suite passes with improved coverage of edge cases

## Additional Context
<!-- Optional but helpful information -->

### Changes Made:
- **ansible_base/jwt_consumer/common/auth.py**: Added claims hash validation logic, cache management, and gateway claims fetching
- **ansible_base/jwt_consumer/common/cache.py**: Added claims hash caching utilities
- **ansible_base/jwt_consumer/hub/auth.py**: Refactored to use `_apply_rbac_permissions` with explicit parameters
- **Test files**: Updated to match new method signatures and added edge case coverage

### Required Actions
<!-- Check if changes require work in other areas -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: https://github.com/ansible-automation-platform/aap-gateway/pull/930
  <!-- Reference blocking PRs/MRs with brief context -->

### Performance Impact:
This change reduces unnecessary gateway API calls by caching claims hashes per user and only fetching fresh claims when the hash indicates changes have occurred.