### PR TITLE
AAP-51591 Remove LDAP composite filter splitter

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -1,6 +1,5 @@
 import inspect
 import logging
-import re
 from collections import OrderedDict
 from typing import Any
 
@@ -248,11 +247,6 @@ def validate_ldap_filter(value: Any, with_user: bool = False) -> None:
 
         dn_value = value.replace(user_search_string, 'USER')
 
-    # Check if this is an and/or filter with multiple subfilters
-    if re.match(r'^\([&|!]\(.*?\)\)$', dn_value):
-        for sub_filter in dn_value[3:-2].split(')('):
-            # We only need to check with_user at the top of the recursion stack
-            validate_ldap_filter(f'({sub_filter})', with_user=False)
     try:
         Filter.parse(dn_value)
     except ParseError:

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -481,11 +481,20 @@ def test_ldap_validate_ldap_filter(ldap_configuration, ldap_settings):
     invalid_filter = "(&(cn=%(user)s)(objectClass=posixAccount)(invalid))"
     with pytest.raises(ValidationError) as e:
         validate_ldap_filter(invalid_filter, True)
-    assert e.value.args[0] == 'Invalid filter: (invalid)'
+    assert "(invalid)" in str(e.value.args[0])
 
+
+@pytest.mark.parametrize(
+    "filter,with_user",
+    [
+        ("(&(sAMAccountName=%(user)s)(memberOf:1.3.850.114256.1.4.1241:=CN=ravioli,CN=Users,DC=username2024,DC=local))", True),
+        ("(&(|(objectclass=userproxy)(objectclass=user))(|(employeeID=%(user)s)(hsbc-ad-SAMAccountName=%(user)s)))", True),
+        ("(|(objectclass=userproxy)(objectclass=user))", False),
+    ],
+)
+def test_ldap_customer_filter_validation(filter, with_user, ldap_configuration, ldap_settings):
     # From AAP-36738
-    customer_filter = "(&(sAMAccountName=%(user)s)(memberOf:1.3.850.114256.1.4.1241:=CN=ravioli,CN=Users,DC=username2024,DC=local))"
-    validate_ldap_filter(customer_filter, True)
+    validate_ldap_filter(filter, with_user)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description

Update to LDAP filter validation to remove splitting function and let python-ldap-filter do the entire validation.  Some composite filters were failing to validate due to improper splitting.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. UT has the two new filters that were failing to be validated, those can be used to test or any valid LDAP filter.
2. 
3. 

### Expected Results
Previously improperly rejected valid filters now treated as valid.
