### PR TITLE
AAP-50879 Add data, remove dups, RBAC access list serializer

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -328,7 +328,7 @@ class UserAccessListMixin(AccessListMixin, serializers.ModelSerializer):
     object_role_assignments = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     related = serializers.SerializerMethodField('_get_related')
-    _expected_fields = ['id', 'url', 'related', 'username', 'is_superuser', 'object_role_assignments']
+    _expected_fields = ['id', 'url', 'related', 'username', 'is_superuser', 'first_name', 'last_name', 'object_role_assignments']
 
 
 class TeamAccessListMixin(AccessListMixin, AbstractCommonModelSerializer):

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -334,7 +334,7 @@ class UserAccessViewSet(
         actor_qs = actor_cls.objects.filter(role_assignments__in=assignment_qs)
         if actor_cls._meta.model_name == 'user':
             actor_qs |= actor_cls.objects.filter(is_superuser=True)
-        return actor_qs
+        return actor_qs.distinct()
 
     def get_serializer(self, *args, **kwargs):
         """Awkwardly override this method, because eda-server uses a custom base viewset class.

--- a/test_app/tests/rbac/api/test_access_lists.py
+++ b/test_app/tests/rbac/api/test_access_lists.py
@@ -10,7 +10,7 @@ from test_app.models import Team, User
 def test_user_access_list(admin_api_client, inv_rd, org_inv_rd, inventory, member_rd):
     url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'})
 
-    u1 = User.objects.create(username='direct-inv-access')
+    u1 = User.objects.create(username='direct-inv-access', first_name='user', last_name='one')
     inv_rd.give_permission(u1, inventory)
 
     u2 = User.objects.create(username='org-level-access')
@@ -33,6 +33,9 @@ def test_user_access_list(admin_api_client, inv_rd, org_inv_rd, inventory, membe
         assert detail_resp.status_code == 200, detail_resp.data
         # This should have the same entries in a list view as the access list had in the assignments list
         assert detail_resp.data['count'] == len(user_detail['object_role_assignments'])
+        if user_detail['username'] == u1.username:
+            assert user_detail['first_name'] == 'user'
+            assert user_detail['last_name'] == 'one'
 
     assert u1.username in user_data
     assert len(user_data[u1.username]) == 1
@@ -112,3 +115,26 @@ def test_intermediary_role_display(admin_api_client, inventory, organization, me
     intermediary_names = [entry['role_definition']['name'] for entry in intermediary]
     assert org_admin_inv_rd.name in intermediary_names
     assert org_view_inv_rd.name in intermediary_names
+
+
+@pytest.mark.django_db
+def test_no_duplicates(rando, inv_rd, inventory, org_inv_rd, admin_api_client):
+    inv_rd.give_permission(rando, inventory)
+    org_inv_rd.give_permission(rando, inventory.organization)
+
+    # the admin user themselves will show up, so filter superusers out
+    url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'}) + '?is_superuser=false'
+    response = admin_api_client.get(url)
+    assert response.status_code == 200, response.data
+    assert response.data['count'] == 1, response.data
+
+
+@pytest.mark.django_db
+def test_no_duplicates_team(team, inv_rd, inventory, org_inv_rd, admin_api_client):
+    inv_rd.give_permission(team, inventory)
+    org_inv_rd.give_permission(team, inventory.organization)
+
+    url = get_relative_url('role-team-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'})
+    response = admin_api_client.get(url)
+    assert response.status_code == 200, response.data
+    assert response.data['count'] == 1, response.data


### PR DESCRIPTION
## Description
two things from the UI
 - access list was showing duplicates
 - add `first_name` and `last_name` to the user-oriented serializer, because they are standard Django User fields and will be presented directly in the UI for the access list

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
