### PR TITLE
AAP-56029 Collect test coverage from everything in the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,14 @@ jobs:
           tox --colored yes -e ${{ matrix.tests.env }}
 
       - name: Inject PR number into coverage.xml
-        if: matrix.tests.sonar
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         run: sed -i '2i <!-- PR ${{ github.event.number }} -->' coverage.xml
 
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v4
-        if: matrix.tests.sonar
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         with:
-          name: coverage
+          name: coverage-${{ matrix.tests.env }}
           path: coverage.xml
 
       - name: Upload jUnit XML test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,32 +4,7 @@ on:
   pull_request:
   push:
 jobs:
-  check:
-    name: django-ansible-base - check
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          show-progress: false
-
-      - name: Install build requirements
-        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
-
-      - name: Install python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Install tox
-        run: pip3.11 install tox tox-docker
-
-      - name: Run linters via tox
-        run: tox --colored yes -e check
-
-  test:
+  tox:
     name: django-ansible-base - ${{ matrix.tests.env }}
     runs-on: ubuntu-latest
     permissions:
@@ -39,17 +14,25 @@ jobs:
       fail-fast: false
       matrix:
         tests:
+          - env: check
+            python-version: "3.11"
+            sonar: false
+            junit-xml-upload: false
           - env: py312
             python-version: "3.12"
+            sonar: false
             junit-xml-upload: false
           - env: py310
             python-version: "3.10"
+            sonar: false
             junit-xml-upload: false
           - env: py311
             python-version: "3.11"
+            sonar: true
             junit-xml-upload: true
           - env: py311sqlite
             python-version: "3.11"
+            sonar: false
             junit-xml-upload: false
     steps:
       - uses: actions/checkout@v4
@@ -73,12 +56,12 @@ jobs:
           tox --colored yes -e ${{ matrix.tests.env }}
 
       - name: Inject PR number into coverage.xml
-        if: hashFiles('coverage.xml') != ''
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         run: sed -i '2i <!-- PR ${{ github.event.number }} -->' coverage.xml
 
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v4
-        if: hashFiles('coverage.xml') != ''
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         with:
           name: coverage-${{ matrix.tests.env }}
           path: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,32 @@ on:
   pull_request:
   push:
 jobs:
-  tox:
+  check:
+    name: django-ansible-base - check
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Install build requirements
+        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
+
+      - name: Install python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install tox
+        run: pip3.11 install tox tox-docker
+
+      - name: Run linters via tox
+        run: tox --colored yes -e check
+
+  test:
     name: django-ansible-base - ${{ matrix.tests.env }}
     runs-on: ubuntu-latest
     permissions:
@@ -14,25 +39,17 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - env: check
-            python-version: "3.11"
-            sonar: false
-            junit-xml-upload: false
           - env: py312
             python-version: "3.12"
-            sonar: false
             junit-xml-upload: false
           - env: py310
             python-version: "3.10"
-            sonar: false
             junit-xml-upload: false
           - env: py311
             python-version: "3.11"
-            sonar: true
             junit-xml-upload: true
           - env: py311sqlite
             python-version: "3.11"
-            sonar: false
             junit-xml-upload: false
     steps:
       - uses: actions/checkout@v4
@@ -56,12 +73,12 @@ jobs:
           tox --colored yes -e ${{ matrix.tests.env }}
 
       - name: Inject PR number into coverage.xml
-        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: hashFiles('coverage.xml') != ''
         run: sed -i '2i <!-- PR ${{ github.event.number }} -->' coverage.xml
 
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v4
-        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: hashFiles('coverage.xml') != ''
         with:
           name: coverage-${{ matrix.tests.env }}
           path: coverage.xml

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -99,6 +99,14 @@ jobs:
           echo "├── Coverage Data: ✅ Available"
           echo "└── Result: ✅ Running SonarCloud PR analysis"
 
+          # Validate coverage paths
+          if [ -z "$coverage_files" ]; then
+            echo "##[error]❌ FATAL: No coverage files found"
+            echo "##[error]This job requires coverage data to run analysis."
+            echo "##[error]The CI workflow should have uploaded coverage artifacts."
+            exit 1
+          fi
+
           # Export to GitHub env for later steps
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
           echo "PR_BASE=$PR_BASE" >> $GITHUB_ENV

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -61,8 +61,8 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Find all downloaded coverage XML files
-          coverage_files=$(find . -name "coverage-*.xml" -type f | tr '\n' ',' | sed 's/,$//')
+          # Find all downloaded coverage XML files (artifacts are extracted into subdirectories)
+          coverage_files=$(find ./coverage-* -name "coverage.xml" -type f 2>/dev/null | tr '\n' ',' | sed 's/,$//')
           echo "Found coverage files: $coverage_files"
           echo "COVERAGE_PATHS=$coverage_files" >> $GITHUB_ENV
 
@@ -72,7 +72,7 @@ jobs:
           echo "├── Repo: $REPO_NAME"
 
           # Extract PR number from first coverage.xml file found
-          first_coverage=$(find . -name "coverage-*.xml" -type f | head -1)
+          first_coverage=$(find ./coverage-* -name "coverage.xml" -type f 2>/dev/null | head -1)
           if [ -f "$first_coverage" ]; then
             PR_NUMBER=$(grep -m 1 '<!-- PR' "$first_coverage" | awk '{print $3}' || echo "")
           else
@@ -154,8 +154,8 @@ jobs:
           BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
           REPO_NAME: ${{ github.event.repository.full_name }}
         run: |
-          # Find all downloaded coverage XML files
-          coverage_files=$(find . -name "coverage-*.xml" -type f | tr '\n' ',' | sed 's/,$//')
+          # Find all downloaded coverage XML files (artifacts are extracted into subdirectories)
+          coverage_files=$(find ./coverage-* -name "coverage.xml" -type f 2>/dev/null | tr '\n' ',' | sed 's/,$//')
           echo "Found coverage files: $coverage_files"
           echo "COVERAGE_PATHS=$coverage_files" >> $GITHUB_ENV
 

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -44,14 +44,14 @@ jobs:
         with:
           show-progress: false
 
-      # Download coverage artifact from CI workflow
-      - name: Download coverage artifact
+      # Download all individual coverage artifacts from CI workflow
+      - name: Download coverage artifacts
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: CI
           run_id: ${{ github.event.workflow_run.id }}
-          name: coverage
+          pattern: coverage-*
 
       # Extract PR metadata from workflow_run event
       - name: Set PR metadata and prepare for analysis
@@ -61,14 +61,20 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Find all downloaded coverage XML files
+          coverage_files=$(find . -name "coverage-*.xml" -type f | tr '\n' ',' | sed 's/,$//')
+          echo "Found coverage files: $coverage_files"
+          echo "COVERAGE_PATHS=$coverage_files" >> $GITHUB_ENV
+
           echo "🔍 SonarCloud Analysis Decision Summary"
           echo "========================================"
           echo "├── CI Event: ✅ Pull Request"
           echo "├── Repo: $REPO_NAME"
 
-          # Extract PR number from coverage.xml
-          if [ -f coverage.xml ]; then
-            PR_NUMBER=$(grep -m 1 '<!-- PR' coverage.xml | awk '{print $3}' || echo "")
+          # Extract PR number from first coverage.xml file found
+          first_coverage=$(find . -name "coverage-*.xml" -type f | head -1)
+          if [ -f "$first_coverage" ]; then
+            PR_NUMBER=$(grep -m 1 '<!-- PR' "$first_coverage" | awk '{print $3}' || echo "")
           else
             PR_NUMBER=""
           fi
@@ -118,6 +124,7 @@ jobs:
             -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
             -Dsonar.pullrequest.branch=${{ env.PR_HEAD }}
             -Dsonar.pullrequest.base=${{ env.PR_BASE }}
+            -Dsonar.python.coverage.reportPaths=${{ env.COVERAGE_PATHS }}
 
   sonar-branch-analysis:
     name: SonarCloud Branch Analysis
@@ -132,33 +139,39 @@ jobs:
         with:
           show-progress: false
 
-      # Download coverage artifact from CI workflow (optional for branch pushes)
-      - name: Download coverage artifact
+      # Download all individual coverage artifacts from CI workflow (optional for branch pushes)
+      - name: Download coverage artifacts
         continue-on-error: true
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: CI
           run_id: ${{ github.event.workflow_run.id }}
-          name: coverage
+          pattern: coverage-*
 
       - name: Print SonarCloud Analysis Summary
         env:
           BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
           REPO_NAME: ${{ github.event.repository.full_name }}
         run: |
+          # Find all downloaded coverage XML files
+          coverage_files=$(find . -name "coverage-*.xml" -type f | tr '\n' ',' | sed 's/,$//')
+          echo "Found coverage files: $coverage_files"
+          echo "COVERAGE_PATHS=$coverage_files" >> $GITHUB_ENV
+
           echo "🔍 SonarCloud Analysis Summary"
           echo "=============================="
           echo "├── CI Event: ✅ Push (via workflow_run)"
           echo "├── Repo: $REPO_NAME"
           echo "├── Branch: $BRANCH_NAME"
-          
-          if [ -f coverage.xml ]; then
+          echo "├── Coverage Files: ${coverage_files:-none}"
+
+          if [ -n "$coverage_files" ]; then
             echo "├── Coverage Data: ✅ Available"
           else
             echo "├── Coverage Data: ⚠️  Not available (analysis will proceed without coverage)"
           fi
-          
+
           echo "└── Result: ✅ Running SonarCloud branch analysis"
 
       - name: SonarCloud Scan
@@ -170,3 +183,4 @@ jobs:
           args: >
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
             -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
+            ${{ env.COVERAGE_PATHS && format('-Dsonar.python.coverage.reportPaths={0}', env.COVERAGE_PATHS) || '' }}


### PR DESCRIPTION
## Description
Collect coverage from all jobs in the tox / test matrix.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
This, itself, modifies testing. Not even testing, collection of coverage of tests. Not even changing whether coverage is collected, but how thoroughly coverage is collected, making it more thorough.

### Prerequisites
none

### Steps to Test
This is _about_ testing.

### Expected Results
coverage for entire matrix collected

## Additional Context
Created because it came up in https://github.com/ansible/django-ansible-base/pull/855, and separated out because that is a highly-blocking issue that we should not scope creep.

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

### Screenshots/Logs
See results of CI for this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Collects coverage from all tox matrix jobs, uploads per-env artifacts, aggregates them in Sonar workflows, and passes coverage paths to SonarCloud for PR and branch analyses.
> 
> - **CI (`.github/workflows/ci.yml`)**:
>   - Inject PR number into `coverage.xml` only when `matrix.tests.env != 'check'` and file exists.
>   - Upload coverage artifact per env as `coverage-${{ matrix.tests.env }}` (instead of single `coverage`).
> - **SonarCloud (`.github/workflows/sonar-pr.yml`)**:
>   - Download all coverage artifacts with pattern `coverage-*` for both PR and branch analyses.
>   - Discover all `coverage.xml` files, set `COVERAGE_PATHS`, and validate presence for PR analysis.
>   - Extract PR number from the first discovered `coverage.xml`.
>   - Pass `-Dsonar.python.coverage.reportPaths=${{ env.COVERAGE_PATHS }}` to SonarCloud (conditionally for branch analysis).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7baba0200d5d89143144266bc7849ccc624c5dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->