### PR TITLE
[AAP-52187] Fix rbac user access viewset permissions

### DIFF
--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -296,6 +296,7 @@ class UserAccessViewSet(
     """
 
     serializer_mixin = UserAccessListMixin
+    permission_classes = try_add_oauth2_scope_permission([permissions.IsAuthenticated])
 
     def get_data_from_url(self):
         if not hasattr(self, 'related_object'):
@@ -378,6 +379,7 @@ class UserAccessAssignmentViewSet(
     """
 
     serializer_class = UserAccessAssignmentSerializer
+    permission_classes = try_add_oauth2_scope_permission([permissions.IsAuthenticated])
 
     def get_url_actor(self):
         actor_pk = self.kwargs.get("actor_pk")

--- a/test_app/tests/rbac/api/test_access_lists.py
+++ b/test_app/tests/rbac/api/test_access_lists.py
@@ -138,3 +138,43 @@ def test_no_duplicates_team(team, inv_rd, inventory, org_inv_rd, admin_api_clien
     response = admin_api_client.get(url)
     assert response.status_code == 200, response.data
     assert response.data['count'] == 1, response.data
+
+
+@pytest.mark.django_db
+def test_org_admin_role_user_access_bug(organization, org_admin_rd):
+    """
+    Test for AAP-52187: Org admin gets 403 on role_user_access despite having proper permissions.
+
+    This test demonstrates the RBAC evaluation bug where:
+    - Org admin can GET /organizations/X/ (works correctly)
+    - Same org admin gets 403 on /role_user_access/shared.organization/X/ (bug)
+    - Both should work since the user has shared.view_organization permission
+    """
+    from rest_framework.test import APIClient
+
+    # Create org admin user for AAP-52187 reproduction
+    org_admin_user = User.objects.create(username='aap52187-org-admin-test-user')
+
+    # Give user Organization Admin role on the organization
+    org_admin_rd.give_permission(org_admin_user, organization)
+
+    # Create API client for the org admin user
+    client = APIClient()
+    client.force_authenticate(user=org_admin_user)
+
+    # Test 1: Org admin should be able to view the organization directly
+    org_detail_url = get_relative_url('organization-detail', kwargs={'pk': organization.pk})
+    response = client.get(org_detail_url)
+    assert response.status_code == 200, f"Org admin should be able to view organization directly: {response.data}"
+
+    # Test 2: Org admin should be able to view role user access for the same organization
+    # This is currently broken due to has_obj_perm evaluation bug in UserAccessViewSet
+    role_access_url = get_relative_url('role-user-access', kwargs={'pk': organization.pk, 'model_name': 'shared.organization'})
+    response = client.get(role_access_url)
+
+    # This assertion will fail with current bug, demonstrating the issue
+    assert response.status_code == 200, (
+        f"AAP-52187 BUG: Org admin should be able to view role access for organization they manage. "
+        f"User has shared.view_organization permission and can access org detail endpoint, "
+        f"but role_user_access fails with: {response.status_code} {response.data}"
+    )


### PR DESCRIPTION
# AAP-52187: Org admin is not allowed to see its Organizations / Users page

## Description

**What is being changed?**
Changed `permission_classes` in `UserAccessViewSet` and `UserAccessAssignmentViewSet` from `[OAuth2ScopePermission, IsSuperuserOrAuditor]` to `try_add_oauth2_scope_permission([permissions.IsAuthenticated])` - these are read-only views so no write operations exist.

**Why is this change needed?**
Org admins got 403 on `/api/gateway/v1/role_user_access/shared.organization/X/` due to `IsSuperuserOrAuditor` permission class blocking them before object-level permission checks.

**How does this change address the issue?**
Read operations now use `IsAuthenticated` (with OAuth2 scope support) + existing `check_permission_to_object()` validation. Object-level permissions still enforced - only users with proper view permissions can access the data.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

### Prerequisites
AAP environment with org admin user assigned to an organization.

### Steps to Test
1. Create org admin user and assign Organization Admin role
2. Login as org admin: `GET /api/gateway/v1/role_user_access/shared.organization/<org_id>/`
3. Should return 200 (was 403 before fix)
4. Test UI: Organizations → [Your Org] → Users tab should load

### Expected Results
Org admins can view role assignments for organizations they manage. Security boundaries maintained.

## Additional Context

**Root Cause:** `UserAccessViewSet.permission_classes = [OAuth2ScopePermission, IsSuperuserOrAuditor]` blocked org admins at viewset level before object permission evaluation.

**How permission_classes Works:**
Django REST Framework automatically enforces `permission_classes` by:
1. Instantiating each permission class during request processing  
2. Calling `has_permission(request, view)` on each class
3. Requiring ALL to pass (AND logic) - any failure → 403
4. This happens **before** view-specific logic like `check_permission_to_object()`

**Reference:** [Django REST Framework Permissions](https://www.django-rest-framework.org/api-guide/permissions/) - "permission_classes attribute is used to specify the permissions that apply to a particular view or viewset... that determine whether a request should be granted or denied access."

### Screenshots/Logs

```mermaid
graph TD
    A["Org Admin User Request"] --> B{"Endpoint Type"}
    
    B -->|"✅ Working"| C["Organization Detail<br/>/organizations/2/"]
    B -->|"❌ Broken"| D["Role User Access<br/>/role_user_access/shared.organization/2/"]
    
    C --> C1["OrganizationViewSet<br/>RoleModelViewSet"]
    C1 --> C2["permission_classes:<br/>AnsibleBaseObjectPermissions"]
    C2 --> C3["✅ Standard RBAC Flow"]
    C3 --> C4["Check: user.has_obj_perm org view"]
    C4 --> C5["✅ Returns True<br/>shared.view_organization found"]
    
    D --> D1["UserAccessViewSet<br/>AnsibleBaseDjangoAppApiView"]
    D1 --> D2["🚨 BUG LOCATION:<br/>permission_classes = IsSuperuserOrAuditor"]
    D2 --> D3["❌ Org admin blocked<br/>Never reaches object permission check"]
    D3 --> D4["403 Forbidden<br/>Before check_permission_to_object"]
    
    C4 -.-> E["Same User: new-org-admin<br/>Same Organization: org ID 2<br/>Same Permission: shared.view_organization"]
    D1 -.-> E
    
    D2 --> F["🔧 FIX APPLIED:<br/>permission_classes = IsAuthenticated"]
    F --> G["✅ Now allows org admin reads<br/>with object-level validation"]
```
API Output
```
GET /api/gateway/v1/role_user_access/shared.organization/2/
```
```json
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept
X-API-Node: myaap-gateway-7f84596c64-q9bbc
X-API-Product-Name: AAP gateway
X-API-Product-Version: 2.6.0
X-API-Time: 0.025s

{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 2,
            "url": "[/api/gateway/v1/users/2/](http://localhost:44926/api/gateway/v1/users/2/)",
            "related": {
                "details": "[/api/gateway/v1/role_user_access/shared.organization/2/6d736b08-c194-4e8b-9397-523311cf192b/](http://localhost:44926/api/gateway/v1/role_user_access/shared.organization/2/6d736b08-c194-4e8b-9397-523311cf192b/)"
            },
            "username": "admin",
            "is_superuser": true,
            "first_name": "",
            "last_name": "",
            "object_role_assignments": []
        },
        {
            "id": 3,
            "url": "[/api/gateway/v1/users/3/](http://localhost:44926/api/gateway/v1/users/3/)",
            "related": {
                "details": "[/api/gateway/v1/role_user_access/shared.organization/2/f77e8067-e1e0-4078-a5aa-e39bb681fffe/](http://localhost:44926/api/gateway/v1/role_user_access/shared.organization/2/f77e8067-e1e0-4078-a5aa-e39bb681fffe/)"
            },
            "username": "new-org-admin",
            "is_superuser": false,
            "first_name": "",
            "last_name": "",
            "object_role_assignments": [
                {
                    "type": "direct",
                    "role_definition": {
                        "name": "Organization Member",
                        "url": "[/api/gateway/v1/role_definitions/5/](http://localhost:44926/api/gateway/v1/role_definitions/5/)"
                    }
                },
                {
                    "type": "direct",
                    "role_definition": {
                        "name": "Organization Admin",
                        "url": "[/api/gateway/v1/role_definitions/4/](http://localhost:44926/api/gateway/v1/role_definitions/4/)"
                    }
                }
            ]
        }
    ]
}
```
Note that display works despite 403 errors from /api/gateway/v1/settings/ 
<img width="963" height="850" alt="Screenshot From 2025-09-04 12-03-49" src="https://github.com/user-attachments/assets/6df4ff31-e75c-49aa-adbc-b30e37fefcb8" />


