### PR TITLE
AAP-56795 feat: Fix AuthenticatorMap OpenAPI schema by making triggers field required

### DIFF
--- a/ansible_base/authentication/serializers/authenticator_map.py
+++ b/ansible_base/authentication/serializers/authenticator_map.py
@@ -8,6 +8,7 @@ from ansible_base.authentication.models import AuthenticatorMap
 from ansible_base.authentication.utils.authenticator_map import _EXPANSION_FIELDS, check_expansion_syntax, check_role_type, has_expansion
 from ansible_base.authentication.utils.trigger_definition import TRIGGER_DEFINITION
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
+from ansible_base.lib.serializers.fields import JSONField
 from ansible_base.lib.utils.string import is_empty
 from ansible_base.lib.utils.typing import TranslatedString
 
@@ -15,6 +16,14 @@ logger = logging.getLogger('ansible_base.authentication.serializers.authenticato
 
 
 class AuthenticatorMapSerializer(NamedCommonModelSerializer):
+    triggers = JSONField(
+        required=True,
+        allow_null=False,
+        error_messages={'required': 'Triggers must be a valid dict'},
+        help_text="Required. Trigger conditions dictionary that determines when this map applies. "
+        "See /trigger_definition/ for structure details. Only one top-level key per request.",
+    )
+
     class Meta:
         model = AuthenticatorMap
         fields = NamedCommonModelSerializer.Meta.fields + ['authenticator', 'map_type', 'role', 'organization', 'team', 'revoke', 'triggers', 'order']


### PR DESCRIPTION
# AAP-56795

## Description
  Update base AuthenticatorMapSerializer to explicitly define triggers as a
  required JSONField, which generates accurate OpenAPI schemas automatically
  while preserving existing PATCH behavior through validate_trigger_data().

  Changes:
  - Add explicit triggers = JSONField(required=True) to AuthenticatorMapSerializer
  - Remove @extend_schema_if_available decorator (no longer needed)
  - Existing validate_trigger_data() method still allows optional triggers for PATCH

  This approach is simpler than specialized serializers and follows DRF patterns
  where field-level requirements control schema generation but custom validation
  can override behavior for specific HTTP methods.

  Co-Authored-By: Claude <noreply@anthropic.com>
  Vibe-Coder: Andrew Potozniak <potozniak@redhat.com>
  AIA: Entirely AI, Human-initiated, Reviewed, Claude Code [Sonnet 4] v1.0
  https://aiattribution.github.io/statements/AIA-EAI-Hin-R-?model=Claude%20Code%20%5BSonnet%204%5D-v1.0

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
TBD

### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [X] Requires backport to 2.6
