### PR TITLE
AAP-46641 Increase trusted header timeout

### DIFF
--- a/ansible_base/jwt_consumer/common/util.py
+++ b/ansible_base/jwt_consumer/common/util.py
@@ -53,10 +53,11 @@ def validate_x_trusted_proxy_header(header_value: str, ignore_cache=False) -> bo
         logger.warning("Failed to validate x-trusted-proxy-header, malformed, expected value to contain a -")
         return False
 
-    # Validate that the header has been cut within the last 300ms (by default)
+    # Validate that the header has been cut within the last 1000ms (by default)
     try:
-        if time.time_ns() - int(timestamp) > get_setting('trusted_header_timeout_in_ns', 300000000):
-            logger.warning(f"Timestamp {timestamp} was too old to be valid alter trusted_header_timeout_in_ns if needed")
+        header_age_ms = round((time.time_ns() - int(timestamp)) / 1000000)
+        if header_age_ms > get_setting('trusted_header_timeout', 1000):
+            logger.warning(f"Timestamp {timestamp} was too old by {header_age_ms}ms to be valid-alter trusted_header_timeout if needed")
             return False
     except ValueError:
         logger.warning(f"Unable to convert timestamp (base64) {b64encode(timestamp.encode('UTF-8'))} into an integer")

--- a/test_app/tests/jwt_consumer/common/test_util.py
+++ b/test_app/tests/jwt_consumer/common/test_util.py
@@ -37,12 +37,12 @@ class TestValidateTrustedProxy:
             # Assert this header is valid if used right away
             assert validate_x_trusted_proxy_header(header) is True
 
-            # By default the header is only valid for 300ms so a 1/2 second sleep will expire it
-            time.sleep(0.5)
+            # By default the header is only valid for 1000ms so a 1.1 second sleep will expire it
+            time.sleep(1.1)
             with expected_log(
                 'ansible_base.jwt_consumer.common.util.logger',
                 'warning',
-                'was too old to be valid alter trusted_header_timeout_in_ns if needed',
+                'was too old by',
             ):
                 assert validate_x_trusted_proxy_header(header) is False
 


### PR DESCRIPTION
## Description
  Update trusted proxy header default timeout to 1 second due to it being very frequently exceeded (was 300 ms) in heavily loaded deployments or slow networking situations.  In gateway the header production will be moved later in the control plan authentication sequence to improve the usable lifetime as well.

  * trusted_header_timeout_in_ns -> trusted_header_timeout
  * Increase default validity period
  * Use milliseconds instead of nanoseconds

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Run unit tests.  Otherwise you need multiple components and some artificial delay insertion.
2. 
3. 

### Expected Results
No changes other than less frequent timeouts in the logs (might still happen sometimes but less frequent)

## Additional Context
This is the validity period of the x-trusted-proxy header that is validated by DAB extending consumer components to ensure traffic originated at the gateway.


### Required Actions
- [?] Requires coordination with other teams
I searched controller, hub and eda code but did not find any instances of this setting being set.

