### PR TITLE
[AAP-58239] Fix pytest error in prefixed authentication tests

### DIFF
--- a/test_app/tests/lib/test_prefixed_authentication_backend.py
+++ b/test_app/tests/lib/test_prefixed_authentication_backend.py
@@ -6,14 +6,14 @@ from test_app.models import User
 
 
 @pytest.fixture
-@pytest.mark.django_db(transaction=True)
-def prefixed_user(local_authenticator):
+def prefixed_user(local_authenticator, db):
     user = User.objects.create(username='dab:foo')
     user.set_password("pass")
     user.save()
     return user
 
 
+@pytest.mark.django_db
 def test_prefixed_user_can_login_with_original_username(prefixed_user):
     url = get_relative_url("rest_framework:login")
     me_url = get_relative_url("user-me")
@@ -27,6 +27,7 @@ def test_prefixed_user_can_login_with_original_username(prefixed_user):
     assert resp.data["username"] == "dab:foo"
 
 
+@pytest.mark.django_db
 def test_prefixed_user_can_login_with_prefixed_username(prefixed_user):
     url = get_relative_url("rest_framework:login")
     me_url = get_relative_url("user-me")


### PR DESCRIPTION
Remove invalid @pytest.mark.django_db decorator from prefixed_user fixture and add db fixture dependency instead. Marks applied to fixtures have no effect and are deprecated in pytest 9.

Also add @pytest.mark.django_db to test functions to ensure proper database access during test execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Addresses CI test failures due to @pytest.mark.django_db raising an error, instead of previously only raising a warning. 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
CI jobs should pass

## Additional Context
CI tests began failing with PytestRemovedIn9Warning after pytest was upgraded. The error occurs because @pytest.mark.django_db was applied directly to fixture functions, which is deprecated in pytest and will be removed in pytest 9.
