### PR TITLE
AAP-56793  feat: Add AuthenticatorUpdateSerializer with read-only type field

### DIFF
--- a/ansible_base/authentication/serializers/__init__.py
+++ b/ansible_base/authentication/serializers/__init__.py
@@ -1,3 +1,3 @@
-from .authenticator import AuthenticatorSerializer  # noqa: 401
+from .authenticator import AuthenticatorSerializer, AuthenticatorUpdateSerializer  # noqa: 401
 from .authenticator_map import AuthenticatorMapSerializer  # noqa: 401
 from .ui_auth import PasswordAuthenticatorSerializer, SSOAuthenticatorSerializer, UIAuthResponseSerializer  # noqa: 401

--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -146,3 +146,12 @@ class AuthenticatorSerializer(NamedCommonModelSerializer, ImmutableFieldsMixin):
             related['users'] = get_relative_url('authenticator-users-list', kwargs={'pk': obj.pk})
 
         return related
+
+
+class AuthenticatorUpdateSerializer(AuthenticatorSerializer):
+    """Specialized serializer for update operations that makes type field read-only."""
+
+    type = ChoiceField(choices=get_authenticator_plugins(), read_only=True, help_text="The type of authentication service this is.")
+
+    class Meta(AuthenticatorSerializer.Meta):
+        read_only_fields = getattr(AuthenticatorSerializer.Meta, 'read_only_fields', []) + ['type']

--- a/ansible_base/authentication/views/authenticator.py
+++ b/ansible_base/authentication/views/authenticator.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
-from ansible_base.authentication.serializers import AuthenticatorSerializer
+from ansible_base.authentication.serializers import AuthenticatorSerializer, AuthenticatorUpdateSerializer
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 logger = logging.getLogger('ansible_base.authentication.views.authenticator')
@@ -35,6 +35,11 @@ class AuthenticatorViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
                     kwargs["instance"] = "object"
 
         return super().get_serializer(*args, **kwargs)
+
+    def get_serializer_class(self):
+        if self.action in ['update', 'partial_update']:
+            return AuthenticatorUpdateSerializer
+        return super().get_serializer_class()
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()


### PR DESCRIPTION
# AAP-56793

## Description
  Replace schema override approach with specialized serializer that makes
  type field read-only for PUT/PATCH operations while keeping it editable
  for POST operations. This provides accurate OpenAPI schema generation
  without manual overrides.

  Changes:
  - Add AuthenticatorUpdateSerializer inheriting from AuthenticatorSerializer
  - Override type field as read-only with appropriate help text
  - Update get_serializer_class() to use update serializer for update/partial_update
  - Remove @extend_schema_if_available decorators (rely on auto-generation)
  - Clean up unused schema import

  This follows existing DAB patterns and generates accurate OpenAPI schemas
  automatically while preventing type field modification after creation.

  Co-Authored-By: Claude <noreply@anthropic.com>
  Vibe-Coder: Andrew Potozniak <potozniak@redhat.com>
  AIA: Entirely AI, Human-initiated, Reviewed, Claude Code [Sonnet 4] v1.0
  https://aiattribution.github.io/statements/AIA-EAI-Hin-R-?model=Claude%20Code%20%5BSonnet%204%5D-v1.0


## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
TBD

### Required Actions
- [X] Requires backport to 2.6
