### PR TITLE
AAP-56394 Fix SAML authentication uid selection

### DIFF
--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -137,7 +137,10 @@ def determine_username_from_uid_social(**kwargs) -> dict:
     if authenticator.setting('USERNAME_IS_FULL_EMAIL', False):
         selected_username = kwargs.get('details', {}).get('email', None)
     else:
-        selected_username = kwargs.get('details', {}).get('username', None)
+        if authenticator.type == 'SAML':
+            selected_username = kwargs.get('uid', None)
+        else:
+            selected_username = kwargs.get('details', {}).get('username', None)
     if not selected_username:
         raise_auth_exception(
             _('Unable to get associated username from details, expected entry "username". Full user details: %(details)s')

--- a/test_app/tests/authentication/utils/test_authentication.py
+++ b/test_app/tests/authentication/utils/test_authentication.py
@@ -249,6 +249,27 @@ class TestAuthenticationUtilsAuthentication:
         )
         assert response == {'username': 'Bob'}
 
+    @pytest.mark.parametrize(
+        "auth_fixture, expected_username, uid_param, details_username",
+        [
+            # SAML authenticator uses uid parameter (line 141)
+            ("saml_authenticator", "SamlUser", "SamlUser", "should_not_be_used"),
+            # Non-SAML authenticators use details['username'] (line 143)
+            ("ldap_authenticator", "LdapUser", "should_not_be_used", "LdapUser"),
+            ("oidc_authenticator", "OidcUser", "should_not_be_used", "OidcUser"),
+            ("keycloak_authenticator", "KeycloakUser", "should_not_be_used", "KeycloakUser"),
+        ],
+    )
+    def test_determine_username_from_uid_social_authenticator_types(self, request, auth_fixture, expected_username, uid_param, details_username):
+        """Test username selection logic for different authenticator types (lines 140-143)"""
+        authenticator = request.getfixturevalue(auth_fixture)
+        response = authentication.determine_username_from_uid_social(
+            details={'username': details_username},
+            backend=get_authenticator_class(authenticator.type)(database_instance=authenticator),
+            uid=uid_param,
+        )
+        assert response == {'username': expected_username}
+
     def test_raise_auth_exception(self):
         try:
             authentication.raise_auth_exception('testing')


### PR DESCRIPTION
## Description

The determine_username_from_uid_social pipeline was selecting the 'username' value from the pipeline kwargs/details, which is generally correct for most authenticators, however for SAML specifically the 'uid' is not the exact username, but the username prepended with 'IdP:' (hard coded for our SAML authenticators).  The incorrect use of 'username' was causing the AuthenticatorUser not to be found.  This was OK in the case that another user didn't exist with the same email, but if such a user does exist, the authentication process errors out with a "more than one user found" error, blocking the SAML user from logging in permanently unless the "conflicting" local user was removed.



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Start gateway with a SAML authenticator configured and log in with a SAML account
2. Create a local user with the same email address as the SAML account
3. Log in again with the SAML user.  This would have failed before the change but will now pass.


### Expected Results
see above

