### PR TITLE
AAP-51351 [devel-only] Drop python 3.9, add 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
             python-version: "3.11"
             sonar: false
             junit-xml-upload: false
-          - env: py39
-            python-version: "3.9"
+          - env: py312
+            python-version: "3.12"
             sonar: false
             junit-xml-upload: false
           - env: py310

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A Django app used by ansible services"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["ansible", "django"]
 license = {text = "Apache-2.0"}
 classifiers = [
@@ -23,9 +23,9 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
@@ -98,12 +98,12 @@ legacy_tox_ini = """
     no_package = true
     env_list =
         check
-        py39
+        py312
         py310
         py311
         py311sqlite
     labels =
-        test = py39, py310, py311, py311sqlite, check
+        test = py312, py310, py311, py311sqlite, check
         lint = flake8, black, isort
 
     [testenv]


### PR DESCRIPTION
## Description
Regular progression of time, from the past, into the future.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove Python 3.9 support, add 3.12, and update packaging metadata and CI/tox matrices accordingly.
> 
> - **Compatibility and Metadata**:
>   - Update `pyproject.toml`: set `requires-python` to `>=3.10`; remove `Python :: 3.9` classifier; add `Python :: 3.12` classifier.
> - **CI**:
>   - Update `.github/workflows/ci.yml` matrix: replace `py39` (3.9) with `py312` (3.12).
> - **Testing/Tox**:
>   - Update `tool.tox` legacy config: replace `py39` with `py312` in `env_list` and `labels.test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d153c9daea6595c8d875d4f931b0c79e279454e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->