### PR TITLE
AAP 51882 - shared jwt authenticator class

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -7,7 +7,6 @@ import jwt
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import IntegrityError
-from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -365,9 +364,16 @@ class RbacAwareJWTAuthentication(JWTAuthentication):
         self.use_rbac_permissions = is_rbac_installed()
 
 
-class RbacAwareJWTAuthScheme(OpenApiAuthenticationExtension):
-    target_class = RbacAwareJWTAuthentication
-    name = "RbacAwareJWTAuthentication"
+try:
+    from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
-    def get_security_definition(self, auto_schema):
-        return {"type": "apiKey", "name": "X-DAB-JW-TOKEN", "in": "header"}
+    class RbacAwareJWTAuthScheme(OpenApiAuthenticationExtension):
+        target_class = RbacAwareJWTAuthentication
+        name = "RbacAwareJWTAuthentication"
+
+        def get_security_definition(self, auto_schema):
+            return {"type": "apiKey", "name": "X-DAB-JW-TOKEN", "in": "header"}
+
+except ImportError:
+    # drf_spectacular is not available, skip the schema definition
+    pass

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -7,6 +7,7 @@ import jwt
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import IntegrityError
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -362,3 +363,11 @@ class RbacAwareJWTAuthentication(JWTAuthentication):
     def __init__(self):
         super().__init__()
         self.use_rbac_permissions = is_rbac_installed()
+
+
+class RbacAwareJWTAuthScheme(OpenApiAuthenticationExtension):
+    target_class = RbacAwareJWTAuthentication
+    name = "RbacAwareJWTAuthentication"
+
+    def get_security_definition(self, auto_schema):
+        return {"type": "apiKey", "name": "X-DAB-JW-TOKEN", "in": "header"}

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -14,6 +14,7 @@ from ansible_base.jwt_consumer.common.cache import JWTCache
 from ansible_base.jwt_consumer.common.cert import JWTCert, JWTCertException
 from ansible_base.jwt_consumer.common.exceptions import HTTP_498_INVALID_TOKEN, InvalidTokenException
 from ansible_base.lib.logging.runtime import log_excess_runtime
+from ansible_base.lib.utils.apps import is_rbac_installed
 from ansible_base.lib.utils.auth import get_user_by_ansible_id
 from ansible_base.lib.utils.translations import translatableConditionally as _
 from ansible_base.resource_registry.models import Resource, ResourceType
@@ -355,5 +356,5 @@ class JWTAuthentication(BaseAuthentication):
             logger.info("process_permissions was not overridden for JWTAuthentication")
 
 
-class RbacEnabledJWTAuthentication(JWTAuthentication):
-    use_rbac_permissions = True
+class RbacAwareJWTAuthentication(JWTAuthentication):
+    use_rbac_permissions = is_rbac_installed()

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -357,4 +357,8 @@ class JWTAuthentication(BaseAuthentication):
 
 
 class RbacAwareJWTAuthentication(JWTAuthentication):
-    use_rbac_permissions = is_rbac_installed()
+    use_rbac_permissions = False
+
+    def __init__(self):
+        super().__init__()
+        self.use_rbac_permissions = is_rbac_installed()

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -353,3 +353,7 @@ class JWTAuthentication(BaseAuthentication):
             self.common_auth.process_rbac_permissions()
         else:
             logger.info("process_permissions was not overridden for JWTAuthentication")
+
+
+class RbacEnabledJWTAuthentication(JWTAuthentication):
+    use_rbac_permissions = True

--- a/ansible_base/jwt_consumer/eda/auth.py
+++ b/ansible_base/jwt_consumer/eda/auth.py
@@ -2,7 +2,7 @@ import logging
 
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
-from ansible_base.jwt_consumer.common.auth import JWTAuthentication
+from ansible_base.jwt_consumer.common.auth import JWTAuthentication, RbacEnabledJWTAuthentication
 
 logger = logging.getLogger("ansible_base.jwt_consumer.eda.auth")
 
@@ -12,8 +12,8 @@ class EDAJWTAuthentication(JWTAuthentication):
 
 
 class EDAJWTAuthScheme(OpenApiAuthenticationExtension):
-    target_class = EDAJWTAuthentication
-    name = "EDAJWTAuthentication"
+    target_class = RbacEnabledJWTAuthentication
+    name = "RbacEnabledJWTAuthentication"
 
     def get_security_definition(self, auto_schema):
         return {"type": "apiKey", "name": "X-DAB-JW-TOKEN", "in": "header"}

--- a/ansible_base/jwt_consumer/eda/auth.py
+++ b/ansible_base/jwt_consumer/eda/auth.py
@@ -12,8 +12,8 @@ class EDAJWTAuthentication(JWTAuthentication):
 
 
 class EDAJWTAuthScheme(OpenApiAuthenticationExtension):
-    target_class = RbacAwareJWTAuthentication
-    name = "RbacAwareJWTAuthentication"
+    target_class = EDAJWTAuthentication
+    name = "EDAJWTAuthentication"
 
     def get_security_definition(self, auto_schema):
         return {"type": "apiKey", "name": "X-DAB-JW-TOKEN", "in": "header"}

--- a/ansible_base/jwt_consumer/eda/auth.py
+++ b/ansible_base/jwt_consumer/eda/auth.py
@@ -2,7 +2,7 @@ import logging
 
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
-from ansible_base.jwt_consumer.common.auth import JWTAuthentication, RbacEnabledJWTAuthentication
+from ansible_base.jwt_consumer.common.auth import JWTAuthentication, RbacAwareJWTAuthentication
 
 logger = logging.getLogger("ansible_base.jwt_consumer.eda.auth")
 
@@ -12,8 +12,8 @@ class EDAJWTAuthentication(JWTAuthentication):
 
 
 class EDAJWTAuthScheme(OpenApiAuthenticationExtension):
-    target_class = RbacEnabledJWTAuthentication
-    name = "RbacEnabledJWTAuthentication"
+    target_class = RbacAwareJWTAuthentication
+    name = "RbacAwareJWTAuthentication"
 
     def get_security_definition(self, auto_schema):
         return {"type": "apiKey", "name": "X-DAB-JW-TOKEN", "in": "header"}

--- a/ansible_base/jwt_consumer/eda/auth.py
+++ b/ansible_base/jwt_consumer/eda/auth.py
@@ -2,7 +2,7 @@ import logging
 
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
-from ansible_base.jwt_consumer.common.auth import JWTAuthentication, RbacAwareJWTAuthentication
+from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 
 logger = logging.getLogger("ansible_base.jwt_consumer.eda.auth")
 

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -10,7 +10,7 @@ from django.test.utils import override_settings
 from jwt.exceptions import DecodeError
 from rest_framework.exceptions import AuthenticationFailed
 
-from ansible_base.jwt_consumer.common.auth import JWTAuthentication, JWTCommonAuth, default_mapped_user_fields
+from ansible_base.jwt_consumer.common.auth import JWTAuthentication, JWTCommonAuth, RbacAwareJWTAuthentication, default_mapped_user_fields
 from ansible_base.jwt_consumer.common.cert import JWTCert, JWTCertException
 from ansible_base.jwt_consumer.common.exceptions import InvalidTokenException
 from ansible_base.lib.utils.translations import translatableConditionally as _
@@ -856,3 +856,37 @@ class TestJWTAuthentication:
             with pytest.raises(Exception) as exc_info:
                 authentication._fetch_jwt_claims_from_gateway(user_ansible_id)
             assert "boom" in str(exc_info.value)
+
+
+class TestRbacAwareJWTAuthentication:
+    @pytest.mark.django_db
+    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'test_app', 'ansible_base.resource_registry', 'ansible_base.rbac'])
+    def test_use_rbac_permissions_true_when_rbac_installed(self):
+        """Test that use_rbac_permissions is True when ansible_base.rbac is in INSTALLED_APPS"""
+        auth = RbacAwareJWTAuthentication()
+        assert auth.use_rbac_permissions is True
+
+    @pytest.mark.django_db
+    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'test_app', 'ansible_base.resource_registry'])
+    def test_use_rbac_permissions_false_when_rbac_not_installed(self):
+        """Test that use_rbac_permissions is False when ansible_base.rbac is not in INSTALLED_APPS"""
+        auth = RbacAwareJWTAuthentication()
+        assert auth.use_rbac_permissions is False
+
+    @pytest.mark.django_db
+    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'test_app', 'ansible_base.resource_registry', 'ansible_base.rbac'])
+    def test_process_permissions_calls_rbac_when_enabled(self):
+        """Test that process_permissions calls RBAC processing when RBAC is installed"""
+        with mock.patch('ansible_base.jwt_consumer.common.auth.JWTCommonAuth.process_rbac_permissions') as mock_process:
+            auth = RbacAwareJWTAuthentication()
+            auth.process_permissions()
+            mock_process.assert_called_once()
+
+    @pytest.mark.django_db
+    @override_settings(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'test_app', 'ansible_base.resource_registry'])
+    def test_process_permissions_skips_rbac_when_disabled(self, caplog, shut_up_logging):
+        """Test that process_permissions logs info message when RBAC is not installed"""
+        with caplog.at_level(logging.INFO):
+            auth = RbacAwareJWTAuthentication()
+            auth.process_permissions()
+            assert "process_permissions was not overridden for JWTAuthentication" in caplog.text


### PR DESCRIPTION
## Description

Currently, there are three component specific JWTConsumer classes in DAB:

AWX: https://github.com/ansible/django-ansible-base/blob/devel/ansible_base/jwt_consumer/awx/auth.py#L9
Hub: https://github.com/ansible/django-ansible-base/blob/devel/ansible_base/jwt_consumer/hub/auth.py#L8
EDA: https://github.com/ansible/django-ansible-base/blob/devel/ansible_base/jwt_consumer/eda/auth.py#L10

They all do the same, the goal of this PR is to provide one common RbacEnabledJWTAuthentication class that all components use.

After this is merged, EDA, AWX and Hub need to be updated to use the common class. Then we can remove the component specific classes in another PR.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change
