### PR TITLE
[AAP-52121] Fix attribute handling with 'and' condition

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -459,7 +459,15 @@ def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: i
         # Check if user has the attribute
         user_value = attributes.get(attribute, None)
         if user_value is None:
-            _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] is not present in user attributes, skipping")
+            # if condition is not "and", the attribute value is not required, just move on
+            if join_condition != 'and':
+                _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] is not present in user attributes, skipping")
+            # else, condition is "and" which means the attribute value IS required, set access to False
+            else:
+                _prefixed_debug(
+                    map_id, tracking_id, f"Attr [{attribute}] is not present in user attributes but is required by condition 'and' changing access to false"
+                )
+                has_access = has_access_with_join(has_access, False, join_condition)
             continue
 
         # Normalize user value and process

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -890,6 +890,27 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             claims.TriggerResult.SKIP,
             id="in operator with string value (invalid) should be ignored",
         ),
+        pytest.param(
+            {"cn": {"ends_with": "_admin"}, "employeeType": {"equals": "manager"}, "join_condition": "and"},
+            {"cn": ["ldap_admin"]},
+            False,
+            claims.TriggerResult.SKIP,
+            id="missing attribute required by 'and' condition should result in skip",
+        ),
+        pytest.param(
+            {"cn": {"ends_with": "_admin"}, "employeeType": {"equals": "manager"}, "join_condition": "or"},
+            {"cn": ["ldap_admin"]},
+            False,
+            claims.TriggerResult.ALLOW,
+            id="missing attribute when using 'or' condition should result in allow",
+        ),
+        pytest.param(
+            {"cn": {"ends_with": "_admin"}, "employeeType": {"equals": "manager"}, "join_condition": "and"},
+            {"cn": ["ldap_org_admin"], "employeeType": ["manager"]},
+            False,
+            claims.TriggerResult.ALLOW,
+            id="all attribute required by 'and' condition should result in allow",
+        ),
     ],
 )
 @pytest.mark.django_db


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - When authentication map is configured with "and" condition and the user who is logging does not have the attribute used in the map, the map can not be applied
- Why is this change needed?
  - The authentication map can be setup to grant access on condition of users having certain attributes, however, without this fix, the mapping was being used even for users who had subset of the attributes (were missing some of them).
- How does this change address the issue?
  - This change ensures that if any attributes used in the mapping are not present for the user the map will not be applied/used for the user

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

Since the issue was reported with LDAP, the testing described here will be for LDAP but it could be tested with different authentication source as well.

Your LDAP configuration will need to have two users, one containing extra attribute. A simple change is to add attribute "employeeType" with value "manager" to one of the existing users:

user 1:
```yaml
  cn: ldap_admin
  sn: LdapAdmin
  mail: ldap-admin@example.org
```
user 2:
```yaml
  cn: ldap_org_admin
  sn: LdapOrgAdmin
  mail: ldap-org-admin@example.org
  employeeType: manager
```
Then setup an authentication map that adds a user to a team, with following condition using "AND" operation:
- cn ends with `_admin`
- employee type is `manager`

Example of such authentication map triggers:
```json
            "triggers": {
                "attributes": {
                    "cn": {
                        "ends_with": "_admin"
                    },
                    "employeeType": {
                        "equals": "manager"
                    },
                    "join_condition": "and"
                }
            }
```

### Steps to Test
1. Setup your users in LDAP as described above and add the mapping
2. Login with the user that does not have the attribute used in the map
3. Login with the user that hase the attribute used in the map

### Expected Results
User with the attribute "employeeType" set to "manager" will be added to a team but the other user will not.
