### PR TITLE
AAPRFE-2425 Fix per-attribute ANY semantics & empty attribute handling

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -562,21 +562,28 @@ def _process_user_value(
 
     evaluate_fn = operators[operator]
 
+    if not user_value:
+        _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] present but empty, skipping")
+        return has_access_with_join(has_access, False, join_condition)
+
+    per_attr_match = False
     for a_user_value in user_value:
         # Normalize user value for comparison
         user_str = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
 
         # Evaluate condition
         result = evaluate_fn(user_str, trigger_value)
-        has_access = has_access_with_join(has_access, result, join_condition)
 
         # Log result
         header = f"Attr [{attribute}] value [{user_str}]"
         message = _get_operator_messages(operator, result)
         _prefixed_debug(map_id, tracking_id, f"{header} {message} [{trigger_value}], {_result_suffix(result)}")
 
-    return has_access
+        if result:
+            per_attr_match = True
+            break
 
+    return has_access_with_join(has_access, per_attr_match, join_condition)
 
 def _result_suffix(result: bool) -> str:
     return "allowing" if result else "skipping"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ optional-dependencies.redis_client = { file = [ "requirements/requirements_redis
 optional-dependencies.oauth2_provider = { file = [ "requirements/requirements_oauth2_provider.in" ] }
 optional-dependencies.resource_registry = { file = [ "requirements/requirements_resource_registry.in" ] }
 optional-dependencies.feature_flags = { file = [ "requirements/requirements_feature_flags.in" ] }
+optional-dependencies.dev = { file = [ "requirements/requirements_dev.txt" ] }
+
 
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm>=8"]

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -747,8 +747,8 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": ["bar@example.com", "foo@example.com"]},
             False,
-            claims.TriggerResult.SKIP,
-            id="user attribute is list, one match, explicit 'and', negative",
+            claims.TriggerResult.ALLOW,
+            id="user attribute is list, one match, explicit 'and', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
@@ -910,6 +910,35 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             False,
             claims.TriggerResult.ALLOW,
             id="all attribute required by 'and' condition should result in allow",
+        ),
+        pytest.param(
+            {
+                "cn": {"contains": "ldap"},
+                "employeeType": {"contains": "manager"},
+                "join_condition": "and",
+            },
+            {"cn": ["ldap_admin"], "employeeType": ["manager", "executor"]},
+            False,
+            claims.TriggerResult.ALLOW,
+            id="regression_any_semantics_and_across_attrs_positive",
+        ),
+        pytest.param(
+            {
+                "cn": {"contains": "ldap"},
+                "employeeType": {"contains": "manager"},
+                "join_condition": "and",
+            },
+            {"cn": ["ldap_admin"], "employeeType": ["executor"]},
+            False,
+            claims.TriggerResult.SKIP,
+            id="regression_any_semantics_and_across_attrs_negative",
+        ),
+        pytest.param(
+            {"cn": {"contains": "ldap"}, "employeeType": {"contains": "manager"}, "join_condition": "or"},
+            {"cn": ["zzz"], "employeeType": ["manager", "executor"]},
+            False,
+            claims.TriggerResult.ALLOW,
+            id="regression_any_semantics_or_across_attrs_positive_one_side",
         ),
     ],
 )


### PR DESCRIPTION
## Description

Linked issue: #845 

### What is being changed?

- Fix evaluation logic in `_process_user_value`:
  - Apply **ANY semantics** (short-circuit on first match) for attributes with multiple values.
  - Treat empty/falsy attributes as no match, log debug message, and join `False`.
- Add `optional-dependencies.dev` in `pyproject.toml`.
- Update `test_claims.py` expectations and add regression cases.

### Why is this change needed?

The previous implementation folded each value into `has_access_with_join` iteratively, effectively resulting in **AND semantics**, which caused false negatives when only one match should allow access.  
Also, empty attributes were not properly handled.

### How does this change address the issue?

- Implements proper **ANY semantics** at the attribute level.
- Handles empty attributes explicitly as no match.
- Expands test coverage to ensure correctness.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Test update  
- [ ] Refactoring (no functional changes)  
- [ ] Development environment change  
- [ ] Configuration change  

## Testing Instructions

### Prerequisites

- Run `rye sync --features "rbac,feature_flags,testing,dev"`  
- Set environment variable: `DJANGO_SETTINGS_MODULE=test_app.sqlite3settings`

### Steps to Test

1. Set up the test environment.  

2. Run the following tests:

   ```bash
   rye run pytest test_app/tests/authentication/utils/test_claims.py --color=yes -q
   ```

3. Verify that all tests pass.
   ```bash
    ❯ rye run pytest test_app/tests/authentication/utils/test_claims.py -q --color=yes
    ============================================================================================ test session starts =============================================================================================
    platform darwin -- Python 3.11.9, pytest-8.4.2, pluggy-1.6.0 -- /Users/yyamashi/gitrepo/django-ansible-base/.venv/bin/python3
    cachedir: .pytest_cache
    django: version: 4.2.21, settings: test_app.sqlite3settings (from env)
    rootdir: /Users/yyamashi/gitrepo/django-ansible-base
    configfile: pyproject.toml
    plugins: asyncio-1.2.0, xdist-3.8.0, django-4.11.1, typeguard-4.4.4, cov-7.0.0
    asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
    collected 240 items
    ===SNIP===
    test_app/tests/authentication/utils/test_claims.py::TestClaimsHelperFunctions::test_normalize_user_value[string_value-expected0] PASSED                                                                [ 98%]
    test_app/tests/authentication/utils/test_claims.py::TestClaimsHelperFunctions::test_normalize_user_value[user_value1-expected1] PASSED                                                                 [ 98%]
    test_app/tests/authentication/utils/test_claims.py::TestClaimsHelperFunctions::test_normalize_user_value[123-expected2] PASSED                                                                         [ 99%]
    test_app/tests/authentication/utils/test_claims.py::TestClaimsHelperFunctions::test_normalize_user_value[None-expected3] PASSED                                                                        [ 99%]
    test_app/tests/authentication/utils/test_claims.py::TestClaimsHelperFunctions::test_normalize_user_value[user_value4-expected4] PASSED                                                                 [100%]
    
    ============================================================================================ 240 passed in 14.22s ============================================================================================
   ```

### Expected Results

- Attributes with multiple values allow access if **any** value matches.  
- Empty attributes are treated as no match (`SKIP`).  
- Regression cases (`cn` / `employeeType` with AND/OR conditions) behave as expected.  

---

## Additional Context

- This change fixes a functional bug without introducing breaking changes.  
- Strengthened test coverage to prevent regressions.  

### Required Actions

- [x] Requires documentation updates  
  - https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/access_management_and_authentication/index#gw-authenticator-map-triggers
    - ```In version 2.5 this field indicates what will happen if the source system returns a list of attributes instead of a single value. For example, if the source system returns multiple emails for a user and Operation was set to and, all of the given emails must match the Comparison for the trigger to be True.```
- [ ] Requires downstream repository changes  
- [ ] Requires infrastructure/deployment changes  
- [ ] Requires coordination with other teams  
- [ ] Blocked by PR/MR: N/A  