### PR TITLE
[AAP-59285] Adding openapi specification validation as a part of the sanity CI checks

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -35,3 +35,9 @@ jobs:
 
       - name: Run help text check
         run: ./manage.py help_text_check --applications=dab --ignore-file=./.help_text_check.ignore
+
+      - name: Validate OpenAPI Specification
+        run: |
+          ./manage.py spectacular --format openapi-json --file dab-openapi.json
+          openapi-spec-validator dab-openapi.json
+          echo "✅ OpenAPI schema validation passed"

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -12,6 +12,7 @@ isort==6.0.0            # Linting tool, if changed update pyproject.toml as well
 tox
 tox-docker
 typeguard
+openapi-spec-validator
 pytest
 pytest-asyncio
 pytest-xdist


### PR DESCRIPTION
# [AAP-59285](https://issues.redhat.com/browse/AAP-59285)

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Adding CI checks for open API specification validation

- Why is this change needed?
Shorter feedback loop to validate specification changes

- How does this change address the issue?
Specification validation is a part of CI

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] New feature (non-breaking change which adds functionality)
- [X] Development environment change
- [X] CI

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
Open a PR with invalid open specification changes, watch CI fail.
Fix PR with valid specification, watch CI pass.
Close PR.

### Required Actions
- [X] Requires infrastructure/deployment changes (CI/CD - but for DAB)

CI will fail on this specifically for the Open API Spec validation until - https://github.com/ansible/django-ansible-base/pull/886 - is merged and this PR is rebased on top of it.