### PR TITLE
[AAP-54064] Allowing for RBAC to not be installed in the JWT consumer

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -16,7 +16,6 @@ from ansible_base.jwt_consumer.common.exceptions import HTTP_498_INVALID_TOKEN, 
 from ansible_base.lib.logging.runtime import log_excess_runtime
 from ansible_base.lib.utils.auth import get_user_by_ansible_id
 from ansible_base.lib.utils.translations import translatableConditionally as _
-from ansible_base.rbac.claims import get_claims_hash, get_user_claims, get_user_claims_hashable_form, save_user_claims
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.rest_client import get_resource_server_client
 from ansible_base.resource_registry.signals.handlers import no_reverse_sync
@@ -230,6 +229,8 @@ class JWTCommonAuth:
         """
         Process RBAC permissions using claims hash logic
         """
+        from ansible_base.rbac.claims import get_claims_hash, get_user_claims, get_user_claims_hashable_form, save_user_claims
+
         if self.token is None or self.user is None:
             logger.error("Unable to process rbac permissions because user or token is not defined")
             return

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -480,11 +480,11 @@ class TestJWTCommonAuth:
         with (
             mock.patch.object(authentication.cache, 'get_cached_claims_hash') as mock_get_cache,
             mock.patch.object(authentication.cache, 'cache_claims_hash') as mock_set_cache,
-            mock.patch('ansible_base.jwt_consumer.common.auth.get_user_claims') as mock_get_claims,
-            mock.patch('ansible_base.jwt_consumer.common.auth.get_user_claims_hashable_form') as mock_get_hashable,
-            mock.patch('ansible_base.jwt_consumer.common.auth.get_claims_hash') as mock_get_hash,
+            mock.patch('ansible_base.rbac.claims.get_user_claims') as mock_get_claims,
+            mock.patch('ansible_base.rbac.claims.get_user_claims_hashable_form') as mock_get_hashable,
+            mock.patch('ansible_base.rbac.claims.get_claims_hash') as mock_get_hash,
             mock.patch.object(authentication, '_fetch_jwt_claims_from_gateway') as mock_gateway,
-            mock.patch('ansible_base.jwt_consumer.common.auth.save_user_claims') as mock_apply,
+            mock.patch('ansible_base.rbac.claims.save_user_claims') as mock_apply,
         ):
 
             # Setup mocks


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Moves an import for rbac into an rbac specific function to allow for a jwt_consumer to not import the RBAC application.

- Why is this change needed?
For lighspeed.

- How does this change address the issue?
We should now be able to overide the process_rbac method without importing the RBAC app.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
