### PR TITLE
Make python 3.12 default

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,10 +25,10 @@ echo "Number of JIRA numbers from commits matching JIRA number from branch name:
 # if no Jira or no magic marker found in branch name, fail
 echo "Checking branch name..."
 if [ "${BRANCH_JIRA}" = "" ]; then
-  echo "Warning: Branch name does not contain a JIRA number or a ${NO_JIRA_MARKER} marker."
-fi
+  echo "Fail: Branch name does not contain a JIRA number or a ${NO_JIRA_MARKER} marker."
+  exit 1
 # if branch does not have the magic marker, check the commits as well
-if [ "${BRANCH_JIRA}" != "${NO_JIRA_MARKER}" ]; then
+elif [ "${BRANCH_JIRA}" != "${NO_JIRA_MARKER}" ]; then
     echo "Checking commit messages..."
     # if there is no Jira number or magic marker, fail
     if [ ${COMMIT_JIRA_COUNT} -eq 0 ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,10 +25,10 @@ echo "Number of JIRA numbers from commits matching JIRA number from branch name:
 # if no Jira or no magic marker found in branch name, fail
 echo "Checking branch name..."
 if [ "${BRANCH_JIRA}" = "" ]; then
-  echo "Fail: Branch name does not contain a JIRA number or a ${NO_JIRA_MARKER} marker."
-  exit 1
+  echo "Warning: Branch name does not contain a JIRA number or a ${NO_JIRA_MARKER} marker."
+fi
 # if branch does not have the magic marker, check the commits as well
-elif [ "${BRANCH_JIRA}" != "${NO_JIRA_MARKER}" ]; then
+if [ "${BRANCH_JIRA}" != "${NO_JIRA_MARKER}" ]; then
     echo "Checking commit messages..."
     # if there is no Jira number or magic marker, fail
     if [ ${COMMIT_JIRA_COUNT} -eq 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,28 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - env: check
+          - env: py311-check
+            python-version: "3.11"
+            sonar: false
+            junit-xml-upload: false
+          - env: py312-check
+            python-version: "3.12"
+            sonar: false
+            junit-xml-upload: false
+          - env: py311
             python-version: "3.11"
             sonar: false
             junit-xml-upload: false
           - env: py312
             python-version: "3.12"
-            sonar: false
-            junit-xml-upload: false
-          - env: py310
-            python-version: "3.10"
-            sonar: false
-            junit-xml-upload: false
-          - env: py311
-            python-version: "3.11"
             sonar: true
             junit-xml-upload: true
-          - env: py311sqlite
+          - env: py311-sqlite
             python-version: "3.11"
             sonar: false
             junit-xml-upload: false
-          - env: py310-django4
-            python-version: "3.10"
+          - env: py312-sqlite
+            python-version: "3.12"
             sonar: false
             junit-xml-upload: false
           - env: py311-django4
@@ -44,6 +44,10 @@ jobs:
             junit-xml-upload: false
           - env: py312-django4
             python-version: "3.12"
+            sonar: false
+            junit-xml-upload: false
+          - env: py311-in-files
+            python-version: "3.11"
             sonar: false
             junit-xml-upload: false
           - env: py312-in-files

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           show-progress: false
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Pull AWX devel image
         run: docker pull ghcr.io/ansible/awx_devel:devel
 
@@ -89,7 +93,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Run eda-server tests
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,21 +32,21 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install python 3.11
+      - name: Install python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install requirments
-        run: pip3.11 install -r requirements/requirements_dev.txt
+        run: pip3.12 install -r requirements/requirements_dev.txt
 
       - name: Install test dependencies for pure-python-imports
         if: matrix.tests.name == 'pure-python-imports'
         run: |
-          pip3.11 install -r requirements/requirements.in
-          pip3.11 install -r requirements/requirements_testing.txt
-          pip3.11 install -r requirements/requirements_channels.in
-          pip3.11 install -r requirements/requirements_redis_client.in
+          pip3.12 install -r requirements/requirements.in
+          pip3.12 install -r requirements/requirements_testing.txt
+          pip3.12 install -r requirements/requirements_channels.in
+          pip3.12 install -r requirements/requirements_redis_client.in
 
       - name: Run pure-python-imports check
         if: matrix.tests.name == 'pure-python-imports'

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Install build requirements
         run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
 
-      - name: Install python 3.11
+      - name: Install python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install requirements
-        run: pip3.11 install -r requirements/requirements_all.txt -r requirements/requirements_dev.txt
+        run: pip3.12 install -r requirements/requirements_all.txt -r requirements/requirements_dev.txt
 
       - name: Run help text check
         run: ./manage.py help_text_check --applications=dab --ignore-file=./.help_text_check.ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM quay.io/centos/centos:stream9
 
 RUN sed -i '/^\[crb\]$/,/^enabled=0$/ s/enabled=0/enabled=1/' /etc/yum.repos.d/centos.repo
 RUN dnf -y install \
-    python3.11 \
-    python3.11-pip \
-    python3.11-devel \
+    python3.12 \
+    python3.12-pip \
+    python3.12-devel \
     gcc \
     openldap-devel \
     xmlsec1 \
@@ -20,7 +20,7 @@ RUN mkdir -p /etc/ansible-automation-platform/testapp
 # add settings.yaml to /etc/ansible-automation-platform/
 COPY test_app/example_files/*.yaml /etc/ansible-automation-platform/testapp/
 
-RUN python3.11 -m venv /venv
+RUN python3.12 -m venv /venv
 
 COPY requirements/requirements_all.txt /tmp/requirements_all.txt
 RUN /venv/bin/pip install -r /tmp/requirements_all.txt

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
-# Prefer python 3.11 but take python3 if 3.11 is not installed
-PYTHON := $(notdir $(shell for i in python3.11 python3; do command -v $$i; done|sed 1q))
+# Prefer python 3.12 but take python3 if 3.12 is not installed
+PYTHON := $(notdir $(shell for i in python3.12 python3; do command -v $$i; done|sed 1q))
 CHECK_SYNTAX_FILES ?= .
 RM ?= /bin/rm
 UID := $(shell id -u)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A Django app used by ansible services"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 keywords = ["ansible", "django"]
 license = {text = "Apache-2.0"}
 classifiers = [
@@ -23,7 +23,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
@@ -97,17 +96,18 @@ legacy_tox_ini = """
     min_version = 4.0
     no_package = true
     env_list =
-        check
-        py312
-        py310
+        py311-check
+        py312-check
         py311
-        py311sqlite
-        py310-django4
+        py312
+        py311-sqlite
+        py312-sqlite
         py311-django4
         py312-django4
+        py311-in-files
         py312-in-files
     labels =
-        test = py312, py310, py311, py311sqlite, py310-django4, py311-django4, py312-django4, check
+        test = py311-check, py312-check, py311, py312, py311-sqlite, py312-sqlite, py312-django4, py311-in-files, py312-in-files
         lint = flake8, black, isort
 
     [testenv]
@@ -118,7 +118,7 @@ legacy_tox_ini = """
     commands = pytest -n auto --color=yes --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch --junit-xml=django-ansible-base-test-results.xml {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}
     docker = db
 
-    [testenv:check]
+    [testenv:py311-check,py312-check]
     deps =
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
@@ -127,12 +127,12 @@ legacy_tox_ini = """
         python3 manage.py check
         python3 manage.py makemigrations --check
 
-    [testenv:py311sqlite]
+    [testenv:py311-sqlite,py312-sqlite]
     docker = db
     setenv =
         DJANGO_SETTINGS_MODULE = test_app.sqlite3settings
 
-    [testenv:py310-django4]
+    [testenv:py311-django4,py312-django4]
     deps =
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
@@ -140,23 +140,7 @@ legacy_tox_ini = """
         python -m pip install --upgrade "Django>=4.2.21,<4.3.0"
     docker = db
 
-    [testenv:py311-django4]
-    deps =
-        -r{toxinidir}/requirements/requirements_all.txt
-        -r{toxinidir}/requirements/requirements_dev.txt
-    commands_pre =
-        python -m pip install --upgrade "Django>=4.2.21,<4.3.0"
-    docker = db
-
-    [testenv:py312-django4]
-    deps =
-        -r{toxinidir}/requirements/requirements_all.txt
-        -r{toxinidir}/requirements/requirements_dev.txt
-    commands_pre =
-        python -m pip install --upgrade "Django>=4.2.21,<4.3.0"
-    docker = db
-
-    [testenv:py312-in-files]
+    [testenv:py311-in-files,py312-in-files]
     deps =
         -r{toxinidir}/requirements/requirements.in
         -r{toxinidir}/requirements/requirements_activitystream.in

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -152,7 +152,7 @@ typing-extensions==4.15.0
     #   referencing
 uritemplate==4.2.0
     # via drf-spectacular
-urllib3==2.5.0
+urllib3==2.6.1
     # via
     #   -r requirements/requirements_resource_registry.in
     #   requests

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -156,7 +156,7 @@ urllib3==2.5.0
     # via
     #   -r requirements/requirements_resource_registry.in
     #   requests
-xmlsec==1.3.13
+xmlsec==1.3.17
     # via
     #   -r requirements/requirements_authentication.in
     #   python3-saml

--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -13,7 +13,7 @@ ldap-filter
 python3-saml
 tacacs_plus
 
-xmlsec==1.3.13 # Pin for https://github.com/xmlsec/python-xmlsec/issues/314
+xmlsec==1.3.17
 
 # RADIUS Authenticator Plugin
 pyrad

--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -13,7 +13,7 @@ ldap-filter
 python3-saml
 tacacs_plus
 
-xmlsec==1.3.17
+xmlsec==1.3.17 # Pin for https://github.com/xmlsec/python-xmlsec/issues/320
 
 # RADIUS Authenticator Plugin
 pyrad

--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -13,7 +13,7 @@ ldap-filter
 python3-saml
 tacacs_plus
 
-xmlsec==1.3.17 # Pin for https://github.com/xmlsec/python-xmlsec/issues/320
+xmlsec
 
 # RADIUS Authenticator Plugin
 pyrad

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ue
 
-PYTHON=python3.11
+PYTHON=python3.12
 
 # Ensure script is run from the requirements/ directory
 if [[ "$(basename $(pwd))" != "requirements" ]]; then
@@ -61,7 +61,7 @@ main() {
       echo ""
       NEEDS_HELP=1
     ;;
-  esac 
+  esac
 
   if [[ "$NEEDS_HELP" == "1" ]] ; then
     echo "This script generates requirements_all.txt from requirements[_*].in"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -43,7 +43,7 @@ sonar.newCode.referenceBranch=devel
 # =============================================================================
 
 # Python versions supported by the project
-#sonar.python.version=3.9,3.10,3.11
+#sonar.python.version=3.11,3.12
 
 # File encoding
 sonar.sourceEncoding=UTF-8
@@ -140,7 +140,7 @@ sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/*
 
 # The following properties are automatically handled by GitHub Actions:
 # sonar.pullrequest.key - handled automatically
-# sonar.pullrequest.branch - handled automatically  
+# sonar.pullrequest.branch - handled automatically
 # sonar.pullrequest.base - handled automatically
 
 # =============================================================================


### PR DESCRIPTION
## Description
- Based on https://github.com/ansible/django-ansible-base/tree/python-3.12-devel
- Make Python 3.12 default
- Keep only python 3.11 and 3.12

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [x] Configuration change

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->
