### PR TITLE
 AAP-50803 500 server error when creating a custom role missing the "View" permission

### DIFF
--- a/ansible_base/rbac/remote.py
+++ b/ansible_base/rbac/remote.py
@@ -52,6 +52,12 @@ class StandinMeta:
         self.app_label = ct.app_label
         self.abstract = abstract
 
+        # Provide Django-like labels for error messaging and display
+        # e.g., "inventory" -> "inventory" (or title-cased if preferred)
+        human_label = self.model_name.replace('_', ' ')
+        self.verbose_name = human_label
+        self.verbose_name_plural = f"{human_label}s"
+
         self.pk = StandInPK(ct)
 
 

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -133,9 +133,7 @@ def check_view_permission_criteria(codename_set: set[str], permissions_by_model:
             local_codenames = {codename for codename in model_permissions if not is_add_perm(codename)}
             if local_codenames and not any('view' in codename for codename in local_codenames):
                 model_label = getattr(cls._meta, 'verbose_name', getattr(cls._meta, 'model_name', 'model'))
-                raise ValidationError(
-                    {'permissions': f'Permissions for model {model_label} needs to include view, got: {prnt_codenames(local_codenames)}'}
-                )
+                raise ValidationError({'permissions': f'Permissions for model {model_label} needs to include view, got: {prnt_codenames(local_codenames)}'})
 
 
 def check_has_change_with_delete(codename_set: set[str], permissions_by_model: dict[Union[Type[Model], Type[RemoteObject]], list[str]]):

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -132,8 +132,9 @@ def check_view_permission_criteria(codename_set: set[str], permissions_by_model:
             model_permissions = set(valid_model_permissions) & codename_set
             local_codenames = {codename for codename in model_permissions if not is_add_perm(codename)}
             if local_codenames and not any('view' in codename for codename in local_codenames):
+                model_label = getattr(cls._meta, 'verbose_name', getattr(cls._meta, 'model_name', 'model'))
                 raise ValidationError(
-                    {'permissions': f'Permissions for model {cls._meta.verbose_name} needs to include view, got: {prnt_codenames(local_codenames)}'}
+                    {'permissions': f'Permissions for model {model_label} needs to include view, got: {prnt_codenames(local_codenames)}'}
                 )
 
 

--- a/test_app/tests/rbac/api/test_rbac_remote_verbose_name.py
+++ b/test_app/tests/rbac/api/test_rbac_remote_verbose_name.py
@@ -1,0 +1,57 @@
+import pytest
+from django.test.utils import override_settings
+
+from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac.models import DABPermission, DABContentType
+from ansible_base.rbac.remote import get_local_resource_prefix
+
+
+@pytest.mark.django_db
+@override_settings(ANSIBLE_BASE_ROLES_REQUIRE_VIEW=True)
+def test_create_remote_role_missing_view_returns_400_with_clear_message(admin_api_client):
+    """Reproduces AAP-50803: remote stand-in cls lacks verbose_name, causing 500.
+
+    Ensure creating a role for a remote content type with change-only permission
+    returns HTTP 400 and a readable message that mentions view permission is required.
+    """
+    # Ensure a remote content type exists (service not shared/local)
+    local_service = get_local_resource_prefix()
+    remote_ct = (
+        DABContentType.objects.exclude(service__in=("shared", local_service)).first()
+    )
+    if remote_ct is None:
+        # Create a representative remote content type (e.g., awx.inventory)
+        remote_ct, _ = DABContentType.objects.get_or_create(
+            service="awx",
+            app_label="awx",
+            model="inventory",
+            defaults={"pk_field_type": "integer"},
+        )
+
+    # Ensure both view and change permissions exist so the validator enforces the view requirement
+    view_perm, _ = DABPermission.objects.get_or_create(
+        content_type=remote_ct,
+        codename="view_inventory",
+        defaults={"name": "Can view inventory"},
+    )
+    change_perm, _ = DABPermission.objects.get_or_create(
+        content_type=remote_ct,
+        codename="change_inventory",
+        defaults={"name": "Can change inventory"},
+    )
+
+    url = get_relative_url('roledefinition-list')
+    response = admin_api_client.post(
+        url,
+        data={
+            'name': 'remote-change-no-view',
+            'description': '',
+            'content_type': remote_ct.api_slug,
+            'permissions': [change_perm.api_slug],
+        },
+    )
+
+    # Expected: 400 with message indicating view is required
+    assert response.status_code == 400, response.data
+    msg = str(response.data).lower()
+    assert 'view' in msg and ('needs to include view' in msg or 'required' in msg) 

--- a/test_app/tests/rbac/api/test_rbac_remote_verbose_name.py
+++ b/test_app/tests/rbac/api/test_rbac_remote_verbose_name.py
@@ -2,7 +2,7 @@ import pytest
 from django.test.utils import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.rbac.models import DABPermission, DABContentType
+from ansible_base.rbac.models import DABContentType, DABPermission
 from ansible_base.rbac.remote import get_local_resource_prefix
 
 
@@ -16,9 +16,7 @@ def test_create_remote_role_missing_view_returns_400_with_clear_message(admin_ap
     """
     # Ensure a remote content type exists (service not shared/local)
     local_service = get_local_resource_prefix()
-    remote_ct = (
-        DABContentType.objects.exclude(service__in=("shared", local_service)).first()
-    )
+    remote_ct = DABContentType.objects.exclude(service__in=("shared", local_service)).first()
     if remote_ct is None:
         # Create a representative remote content type (e.g., awx.inventory)
         remote_ct, _ = DABContentType.objects.get_or_create(
@@ -54,4 +52,4 @@ def test_create_remote_role_missing_view_returns_400_with_clear_message(admin_ap
     # Expected: 400 with message indicating view is required
     assert response.status_code == 400, response.data
     msg = str(response.data).lower()
-    assert 'view' in msg and ('needs to include view' in msg or 'required' in msg) 
+    assert 'view' in msg and ('needs to include view' in msg or 'required' in msg)


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Fix AAP-50803: prevent 500 on custom roles missing “view” for remote models by adding verbose_name to StandinMeta 
- a safe fallback in validator; 
- include regression test.
## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x ] Test update


## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ X] I have performed a self-review of my code
- [ X] I have added relevant comments to complex code sections
- [ X] I have updated documentation where needed
- [ X] I have considered the security impact of these changes
- [ X] I have considered performance implications
- [ X] I have thought about error handling and edge cases
- [ x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Create a new role at [api/access/roles/create](http://localhost:44926/access/roles/create)
### Expected Results

Error message:
`Permissions for model inventory needs to include view, got ....`

### Root cause
Remote stand‑in metadata did not define `verbose_name`, and the validator assumed it existed.

### Fix
1) Remote metadata enhancement
- Add `verbose_name` to `StandinMeta` (derived from `model_name`, humanized/title‑cased). Optionally add `verbose_name_plural`.

2) Validator hardening
- In `check_view_permission_criteria`, safely obtain a model label via:
  - `getattr(cls._meta, "verbose_name", getattr(cls._meta, "model_name", "model"))`
- Use this label in the error to avoid `AttributeError`.

### Result
- The API now returns HTTP 400 with a clear validation message indicating that the `view` permission is required for the target model, instead of a server error.

### Manual verification

How to verify in the AAP UI 

1. Sign in to the AAP web UI.
2. Navigate to Access Management → Roles.
3. Click “Create role”.
4. Enter values for Name, Display name, and Description.
5. Click “Add permission” but do not specify `view`.
6. Choose a remote content type (e.g., Service “AWX” → Resource “Inventory” or another remote model).
7. For Actions, select only “Change” (or any non‑View action) and do not add the corresponding “View” action for that same model.
8. Click “Save”.
9. Expected: The role is not created and an error is shown indicating the View permission is required for that model. 

(Optional: In browser DevTools → Network, the POST to /api/gateway/v1/role_definitions/ returns HTTP 400 with the same message.)

### Backwards compatibility
- Existing clients that already include the `view` permission are unaffected.
- Behavior changes only the error path: 500 → 400 with a user‑friendly message.

### Tests
- Add a unit test covering a remote content type where only a non‑`view` permission is provided.
- Assert that a DRF `ValidationError` (400) is raised and the error message includes the model label without raising `AttributeError`. 

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
<img width="898" height="403" alt="image" src="https://github.com/user-attachments/assets/e9643c68-b1bf-4443-8216-b42592521aeb" />