### PR TITLE
AAP-51883 Fix unsafe assumption about org content type

### DIFF
--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -186,8 +186,13 @@ class PermissionRegistry:
 
     @cached_property
     def org_ct_id(self):
-        team_parent_model = self.get_parent_model(self.team_model)
-        return self.content_type_model.objects.get_for_model(team_parent_model).id
+        # This should be safe to import at top of file because it is ansible_base.lib
+        # but it is not because of issue:
+        # https://github.com/ansible/django-ansible-base/issues/443
+        from ansible_base.lib.utils.auth import get_organization_model
+
+        org_model = get_organization_model()
+        return self.content_type_model.objects.get_for_model(org_model).id
 
     @property
     def permission_qs(self):


### PR DESCRIPTION
## Description
This fixes a server error, part of the traceback

```
  File "/app/django-ansible-base/ansible_base/jwt_consumer/common/auth.py", line 327, in authenticate
    self.process_permissions()
  File "/app/django-ansible-base/ansible_base/jwt_consumer/common/auth.py", line 338, in process_permissions
    self.common_auth.process_rbac_permissions()
  File "/app/django-ansible-base/ansible_base/jwt_consumer/common/auth.py", line 283, in process_rbac_permissions
    save_user_claims(self.user, objects, object_roles, global_roles)
  File "/app/django-ansible-base/ansible_base/rbac/claims.py", line 356, in save_user_claims
    assignment = rd.give_permission(user, obj)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/django-ansible-base/ansible_base/rbac/models/role.py", line 225, in give_permission
    return self.give_or_remove_permission(actor, content_object, giving=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/django-ansible-base/ansible_base/rbac/models/role.py", line 298, in give_or_remove_permission
    update_after_assignment(update_teams, to_update)
  File "/app/django-ansible-base/ansible_base/rbac/triggers.py", line 89, in update_after_assignment
    compute_team_member_roles()
  File "/app/django-ansible-base/ansible_base/rbac/caching.py", line 134, in compute_team_member_roles
    direct_member_roles = get_direct_team_member_roles(org_team_mapping)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/django-ansible-base/ansible_base/rbac/caching.py", line 86, in get_direct_team_member_roles
    elif object_role.content_type_id == permission_registry.org_ct_id:
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/django/utils/functional.py", line 57, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
                                         ^^^^^^^^^^^^^^^^^^^
  File "/app/django-ansible-base/ansible_base/rbac/permission_registry.py", line 190, in org_ct_id
    return self.content_type_model.objects.get_for_model(team_parent_model).id
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/django-ansible-base/ansible_base/rbac/models/content_type.py", line 66, in get_for_model
    query_service = get_resource_prefix(model)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/django-ansible-base/ansible_base/rbac/remote.py", line 174, in get_resource_prefix
    resource_config = registry.get_config_for_model(model)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/django-ansible-base/ansible_base/resource_registry/registry.py", line 103, in get_config_for_model
    raise AttributeError(_("Must include either model or model_label arg."))
rest_framework.request.WrappedAttributeError: Must include either model or model_label arg.
```

This is due to, specifically, the registration of the `Team` model in galaxy_ng with no parent model.

https://github.com/ansible/galaxy_ng/blob/5fce949deb374e1755029f7d9a5a6d109d031e69/galaxy_ng/app/models/__init__.py#L50-L59

Knowing that the parent model is null, you can read the traceback in a way that makes sense. The variable `team_parent_model` gets a value of `None`, which is 100% unexpected.

At the end, `model` was _intended_ to be passed, but it has a value of `None`, which the method interprets as not being provided.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

