### PR TITLE
[AAP-59444] Add metadata to return the AuthenticatorUpdateSerializer to say 'type' is read only

### DIFF
--- a/ansible_base/authentication/views/authenticator.py
+++ b/ansible_base/authentication/views/authenticator.py
@@ -37,7 +37,7 @@ class AuthenticatorViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
         return super().get_serializer(*args, **kwargs)
 
     def get_serializer_class(self):
-        if self.action in ['update', 'partial_update']:
+        if self.action in ['update', 'partial_update', 'metadata']:
             return AuthenticatorUpdateSerializer
         return super().get_serializer_class()
 


### PR DESCRIPTION
# AAP-59444

## Description
- What is being changed? Adding metadata to the checks for the serializer to make type read-only.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [X] Requires backport