### PR TITLE
AAP-51895 improve logging

### DIFF
--- a/ansible_base/resource_registry/models/resource.py
+++ b/ansible_base/resource_registry/models/resource.py
@@ -1,6 +1,6 @@
 import uuid
 from functools import lru_cache
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -10,6 +10,9 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.serializers import ValidationError
 
 from .service_identifier import service_id
+
+if TYPE_CHECKING:
+    from ..utils.resource_type_processor import ResourceTypeProcessor
 
 
 @lru_cache(maxsize=None)
@@ -152,11 +155,11 @@ class Resource(models.Model):
         serializer = resource_type.serializer_class(data=resource_data)
         serializer.is_valid(raise_exception=True)
         resource_data = serializer.validated_data
-        processor = serializer.get_processor()
+        processor: type["ResourceTypeProcessor"] = serializer.get_processor()
 
         with transaction.atomic():
             ObjModel = c_type.model_class()
-            content_object = processor(ObjModel())
+            content_object: "ResourceTypeProcessor" = processor(ObjModel())
             with no_reverse_sync():
                 content_object.save(resource_data, is_new=True)
             resource = cls.objects.get(object_id=content_object.instance.pk, content_type=c_type)
@@ -170,7 +173,9 @@ class Resource(models.Model):
 
             return resource
 
-    def update_resource(self, resource_data: dict, ansible_id=None, is_partially_migrated=None, partial=False, service_id: Union[str, uuid.UUID, None] = None):
+    def update_resource(
+        self, resource_data: dict, ansible_id=None, is_partially_migrated=None, partial=False, service_id: Union[str, uuid.UUID, None] = None
+    ) -> bool:
         from ..signals.handlers import no_reverse_sync
 
         resource_type = self.content_type.resource_type
@@ -179,20 +184,26 @@ class Resource(models.Model):
         serializer.is_valid(raise_exception=True)
         resource_data = serializer.validated_data
 
-        processor = serializer.get_processor()
+        processor: type["ResourceTypeProcessor"] = serializer.get_processor()
 
+        changed_metadata = False
         with transaction.atomic():
             if ansible_id:
                 self.ansible_id = ansible_id
+                changed_metadata = True
             if service_id:
                 self.service_id = service_id
+                changed_metadata = True
             if is_partially_migrated is not None:
                 self.is_partially_migrated = is_partially_migrated
+                changed_metadata = True
             self.save()
 
-            content_object = processor(self.content_object)
+            content_object: "ResourceTypeProcessor" = processor(self.content_object)
             with no_reverse_sync():
-                content_object.save(resource_data)
+                (changed_data, _) = content_object.save(resource_data)
+
+        return changed_data or changed_metadata
 
 
 # This is a separate function so that it can work with models from apps in the

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -445,7 +445,8 @@ def _attempt_update_resource(
 ) -> SyncResult:
     """Try to update existing resource."""
     try:
-        resource.update_resource(resource_data, partial=True, **kwargs)
+        if not resource.update_resource(resource_data, partial=True, **kwargs):
+            return SyncResult(SyncStatus.NOOP, manifest_item)
     except IntegrityError:  # pragma: no cover
         # This typically means that there was a duplicate key error. To mitigate this
         # we will attempt to hanlde the conflicting resource and perform the operation

--- a/ansible_base/resource_registry/utils/resource_type_processor.py
+++ b/ansible_base/resource_registry/utils/resource_type_processor.py
@@ -1,3 +1,10 @@
+from typing import Any, Dict, List, Tuple
+
+from django.db import models
+
+from ansible_base.rbac.models.role import RoleDefinition
+
+
 class ResourceTypeProcessor:
     """
     This class allows services to customize how objects are serialized and
@@ -9,10 +16,10 @@ class ResourceTypeProcessor:
     whereas AWX uses roles to track membership.
     """
 
-    def __init__(self, instance):
+    def __init__(self, instance: models.Model) -> None:
         self.instance = instance
 
-    def pre_serialize(self):
+    def pre_serialize(self) -> models.Model:
         """
         This gets called on an instance of a model before it is sent in the
         `instance` kwarg to the ResourceType serializer. This can be customized
@@ -21,36 +28,42 @@ class ResourceTypeProcessor:
         """
         return self.instance
 
-    def pre_serialize_additional(self):
+    def pre_serialize_additional(self) -> models.Model:
         """
         Same as pre_serialize, but is called before ADDITIONAL_DATA_SERIALIZER
         is instantiated.
         """
         raise NotImplementedError("Additional data is not supported by default.")
 
-    def save(self, validated_data, is_new=False):
+    def save(self, validated_data: Dict[str, Any], is_new: bool = False, skip_keys: List[str] = []) -> Tuple[bool, models.Model]:
         """
         This gets called when an instance of a Resource is saved and allows for
         services to customize how the resource gets saved with their local copy
         of the model.
         """
+        changed = False
         for k, val in validated_data.items():
+            if k in skip_keys:
+                continue
+            if not hasattr(self.instance, k) or getattr(self.instance, k) != val:
+                changed = True
             setattr(self.instance, k, val)
 
         self.instance.save()
-        return self.instance
+        return (changed, self.instance)
 
 
 class RoleDefinitionProcessor(ResourceTypeProcessor):
-    def save(self, validated_data, is_new=False):
+    def save(self, validated_data: Dict[str, Any], is_new: bool = False, skip_keys: List[str] = []) -> Tuple[bool, RoleDefinition]:
+        (changed, instance) = super().save(validated_data, is_new=is_new, skip_keys=skip_keys + ['permissions'])
         permissions = None  # many-to-many field
         for k, val in validated_data.items():
             if k == 'permissions':
                 permissions = val
-            else:
-                setattr(self.instance, k, val)
 
-        self.instance.save()
         if permissions is not None:
-            self.instance.permissions.set(permissions)
-        return self.instance
+            old_permissions = set(self.instance.permissions.all())
+            if old_permissions != set(permissions):
+                self.instance.permissions.set(permissions)
+                changed = True
+        return (changed, self.instance)

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -10,7 +10,14 @@ from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.models.service_identifier import service_id
-from ansible_base.resource_registry.tasks.sync import AssignmentTuple, ManifestItem, ResourceSyncHTTPError, SyncExecutor, _attempt_create_resource
+from ansible_base.resource_registry.tasks.sync import (
+    AssignmentTuple,
+    ManifestItem,
+    ResourceSyncHTTPError,
+    SyncExecutor,
+    _attempt_create_resource,
+    _attempt_update_resource,
+)
 
 
 @pytest.fixture(scope="function")
@@ -209,6 +216,71 @@ def test_resource_sync_create_non_local_role_definition(static_api_client, stdou
     assert result.status == 'noop'
 
     assert not RoleDefinition.objects.filter(name="Remote Role").exists()
+
+
+@pytest.mark.parametrize(
+    "name,expected_status",
+    [
+        ("Platform Auditor", "noop"),  # Same name as existing resource, should skip
+        ("Platform Auditor DIFFERENCE", "updated"),  # Different name, should update
+    ],
+)
+@pytest.mark.django_db
+def test_resource_sync_update_scenarios(static_api_client, resource_to_update, name, expected_status):
+    """Test resource sync update scenarios with different names."""
+    # Get the existing resource that was created by the fixture
+    resource = Resource.objects.get(ansible_id="97447387-8596-404f-b0d0-6429b04c8d22")
+    auditor_rd = RoleDefinition.objects.managed.sys_auditor
+    resource = auditor_rd.resource
+
+    # Create manifest item and resource data with invalid content_type
+    item_data = {
+        'name': name,
+        'description': 'Has view permissions to all objects',
+        'managed': True,
+        'content_type': None,
+        'permissions': [
+            'eda.view_activation',
+            'galaxy.view_ansiblerepository',
+            'eda.view_auditrule',
+            'galaxy.view_collection',
+            'galaxy.view_collectionimport',
+            'galaxy.view_collectionremote',
+            'galaxy.view_containernamespace',
+            'galaxy.view_containerregistryremote',
+            'galaxy.view_containerrepository',
+            'awx.view_credential',
+            'eda.view_credentialinputsource',
+            'eda.view_decisionenvironment',
+            'eda.view_edacredential',
+            'eda.view_eventstream',
+            'awx.view_instancegroup',
+            'awx.view_inventory',
+            'shared.view_organization',
+            'awx.view_jobtemplate',
+            'galaxy.view_namespace',
+            'awx.view_notificationtemplate',
+            'awx.view_project',
+            'eda.view_project',
+            'eda.view_rulebook',
+            'eda.view_rulebookprocess',
+            'galaxy.view_task',
+            'shared.view_team',
+            'awx.view_workflowjobtemplate',
+        ],
+    }
+    item_data['permissions'] += [perm.api_slug for perm in auditor_rd.permissions.all()]
+    manifest_item = ManifestItem("97447387-8596-404f-b0d0-6429b04c8d22", str(uuid4()), item_data)
+
+    # Test the update behavior
+    result = _attempt_update_resource(
+        manifest_item=manifest_item,
+        resource=resource,
+        resource_data=item_data,
+        api_client=static_api_client,
+    )
+
+    assert result.status == expected_status
 
 
 @pytest.mark.django_db

--- a/test_app/tests/resource_registry/test_resources_api.py
+++ b/test_app/tests/resource_registry/test_resources_api.py
@@ -376,7 +376,7 @@ def test_processor_save(admin_api_client):
         def save(self, validated_data, is_new=False):
             self.instance.name = "HELLO " + validated_data["name"]
             self.instance.save()
-            return self.instance
+            return (True, self.instance)
 
     class PatchedConfig(APIConfig):
         custom_resource_processors = {"shared.organization": CustomProcessor}


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Resource sync operation status for role type definition when permissions are not actually updated now raises a SkipResource rather than being considered an update.

- Why is this change needed?
Without this, resource sync will continually report the operation as an UPDATE, every time, even when nothing changes in the system.

- How does this change address the issue?
By raising a SkipResource.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- 2.5 -> 2.6 production upgrade


### Steps to Test
1. on a controller instance run `awx-manage resource_sync` twice
2. notice some of the same UPDATE operations
3. Apply the changes to code
4. on a controller instance run `awx-manage resource_sync` twice
5. notice the previous UPDATE operations are now not present, they are NOOPs

### Expected Results
For no UPDATE requests the second sync run.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->




# One shot prompt
@test_app/tests/resource_registry/test_resource_sync.py adds the test `test_resource_sync_update_skip_resource` and is expected to fail because we are doing TDD. Make the necessary code changes to make it pass.

I tried to implement `is_valid` in @ansible_base/resource_registry/utils/resource_type_serializers.py but that didn't seem to be the right place.

# Testing

* source the virtualenv `source .venv/bin/activate`
* Run `DJANGO_SETTINGS_MODULE=test_app.sqlite3settings pytest test_app/tests/resource_registry/test_resource_sync.py::test_resource_sync_update_skip_resource --reuse-db --migrations` 

# Data

Below is the role definition in the test scenario.
```
auditor_rd = RoleDefinition.objects.managed.sys_auditorp 51895
(Pdb) auditor_rd
<RoleDefinition: RoleDefinition(pk=1, name=Platform Auditor, managed=True)>
(Pdb) auditor_rd.permissions.all()
<QuerySet [<DABPermission: <DABPermission: view_organization>>, <DABPermission: <DABPermission: view_team>>]>
```

Below is the incoming manifest item, which is a wanted modification.
```python
{
  "name": "Platform Auditor",
  "description": "Has view permissions to all objects",
  "managed": true,
  "content_type": null,
  "permissions": [
    "eda.view_activation",
    "galaxy.view_ansiblerepository",
    "eda.view_auditrule",
    "galaxy.view_collection",
    "galaxy.view_collectionimport",
    "galaxy.view_collectionremote",
    "galaxy.view_containernamespace",
    "galaxy.view_containerregistryremote",
    "galaxy.view_containerrepository",
    "awx.view_credential",
    "eda.view_credentialinputsource",
    "eda.view_decisionenvironment",
    "eda.view_edacredential",
    "eda.view_eventstream",
    "awx.view_instancegroup",
    "awx.view_inventory",
    "awx.view_jobtemplate",
    "galaxy.view_namespace",
    "awx.view_notificationtemplate",
    "shared.view_organization",
    "awx.view_project",
    "eda.view_project",
    "eda.view_rulebook",
    "eda.view_rulebookprocess",
    "galaxy.view_task",
    "shared.view_team",
    "awx.view_workflowjobtemplate"
  ]
}
```

# Requirements

- R1 - Raise `SkipResource` when local updates to permissions do not need to be made.

# Why is this tricky?

The resource sync does a hash check to determine if the manifest item can be skipped for reasons of the local machine having the same state as the remote state. However, in this case, making the local state match the remote state is not what is wanted. Thus, this check will always fail and fall through to the next piece of logic which fetches the resource (manifest item) from the remote server.

I am unsure if this problem exists for items other than `RoleDefinitionType`.

For a `RoleDefinitionType` manifest item may have permissions that:

1. We don't care about (i.e. `galaxy.view_task`)
2. Permissions that we care about (i.e. `shared.view_team`)
3. The absense of permissions that we care about (i.e. NO `shared.view_organization`)

Currently, it's logically correct if we do _not_ implement requirement R1. The system knows to filter 1. and will use a `set()` operation to handle 2 and 3.


# Solution Ideas

1. The easiest/hackiest solution would be to allow the system to do the operation, since that already works, and compare the `permissions` set before and after to see if a change was made. If a change was not made then raise the `SkipResource`

<i>Why is this not ideal?</i>

Introspection of the state to determine modified violates the layers of abstraction. A slightly better solution would be for the inside layers to return/communicate if a modification was made.

2. `RoleDefinitionType.is_valid()` serializer.

~The serializer doens't seem to have enough data (i.e. pk) to actually get the `RoleDefinition` object to be able to get the exisiting permissions.~ The serializer is used by the API views. The API views don't want an exception raised when a superset of permissions are specified.

3. After the initial `sync.py` hash short-circuit logic. Re-hash with just the subset of valid permissions.

4. Rework the hash.

* The resource server (Gateway) would need to know the requesting service to know which permissions to filter from the hash.
* `SharedResourceTypeSerializer` _looks_ like it has facilities to help in a little bit of this see `ADDITIONAL_DATA_SERIALIZER`

5. Detect if the sync resulted in a change in the local resource at the lowest level, in the processor `save()` and propagate a changed flag back up.

# Conclusion

I ended up going with solution 5 above.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detect and surface NOOP on resource sync updates by having processors report whether data/permissions changed, propagating up to sync.
> 
> - **Resource model (`models/resource.py`)**:
>   - `Resource.update_resource(...)` now returns `bool` indicating if metadata or content changed; propagates change flag from processor.
>   - Added precise typing for processors.
> - **Processors (`utils/resource_type_processor.py`)**:
>   - `ResourceTypeProcessor.save(...)` returns `(changed, instance)` and detects field diffs (with `skip_keys`).
>   - `RoleDefinitionProcessor.save(...)` only marks changed when `permissions` set actually differs.
> - **Sync (`tasks/sync.py`)**:
>   - `_attempt_update_resource(...)` treats unchanged updates as `NOOP` based on `Resource.update_resource` return value.
> - **Tests**:
>   - Add/update tests for role definition create/skip and update scenarios, and adjust custom processor test to match new return signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41027956272f42f0721b154c1a661a8fb3e04c47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->