### PR TITLE
Include feature flags definitions in package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ exclude manage.py
 recursive-exclude docs *
 recursive-exclude test_app *
 recursive-exclude tools *
+recursive-include ansible_base/feature_flags/definitions *


### PR DESCRIPTION
## Description
- **What is being changed?** Added `recursive-include ansible_base/feature_flags/definitions *` to MANIFEST.in to include feature flags definitions in the package distribution
- **Why is this change needed?** Feature flags definitions need to be included in the package when django-ansible-base is distributed, ensuring that feature flag configuration files are available in installed packages
- **How does this change address the issue?** The MANIFEST.in file controls which files are included in Python package distributions. By adding this line, we ensure that all files in the `ansible_base/feature_flags/definitions/` directory are included when the package is built and distributed

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- Python packaging tools (setuptools, wheel)
- Access to django-ansible-base source code

### Steps to Test
1. Build the package: `python setup.py sdist bdist_wheel`
2. Extract the built distribution archive
3. Verify that `ansible_base/feature_flags/definitions/` directory and its contents are present in the package
4. Install the package in a clean environment
5. Verify that feature flag definitions are accessible from the installed package

### Expected Results
- The built package should contain all files from `ansible_base/feature_flags/definitions/`
- Feature flags functionality should work correctly when using the distributed package
- No missing file errors when feature flags are loaded

## Additional Context
This change ensures that the feature flags definitions introduced in recent commits are properly included in the package distribution. Without this change, installations of django-ansible-base would be missing the feature flag definition files, potentially causing runtime errors when feature flags are accessed.

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

This is a straightforward packaging fix with no external dependencies or coordination required.