### PR TITLE
Make role assignment sync logging more descriptive

### DIFF
--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -714,14 +714,14 @@ class SyncExecutor:
                 if delete_local_assignment(assignment_tuple):
                     delete_msg = (
                         f"DELETED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                        f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                     )
                     self.write(delete_msg)
                     self.results["deleted_assignments"].append(delete_msg)
                 else:
                     error_msg = (
                         f"ERRORED while DELETING assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                        f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                     )
                     self.write(error_msg)
                     self.results["errored_assignments"].append(error_msg)
@@ -731,14 +731,14 @@ class SyncExecutor:
                 if create_local_assignment(assignment_tuple):
                     created_msg = (
                         f"CREATED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                        f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                     )
                     self.write(created_msg)
                     self.results["created_assigments"].append(created_msg)
                 else:
                     error_msg = (
                         f"ERRORED while CREATING assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                        f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                     )
                     self.write(error_msg)
                     self.results["errored_assignments"].append(error_msg)

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -705,38 +705,50 @@ class SyncExecutor:
             to_delete = local_assignments - remote_assignments
             to_create = remote_assignments - local_assignments
 
-            deleted_count = 0
-            created_count = 0
-            error_count = 0
+            deleted_assignments = []
+            created_assigments = []
+            errored_assignments = []
 
             # Delete local assignments that don't exist remotely
             for assignment_tuple in to_delete:
                 if delete_local_assignment(assignment_tuple):
-                    deleted_count += 1
-                    self.write(
+                    delete_msg = (
                         f"DELETED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
                         " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                     )
+                    self.write(delete_msg)
+                    self.results["deleted_assignments"].append(delete_msg)
                 else:
-                    error_count += 1
+                    error_msg = (
+                        f"ERRORED while DELETING assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
+                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                    )
+                    self.write(error_msg)
+                    self.results["errored_assignments"].append(error_msg)
 
             # Create local assignments that exist remotely but not locally
             for assignment_tuple in to_create:
                 if create_local_assignment(assignment_tuple):
-                    created_count += 1
-                    self.write(
+                    created_msg = (
                         f"CREATED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
                         " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                     )
+                    self.write(created_msg)
+                    self.results["created_assigments"].append(created_msg)
                 else:
-                    error_count += 1
+                    error_msg = (
+                        f"ERRORED while CREATING assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
+                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                    )
+                    self.write(error_msg)
+                    self.results["errored_assignments"].append(error_msg)
 
-            self.write(f"Assignment sync completed: Created {created_count} | Deleted {deleted_count} | Errors {error_count}")
+            self.write(f"Assignment sync completed: Created {len(created_assigments)} | Deleted {len(deleted_assignments)} | Errors {len(errored_assignments)}")
 
             # Store results for reporting
-            self.results["assignments_created"] = [created_count]
-            self.results["assignments_deleted"] = [deleted_count]
-            self.results["assignment_errors"] = [error_count]
+            self.results["assignments_created"] = created_assigments
+            self.results["assignments_deleted"] = deleted_assignments
+            self.results["assignment_errors"] = errored_assignments
 
         except Exception as e:
             self.write(f"Assignment sync failed: {e}")


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Make role assignment sync logging more descriptive. Currently all we return is the number of assignments that have changed which is not helpful for debugging.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Refactoring (no functional changes)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X ] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
