### PR TITLE
AAP-50843 Allow normal users access to role types

### DIFF
--- a/ansible_base/rbac/service_api/views.py
+++ b/ansible_base/rbac/service_api/views.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from rest_framework import status
+from rest_framework import permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, mixins
@@ -22,6 +22,7 @@ class RoleContentTypeViewSet(
 
     queryset = DABContentType.objects.prefetch_related('parent_content_type').all()
     serializer_class = service_serializers.DABContentTypeSerializer
+    permission_classes = try_add_oauth2_scope_permission([permissions.IsAuthenticated])
 
 
 class RolePermissionTypeViewSet(
@@ -33,6 +34,7 @@ class RolePermissionTypeViewSet(
 
     queryset = DABPermission.objects.prefetch_related('content_type').all()
     serializer_class = service_serializers.DABPermissionSerializer
+    permission_classes = try_add_oauth2_scope_permission([permissions.IsAuthenticated])
 
 
 # NOTE: role definitions are exchanged via the resources endpoint, so not included here

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -269,6 +269,7 @@ def test_filter_assignment_list(admin_api_client, rando, inv_rd, view_inv_rd, or
 @pytest.mark.parametrize(
     'reverse_name,normal_case,unauth_case',
     [
+        ('service-index-root', 200, 401),
         ('dabcontenttype-list', 200, 401),  # could change unauthenticated case, depends on need
         ('dabpermission-list', 200, 401),
         ('resource-list', 403, 401),
@@ -287,6 +288,32 @@ def test_service_api_permissions(reverse_name, normal_case, unauth_case, admin_a
 
     unauth_response = unauthenticated_api_client.get(url)
     assert unauth_response.status_code == unauth_case, unauth_response.data
+
+
+@pytest.mark.django_db
+def test_role_types_and_permissions_payload_shape(user_api_client):
+    """Minimal payload-shape checks for role types and permissions when accessed by normal user."""
+    # role types
+    url_ct = get_relative_url('dabcontenttype-list')
+    resp_ct = user_api_client.get(url_ct)
+    assert resp_ct.status_code == 200, resp_ct.data
+    # Results should be paginated list; spot-check first item fields if present
+    if resp_ct.data.get('count', 0) and resp_ct.data.get('results'):
+        item = resp_ct.data['results'][0]
+        for key in ('api_slug', 'service', 'app_label', 'model', 'pk_field_type'):
+            assert key in item
+        # parent_content_type is allowed to be null
+        assert 'parent_content_type' in item
+
+    # role permissions
+    url_perm = get_relative_url('dabpermission-list')
+    resp_perm = user_api_client.get(url_perm)
+    assert resp_perm.status_code == 200, resp_perm.data
+    if resp_perm.data.get('count', 0) and resp_perm.data.get('results'):
+        item = resp_perm.data['results'][0]
+        for key in ('api_slug', 'codename', 'name'):
+            assert key in item
+        assert 'content_type' in item  # slug of related content type
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# AAP-50843: Allow authenticated users to read service-index role metadata

## Description
- What is being changed?
  - Relax permissions on two read-only service-index endpoints so any authenticated user can list RBAC metadata:
    - `ansible_base.rbac.service_api.views.RoleContentTypeViewSet`
    - `ansible_base.rbac.service_api.views.RolePermissionTypeViewSet`
  - Both viewsets now set `permission_classes = try_add_oauth2_scope_permission([permissions.IsAuthenticated])`.
  - No changes to other service-index endpoints (e.g., resources, role assignments).
- Why is this change needed?
  - Fixes AAP-50843: normal (non-admin) users receive 403 from `GET /service-index/role-types/`, breaking the UI Roles filter population.
  - In gateway, strict default permissions (e.g., admin/auditor only) were unintentionally inherited by these metadata endpoints.
- How does this change address the issue?
  - Explicitly sets authenticated-only read access for metadata endpoints while preserving OAuth2 scope checks via `try_add_oauth2_scope_permission`.
  - Keeps other sensitive service-index APIs protected by `HasResourceRegistryPermissions`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update (tests added in gateway to verify behavior)
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections (where applicable)
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment (see steps below)

## Testing Instructions

### Prerequisites
- Python virtual environment activated
- Gateway app available for running tests against the mounted service-index endpoints
- Postgres available for gateway tests
- For gateway runs: set `GATEWAY_SECRET_KEY_FILE` to a valid secret (e.g., `tools/configs/dev_secret_key`)

### Steps to Test (Gateway)

### Expected Results
- Normal authenticated users receive 200 from:
  - `GET /service-index/role-types/`
  - `GET /service-index/role-permissions/`
- Negative controls: normal users are still denied (401/403) for:
  - `GET /service-index/resources/`
  - `GET /service-index/role-user-assignments/` and `role-team-assignments/`
- Anonymous users remain denied for all of the above.

## Additional Context
- Related: AAP-50843
- Root cause: gateway’s strict default permission classes were inherited by DAB service-index metadata endpoints which are intended to be readable by any authenticated user.

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: N/A

### Screenshots/Logs
- See local evidence and steps in repository notes for AAP-50843 if needed. 