### PR TITLE
AAP-50805 Ignore role content types not known to system in sync

### DIFF
--- a/ansible_base/resource_registry/shared_types.py
+++ b/ansible_base/resource_registry/shared_types.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from ansible_base.rbac.models import DABContentType, DABPermission
 from ansible_base.resource_registry.utils.resource_type_serializers import AnsibleResourceForeignKeyField, SharedResourceTypeSerializer
@@ -104,3 +105,18 @@ class RoleDefinitionType(SharedResourceTypeSerializer):
         default=None,
     )
     permissions = LenientPermissionSlugListField()
+
+    def is_valid(self, raise_exception=False):
+        if not raise_exception:
+            return super().is_valid(raise_exception=False)
+
+        try:
+            return super().is_valid(raise_exception=True)
+        except ValidationError as e:
+            if hasattr(e, 'detail') and 'content_type' in e.detail:
+                fd_detail = e.detail['content_type'][0]
+                if fd_detail.code == "does_not_exist":
+                    from ansible_base.resource_registry.tasks.sync import SkipResource
+
+                    raise SkipResource(*e.args)
+            raise

--- a/ansible_base/resource_registry/shared_types.py
+++ b/ansible_base/resource_registry/shared_types.py
@@ -107,11 +107,8 @@ class RoleDefinitionType(SharedResourceTypeSerializer):
     permissions = LenientPermissionSlugListField()
 
     def is_valid(self, raise_exception=False):
-        if not raise_exception:
-            return super().is_valid(raise_exception=False)
-
         try:
-            return super().is_valid(raise_exception=True)
+            return super().is_valid(raise_exception=raise_exception)
         except ValidationError as e:
             if hasattr(e, 'detail') and 'content_type' in e.detail:
                 fd_detail = e.detail['content_type'][0]

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -36,6 +36,11 @@ class ResourceDeletionError(Error):
 class ResourceSyncHTTPError(HTTPError):
     """Custom catchall error"""
 
+class SkipResource(ValidationError):
+    """To raise by serializers if the item should be skipped"""
+    default_detail = "The specified content_type slug was not found."
+    default_code = "content_type_does_not_exist"
+
 
 class SyncStatus(str, Enum):
     CREATED = "created"
@@ -226,6 +231,8 @@ def _attempt_create_resource(
             ansible_id=manifest_item.ansible_id,
             service_id=resource_service_id,
         )
+    except SkipResource:
+        return SyncResult(SyncStatus.NOOP, manifest_item)
     except IntegrityError:
         # This typically means that there was a duplicate key error. To mitigate this
         # we will attempt to hanlde the conflicting resource and perform the operation

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -36,8 +36,10 @@ class ResourceDeletionError(Error):
 class ResourceSyncHTTPError(HTTPError):
     """Custom catchall error"""
 
+
 class SkipResource(ValidationError):
     """To raise by serializers if the item should be skipped"""
+
     default_detail = "The specified content_type slug was not found."
     default_code = "content_type_does_not_exist"
 

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -7,9 +7,11 @@ from django.db.utils import Error
 
 from ansible_base.lib.testing.util import StaticResourceAPIClient
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.resource_registry.models import Resource
+from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.models.service_identifier import service_id
-from ansible_base.resource_registry.tasks.sync import ResourceSyncHTTPError, SyncExecutor
+from ansible_base.resource_registry.tasks.sync import ResourceSyncHTTPError, SyncExecutor, _attempt_create_resource, ManifestItem
+from ansible_base.rbac import permission_registry
+from ansible_base.rbac.models import RoleDefinition
 
 
 @pytest.fixture(scope="function")
@@ -176,6 +178,36 @@ def test_resource_sync_update_conflict(static_api_client, stdout, resource_to_up
     assert any('Updated 1' in line for line in stdout.lines)
 
     assert Resource.objects.get(ansible_id=new_id).name == "was_renamed"
+
+
+@pytest.mark.django_db
+def test_resource_sync_create_local_role_definition(static_api_client, stdout, resource_to_update):
+    item_data = {"name": "Organization Inventory Role", "content_type": "shared.organization", "managed": True, "permissions": []}
+    manifest_item = ManifestItem(str(uuid4()), str(uuid4()), item_data)
+    result = _attempt_create_resource(
+        manifest_item=manifest_item,
+        resource_data=item_data,
+        resource_type=ResourceType.objects.get(name='shared.roledefinition'),
+        resource_service_id=str(uuid4()),
+        api_client=static_api_client  # unused
+    )
+    assert result.status == 'created'
+
+
+@pytest.mark.django_db
+def test_resource_sync_create_non_local_role_definition(static_api_client, stdout, resource_to_update):
+    item_data = {"name": "Remote Role", "content_type": "shared.foo_type", "managed": True, "permissions": []}
+    manifest_item = ManifestItem(str(uuid4()), str(uuid4()), item_data)
+    result = _attempt_create_resource(
+        manifest_item=manifest_item,
+        resource_data=item_data,
+        resource_type=ResourceType.objects.get(name='shared.roledefinition'),
+        resource_service_id=str(uuid4()),
+        api_client=static_api_client  # unused
+    )
+    assert result.status == 'noop'
+
+    assert not RoleDefinition.objects.filter(name="Remote Role").exists()
 
 
 @pytest.mark.django_db

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -7,11 +7,10 @@ from django.db.utils import Error
 
 from ansible_base.lib.testing.util import StaticResourceAPIClient
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac.models import RoleDefinition
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.models.service_identifier import service_id
-from ansible_base.resource_registry.tasks.sync import ResourceSyncHTTPError, SyncExecutor, _attempt_create_resource, ManifestItem
-from ansible_base.rbac import permission_registry
-from ansible_base.rbac.models import RoleDefinition
+from ansible_base.resource_registry.tasks.sync import ManifestItem, ResourceSyncHTTPError, SyncExecutor, _attempt_create_resource
 
 
 @pytest.fixture(scope="function")
@@ -189,7 +188,7 @@ def test_resource_sync_create_local_role_definition(static_api_client, stdout, r
         resource_data=item_data,
         resource_type=ResourceType.objects.get(name='shared.roledefinition'),
         resource_service_id=str(uuid4()),
-        api_client=static_api_client  # unused
+        api_client=static_api_client,  # unused
     )
     assert result.status == 'created'
 
@@ -203,7 +202,7 @@ def test_resource_sync_create_non_local_role_definition(static_api_client, stdou
         resource_data=item_data,
         resource_type=ResourceType.objects.get(name='shared.roledefinition'),
         resource_service_id=str(uuid4()),
-        api_client=static_api_client  # unused
+        api_client=static_api_client,  # unused
     )
     assert result.status == 'noop'
 


### PR DESCRIPTION
## Description
The bug here is that AWX `periodic_resource_sync` will result in an error.

It seems there was an attempt to log an error and continue on when getting a `ValidationError`, it seems this only targeted the Django validation error exception, leaving the more common DRF ValidationError uncaught. This means that the issue broke the resource sync, globally. That means the periodic sync was effectively broken by the referenced bug.

We could change that, but we wanted to have a targeted and more intentional special-case just for roles, and that is what this implements.

If the field `RoleDefinition.content_type` references a type that does not exist locally, we don't bother in the _periodic fallback_ sync and just skip over that record. This is very sensible behavior, and it will be reported as a no-op, as one should expect.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
Working on an aap-dev manual reproducer demo for this, which is important considering the limited scope of the unit tests added.

shell into `awx-manage shell_plus`:

```
In [1]: from awx.main.tasks.system import periodic_resource_sync

In [2]: periodic_resource_sync()
2025-08-18 22:07:04,415 INFO     [-] awx.main.tasks.system Periodic resource sync updated:
[ManifestItem(ansible_id='fc86960a-41f9-45cb-b098-cc645bf582f9', resource_hash='8e6e201516644eb39c14e84d74c88e11a32b22061a9dde3341d7e6bfa7a8eb25', resource_data={'name': 'Platform Auditor', 'description': 'Has view permissions to all objects', 'managed': True, 'content_type': None, 'permissions': ['eda.view_activation', 'galaxy.view_ansiblerepository', 'eda.view_auditrule', 'galaxy.view_collection', 'galaxy.view_collectionimport', 'galaxy.view_collectionremote', 'galaxy.view_containernamespace', 'galaxy.view_containerregistryremote', 'galaxy.view_containerrepository', 'awx.view_credential', 'eda.view_credentialinputsource', 'eda.view_decisionenvironment', 'eda.view_edacredential', 'eda.view_eventstream', 'awx.view_instancegroup', 'awx.view_inventory', 'awx.view_jobtemplate', 'galaxy.view_namespace', 'awx.view_notificationtemplate', 'shared.view_organization', 'awx.view_project', 'eda.view_project', 'eda.view_rulebook', 'eda.view_rulebookprocess', 'galaxy.view_task', 'shared.view_team', 'awx.view_workflowjobtemplate']}), ManifestItem(ansible_id='b0934863-30ed-4e63-84c3-2cc0bb79a934', resource_hash='4ef46fea6b695f152e26ddffa59afb98fb6bae445c4a62bfb54008d5852c1dbf', resource_data={'name': 'Organization Admin', 'description': 'Has all permissions to a single organization and all objects inside of it', 'managed': True, 'content_type': 'shared.organization', 'permissions': ['eda.add_activation', 'eda.change_activation', 'eda.delete_activation', 'eda.disable_activation', 'eda.enable_activation', 'eda.restart_activation', 'eda.view_activation', 'eda.view_auditrule', 'awx.add_credential', 'awx.change_credential', 'awx.delete_credential', 'awx.use_credential', 'awx.view_credential', 'eda.add_credentialinputsource', 'eda.change_credentialinputsource', 'eda.delete_credentialinputsource', 'eda.view_credentialinputsource', 'eda.add_decisionenvironment', 'eda.change_decisionenvironment', 'eda.delete_decisionenvironment', 'eda.view_decisionenvironment', 'eda.add_edacredential', 'eda.change_edacredential', 'eda.delete_edacredential', 'eda.view_edacredential', 'eda.add_eventstream', 'eda.change_eventstream', 'eda.delete_eventstream', 'eda.view_eventstream', 'awx.add_executionenvironment', 'awx.change_executionenvironment', 'awx.delete_executionenvironment', 'awx.add_inventory', 'awx.adhoc_inventory', 'awx.change_inventory', 'awx.delete_inventory', 'awx.update_inventory', 'awx.use_inventory', 'awx.view_inventory', 'awx.change_jobtemplate', 'awx.delete_jobtemplate', 'awx.execute_jobtemplate', 'awx.view_jobtemplate', 'awx.add_notificationtemplate', 'awx.change_notificationtemplate', 'awx.delete_notificationtemplate', 'awx.view_notificationtemplate', 'shared.audit_organization', 'shared.change_organization', 'shared.delete_organization', 'shared.member_organization', 'shared.view_organization', 'awx.add_project', 'eda.add_project', 'eda.change_project', 'awx.change_project', 'eda.delete_project', 'awx.delete_project', 'eda.sync_project', 'awx.update_project', 'awx.use_project', 'awx.view_project', 'eda.view_project', 'eda.view_rulebook', 'eda.view_rulebookprocess', 'shared.add_team', 'shared.change_team', 'shared.delete_team', 'shared.member_team', 'shared.view_team', 'awx.add_workflowjobtemplate', 'awx.approve_workflowjobtemplate', 'awx.change_workflowjobtemplate', 'awx.delete_workflowjobtemplate', 'awx.execute_workflowjobtemplate', 'awx.view_workflowjobtemplate']}), ManifestItem(ansible_id='cfd1601a-3ee2-429f-aa13-cd38a7dc5667', resource_hash='7488247fd9cd5b00237179a5cb820d92f0ecd7f4db491869bb1a4b7189f1d81e', resource_data={'name': 'System Auditor', 'description': 'Has view permissions to all objects', 'managed': True, 'content_type': None, 'permissions': ['galaxy.view_ansiblerepository', 'galaxy.view_collection', 'galaxy.view_collectionimport', 'galaxy.view_collectionremote', 'galaxy.view_containernamespace', 'galaxy.view_containerregistryremote', 'galaxy.view_containerrepository', 'galaxy.view_namespace', 'shared.view_organization', 'galaxy.view_task', 'shared.view_team']})]
2025-08-18 22:07:04,415 INFO     [-] awx.main.tasks.system Periodic resource sync created, first 10 items:
[ManifestItem(ansible_id='c7f3aa95-1651-4b99-ad18-0ccc227efdb9', resource_hash='fe544ff88d6eac00d91d4d923b2b92508f2903ea47da733206a89a1b6a2f7998', resource_data={'name': 'galaxy.content_admin', 'description': 'galaxy.content_admin', 'managed': True, 'content_type': None, 'permissions': ['galaxy.add_ansiblerepository', 'galaxy.change_ansiblerepository', 'galaxy.delete_ansiblerepository', 'galaxy.manage_roles_ansiblerepository', 'galaxy.modify_ansible_repo_content', 'galaxy.repair_ansiblerepository', 'galaxy.sign_ansiblerepository', 'galaxy.view_ansiblerepository', 'galaxy.delete_collection', 'galaxy.add_collectionremote', 'galaxy.change_collectionremote', 'galaxy.delete_collectionremote', 'galaxy.manage_roles_collectionremote', 'galaxy.view_collectionremote', 'galaxy.add_containernamespace', 'galaxy.change_containernamespace', 'galaxy.manage_roles_containernamespace', 'galaxy.namespace_add_containerdistribution', 'galaxy.namespace_change_containerdistribution', 'galaxy.namespace_modify_content_containerpushrepository', 'galaxy.namespace_push_containerdistribution', 'galaxy.view_containernamespace', 'galaxy.add_containerregistryremote', 'galaxy.change_containerregistryremote', 'galaxy.delete_containerregistryremote', 'galaxy.delete_containerrepository', 'galaxy.add_namespace', 'galaxy.change_namespace', 'galaxy.delete_namespace', 'galaxy.upload_to_namespace']}), ManifestItem(ansible_id='98e301c6-767a-4cee-b39d-005c75322523', resource_hash='80f2d709f8c3c3a9300d6a7eb42e545ad0c27c20364a2c44ae1e9b4cca71bb5b', resource_data={'name': 'galaxy.collection_admin', 'description': 'galaxy.collection_admin', 'managed': True, 'content_type': None, 'permissions': ['galaxy.add_ansiblerepository', 'galaxy.change_ansiblerepository', 'galaxy.delete_ansiblerepository', 'galaxy.manage_roles_ansiblerepository', 'galaxy.modify_ansible_repo_content', 'galaxy.repair_ansiblerepository', 'galaxy.sign_ansiblerepository', 'galaxy.view_ansiblerepository', 'galaxy.delete_collection', 'galaxy.add_collectionremote', 'galaxy.change_collectionremote', 'galaxy.delete_collectionremote', 'galaxy.manage_roles_collectionremote', 'galaxy.view_collectionremote', 'galaxy.add_namespace', 'galaxy.change_namespace', 'galaxy.delete_namespace', 'galaxy.upload_to_namespace']}), ManifestItem(ansible_id='3bfa9323-cd6b-48f1-91f4-d0a453db7762', resource_hash='1c8276b30a094862636d9f8fa21ef129b597730433fbc126e1092c3750e1217e', resource_data={'name': 'galaxy.collection_curator', 'description': 'galaxy.collection_curator', 'managed': True, 'content_type': None, 'permissions': ['galaxy.add_ansiblerepository', 'galaxy.change_ansiblerepository', 'galaxy.delete_ansiblerepository', 'galaxy.manage_roles_ansiblerepository', 'galaxy.modify_ansible_repo_content', 'galaxy.repair_ansiblerepository', 'galaxy.sign_ansiblerepository', 'galaxy.view_ansiblerepository', 'galaxy.add_collectionremote', 'galaxy.change_collectionremote', 'galaxy.delete_collectionremote', 'galaxy.manage_roles_collectionremote', 'galaxy.view_collectionremote']}), ManifestItem(ansible_id='e51c0322-69a4-4ccc-95a1-b67ebeb645e0', resource_hash='034dfe48cafc971c2b801c61b49d492770d3ed604052ea8ad805b46bb38f7993', resource_data={'name': 'galaxy.execution_environment_admin', 'description': 'galaxy.execution_environment_admin', 'managed': True, 'content_type': None, 'permissions': ['galaxy.add_containernamespace', 'galaxy.change_containernamespace', 'galaxy.manage_roles_containernamespace', 'galaxy.namespace_add_containerdistribution', 'galaxy.namespace_change_containerdistribution', 'galaxy.namespace_modify_content_containerpushrepository', 'galaxy.namespace_push_containerdistribution', 'galaxy.view_containernamespace', 'galaxy.add_containerregistryremote', 'galaxy.change_containerregistryremote', 'galaxy.delete_containerregistryremote', 'galaxy.delete_containerrepository']}), ManifestItem(ansible_id='d28f535c-c883-44b8-8b74-6ec43ddc29de', resource_hash='fd17177f13145c3d9e9d7ea9e9ac78d7089773e139329ec90fb15b8d815dcca7', resource_data={'name': 'Organization Editor', 'description': 'Has create and update permissions to all objects within a single organization', 'managed': True, 'content_type': 'shared.organization', 'permissions': ['eda.add_activation', 'eda.change_activation', 'eda.view_activation', 'eda.view_auditrule', 'eda.add_credentialinputsource', 'eda.change_credentialinputsource', 'eda.view_credentialinputsource', 'eda.add_decisionenvironment', 'eda.change_decisionenvironment', 'eda.view_decisionenvironment', 'eda.add_edacredential', 'eda.change_edacredential', 'eda.view_edacredential', 'eda.add_eventstream', 'eda.change_eventstream', 'eda.view_eventstream', 'shared.view_organization', 'eda.add_project', 'eda.change_project', 'eda.view_project', 'eda.view_rulebook', 'eda.view_rulebookprocess', 'shared.view_team']}), ManifestItem(ansible_id='22b74935-bcec-410b-b025-123cc5f2e279', resource_hash='7c13d7bf3e6b98b47cd308f5266595628d7fa01b8480cf79186835b604ddd305', resource_data={'name': 'Organization Contributor', 'description': 'Has create and update permissions to all objects and enable/disable/restart permissions to all rulebook activations within a single organization', 'managed': True, 'content_type': 'shared.organization', 'permissions': ['eda.add_activation', 'eda.change_activation', 'eda.disable_activation', 'eda.enable_activation', 'eda.restart_activation', 'eda.view_activation', 'eda.view_auditrule', 'eda.add_credentialinputsource', 'eda.change_credentialinputsource', 'eda.view_credentialinputsource', 'eda.add_decisionenvironment', 'eda.change_decisionenvironment', 'eda.view_decisionenvironment', 'eda.add_edacredential', 'eda.change_edacredential', 'eda.view_edacredential', 'eda.add_eventstream', 'eda.change_eventstream', 'eda.view_eventstream', 'shared.view_organization', 'eda.add_project', 'eda.change_project', 'eda.view_project', 'eda.view_rulebook', 'eda.view_rulebookprocess', 'shared.view_team']}), ManifestItem(ansible_id='3d338601-0bd4-4807-add6-28a758b13d40', resource_hash='9ef7d27c17a7a469335449789b7a856a34de25fa887a860400e81e8a35d86b94', resource_data={'name': 'Organization Operator', 'description': 'Has read permission to all objects and enable/disable/restart permissions for all rulebook activations within a single organization', 'managed': True, 'content_type': 'shared.organization', 'permissions': ['eda.disable_activation', 'eda.enable_activation', 'eda.restart_activation', 'eda.view_activation', 'eda.view_auditrule', 'eda.view_credentialinputsource', 'eda.view_decisionenvironment', 'eda.view_edacredential', 'eda.view_eventstream', 'shared.view_organization', 'eda.view_project', 'eda.view_rulebook', 'eda.view_rulebookprocess', 'shared.view_team']}), ManifestItem(ansible_id='4e545f21-477e-44fc-9f6d-ea1b46f26d9b', resource_hash='576038542e41dffcb31605b466535d9800122ed0a4741c5f40e09bd382c3eb94', resource_data={'name': 'Organization Auditor', 'description': 'Has read permission to all objects within a single organization', 'managed': True, 'content_type': 'shared.organization', 'permissions': ['eda.view_activation', 'eda.view_auditrule', 'eda.view_credentialinputsource', 'eda.view_decisionenvironment', 'eda.view_edacredential', 'eda.view_eventstream', 'shared.view_organization', 'eda.view_project', 'eda.view_rulebook', 'eda.view_rulebookprocess', 'shared.view_team']}), ManifestItem(ansible_id='40ee79c2-a776-46c3-a9b8-a9eddd0f63c6', resource_hash='2b99f03bf318e197ec1e94eee04796079e63e3d9c7d109b2aaca17001d21859b', resource_data={'name': 'Organization Viewer', 'description': 'Has read permission to all objects within a single organization', 'managed': True, 'content_type': 'shared.organization', 'permissions': ['eda.view_activation', 'eda.view_auditrule', 'eda.view_credentialinputsource', 'eda.view_decisionenvironment', 'eda.view_edacredential', 'eda.view_eventstream', 'shared.view_organization', 'eda.view_project', 'eda.view_rulebook', 'eda.view_rulebookprocess', 'shared.view_team']}), ManifestItem(ansible_id='3d741c0f-ae7f-48d3-b351-f767310d32da', resource_hash='dd172f12df69ac63ec92b7c1f6aee18c42587eb09c5957f6a102c7de1b1a06f3', resource_data={'name': 'Organization Credential Input Source Admin', 'description': 'Has all permissions to credential input sources within an organization', 'managed': True, 'content_type': 'shared.organization', 'permissions': ['eda.add_credentialinputsource', 'eda.change_credentialinputsource', 'eda.delete_credentialinputsource', 'eda.view_credentialinputsource', 'shared.view_organization']})]

```

so it does not error


### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

