### PR TITLE
AAP-58110 Update django version for CVE

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
 cryptography
-Django>=4.2.26,<6.0
+Django>=4.2.26,<6.0    # Updating for CVE-2025-64459
 djangorestframework
 django-crum
 inflection

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
 cryptography
-Django>=4.2.21,<6.0
+Django>=4.2.26,<6.0
 djangorestframework
 django-crum
 inflection

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -24,7 +24,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==5.2.7
+django==5.2.8
     # via
     #   -r requirements/requirements.in
     #   channels

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,7 +1,7 @@
 ansible                 # Used in build process to generate some configs
 black==25.1.0           # Linting tool, if changed update pyproject.toml as well
 build
-django==5.2.7
+django==5.2.8
 django-debug-toolbar
 django-extensions
 djangorestframework


### PR DESCRIPTION
## Description

CVE-2025-64459 requires update of django to 4.2.26+ (or 5.2.8+ or 5.1.14+) due to an SQL injection vulnerability

The version spec is a bit concerning due to our acceptance of 4.2 track or 5.2 track.

Django>=4.2.26,<6.0

This sets the minimum for 4.2.x, but not for 5.1.x and 5.2.x.  I am not sure this is a problem or not, will check with PDE and/or Konflux folks.  If anyone is aware of a construction that can set a minimum for multiple minor version tracks, let me know.  I did not see one.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. No issues expected, regular UT/ATF regression tests.
2. 
3. 

### Expected Results
No issues expected, business as usual.

