### PR TITLE
[AAP-47897] Use configured groups attribute in SAML authenticator

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -299,7 +299,7 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
             logger.debug("Setting Group from attribute: Group")
             response["Group"] = attrs["Group"]
         else:
-            # else get configured group attribute from configuration and set group from that attribute
+            # get configured group attribute set Group from that attribute
             configuration = self.database_instance.configuration
             idp_groups_attribute_name = self.configuration_class.settings_to_enabled_idps_fields['IDP_GROUPS']
             configured_groups_attribute = configuration['ENABLED_IDPS'][idp_string][idp_groups_attribute_name]

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -294,18 +294,17 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
             if perm in attrs:
                 kwargs["social"].extra_data[perm] = attrs[perm]
 
-        # Move group spec up a level if present
-        if "Group" in attrs:
+        # Get configured group attribute, if present
+        configuration = self.database_instance.configuration if hasattr(self.database_instance, 'configuration') else None
+        idp_groups_attribute_name = self.configuration_class.settings_to_enabled_idps_fields['IDP_GROUPS']
+        configured_groups_attribute = configuration['ENABLED_IDPS'][idp_string].get(idp_groups_attribute_name) if configuration is not None else None
+        if configured_groups_attribute is not None and configured_groups_attribute in attrs:
+            logger.debug(f"Setting Group from attribute: {configured_groups_attribute}")
+            response["Group"] = attrs[configured_groups_attribute]
+        # Else try getting the "Group" attribute, if present
+        elif "Group" in attrs:
             logger.debug("Setting Group from attribute: Group")
             response["Group"] = attrs["Group"]
-        else:
-            # get configured group attribute set Group from that attribute
-            configuration = self.database_instance.configuration
-            idp_groups_attribute_name = self.configuration_class.settings_to_enabled_idps_fields['IDP_GROUPS']
-            configured_groups_attribute = configuration['ENABLED_IDPS'][idp_string].get(idp_groups_attribute_name)
-            if configured_groups_attribute is not None and configured_groups_attribute in attrs:
-                logger.debug(f"Setting Group from attribute: {configured_groups_attribute}")
-                response["Group"] = attrs[configured_groups_attribute]
         data = super().extra_data(user, backend, response, *args, **kwargs)
 
         # Ideally we would always have a DB instance

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -302,8 +302,8 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
             # get configured group attribute set Group from that attribute
             configuration = self.database_instance.configuration
             idp_groups_attribute_name = self.configuration_class.settings_to_enabled_idps_fields['IDP_GROUPS']
-            configured_groups_attribute = configuration['ENABLED_IDPS'][idp_string][idp_groups_attribute_name]
-            if configured_groups_attribute in attrs:
+            configured_groups_attribute = configuration['ENABLED_IDPS'][idp_string].get(idp_groups_attribute_name)
+            if configured_groups_attribute is not None and configured_groups_attribute in attrs:
                 logger.debug(f"Setting Group from attribute: {configured_groups_attribute}")
                 response["Group"] = attrs[configured_groups_attribute]
         data = super().extra_data(user, backend, response, *args, **kwargs)

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -295,16 +295,20 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
                 kwargs["social"].extra_data[perm] = attrs[perm]
 
         # Get configured group attribute, if present
-        configuration = self.database_instance.configuration if hasattr(self.database_instance, 'configuration') else None
-        idp_groups_attribute_name = self.configuration_class.settings_to_enabled_idps_fields['IDP_GROUPS']
-        configured_groups_attribute = configuration['ENABLED_IDPS'][idp_string].get(idp_groups_attribute_name) if configuration is not None else None
-        if configured_groups_attribute is not None and configured_groups_attribute in attrs:
-            logger.debug(f"Setting Group from attribute: {configured_groups_attribute}")
-            response["Group"] = attrs[configured_groups_attribute]
+        configuration = getattr(self.database_instance, 'configuration', {})
+        idp_groups_attribute_name = self.configuration_class.settings_to_enabled_idps_fields.get('IDP_GROUPS', None)
+        configured_groups_attribute = configuration.get('ENABLED_IDPS', {}).get(idp_string, {}).get(idp_groups_attribute_name, None)
+
+        if configured_groups_attribute in attrs:
+            logger.debug(f"Setting {self.groups_claim} from attribute: {configured_groups_attribute}")
+            response[self.groups_claim] = attrs[configured_groups_attribute]
         # Else try getting the "Group" attribute, if present
-        elif "Group" in attrs:
-            logger.debug("Setting Group from attribute: Group")
-            response["Group"] = attrs["Group"]
+        elif self.groups_claim in attrs:
+            logger.debug(f"Setting {self.groups_claim} from attribute: {self.groups_claim}")
+            response[self.groups_claim] = attrs[self.groups_claim]
+        else:
+            logger.debug("Unable to get any group claims from the SAML response")
+
         data = super().extra_data(user, backend, response, *args, **kwargs)
 
         # Ideally we would always have a DB instance

--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -296,7 +296,16 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
 
         # Move group spec up a level if present
         if "Group" in attrs:
+            logger.debug("Setting Group from attribute: Group")
             response["Group"] = attrs["Group"]
+        else:
+            # else get configured group attribute from configuration and set group from that attribute
+            configuration = self.database_instance.configuration
+            idp_groups_attribute_name = self.configuration_class.settings_to_enabled_idps_fields['IDP_GROUPS']
+            configured_groups_attribute = configuration['ENABLED_IDPS'][idp_string][idp_groups_attribute_name]
+            if configured_groups_attribute in attrs:
+                logger.debug(f"Setting Group from attribute: {configured_groups_attribute}")
+                response["Group"] = attrs[configured_groups_attribute]
         data = super().extra_data(user, backend, response, *args, **kwargs)
 
         # Ideally we would always have a DB instance

--- a/test_app/tests/authentication/authenticator_plugins/test_saml.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_saml.py
@@ -369,12 +369,14 @@ def test_extra_data(mockedsuper):
                 'attr_last_name': 'last_name',
                 'attr_first_name': 'first_name',
                 'attr_user_permanent_id': 'name_id',
+                'attr_groups': 'member',
             },
             {
                 'last_name': ['Admin'],
                 'username': ['gateway_admin'],
                 'first_name': ['Gateway'],
                 'name_id': 'gateway_admin',
+                'member': ['group-1', 'group-2'],
             },
         ),
     ],
@@ -403,6 +405,7 @@ def test_extra_data_default_attrs(idp_fields, expected_results):
             'first_name': ['Gateway'],
             'Role': ['default-roles-gateway realm', 'manage-account', 'uma_authorization', 'view-profile', 'offline_access', 'manage-account-links'],
             'name_id': 'gateway_admin',
+            'member': ['group-1', 'group-2']
         },
     }
     au = AuthenticatorUser()

--- a/test_app/tests/authentication/authenticator_plugins/test_saml.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_saml.py
@@ -405,7 +405,7 @@ def test_extra_data_default_attrs(idp_fields, expected_results):
             'first_name': ['Gateway'],
             'Role': ['default-roles-gateway realm', 'manage-account', 'uma_authorization', 'view-profile', 'offline_access', 'manage-account-links'],
             'name_id': 'gateway_admin',
-            'member': ['group-1', 'group-2']
+            'member': ['group-1', 'group-2'],
         },
     }
     au = AuthenticatorUser()

--- a/test_app/tests/authentication/authenticator_plugins/test_saml.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_saml.py
@@ -379,6 +379,22 @@ def test_extra_data(mockedsuper):
                 'member': ['group-1', 'group-2'],
             },
         ),
+        (
+            {
+                'attr_username': 'username',
+                'attr_last_name': 'last_name',
+                'attr_first_name': 'first_name',
+                'attr_user_permanent_id': 'name_id',
+                'attr_groups': 'nonexistent_group_attr',  # Configure a group attribute that won't be in response
+            },
+            {
+                'last_name': ['Admin'],
+                'username': ['gateway_admin'],
+                'first_name': ['Gateway'],
+                'name_id': 'gateway_admin',
+                # No group data should be present - will hit the "Unable to get any group claims" branch
+            },
+        ),
     ],
 )
 def test_extra_data_default_attrs(idp_fields, expected_results):
@@ -412,6 +428,51 @@ def test_extra_data_default_attrs(idp_fields, expected_results):
     with mock.patch('social_core.backends.saml.SAMLAuth.extra_data', return_value={}):
         results = ap.extra_data(None, 'IdP:gateway_admin', response, **{'social': au})
         assert results == expected_results
+
+
+def test_extra_data_no_group_claims_logging(caplog):
+    """Test that the 'Unable to get any group claims' logging is triggered when no group attributes are found."""
+    import logging
+
+    from ansible_base.authentication.authenticator_plugins.saml import idp_string
+    from ansible_base.authentication.models import AuthenticatorUser
+
+    ap = AuthenticatorPlugin()
+    database_instance = SimpleNamespace()
+    enabled_idps = {
+        'ENABLED_IDPS': {
+            idp_string: {
+                'attr_username': 'username',
+                'attr_user_permanent_id': 'name_id',
+                'attr_groups': 'missing_group_attr',  # This attribute won't be in the response
+            },
+        }
+    }
+    database_instance.configuration = enabled_idps
+    ap.database_instance = database_instance
+
+    response = {
+        'idp_name': 'IdP',
+        'attributes': {
+            'username': ['gateway_admin'],
+            'name_id': 'gateway_admin',
+            # Note: No 'missing_group_attr' and no default 'Group' attribute
+        },
+    }
+
+    au = AuthenticatorUser()
+
+    # Set logging level to DEBUG to capture the debug message
+    with caplog.at_level(logging.DEBUG, logger='ansible_base.authentication.authenticator_plugins.saml'):
+        with mock.patch('social_core.backends.saml.SAMLAuth.extra_data', return_value={}):
+            results = ap.extra_data(None, 'IdP:gateway_admin', response, **{'social': au})
+
+    # Verify the log message was captured
+    assert "Unable to get any group claims from the SAML response" in caplog.text
+
+    # Verify no group data in results
+    assert 'missing_group_attr' not in results
+    assert 'Group' not in results
 
 
 def test_saml_create_via_api_without_callback_url(admin_api_client, saml_configuration):


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - SAML authenticator will use group attribute specified in the IDP configuration rather than only expecting to find "Group" attribute
- Why is this change needed?
  - Users expect to be able to use groups from configured attribute and then use group mapping instead of attribute mapping in authenticator
- How does this change address the issue?
  - This change adds logic that will set Group in this order:
    -  First, "Group" attribute - original behavior using hard-coded "Group" attribute
    - Second, Configured group attribute  

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Pull down the PR, in aap-gateway enable keycloak and start aap-gateway with `make docker-compose`
2. Modify SAML configuration in AAP to use Groups field other than "Groups". Also add mapping that will use groups to assign membership or something that you can verify later on.
3. In Keycloak create couple of groups and a user belonging to the groups. Also, in client scope for SAML add a group list type mapper named "member" (this should match what you expect the field above to be)
4. Login with the user created above and verify user got expected membership.

### Expected Results
<!-- Describe what should happen after following the steps -->
Below is a snippet from gateway log showing how user's groups were picked (message is "Setting Group from attribute: member"):

```
2025-08-12 19:59:37,345 INFO      ansible_base.authentication.social_auth Stored OAuth email test@somewhere.com for user test from Dev Keycloak SAML
aap_gw_1           | 2025-08-12 19:59:37,346 DEBUG     ansible_base.authentication.authenticator_plugins.utils Attempting to load class ansible_base.authentication.authenticator_plugins.saml
aap_gw_1           | 2025-08-12 19:59:37,346 DEBUG     ansible_base.authentication.social_auth Attempting to load social settings from aap_gateway_api.authentication.util.load_social_auth_settings
aap_gw_1           | 2025-08-12 19:59:37,346 DEBUG     aap.gateway.authentication.util Loading gateway social auth settings
aap_gw_1           | 2025-08-12 19:59:37,349 DEBUG     ansible_base.authentication.authenticator_plugins.saml Setting Group from attribute: member
aap_gw_1           | 2025-08-12 19:59:37,351 DEBUG     aap.gateway.utils.jwt_cache Invalidating and issuing new JWT token for test
aap_gw_1           | 2025-08-12 19:59:37,361 DEBUG     ansible_base.authentication.social_auth groups extracted from UserInfo. "Group": ['/G1', '/G2', '/G2.5']
aap_gw_1           | 2025-08-12 19:59:37,361 DEBUG     ansible_base.authentication.social_auth updating user claims with groups claim "Group": ['/G1', '/G2', '/G2.5']
aap_gw_1           | 2025-08-12 19:59:37,365 INFO      ansible_base.authentication.utils.claims Creating mapping for user test through authenticator Dev Keycloak SAML
aap_gw_1           | 2025-08-12 19:59:37,365 DEBUG     ansible_base.authentication.utils.claims test's groups: ['/G1', '/G2', '/G2.5']
aap_gw_1           | 2025-08-12 19:59:37,365 DEBUG     ansible_base.authentication.utils.claims test's attrs: {'idp_name': 'IdP', 'attributes': {'email': ['test@somewhere.com'], 'last_name': ['Tester'], 'username': ['test'], 'member': ['/G1', '/G2', '/G2.5'], 'first_name': ['Test'], 'Role': ['manage-account', 'default-roles-gateway realm', 'uma_authorization', 'view-profile', 'offline_access', 'manage-account-links'], 'name_id': 'test'}, 'session_index': 'bd0bfbf5-6715-47df-b271-e8a22630116a::0cb841a2-0a31-4976-86fa-a765f09426da', 'auth_time': '2025-08-12T19:59:37.363584Z', 'name_id': 'test', 'email': ['test@somewhere.com'], 'member': ['/G1', '/G2', '/G2.5'], 'username': ['test'], 'last_name': ['Tester'], 'first_name': ['Test']}
aap_gw_1           | 2025-08-12 19:59:37,365 DEBUG     ansible_base.authentication.utils.claims Authenticator ID: 3
aap_gw_1           | 2025-08-12 19:59:37,365 DEBUG     ansible_base.authentication.utils.claims ==============================================================
aap_gw_1           | 2025-08-12 19:59:37,365 DEBUG     ansible_base.authentication.utils.claims Processing {maps.count()} map(s) for this authenticator
aap_gw_1           | 2025-08-12 19:59:37,366 DEBUG     ansible_base.authentication.utils.claims Processing map Dev Keycloak SAML Map - superuser 4
aap_gw_1           | 2025-08-12 19:59:37,367 DEBUG     ansible_base.authentication.utils.claims Processing map Dev Keycloak SAML Map - auditor 5
aap_gw_1           | 2025-08-12 19:59:37,367 DEBUG     ansible_base.authentication.utils.claims Processing map Dev Keycloak SAML Map - org 6
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims Processing map G1 becomes superuser 7
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims access_allowed: True
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims Setting new attribute access_allowed for test
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims is_superuser: True
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims Setting new attribute is_superuser for test
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims claims: {'team_membership': {}, 'organization_membership': {'Default': True}, 'rbac_roles': {'system': {'roles': {}}, 'organizations': {'Default': {'roles': {'Organization Member': True}, 'teams': {}}}}}
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims Setting new attribute claims for test
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims last_login_map_results: [{4: 'skipped', 'enabled': True}, {5: 'skipped', 'enabled': True}, {6: True, 'enabled': True}, {7: True, 'enabled': True}]
aap_gw_1           | 2025-08-12 19:59:37,369 DEBUG     ansible_base.authentication.utils.claims Setting new attribute last_login_map_results for test
aap_gw_1           | 2025-08-12 19:59:37,371 DEBUG     aap.gateway.utils.jwt_cache Invalidating and issuing new JWT token for test
aap_gw_1           | 2025-08-12 19:59:37,383 INFO      ansible_base.authentication.utils.claims Reconciling user claims
aap_gw_1           | 2025-08-12 19:59:37,387 DEBUG     ansible_base.authentication.authenticator_plugins.utils Attempting to load class ansible_base.authentication.authenticator_plugins.saml
aap_gw_1           | 2025-08-12 19:59:37,387 DEBUG     ansible_base.authentication.social_auth Attempting to load social settings from aap_gateway_api.authentication.util.load_social_auth_settings
aap_gw_1           | 2025-08-12 19:59:37,387 DEBUG     aap.gateway.authentication.util Loading gateway social auth settings
aap_gw_1           | 2025-08-12 19:59:37,392 INFO      ansible_base.authentication.utils.claims Assigning role 'Organization Member' to user 'test' in 'Organization
aap_gw_1           | 2025-08-12 19:59:37,401 DEBUG     aap.gateway.utils.jwt_cache Invalidating and issuing new JWT token for test
aap_gw_1           | 2025-08-12 19:59:37,410 DEBUG     ansible_base.rbac.caching Adding 2 object-permissions to ObjectRole(pk=6, organization=1)
aap_gw_1           | 2025-08-12 19:59:37,410 INFO      ansible_base.rbac.caching Adding 2 object-permission records
aap_gw_1           | 2025-08-12 19:59:37,412 INFO      ansible_base.authentication.backend User test logged in from authenticator with ID "3"
aap_gw_1           | 2025-08-12 19:59:37,412 DEBUG     aap.gateway.utils.jwt_cache Invalidating and issuing new JWT token for test
aap_gw_1           | 2025-08-12 19:59:37,427 DEBUG     aap.gateway.utils.jwt_cache Invalidating and issuing new JWT token for test
aap_gw_1           | 2025-08-12 19:59:37,434 DEBUG     ansible_base.authentication.authenticator_plugins.utils Attempting to load class ansible_base.authentication.authenticator_plugins.saml
aap_gw_1           | 2025-08-12 19:59:37,434 DEBUG     ansible_base.authentication.social_auth Attempting to load social settings from aap_gateway_api.authentication.util.load_social_auth_settings
aap_gw_1           | 2025-08-12 19:59:37,434 DEBUG     aap.gateway.authentication.util Loading gateway social auth settings

```
