### PR TITLE
AAP-51502 Make authenticator.configuration reqd

### DIFF
--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -35,7 +35,10 @@ class AuthenticatorSerializer(NamedCommonModelSerializer, ImmutableFieldsMixin):
             "slug": {
                 "allow_blank": True,
                 "required": False,
-            }
+            },
+            "configuration": {
+                "required": True,
+            },
         }
 
     # TODO: Do we need/want to delve into dicts and search their keys?

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -50,7 +50,7 @@ djangorestframework==3.15.2
     # via
     #   -r requirements/requirements.in
     #   drf-spectacular
-drf-spectacular==0.28.0
+drf-spectacular==0.26.5
     # via -r requirements/requirements_api_documentation.in
 dynaconf==3.2.10
     # via -r requirements/requirements.in

--- a/requirements/requirements_api_documentation.in
+++ b/requirements/requirements_api_documentation.in
@@ -1,1 +1,1 @@
-drf-spectacular
+drf-spectacular==0.26.5


### PR DESCRIPTION
 * The model lists the field as blank=True but it is required by the validator (blank is OK for some auth types)
 * Required for all operations except PATCH
 * Fixes openapi spec/ATF
 * Pins drf-spectacular in dev to the same version used by PDE (aligns spec file output)

## Description
- What is being changed?  "configuration" field made required in serializer
- Why is this change needed? to fix openapi spec for ATF purposes
- How does this change address the issue? DRF spectacular respects the serializer configuration, showing configuration as required

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Start gateway, load docs from /api/gateway/v1/docs/
2. See that configuration field is shown as required for all operations except PATCH
3. 

### Expected Results
Openapi spec is correct.

