### PR TITLE
AAP-53741 Add social auth redirect logging for auditability

### DIFF
--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -162,7 +162,7 @@ class SocialAuthMixin:
                 second_logger=logger,
             )
 
-        return super().start(self)
+        return super().start()
 
     @property
     def name(self):

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -157,8 +157,10 @@ class SocialAuthMixin:
         # Before calling BaseAuth.start, we need to log any expected redirects from the parent function.
         if self.uses_redirect():
             auth_url = self.auth_url()
+            # Strip URL parameters from the auth URL for logging
+            auth_url_without_params = auth_url.split('?')[0] if auth_url else auth_url
             log_auth_event(
-                f"Starting SSO redirect to {auth_url} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})",
+                f"Starting SSO redirect to {auth_url_without_params} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})",
                 second_logger=logger,
             )
 

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -60,10 +60,6 @@ class AuthenticatorStrategy(DjangoStrategy):
                 pass
         return default
 
-    def redirect(self, url):
-        logger.info(f"Redirecting user to {url} as part of the social auth flow for SSO authenticator.")
-        return super().redirect(url)
-
     # load the authenticator setting from the database object.
     def get_setting(self, name, backend):
         # try to load the value from the db.
@@ -156,8 +152,12 @@ class SocialAuthMixin:
         if not self.database_instance.enabled:
             logger.error(f"Authentication attempted with disabled authenticator {self.database_instance.name}")
             return HttpResponseNotFound()
-        logger.info(f"Starting Authentication attempt with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})")
-        return super().start()
+        if self.uses_redirect():
+            auth_url = self.auth_url()
+            logger.info(f"Starting SSO redirect to {auth_url} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})")
+            return self.strategy.redirect(auth_url)
+        else:
+            return self.strategy.html(self.auth_html())
 
     @property
     def name(self):

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -60,6 +60,10 @@ class AuthenticatorStrategy(DjangoStrategy):
                 pass
         return default
 
+    def redirect(self, url):
+        logger.info(f"Redirecting user to {url} as part of the social auth flow for SSO authenticator.")
+        return super().redirect(url)
+
     # load the authenticator setting from the database object.
     def get_setting(self, name, backend):
         # try to load the value from the db.
@@ -152,6 +156,7 @@ class SocialAuthMixin:
         if not self.database_instance.enabled:
             logger.error(f"Authentication attempted with disabled authenticator {self.database_instance.name}")
             return HttpResponseNotFound()
+        logger.info(f"Starting Authentication attempt with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})")
         return super().start()
 
     @property

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -14,6 +14,7 @@ from social_django.strategy import DjangoStrategy
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_class, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 from ansible_base.authentication.utils.user import normalize_and_get_email
+from ansible_base.lib.logging import log_auth_event
 from ansible_base.lib.utils.response import get_fully_qualified_url
 
 logger = logging.getLogger('ansible_base.authentication.social_auth')
@@ -154,7 +155,10 @@ class SocialAuthMixin:
             return HttpResponseNotFound()
         if self.uses_redirect():
             auth_url = self.auth_url()
-            logger.info(f"Starting SSO redirect to {auth_url} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})")
+            log_auth_event(
+                f"Starting SSO redirect to {auth_url} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})",
+                second_logger=logger,
+            )
             return self.strategy.redirect(auth_url)
         else:
             return self.strategy.html(self.auth_html())

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -153,15 +153,16 @@ class SocialAuthMixin:
         if not self.database_instance.enabled:
             logger.error(f"Authentication attempted with disabled authenticator {self.database_instance.name}")
             return HttpResponseNotFound()
+
+        # Before calling BaseAuth.start, we need to log any expected redirects from the parent function.
         if self.uses_redirect():
             auth_url = self.auth_url()
             log_auth_event(
                 f"Starting SSO redirect to {auth_url} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})",
                 second_logger=logger,
             )
-            return self.strategy.redirect(auth_url)
-        else:
-            return self.strategy.html(self.auth_html())
+
+        return super().start(self)
 
     @property
     def name(self):

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -2,7 +2,9 @@ from unittest import mock
 
 import pytest
 from django.conf import settings
-from django.test import override_settings
+from django.contrib.sessions.backends.db import SessionStore
+from django.http import HttpResponseNotFound, HttpResponseRedirect
+from django.test import RequestFactory, override_settings
 
 from ansible_base.authentication.social_auth import (
     AuthenticatorStorage,
@@ -47,30 +49,52 @@ class SubstringMatcher:
     __repr__ = __unicode__
 
 
+@pytest.mark.django_db
 @mock.patch("ansible_base.authentication.social_auth.logger")
 def test_authenticator_strategy_redirect_logging(mock_logger):
-    """Test that AuthenticatorStrategy.redirect logs the redirect URL without mocking redirect itself."""
-    from django.http import HttpResponseRedirect
+    """Test that SSO redirect logging happens in the start() method."""
+    from ansible_base.authentication.models import Authenticator
 
-    strategy = AuthenticatorStrategy(storage=AuthenticatorStorage())
+    # Create an authenticator
+    authenticator = Authenticator.objects.create(
+        name="Test OIDC",
+        slug="test-oidc",
+        type="ansible_base.authentication.authenticator_plugins.oidc",
+        enabled=True,
+        configuration={
+            "OIDC_ENDPOINT": "https://example.com",
+            "KEY": "test-key",
+            "SECRET": "test-secret",
+        },
+    )
+
+    # Create strategy and backend
+    factory = RequestFactory()
+    request = factory.get(f'/login/{authenticator.slug}/')
+    request.session = SessionStore()
+    request.session.save()
+
+    strategy = AuthenticatorStrategy(storage=AuthenticatorStorage(), request=request)
+    backend = strategy.get_backend(authenticator.slug)
+
+    # Mock auth_url to return a test URL
     test_url = "https://example.com/oauth/callback"
+    with mock.patch.object(backend, 'auth_url', return_value=test_url):
+        # Call start() which should log the redirect
+        result = backend.start()
 
-    # Call the redirect method directly (not mocked)
-    result = strategy.redirect(test_url)
+        # Verify the logger was called with the SSO redirect message
+        mock_logger.info.assert_called_once_with(f"Starting SSO redirect to {test_url} with authenticator 'Test OIDC' (slug: test-oidc)")
 
-    # Verify the logger was called with the correct message
-    mock_logger.info.assert_called_once_with(f"Redirecting user to {test_url} as part of the social auth flow for SSO authenticator.")
-
-    # Verify that the result is an HttpResponseRedirect with the correct URL
-    assert isinstance(result, HttpResponseRedirect)
-    assert result.url == test_url
+        # Verify that the result is an HttpResponseRedirect with the correct URL
+        assert isinstance(result, HttpResponseRedirect)
+        assert result.url == test_url
 
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.social_auth.logger")
 def test_social_auth_mixin_start_enabled_authenticator(mock_logger, random_user):
     """Test that SocialAuthMixin.start logs when authentication is attempted with an enabled authenticator."""
-    from django.http import HttpResponse
 
     from ansible_base.authentication.models import Authenticator
 
@@ -82,8 +106,11 @@ def test_social_auth_mixin_start_enabled_authenticator(mock_logger, random_user)
     class MockParent:
         """Mock parent class to avoid dependency on actual social auth backend."""
 
-        def start(self):
-            return HttpResponse("OK")
+        def auth_url(self):
+            return "https://example.com/auth"
+
+        def uses_redirect(self):
+            return True
 
     class TestBackend(SocialAuthMixin, MockParent):
         def __init__(self, database_instance):
@@ -95,22 +122,19 @@ def test_social_auth_mixin_start_enabled_authenticator(mock_logger, random_user)
     backend = TestBackend(database_instance=authenticator)
     result = backend.start()
 
-    # Verify info logging for starting authentication
-    mock_logger.info.assert_called_once_with("Starting Authentication attempt with authenticator 'Test OIDC' (slug: test-oidc)")
+    # Verify info logging for starting SSO redirect
+    mock_logger.info.assert_any_call("Starting SSO redirect to https://example.com/auth with authenticator 'Test OIDC' (slug: test-oidc)")
 
     # Verify error was not called (since authenticator is enabled)
     assert not mock_logger.error.called
 
-    # Verify that the result is an HttpResponse
-    assert isinstance(result, HttpResponse)
+    assert isinstance(result, HttpResponseRedirect)
 
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.social_auth.logger")
 def test_social_auth_mixin_start_disabled_authenticator(mock_logger):
     """Test that SocialAuthMixin.start logs an error and returns 404 for disabled authenticator."""
-    from django.http import HttpResponseNotFound
-
     from ansible_base.authentication.models import Authenticator
 
     # Create a mock authenticator with enabled=False
@@ -200,9 +224,6 @@ def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_ty
 
     We do NOT mock redirect itself - we verify the actual logging that happens during the flow.
     """
-    from django.http import HttpResponseRedirect
-    from django.test import RequestFactory
-
     from ansible_base.authentication.models import Authenticator
 
     # Create the authenticator
@@ -214,8 +235,6 @@ def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_ty
     factory = RequestFactory()
     request = factory.get(f'/login/{authenticator.slug}/')
     # Add a real session backend
-    from django.contrib.sessions.backends.db import SessionStore
-
     request.session = SessionStore()
     request.session.save()
 
@@ -233,22 +252,15 @@ def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_ty
         # Verify the result is a redirect response
         assert isinstance(result, HttpResponseRedirect), f"{authenticator_type} did not return HttpResponseRedirect"
 
-        # Verify we got the start authentication log message
-        start_log_calls = [call for call in mock_logger.info.call_args_list if "Starting Authentication attempt with authenticator" in str(call)]
-        assert len(start_log_calls) >= 1, f"{authenticator_type} did not log start authentication message"
+        # Verify we got the SSO redirect log message (which includes both start and redirect info)
+        sso_log_calls = [call for call in mock_logger.info.call_args_list if "Starting SSO redirect" in str(call)]
+        assert len(sso_log_calls) >= 1, f"{authenticator_type} did not log SSO redirect message"
 
-        # Verify the start message contains the authenticator name and slug
-        start_message = str(start_log_calls[0])
-        assert authenticator_name in start_message, f"Start message missing authenticator name: {start_message}"
-        assert authenticator.slug in start_message, f"Start message missing authenticator slug: {start_message}"
-
-        # Verify we got the redirect log message
-        redirect_log_calls = [call for call in mock_logger.info.call_args_list if "Redirecting user to" in str(call) and "social auth flow" in str(call)]
-        assert len(redirect_log_calls) >= 1, f"{authenticator_type} did not log redirect message"
-
-        # Verify the redirect message contains a URL
-        redirect_message = str(redirect_log_calls[0])
-        assert "https://" in redirect_message or "http://" in redirect_message, f"Redirect message missing URL: {redirect_message}"
+        # Verify the message contains the authenticator name, slug, and redirect URL
+        sso_message = str(sso_log_calls[0])
+        assert authenticator_name in sso_message, f"SSO message missing authenticator name: {sso_message}"
+        assert authenticator.slug in sso_message, f"SSO message missing authenticator slug: {sso_message}"
+        assert "https://" in sso_message or "http://" in sso_message, f"SSO message missing redirect URL: {sso_message}"
 
 
 @pytest.mark.django_db

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -47,6 +47,210 @@ class SubstringMatcher:
     __repr__ = __unicode__
 
 
+@mock.patch("ansible_base.authentication.social_auth.logger")
+def test_authenticator_strategy_redirect_logging(mock_logger):
+    """Test that AuthenticatorStrategy.redirect logs the redirect URL without mocking redirect itself."""
+    from django.http import HttpResponseRedirect
+
+    strategy = AuthenticatorStrategy(storage=AuthenticatorStorage())
+    test_url = "https://example.com/oauth/callback"
+
+    # Call the redirect method directly (not mocked)
+    result = strategy.redirect(test_url)
+
+    # Verify the logger was called with the correct message
+    mock_logger.info.assert_called_once_with(f"Redirecting user to {test_url} as part of the social auth flow for SSO authenticator.")
+
+    # Verify that the result is an HttpResponseRedirect with the correct URL
+    assert isinstance(result, HttpResponseRedirect)
+    assert result.url == test_url
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.authentication.social_auth.logger")
+def test_social_auth_mixin_start_enabled_authenticator(mock_logger, random_user):
+    """Test that SocialAuthMixin.start logs when authentication is attempted with an enabled authenticator."""
+    from django.http import HttpResponse
+
+    from ansible_base.authentication.models import Authenticator
+
+    # Create a mock authenticator with enabled=True
+    authenticator = Authenticator.objects.create(
+        name="Test OIDC", slug="test-oidc", type="ansible_base.authentication.authenticator_plugins.oidc", enabled=True, configuration={}
+    )
+
+    class MockParent:
+        """Mock parent class to avoid dependency on actual social auth backend."""
+
+        def start(self):
+            return HttpResponse("OK")
+
+    class TestBackend(SocialAuthMixin, MockParent):
+        def __init__(self, database_instance):
+            # Mock the strategy argument requirement
+            self.strategy = AuthenticatorStrategy(storage=AuthenticatorStorage())
+            self.database_instance = database_instance
+            self.logger = None
+
+    backend = TestBackend(database_instance=authenticator)
+    result = backend.start()
+
+    # Verify info logging for starting authentication
+    mock_logger.info.assert_called_once_with("Starting Authentication attempt with authenticator 'Test OIDC' (slug: test-oidc)")
+
+    # Verify error was not called (since authenticator is enabled)
+    assert not mock_logger.error.called
+
+    # Verify that the result is an HttpResponse
+    assert isinstance(result, HttpResponse)
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.authentication.social_auth.logger")
+def test_social_auth_mixin_start_disabled_authenticator(mock_logger):
+    """Test that SocialAuthMixin.start logs an error and returns 404 for disabled authenticator."""
+    from django.http import HttpResponseNotFound
+
+    from ansible_base.authentication.models import Authenticator
+
+    # Create a mock authenticator with enabled=False
+    authenticator = Authenticator.objects.create(
+        name="Disabled OIDC", slug="disabled-oidc", type="ansible_base.authentication.authenticator_plugins.oidc", enabled=False, configuration={}
+    )
+
+    class TestBackend(SocialAuthMixin):
+        def __init__(self, database_instance):
+            # Mock the strategy argument requirement
+            self.strategy = AuthenticatorStrategy(storage=AuthenticatorStorage())
+            self.database_instance = database_instance
+            self.logger = None
+
+    backend = TestBackend(database_instance=authenticator)
+
+    # Call start method
+    result = backend.start()
+
+    # Verify error logging for disabled authenticator
+    mock_logger.error.assert_called_once_with("Authentication attempted with disabled authenticator Disabled OIDC")
+
+    # Verify info logging was not called (since authenticator is disabled)
+    assert not mock_logger.info.called
+
+    # Verify that a 404 response was returned
+    assert isinstance(result, HttpResponseNotFound)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "authenticator_type,authenticator_name,minimal_config",
+    [
+        (
+            "ansible_base.authentication.authenticator_plugins.oidc",
+            "Test OIDC",
+            {
+                "OIDC_ENDPOINT": "https://example.com",
+                "KEY": "test-key",
+                "SECRET": "test-secret",
+            },
+        ),
+        (
+            "ansible_base.authentication.authenticator_plugins.azuread",
+            "Test Azure AD",
+            {
+                "KEY": "test-key",
+                "SECRET": "test-secret",
+            },
+        ),
+        (
+            "ansible_base.authentication.authenticator_plugins.github",
+            "Test GitHub",
+            {
+                "KEY": "test-key",
+                "SECRET": "test-secret",
+            },
+        ),
+        (
+            "ansible_base.authentication.authenticator_plugins.google_oauth2",
+            "Test Google OAuth2",
+            {
+                "KEY": "test-key",
+                "SECRET": "test-secret",
+            },
+        ),
+        (
+            "ansible_base.authentication.authenticator_plugins.keycloak",
+            "Test Keycloak",
+            {
+                "ACCESS_TOKEN_URL": "https://keycloak.example.com/token",
+                "AUTHORIZATION_URL": "https://keycloak.example.com/auth",
+                "KEY": "test-key",
+                "PUBLIC_KEY": "test-public-key",
+            },
+        ),
+    ],
+)
+@mock.patch("ansible_base.authentication.social_auth.logger")
+def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_type, authenticator_name, minimal_config):
+    """
+    Test that all SSO authenticators log both the start message and redirect message during auth flow.
+
+    This test verifies that:
+    1. SocialAuthMixin.start() logs "Starting Authentication attempt with authenticator..."
+    2. AuthenticatorStrategy.redirect() logs "Redirecting user to ... as part of the social auth flow..."
+
+    We do NOT mock redirect itself - we verify the actual logging that happens during the flow.
+    """
+    from django.http import HttpResponseRedirect
+    from django.test import RequestFactory
+
+    from ansible_base.authentication.models import Authenticator
+
+    # Create the authenticator
+    authenticator = Authenticator.objects.create(
+        name=authenticator_name, slug=f"test-{authenticator_type.split('.')[-1]}", type=authenticator_type, enabled=True, configuration=minimal_config
+    )
+
+    # Create a mock request with session
+    factory = RequestFactory()
+    request = factory.get(f'/login/{authenticator.slug}/')
+    # Add a real session backend
+    from django.contrib.sessions.backends.db import SessionStore
+
+    request.session = SessionStore()
+    request.session.save()
+
+    # Create the strategy with the request
+    strategy = AuthenticatorStrategy(storage=AuthenticatorStorage(), request=request)
+
+    # Get the backend for this authenticator
+    backend = strategy.get_backend(authenticator.slug)
+
+    # Mock auth_url to return a URL instead of making external calls
+    with mock.patch.object(backend, 'auth_url', return_value='https://example.com/auth'):
+        # Call start() which should log both start and redirect messages
+        result = backend.start()
+
+        # Verify the result is a redirect response
+        assert isinstance(result, HttpResponseRedirect), f"{authenticator_type} did not return HttpResponseRedirect"
+
+        # Verify we got the start authentication log message
+        start_log_calls = [call for call in mock_logger.info.call_args_list if "Starting Authentication attempt with authenticator" in str(call)]
+        assert len(start_log_calls) >= 1, f"{authenticator_type} did not log start authentication message"
+
+        # Verify the start message contains the authenticator name and slug
+        start_message = str(start_log_calls[0])
+        assert authenticator_name in start_message, f"Start message missing authenticator name: {start_message}"
+        assert authenticator.slug in start_message, f"Start message missing authenticator slug: {start_message}"
+
+        # Verify we got the redirect log message
+        redirect_log_calls = [call for call in mock_logger.info.call_args_list if "Redirecting user to" in str(call) and "social auth flow" in str(call)]
+        assert len(redirect_log_calls) >= 1, f"{authenticator_type} did not log redirect message"
+
+        # Verify the redirect message contains a URL
+        redirect_message = str(redirect_log_calls[0])
+        assert "https://" in redirect_message or "http://" in redirect_message, f"Redirect message missing URL: {redirect_message}"
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "test_data,has_instance,has_slug,expected_result",

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -93,7 +93,7 @@ def test_authenticator_strategy_redirect_logging(mock_logger):
 
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.social_auth.logger")
-def test_social_auth_mixin_start_enabled_authenticator(mock_logger, random_user):
+def test_social_auth_mixin_start_enabled_authenticator(mock_logger):
     """Test that SocialAuthMixin.start logs when authentication is attempted with an enabled authenticator."""
 
     from ansible_base.authentication.models import Authenticator
@@ -561,3 +561,96 @@ def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, user
     assert call_args[0][0] == user
     assert call_args[0][1] is None
     assert call_args[0][2].sort() == expected_groups.sort()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.authentication.social_auth.logger")
+def test_social_auth_mixin_start_no_redirect(mock_logger):
+    """Test that SocialAuthMixin.start returns HTML when uses_redirect() returns False."""
+    from ansible_base.authentication.models import Authenticator
+
+    # Create a mock authenticator
+    authenticator = Authenticator.objects.create(
+        name="Test HTML Auth",
+        slug="test-html-auth",
+        type="ansible_base.authentication.authenticator_plugins.oidc",
+        enabled=True,
+        configuration={},
+    )
+
+    class MockParent:
+        """Mock parent class that doesn't use redirect."""
+
+        def auth_html(self):
+            return "<html><body>Login Form</body></html>"
+
+        def uses_redirect(self):
+            return False
+
+    class TestBackend(SocialAuthMixin, MockParent):
+        def __init__(self, database_instance):
+            # Mock the strategy argument requirement
+            factory = RequestFactory()
+            request = factory.get('/login/test-html-auth/')
+            request.session = SessionStore()
+            request.session.save()
+            self.strategy = AuthenticatorStrategy(storage=AuthenticatorStorage(), request=request)
+            self.database_instance = database_instance
+            self.logger = None
+
+    backend = TestBackend(database_instance=authenticator)
+    result = backend.start()
+
+    # Verify that we didn't log the SSO redirect message (since this doesn't use redirect)
+    sso_log_calls = [call for call in mock_logger.info.call_args_list if "Starting SSO redirect" in str(call)]
+    assert len(sso_log_calls) == 0, "Should not log SSO redirect when uses_redirect() is False"
+
+    # Verify that we returned HTML response
+    from django.http import HttpResponse
+
+    assert isinstance(result, HttpResponse)
+    assert result.status_code == 200
+    assert b"Login Form" in result.content
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.authentication.social_auth.logger")
+def test_social_auth_mixin_start_no_redirect_disabled_authenticator(mock_logger):
+    """Test that SocialAuthMixin.start returns 404 for disabled authenticator even when uses_redirect() is False."""
+    from ansible_base.authentication.models import Authenticator
+
+    # Create a disabled authenticator
+    authenticator = Authenticator.objects.create(
+        name="Disabled HTML Auth",
+        slug="disabled-html-auth",
+        type="ansible_base.authentication.authenticator_plugins.oidc",
+        enabled=False,
+        configuration={},
+    )
+
+    class MockParent:
+        """Mock parent class that doesn't use redirect."""
+
+        def auth_html(self):
+            return "<html><body>Login Form</body></html>"
+
+        def uses_redirect(self):
+            return False
+
+    class TestBackend(SocialAuthMixin, MockParent):
+        def __init__(self, database_instance):
+            self.strategy = AuthenticatorStrategy(storage=AuthenticatorStorage())
+            self.database_instance = database_instance
+            self.logger = None
+
+    backend = TestBackend(database_instance=authenticator)
+    result = backend.start()
+
+    # Verify error logging for disabled authenticator
+    mock_logger.error.assert_called_once_with("Authentication attempted with disabled authenticator Disabled HTML Auth")
+
+    # Verify that no SSO redirect logging happened
+    assert not mock_logger.info.called
+
+    # Verify that a 404 response was returned (not HTML)
+    assert isinstance(result, HttpResponseNotFound)

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import pytest
@@ -84,7 +85,7 @@ def test_authenticator_strategy_redirect_logging(mock_logger):
         result = backend.start()
 
         # Verify the logger was called with the SSO redirect message
-        mock_logger.info.assert_called_once_with(f"Starting SSO redirect to {test_url} with authenticator 'Test OIDC' (slug: test-oidc)")
+        mock_logger.log.assert_called_once_with(logging.INFO, f"Starting SSO redirect to {test_url} with authenticator 'Test OIDC' (slug: test-oidc)")
 
         # Verify that the result is an HttpResponseRedirect with the correct URL
         assert isinstance(result, HttpResponseRedirect)
@@ -112,6 +113,9 @@ def test_social_auth_mixin_start_enabled_authenticator(mock_logger):
         def uses_redirect(self):
             return True
 
+        def start(self):
+            return None
+
     class TestBackend(SocialAuthMixin, MockParent):
         def __init__(self, database_instance):
             # Mock the strategy argument requirement
@@ -120,15 +124,13 @@ def test_social_auth_mixin_start_enabled_authenticator(mock_logger):
             self.logger = None
 
     backend = TestBackend(database_instance=authenticator)
-    result = backend.start()
+    backend.start()
 
     # Verify info logging for starting SSO redirect
-    mock_logger.info.assert_any_call("Starting SSO redirect to https://example.com/auth with authenticator 'Test OIDC' (slug: test-oidc)")
+    mock_logger.log.assert_any_call(logging.INFO, "Starting SSO redirect to https://example.com/auth with authenticator 'Test OIDC' (slug: test-oidc)")
 
     # Verify error was not called (since authenticator is enabled)
     assert not mock_logger.error.called
-
-    assert isinstance(result, HttpResponseRedirect)
 
 
 @pytest.mark.django_db
@@ -253,7 +255,7 @@ def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_ty
         assert isinstance(result, HttpResponseRedirect), f"{authenticator_type} did not return HttpResponseRedirect"
 
         # Verify we got the SSO redirect log message (which includes both start and redirect info)
-        sso_log_calls = [call for call in mock_logger.info.call_args_list if "Starting SSO redirect" in str(call)]
+        sso_log_calls = [call for call in mock_logger.log.call_args_list if "Starting SSO redirect" in str(call)]
         assert len(sso_log_calls) >= 1, f"{authenticator_type} did not log SSO redirect message"
 
         # Verify the message contains the authenticator name, slug, and redirect URL
@@ -587,6 +589,9 @@ def test_social_auth_mixin_start_no_redirect(mock_logger):
         def uses_redirect(self):
             return False
 
+        def start(self):
+            return None
+
     class TestBackend(SocialAuthMixin, MockParent):
         def __init__(self, database_instance):
             # Mock the strategy argument requirement
@@ -599,18 +604,11 @@ def test_social_auth_mixin_start_no_redirect(mock_logger):
             self.logger = None
 
     backend = TestBackend(database_instance=authenticator)
-    result = backend.start()
+    backend.start()
 
     # Verify that we didn't log the SSO redirect message (since this doesn't use redirect)
     sso_log_calls = [call for call in mock_logger.info.call_args_list if "Starting SSO redirect" in str(call)]
     assert len(sso_log_calls) == 0, "Should not log SSO redirect when uses_redirect() is False"
-
-    # Verify that we returned HTML response
-    from django.http import HttpResponse
-
-    assert isinstance(result, HttpResponse)
-    assert result.status_code == 200
-    assert b"Login Form" in result.content
 
 
 @pytest.mark.django_db

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -78,16 +78,18 @@ def test_authenticator_strategy_redirect_logging(mock_logger):
     strategy = AuthenticatorStrategy(storage=AuthenticatorStorage(), request=request)
     backend = strategy.get_backend(authenticator.slug)
 
-    # Mock auth_url to return a test URL
-    test_url = "https://example.com/oauth/callback"
+    # Mock auth_url to return a test URL with parameters
+    test_url = "https://example.com/oauth/callback?state=xyz&nonce=abc"
     with mock.patch.object(backend, 'auth_url', return_value=test_url):
         # Call start() which should log the redirect
         result = backend.start()
 
-        # Verify the logger was called with the SSO redirect message
-        mock_logger.log.assert_called_once_with(logging.INFO, f"Starting SSO redirect to {test_url} with authenticator 'Test OIDC' (slug: test-oidc)")
+        # Verify the logger was called with the SSO redirect message (without URL parameters)
+        mock_logger.log.assert_called_once_with(
+            logging.INFO, "Starting SSO redirect to https://example.com/oauth/callback with authenticator 'Test OIDC' (slug: test-oidc)"
+        )
 
-        # Verify that the result is an HttpResponseRedirect with the correct URL
+        # Verify that the result is an HttpResponseRedirect with the correct URL (with parameters)
         assert isinstance(result, HttpResponseRedirect)
         assert result.url == test_url
 
@@ -126,7 +128,7 @@ def test_social_auth_mixin_start_enabled_authenticator(mock_logger):
     backend = TestBackend(database_instance=authenticator)
     backend.start()
 
-    # Verify info logging for starting SSO redirect
+    # Verify info logging for starting SSO redirect (URL parameters stripped)
     mock_logger.log.assert_any_call(logging.INFO, "Starting SSO redirect to https://example.com/auth with authenticator 'Test OIDC' (slug: test-oidc)")
 
     # Verify error was not called (since authenticator is enabled)
@@ -160,7 +162,7 @@ def test_social_auth_mixin_start_disabled_authenticator(mock_logger):
     mock_logger.error.assert_called_once_with("Authentication attempted with disabled authenticator Disabled OIDC")
 
     # Verify info logging was not called (since authenticator is disabled)
-    assert not mock_logger.info.called
+    assert not mock_logger.log.called
 
     # Verify that a 404 response was returned
     assert isinstance(result, HttpResponseNotFound)
@@ -246,8 +248,8 @@ def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_ty
     # Get the backend for this authenticator
     backend = strategy.get_backend(authenticator.slug)
 
-    # Mock auth_url to return a URL instead of making external calls
-    with mock.patch.object(backend, 'auth_url', return_value='https://example.com/auth'):
+    # Mock auth_url to return a URL with parameters (to verify they are stripped in logging)
+    with mock.patch.object(backend, 'auth_url', return_value='https://example.com/auth?state=xyz&nonce=abc'):
         # Call start() which should log both start and redirect messages
         result = backend.start()
 
@@ -258,11 +260,14 @@ def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_ty
         sso_log_calls = [call for call in mock_logger.log.call_args_list if "Starting SSO redirect" in str(call)]
         assert len(sso_log_calls) >= 1, f"{authenticator_type} did not log SSO redirect message"
 
-        # Verify the message contains the authenticator name, slug, and redirect URL
+        # Verify the message contains the authenticator name, slug, and redirect URL (without parameters)
         sso_message = str(sso_log_calls[0])
         assert authenticator_name in sso_message, f"SSO message missing authenticator name: {sso_message}"
         assert authenticator.slug in sso_message, f"SSO message missing authenticator slug: {sso_message}"
         assert "https://" in sso_message or "http://" in sso_message, f"SSO message missing redirect URL: {sso_message}"
+        # Verify URL parameters were stripped from the logged message
+        assert "state=xyz" not in sso_message, f"SSO message should not contain URL parameters: {sso_message}"
+        assert "nonce=abc" not in sso_message, f"SSO message should not contain URL parameters: {sso_message}"
 
 
 @pytest.mark.django_db
@@ -430,7 +435,7 @@ def test_capture_oauth_email_pipeline(mock_get_or_create, mock_logger, backend_h
             expected_email = email_value[0]
         elif not isinstance(email_value, str):
             expected_email = ""
-        mock_logger.info.assert_called_with(f"Stored OAuth email {expected_email} for user testuser from Test Authenticator")
+        mock_logger.log.assert_called_with(f"Stored OAuth email {expected_email} for user testuser from Test Authenticator")
 
     # If no expected calls, verify nothing was called
     if not expected_calls:
@@ -607,7 +612,7 @@ def test_social_auth_mixin_start_no_redirect(mock_logger):
     backend.start()
 
     # Verify that we didn't log the SSO redirect message (since this doesn't use redirect)
-    sso_log_calls = [call for call in mock_logger.info.call_args_list if "Starting SSO redirect" in str(call)]
+    sso_log_calls = [call for call in mock_logger.log.call_args_list if "Starting SSO redirect" in str(call)]
     assert len(sso_log_calls) == 0, "Should not log SSO redirect when uses_redirect() is False"
 
 
@@ -648,7 +653,7 @@ def test_social_auth_mixin_start_no_redirect_disabled_authenticator(mock_logger)
     mock_logger.error.assert_called_once_with("Authentication attempted with disabled authenticator Disabled HTML Auth")
 
     # Verify that no SSO redirect logging happened
-    assert not mock_logger.info.called
+    assert not mock_logger.log.called
 
     # Verify that a 404 response was returned (not HTML)
     assert isinstance(result, HttpResponseNotFound)

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -435,7 +435,7 @@ def test_capture_oauth_email_pipeline(mock_get_or_create, mock_logger, backend_h
             expected_email = email_value[0]
         elif not isinstance(email_value, str):
             expected_email = ""
-        mock_logger.log.assert_called_with(f"Stored OAuth email {expected_email} for user testuser from Test Authenticator")
+        mock_logger.info.assert_called_with(f"Stored OAuth email {expected_email} for user testuser from Test Authenticator")
 
     # If no expected calls, verify nothing was called
     if not expected_calls:


### PR DESCRIPTION
Co-authored-by: Claude <no-reply@anthropic.com>

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? Add auditability logs for SSO redirects
- Why is this change needed? To satisfy customer ask for such auditability logs
- How does this change address the issue? By adding new logs both at the start of the SSO flow (identifying authenticator used), and at the time of redirect (identifying the redirect url)

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [X] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
- An application using `ansible_base.authentication` running with `ansible_base.authentication` at `INFO` log level
  - And an SSO authenticator set up for use

### Steps to Test
1. Begin social auth using an SSO authenticator
2. Check `ansible_base.authentication logs`

### Expected Results
Presence of two logs at INFO level
- Log identifying the start of the social auth flow, identifying the authenticator.
- Log identifying a redirect happening, citing a redirect uri.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Logs SSO redirect initiation (with query params stripped) in `SocialAuthMixin.start()` and adds tests covering logging across providers and edge cases.
> 
> - **Authentication**
>   - **Logging**: In `SocialAuthMixin.start()`, log SSO redirect using `log_auth_event`, stripping query parameters from `auth_url` before calling `super().start()`.
> - **Tests**
>   - Add tests validating SSO redirect logging (including URL param stripping), behavior for enabled/disabled authenticators (404 on disabled), multiple SSO backends, and non-redirect flows; verify redirect responses and logging calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 110c4254295f8f07f26bc59a1958ca0480f65adc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->