### PR TITLE
AAP-53741 Log when OAuth2 tokens are created, modified, used

### DIFF
--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -112,48 +112,6 @@ class AuditableModel(models.Model):
     # Adding field names to this list will limit the activity stream changes dictionaries to only include these fields
     activity_stream_limit_field_names = []
 
-    def _has_non_trivial_changes(self, update_fields=None):
-        """Check if any non-timestamp fields have changed.
-
-        Args:
-            update_fields: Optional list/set of field names being updated. If provided,
-                          only these fields will be checked for changes.
-
-        Returns:
-            bool: True if any non-timestamp field has changed, False otherwise.
-        """
-        if not self.pk:
-            return True
-
-        Model = self.__class__
-        try:
-            old_instance = Model.objects.get(pk=self.pk)
-        except Model.DoesNotExist:
-            pass
-            # Fields to exclude from change detection (timestamp/auto-updated fields)
-
-        # If update_fields is specified, only check those fields (minus excluded ones)
-        if update_fields is not None:
-            fields_to_check = set(update_fields) - set(self.activity_stream_excluded_field_names)
-            if not fields_to_check:
-                # Only timestamp fields are being updated
-                return False
-            # Check only the specified fields
-            for field_name in fields_to_check:
-                old_value = getattr(old_instance, field_name, None)
-                new_value = getattr(self, field_name, None)
-                if old_value != new_value:
-                    return True
-        else:
-            # Check all non-timestamp fields
-            for field in self._meta.get_fields():
-                if field.concrete and hasattr(field, 'name') and field.name not in self.activity_stream_excluded_field_names:
-                    old_value = getattr(old_instance, field.name, None)
-                    new_value = getattr(self, field.name, None)
-                    if old_value != new_value:
-                        return True
-        return False
-
     @property
     def activity_stream_entries(self):
         """

--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -112,6 +112,48 @@ class AuditableModel(models.Model):
     # Adding field names to this list will limit the activity stream changes dictionaries to only include these fields
     activity_stream_limit_field_names = []
 
+    def _has_non_trivial_changes(self, update_fields=None):
+        """Check if any non-timestamp fields have changed.
+
+        Args:
+            update_fields: Optional list/set of field names being updated. If provided,
+                          only these fields will be checked for changes.
+
+        Returns:
+            bool: True if any non-timestamp field has changed, False otherwise.
+        """
+        if not self.pk:
+            return True
+
+        Model = self.__class__
+        try:
+            old_instance = Model.objects.get(pk=self.pk)
+        except Model.DoesNotExist:
+            pass
+            # Fields to exclude from change detection (timestamp/auto-updated fields)
+
+        # If update_fields is specified, only check those fields (minus excluded ones)
+        if update_fields is not None:
+            fields_to_check = set(update_fields) - set(self.activity_stream_excluded_field_names)
+            if not fields_to_check:
+                # Only timestamp fields are being updated
+                return False
+            # Check only the specified fields
+            for field_name in fields_to_check:
+                old_value = getattr(old_instance, field_name, None)
+                new_value = getattr(self, field_name, None)
+                if old_value != new_value:
+                    return True
+        else:
+            # Check all non-timestamp fields
+            for field in self._meta.get_fields():
+                if field.concrete and hasattr(field, 'name') and field.name not in self.activity_stream_excluded_field_names:
+                    old_value = getattr(old_instance, field.name, None)
+                    new_value = getattr(self, field.name, None)
+                    if old_value != new_value:
+                        return True
+        return False
+
     @property
     def activity_stream_entries(self):
         """

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -41,6 +41,8 @@ def _store_activitystream_entry(old, new, operation, update_fields=None):
 
     # We only want to diff the fields that were updated, so we have to take the intersection of the limited fields and the update fields
     if operation == 'update' and update_fields is not None:
+        if not update_fields:
+            return
         # If limit is otherwise empty (meaning no pre-existing limit), then we just need to make the updated fields the limit
         if not limit:
             limit = update_fields

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -26,7 +26,7 @@ def no_activity_stream():
         activitystream_enabled.enabled = previous_value
 
 
-def _store_activitystream_entry(old, new, operation):
+def _store_activitystream_entry(old, new, operation, update_fields=None):
     if not activitystream_enabled:
         return
 
@@ -38,6 +38,19 @@ def _store_activitystream_entry(old, new, operation):
 
     excluded = getattr(new, 'activity_stream_excluded_field_names', [])
     limit = getattr(new, 'activity_stream_limit_field_names', [])
+
+    # We only want to diff the fields that were updated, so we have to take the intersection of the limited fields and the update fields
+    if operation == 'update' and update_fields is not None:
+        # If limit is otherwise empty (meaning no pre-existing limit), then we just need to make the updated fields the limit
+        if not limit:
+            limit = update_fields
+        else:
+            limit = list(set(limit).intersection(set(update_fields)))
+            # If only a non-included field is updated, we can be certain that the delta will be empty;
+            # Continuing with the diff would introduce a bug where we diff all non-excluded fields.
+            if not limit:
+                return
+
     delta = diff(old, new, exclude_fields=excluded, limit_fields=limit, all_values_as_strings=True)
 
     if not delta:
@@ -124,7 +137,7 @@ def activitystream_update(sender, instance, raw, using, update_fields, **kwargs)
     except sender.DoesNotExist:
         return
 
-    _store_activitystream_entry(old, instance, 'update')
+    _store_activitystream_entry(old, instance, 'update', update_fields=update_fields)
 
 
 # pre_delete

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -41,6 +41,50 @@ class ModifiableModel(models.Model):
     class Meta:
         abstract = True
 
+    trivial_fields = ["modified", "modified_by"]
+
+    def _has_non_trivial_changes(self, update_fields=None):
+        """Check if any non-timestamp fields have changed.
+
+        Args:
+            update_fields: Optional list/set of field names being updated. If provided,
+                          only these fields will be checked for changes.
+
+        Returns:
+            bool: True if any non-timestamp field has changed, False otherwise.
+        """
+        if not self.pk:
+            return True
+
+        Model = self.__class__
+        try:
+            old_instance = Model.objects.get(pk=self.pk)
+        except Model.DoesNotExist:
+            pass
+            # Fields to exclude from change detection (timestamp/auto-updated fields)
+
+        # If update_fields is specified, only check those fields (minus excluded ones)
+        if update_fields is not None:
+            fields_to_check = set(update_fields) - set(self.trivial_fields)
+            if not fields_to_check:
+                # Only timestamp fields are being updated
+                return False
+            # Check only the specified fields
+            for field_name in fields_to_check:
+                old_value = getattr(old_instance, field_name, None)
+                new_value = getattr(self, field_name, None)
+                if old_value != new_value:
+                    return True
+        else:
+            # Check all non-timestamp fields
+            for field in self._meta.get_fields():
+                if field.concrete and hasattr(field, 'name') and field.name not in self.trivial_fields:
+                    old_value = getattr(old_instance, field.name, None)
+                    new_value = getattr(self, field.name, None)
+                    if old_value != new_value:
+                        return True
+        return False
+
     modified = models.DateTimeField(
         editable=False,
         help_text=_("The date/time this resource was created."),

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -56,33 +56,29 @@ class ModifiableModel(models.Model):
         if not self.pk:
             return True
 
-        Model = self.__class__
+        model_cls = self.__class__
         try:
-            old_instance = Model.objects.get(pk=self.pk)
-        except Model.DoesNotExist:
-            pass
-            # Fields to exclude from change detection (timestamp/auto-updated fields)
+            old_instance = model_cls.objects.get(pk=self.pk)
+        except model_cls.DoesNotExist:
+            return True
 
         # If update_fields is specified, only check those fields (minus excluded ones)
         if update_fields is not None:
-            fields_to_check = set(update_fields) - set(self.trivial_fields)
-            if not fields_to_check:
-                # Only timestamp fields are being updated
-                return False
-            # Check only the specified fields
-            for field_name in fields_to_check:
-                old_value = getattr(old_instance, field_name, None)
-                new_value = getattr(self, field_name, None)
-                if old_value != new_value:
-                    return True
+            fields_we_can_check = set(update_fields)
         else:
-            # Check all non-timestamp fields
-            for field in self._meta.get_fields():
-                if field.concrete and hasattr(field, 'name') and field.name not in self.trivial_fields:
-                    old_value = getattr(old_instance, field.name, None)
-                    new_value = getattr(self, field.name, None)
-                    if old_value != new_value:
-                        return True
+            fields_we_can_check = [field.name for field in self._meta.get_fields() if field.concrete and hasattr(field, "name")]
+
+        fields_to_check = set(fields_we_can_check) - set(self.trivial_fields)
+
+        if not fields_to_check:
+            # Only timestamp fields are being updated
+            return False
+        # Check only the specified fields
+        for field_name in fields_to_check:
+            old_value = getattr(old_instance, field_name, None)
+            new_value = getattr(self, field_name, None)
+            if old_value != new_value:
+                return True
         return False
 
     modified = models.DateTimeField(

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -66,7 +66,7 @@ class ModifiableModel(models.Model):
         if update_fields is not None:
             fields_we_can_check = set(update_fields)
         else:
-            fields_we_can_check = [field.name for field in self._meta.get_fields() if field.concrete and hasattr(field, "name")]
+            fields_we_can_check = [field.name for field in self._meta.concrete_fields if hasattr(field, "name")]
 
         fields_to_check = set(fields_we_can_check) - set(self.trivial_fields)
 

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -71,7 +71,7 @@ class ModifiableModel(models.Model):
         fields_to_check = set(fields_we_can_check) - set(self.trivial_fields)
 
         if not fields_to_check:
-            # Only timestamp fields are being updated
+            # Only trivial fields are being updated
             return False
         # Check only the specified fields
         for field_name in fields_to_check:

--- a/ansible_base/oauth2_provider/authentication.py
+++ b/ansible_base/oauth2_provider/authentication.py
@@ -6,6 +6,7 @@ from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from oauth2_provider.oauth2_backends import OAuthLibCore as _OAuthLibCore
 from rest_framework.exceptions import UnsupportedMediaType
 
+from ansible_base.lib.logging import log_auth_event
 from ansible_base.lib.utils.hashing import hash_string
 
 logger = logging.getLogger('ansible_base.oauth2_provider.authentication')
@@ -44,7 +45,7 @@ class LoggedOAuth2Authentication(OAuth2Authentication):
             username = user.username if user else '<none>'
             oauth2_application_pk = token.application.pk if token.application else "N/A"
             oauth2_application_name = token.application.name if token.application else "Personal Access Token"
-            logger.info(
+            log_auth_event(
                 smart_str(
                     u"User {} performed a {} to {} through the API using OAuth 2 token {} for OAuth2 application {} ({}).".format(
                         username, request.method, request.path, token.pk, oauth2_application_pk, oauth2_application_name

--- a/ansible_base/oauth2_provider/authentication.py
+++ b/ansible_base/oauth2_provider/authentication.py
@@ -50,7 +50,8 @@ class LoggedOAuth2Authentication(OAuth2Authentication):
                     u"User {} performed a {} to {} through the API using OAuth 2 token {} for OAuth2 application {} ({}).".format(
                         username, request.method, request.path, token.pk, oauth2_application_pk, oauth2_application_name
                     )
-                )
+                ),
+                logger,
             )
             # TODO: check oauth_scopes when we have RBAC in Gateway
             setattr(user, 'oauth_scopes', [x for x in token.scope.split() if x])

--- a/ansible_base/oauth2_provider/authentication.py
+++ b/ansible_base/oauth2_provider/authentication.py
@@ -42,8 +42,14 @@ class LoggedOAuth2Authentication(OAuth2Authentication):
         if ret:
             user, token = ret
             username = user.username if user else '<none>'
+            oauth2_application_pk = token.application.pk if token.application else "N/A"
+            oauth2_application_name = token.application.name if token.application else "Personal Access Token"
             logger.info(
-                smart_str(u"User {} performed a {} to {} through the API using OAuth 2 token {}.".format(username, request.method, request.path, token.pk))
+                smart_str(
+                    u"User {} performed a {} to {} through the API using OAuth 2 token {} for OAuth2 application {} ({}).".format(
+                        username, request.method, request.path, token.pk, oauth2_application_pk, oauth2_application_name
+                    )
+                )
             )
             # TODO: check oauth_scopes when we have RBAC in Gateway
             setattr(user, 'oauth_scopes', [x for x in token.scope.split() if x])

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -41,6 +41,7 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
     router_basename = 'token'
     ignore_relations = ['refresh_token']
     activity_stream_excluded_field_names = ['last_used', "modified", "modified_by"]
+    trivial_fields = activity_stream_excluded_field_names
 
     class Meta(oauth2_models.AbstractAccessToken.Meta):
         verbose_name = _('access token')

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -40,7 +40,7 @@ if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
 class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activitystream):
     router_basename = 'token'
     ignore_relations = ['refresh_token']
-    activity_stream_excluded_field_names = ['last_used']
+    activity_stream_excluded_field_names = ['last_used', "modified", "modified_by"]
 
     class Meta(oauth2_models.AbstractAccessToken.Meta):
         verbose_name = _('access token')
@@ -87,21 +87,43 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
             connection.on_commit(_update_last_used)
         return valid
 
-    def _has_non_timestamp_changes(self):
-        """Check if any non-timestamp fields have changed."""
+    def _has_non_timestamp_changes(self, update_fields=None):
+        """Check if any non-timestamp fields have changed.
+
+        Args:
+            update_fields: Optional list/set of field names being updated. If provided,
+                          only these fields will be checked for changes.
+
+        Returns:
+            bool: True if any non-timestamp field has changed, False otherwise.
+        """
         if not self.pk:
             return False
         try:
             old_instance = OAuth2AccessToken.objects.get(pk=self.pk)
             # Fields to exclude from change detection (timestamp/auto-updated fields)
             exclude_fields = {'created', 'created_by', 'modified', 'modified_by', 'last_used'}
-            # Check if any non-timestamp field has changed
-            for field in self._meta.get_fields():
-                if hasattr(field, 'name') and field.name not in exclude_fields:
-                    old_value = getattr(old_instance, field.name, None)
-                    new_value = getattr(self, field.name, None)
+
+            # If update_fields is specified, only check those fields (minus excluded ones)
+            if update_fields is not None:
+                fields_to_check = set(update_fields) - exclude_fields
+                if not fields_to_check:
+                    # Only timestamp fields are being updated
+                    return False
+                # Check only the specified fields
+                for field_name in fields_to_check:
+                    old_value = getattr(old_instance, field_name, None)
+                    new_value = getattr(self, field_name, None)
                     if old_value != new_value:
                         return True
+            else:
+                # Check all non-timestamp fields
+                for field in self._meta.get_fields():
+                    if hasattr(field, 'name') and field.name not in exclude_fields:
+                        old_value = getattr(old_instance, field.name, None)
+                        new_value = getattr(self, field.name, None)
+                        if old_value != new_value:
+                            return True
         except OAuth2AccessToken.DoesNotExist:
             pass
         return False
@@ -117,7 +139,8 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
 
     def save(self, *args, **kwargs):
         creating_token = not bool(self.pk)
-        modifying_token = self._has_non_timestamp_changes() if not creating_token else False
+        update_fields = kwargs.get('update_fields')
+        modifying_token = self._has_non_timestamp_changes(update_fields) if not creating_token else False
 
         if creating_token:
             self.validate_external_users()

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -97,10 +97,18 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
                 )
 
     def save(self, *args, **kwargs):
-        if not self.pk:
+        creating_token = not bool(self.pk)
+        if creating_token:
             self.validate_external_users()
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
         super().save(*args, **kwargs)
         app_name = self.application.name if self.application else "N/A (Personal Access Token)"
         user_name = self.user.username if self.user else "N/A"
-        log_auth_event(f"Creating OAuth2 access token for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger)
+        if creating_token:
+            log_auth_event(
+                f"Created OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
+            )
+        else:
+            log_auth_event(
+                f"Modified OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
+            )

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -87,47 +87,6 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
             connection.on_commit(_update_last_used)
         return valid
 
-    def _has_non_timestamp_changes(self, update_fields=None):
-        """Check if any non-timestamp fields have changed.
-
-        Args:
-            update_fields: Optional list/set of field names being updated. If provided,
-                          only these fields will be checked for changes.
-
-        Returns:
-            bool: True if any non-timestamp field has changed, False otherwise.
-        """
-        if not self.pk:
-            return False
-        try:
-            old_instance = OAuth2AccessToken.objects.get(pk=self.pk)
-            # Fields to exclude from change detection (timestamp/auto-updated fields)
-            exclude_fields = {'created', 'created_by', 'modified', 'modified_by', 'last_used'}
-
-            # If update_fields is specified, only check those fields (minus excluded ones)
-            if update_fields is not None:
-                fields_to_check = set(update_fields) - exclude_fields
-                if not fields_to_check:
-                    # Only timestamp fields are being updated
-                    return False
-                # Check only the specified fields
-                for field_name in fields_to_check:
-                    old_value = getattr(old_instance, field_name, None)
-                    new_value = getattr(self, field_name, None)
-                    if old_value != new_value:
-                        return True
-            else:
-                # Check all non-timestamp fields
-                for field in self._meta.get_fields():
-                    if field.concrete and hasattr(field, 'name') and field.name not in exclude_fields:
-                        old_value = getattr(old_instance, field.name, None)
-                        new_value = getattr(self, field.name, None)
-                        if old_value != new_value:
-                            return True
-        except OAuth2AccessToken.DoesNotExist:
-            pass
-        return False
-
     def validate_external_users(self):
         if self.user and get_setting('ALLOW_OAUTH2_FOR_EXTERNAL_USERS') is False:
             external_account = is_external_account(self.user)
@@ -138,21 +97,18 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
                 )
 
     def save(self, *args, **kwargs):
-        creating_token = not bool(self.pk)
         update_fields = kwargs.get('update_fields')
-        modifying_token = self._has_non_timestamp_changes(update_fields) if not creating_token else False
-
-        if creating_token:
+        has_non_trivial_fields = self._has_non_trivial_changes(update_fields)
+        logging_verb = 'Modified'
+        if not self.pk:
             self.validate_external_users()
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
+            logging_verb = 'Created'
         super().save(*args, **kwargs)
         app_name = self.application.name if self.application else "N/A (Personal Access Token)"
         user_name = self.user.username if self.user else "N/A"
-        if creating_token:
+        if has_non_trivial_fields:
             log_auth_event(
-                f"Created OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
-            )
-        elif modifying_token:
-            log_auth_event(
-                f"Modified OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
+                f"{logging_verb} OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'",
+                second_logger=logger,
             )

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -99,7 +99,7 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
         if not self.pk:
             self.validate_external_users()
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
-            app_name = self.application.name if self.application else "N/A (Personal Access Token)"
-            user_name = self.user.username if self.user else "N/A"
-            logger.info(f"Creating OAuth2 access token for user '{user_name}' with application '{app_name}' and scope '{self.scope}'")
         super().save(*args, **kwargs)
+        app_name = self.application.name if self.application else "N/A (Personal Access Token)"
+        user_name = self.user.username if self.user else "N/A"
+        logger.info(f"Creating OAuth2 access token for user '{user_name}' with application '{app_name}' and scope '{self.scope}'")

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -87,6 +87,25 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
             connection.on_commit(_update_last_used)
         return valid
 
+    def _has_non_timestamp_changes(self):
+        """Check if any non-timestamp fields have changed."""
+        if not self.pk:
+            return False
+        try:
+            old_instance = OAuth2AccessToken.objects.get(pk=self.pk)
+            # Fields to exclude from change detection (timestamp/auto-updated fields)
+            exclude_fields = {'created', 'created_by', 'modified', 'modified_by', 'last_used'}
+            # Check if any non-timestamp field has changed
+            for field in self._meta.get_fields():
+                if hasattr(field, 'name') and field.name not in exclude_fields:
+                    old_value = getattr(old_instance, field.name, None)
+                    new_value = getattr(self, field.name, None)
+                    if old_value != new_value:
+                        return True
+        except OAuth2AccessToken.DoesNotExist:
+            pass
+        return False
+
     def validate_external_users(self):
         if self.user and get_setting('ALLOW_OAUTH2_FOR_EXTERNAL_USERS') is False:
             external_account = is_external_account(self.user)
@@ -98,6 +117,8 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
 
     def save(self, *args, **kwargs):
         creating_token = not bool(self.pk)
+        modifying_token = self._has_non_timestamp_changes() if not creating_token else False
+
         if creating_token:
             self.validate_external_users()
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
@@ -107,4 +128,8 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
         if creating_token:
             log_auth_event(
                 f"Created OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
+            )
+        elif modifying_token:
+            log_auth_event(
+                f"Modified OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
             )

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from oauthlib import oauth2
 
 from ansible_base.lib.abstract_models.common import CommonModel
+from ansible_base.lib.logging import log_auth_event
 from ansible_base.lib.utils.hashing import hash_string
 from ansible_base.lib.utils.models import prevent_search
 from ansible_base.lib.utils.settings import get_setting
@@ -102,4 +103,4 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
         super().save(*args, **kwargs)
         app_name = self.application.name if self.application else "N/A (Personal Access Token)"
         user_name = self.user.username if self.user else "N/A"
-        logger.info(f"Creating OAuth2 access token for user '{user_name}' with application '{app_name}' and scope '{self.scope}'")
+        log_auth_event(f"Creating OAuth2 access token for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger)

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -119,7 +119,7 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
             else:
                 # Check all non-timestamp fields
                 for field in self._meta.get_fields():
-                    if hasattr(field, 'name') and field.name not in exclude_fields:
+                    if field.concrete and hasattr(field, 'name') and field.name not in exclude_fields:
                         old_value = getattr(old_instance, field.name, None)
                         new_value = getattr(self, field.name, None)
                         if old_value != new_value:

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 
 import oauth2_provider.models as oauth2_models
 from django.conf import settings
@@ -13,6 +14,8 @@ from ansible_base.lib.utils.hashing import hash_string
 from ansible_base.lib.utils.models import prevent_search
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.oauth2_provider.utils import is_external_account
+
+logger = logging.getLogger('ansible_base.oauth2_provider.models.access_token')
 
 SCOPES = ['read', 'write']
 
@@ -96,4 +99,7 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
         if not self.pk:
             self.validate_external_users()
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
+            app_name = self.application.name if self.application else "N/A (Personal Access Token)"
+            user_name = self.user.username if self.user else "N/A"
+            logger.info(f"Creating OAuth2 access token for user '{user_name}' with application '{app_name}' and scope '{self.scope}'")
         super().save(*args, **kwargs)

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -108,7 +108,3 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
             log_auth_event(
                 f"Created OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
             )
-        else:
-            log_auth_event(
-                f"Modified OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'", second_logger=logger
-            )

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -29,8 +29,29 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
     token = prevent_search(models.CharField(max_length=255, help_text=_("The refresh token value.")))
     updated = None  # Tracked in CommonModel with 'modified', no need for this
 
+    def _has_non_timestamp_changes(self):
+        """Check if any non-timestamp fields have changed."""
+        if not self.pk:
+            return False
+        try:
+            old_instance = OAuth2RefreshToken.objects.get(pk=self.pk)
+            # Fields to exclude from change detection (timestamp/auto-updated fields)
+            exclude_fields = {'created', 'created_by', 'modified', 'modified_by'}
+            # Check if any non-timestamp field has changed
+            for field in self._meta.get_fields():
+                if hasattr(field, 'name') and field.name not in exclude_fields:
+                    old_value = getattr(old_instance, field.name, None)
+                    new_value = getattr(self, field.name, None)
+                    if old_value != new_value:
+                        return True
+        except OAuth2RefreshToken.DoesNotExist:
+            pass
+        return False
+
     def save(self, *args, **kwargs):
         create_token = not bool(self.pk)
+        modifying_token = self._has_non_timestamp_changes() if not create_token else False
+
         if create_token:
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
         super().save(*args, **kwargs)
@@ -38,3 +59,5 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
         user_name = self.user.username if self.user else "N/A"
         if create_token:
             log_auth_event(f"Created OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
+        elif modifying_token:
+            log_auth_event(f"Modified OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -29,28 +29,51 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
     token = prevent_search(models.CharField(max_length=255, help_text=_("The refresh token value.")))
     updated = None  # Tracked in CommonModel with 'modified', no need for this
 
-    def _has_non_timestamp_changes(self):
-        """Check if any non-timestamp fields have changed."""
+    def _has_non_timestamp_changes(self, update_fields=None):
+        """Check if any non-timestamp fields have changed.
+
+        Args:
+            update_fields: Optional list/set of field names being updated. If provided,
+                          only these fields will be checked for changes.
+
+        Returns:
+            bool: True if any non-timestamp field has changed, False otherwise.
+        """
         if not self.pk:
             return False
         try:
             old_instance = OAuth2RefreshToken.objects.get(pk=self.pk)
             # Fields to exclude from change detection (timestamp/auto-updated fields)
             exclude_fields = {'created', 'created_by', 'modified', 'modified_by'}
-            # Check if any non-timestamp field has changed
-            for field in self._meta.get_fields():
-                if hasattr(field, 'name') and field.name not in exclude_fields:
-                    old_value = getattr(old_instance, field.name, None)
-                    new_value = getattr(self, field.name, None)
+
+            # If update_fields is specified, only check those fields (minus excluded ones)
+            if update_fields is not None:
+                fields_to_check = set(update_fields) - exclude_fields
+                if not fields_to_check:
+                    # Only timestamp fields are being updated
+                    return False
+                # Check only the specified fields
+                for field_name in fields_to_check:
+                    old_value = getattr(old_instance, field_name, None)
+                    new_value = getattr(self, field_name, None)
                     if old_value != new_value:
                         return True
+            else:
+                # Check all non-timestamp fields
+                for field in self._meta.get_fields():
+                    if hasattr(field, 'name') and field.name not in exclude_fields:
+                        old_value = getattr(old_instance, field.name, None)
+                        new_value = getattr(self, field.name, None)
+                        if old_value != new_value:
+                            return True
         except OAuth2RefreshToken.DoesNotExist:
             pass
         return False
 
     def save(self, *args, **kwargs):
         create_token = not bool(self.pk)
-        modifying_token = self._has_non_timestamp_changes() if not create_token else False
+        update_fields = kwargs.get('update_fields')
+        modifying_token = self._has_non_timestamp_changes(update_fields) if not create_token else False
 
         if create_token:
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -30,9 +30,13 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
     updated = None  # Tracked in CommonModel with 'modified', no need for this
 
     def save(self, *args, **kwargs):
-        if not self.pk:
+        create_token = not bool(self.pk)
+        if create_token:
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
         super().save(*args, **kwargs)
         access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
         user_name = self.user.username if self.user else "N/A"
-        log_auth_event(f"Creating OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
+        if create_token:
+            log_auth_event(f"Created OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
+        else:
+            log_auth_event(f"Modified OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -61,7 +61,7 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
             else:
                 # Check all non-timestamp fields
                 for field in self._meta.get_fields():
-                    if hasattr(field, 'name') and field.name not in exclude_fields:
+                    if field.concrete and hasattr(field, 'name') and field.name not in exclude_fields:
                         old_value = getattr(old_instance, field.name, None)
                         new_value = getattr(self, field.name, None)
                         if old_value != new_value:

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -38,5 +38,3 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
         user_name = self.user.username if self.user else "N/A"
         if create_token:
             log_auth_event(f"Created OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
-        else:
-            log_auth_event(f"Modified OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -29,58 +29,17 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
     token = prevent_search(models.CharField(max_length=255, help_text=_("The refresh token value.")))
     updated = None  # Tracked in CommonModel with 'modified', no need for this
 
-    def _has_non_timestamp_changes(self, update_fields=None):
-        """Check if any non-timestamp fields have changed.
-
-        Args:
-            update_fields: Optional list/set of field names being updated. If provided,
-                          only these fields will be checked for changes.
-
-        Returns:
-            bool: True if any non-timestamp field has changed, False otherwise.
-        """
-        if not self.pk:
-            return False
-        try:
-            old_instance = OAuth2RefreshToken.objects.get(pk=self.pk)
-            # Fields to exclude from change detection (timestamp/auto-updated fields)
-            exclude_fields = {'created', 'created_by', 'modified', 'modified_by'}
-
-            # If update_fields is specified, only check those fields (minus excluded ones)
-            if update_fields is not None:
-                fields_to_check = set(update_fields) - exclude_fields
-                if not fields_to_check:
-                    # Only timestamp fields are being updated
-                    return False
-                # Check only the specified fields
-                for field_name in fields_to_check:
-                    old_value = getattr(old_instance, field_name, None)
-                    new_value = getattr(self, field_name, None)
-                    if old_value != new_value:
-                        return True
-            else:
-                # Check all non-timestamp fields
-                for field in self._meta.get_fields():
-                    if field.concrete and hasattr(field, 'name') and field.name not in exclude_fields:
-                        old_value = getattr(old_instance, field.name, None)
-                        new_value = getattr(self, field.name, None)
-                        if old_value != new_value:
-                            return True
-        except OAuth2RefreshToken.DoesNotExist:
-            pass
-        return False
-
     def save(self, *args, **kwargs):
-        create_token = not bool(self.pk)
         update_fields = kwargs.get('update_fields')
-        modifying_token = self._has_non_timestamp_changes(update_fields) if not create_token else False
-
-        if create_token:
+        has_non_trivial_fields = self._has_non_trivial_changes(update_fields)
+        logging_verb = 'Modified'
+        if not self.pk:
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
+            logging_verb = 'Created'
         super().save(*args, **kwargs)
         access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
         user_name = self.user.username if self.user else "N/A"
-        if create_token:
-            log_auth_event(f"Created OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
-        elif modifying_token:
-            log_auth_event(f"Modified OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
+        if has_non_trivial_fields:
+            log_auth_event(
+                f"{logging_verb} OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger
+            )

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -31,7 +31,7 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
     def save(self, *args, **kwargs):
         if not self.pk:
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
-            access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
-            user_name = self.user.username if self.user else "N/A"
-            logger.info(f"Creating OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}")
         super().save(*args, **kwargs)
+        access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
+        user_name = self.user.username if self.user else "N/A"
+        logger.info(f"Creating OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}")

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.abstract_models.common import CommonModel
+from ansible_base.lib.logging import log_auth_event
 from ansible_base.lib.utils.hashing import hash_string
 from ansible_base.lib.utils.models import prevent_search
 
@@ -34,4 +35,4 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
         super().save(*args, **kwargs)
         access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
         user_name = self.user.username if self.user else "N/A"
-        logger.info(f"Creating OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}")
+        log_auth_event(f"Creating OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 
 import oauth2_provider.models as oauth2_models
 from django.conf import settings
@@ -8,6 +9,8 @@ from django.utils.translation import gettext_lazy as _
 from ansible_base.lib.abstract_models.common import CommonModel
 from ansible_base.lib.utils.hashing import hash_string
 from ansible_base.lib.utils.models import prevent_search
+
+logger = logging.getLogger('ansible_base.oauth2_provider.models.refresh_token')
 
 activitystream = object
 if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
@@ -28,4 +31,7 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
     def save(self, *args, **kwargs):
         if not self.pk:
             self.token = hash_string(self.token, hasher=hashlib.sha256, algo="sha256")
+            access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
+            user_name = self.user.username if self.user else "N/A"
+            logger.info(f"Creating OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}")
         super().save(*args, **kwargs)

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -37,6 +37,6 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
         access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
         user_name = self.user.username if self.user else "N/A"
         if create_token:
-            log_auth_event(f"Created OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
+            log_auth_event(f"Created OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
         else:
-            log_auth_event(f"Modified OAuth2 refresh token for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)
+            log_auth_event(f"Modified OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger)

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -330,3 +330,150 @@ def test_activitystream_user_password_sanitized(user):
     user.set_password('new_password')
     user.save()
     assert entries.last().changes['changed_fields']['password'] == [ENCRYPTED_STRING, ENCRYPTED_STRING]
+
+
+@pytest.mark.django_db
+def test_activitystream_update_fields_limits_diff():
+    """
+    Ensure that when update_fields is provided to save(), only those fields are
+    included in the activity stream entry.
+    """
+    from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
+
+    city = City.objects.create(name='New York', country='USA', population=1000)
+    initial_entry_count = city.activity_stream_entries.count()
+
+    # Update both name and country, but only save country via update_fields
+    city.name = 'Albany'
+    city.country = 'Canada'
+    city.save(update_fields=['country'])
+
+    entries = city.activity_stream_entries
+    assert entries.count() == initial_entry_count + 1
+    entry = entries.last()
+    assert entry.operation == 'update'
+
+    # Only country should be in the changed_fields, not name
+    # Note: country is encrypted (prevent_search) so values show as ENCRYPTED_STRING
+    assert 'country' in entry.changes['changed_fields']
+    assert 'name' not in entry.changes['changed_fields']
+    assert len(entry.changes['changed_fields']) == 1
+    assert entry.changes['changed_fields']['country'] == [ENCRYPTED_STRING, ENCRYPTED_STRING]
+
+
+@pytest.mark.django_db
+def test_activitystream_update_fields_no_entry_when_only_excluded_fields():
+    """
+    Ensure that when update_fields contains only fields that are in
+    activity_stream_limit_field_names, and those fields haven't changed,
+    no activity stream entry is created.
+    """
+    city = City.objects.create(name='New York', country='USA')
+    initial_entry_count = city.activity_stream_entries.count()
+
+    # Update name but not country, and save only name via update_fields
+    # Since City has activity_stream_limit_field_names = ['country'],
+    # updating only 'name' should not create an entry
+    city.name = 'Albany'
+    city.save(update_fields=['name'])
+
+    entries = city.activity_stream_entries
+    # No new entry should be created because 'name' is not in the limit_fields
+    assert entries.count() == initial_entry_count
+
+
+@pytest.mark.django_db
+def test_activitystream_update_fields_with_limit_fields_intersection():
+    """
+    Ensure that when both activity_stream_limit_field_names and update_fields
+    are provided, only the intersection of those fields is diffed.
+    """
+    city = City.objects.create(name='New York', country='USA')
+    initial_entry_count = city.activity_stream_entries.count()
+
+    # City has activity_stream_limit_field_names = ['country']
+    # If we update both name and country with update_fields=['name', 'country']
+    # only country should appear in the activity stream
+    city.name = 'Albany'
+    city.country = 'Canada'
+    city.save(update_fields=['name', 'country'])
+
+    entries = city.activity_stream_entries
+    assert entries.count() == initial_entry_count + 1
+    entry = entries.last()
+
+    # Only country should be in changed_fields (intersection of limit and update_fields)
+    assert 'country' in entry.changes['changed_fields']
+    assert 'name' not in entry.changes['changed_fields']
+    assert len(entry.changes['changed_fields']) == 1
+
+
+@pytest.mark.django_db
+def test_activitystream_update_fields_empty_delta_no_entry():
+    """
+    Ensure that when update_fields is provided but the field value hasn't
+    actually changed, no activity stream entry is created (empty delta).
+    """
+    animal = Animal.objects.create(name='Fluffy')
+    initial_entry_count = animal.activity_stream_entries.count()
+
+    # Save with update_fields but without actually changing the value
+    animal.save(update_fields=['name'])
+
+    entries = animal.activity_stream_entries
+    # No new entry should be created because there's no actual change
+    assert entries.count() == initial_entry_count
+
+
+@pytest.mark.django_db
+def test_activitystream_update_fields_multiple_fields():
+    """
+    Ensure that multiple fields can be updated via update_fields and all
+    appear in the activity stream entry.
+    """
+    animal = Animal.objects.create(name='Fluffy', age=2)
+    initial_entry_count = animal.activity_stream_entries.count()
+
+    # Update multiple fields
+    # Note: 'age' is in activity_stream_excluded_field_names, so it won't show up
+    animal.name = 'Rocky'
+    animal.age = 3
+    animal.save(update_fields=['name', 'age'])
+
+    entries = animal.activity_stream_entries
+    assert entries.count() == initial_entry_count + 1
+    entry = entries.last()
+
+    # Only name should be in changed_fields (age is excluded)
+    assert 'name' in entry.changes['changed_fields']
+    assert 'age' not in entry.changes['changed_fields']
+    assert entry.changes['changed_fields']['name'] == ['Fluffy', 'Rocky']
+
+
+@pytest.mark.django_db
+def test_activitystream_update_fields_none_with_limit_fields():
+    """
+    Ensure that when update_fields is None (not provided) and model has
+    activity_stream_limit_field_names, only limited fields are tracked.
+    """
+    from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
+
+    city = City.objects.create(name='New York', country='USA', population=1000)
+    initial_entry_count = city.activity_stream_entries.count()
+
+    # City has activity_stream_limit_field_names = ['country']
+    # So only changes to country should be tracked
+    city.name = 'Albany'
+    city.country = 'Canada'
+    city.population = 2000
+    city.save()
+
+    entries = city.activity_stream_entries
+    assert entries.count() == initial_entry_count + 1
+    entry = entries.last()
+
+    # Only country should be in changed_fields (it's the only limited field)
+    assert 'country' in entry.changes['changed_fields']
+    assert 'name' not in entry.changes['changed_fields']
+    assert 'population' not in entry.changes['changed_fields']
+    assert entry.changes['changed_fields']['country'] == [ENCRYPTED_STRING, ENCRYPTED_STRING]

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -225,7 +225,7 @@ def test_oauth2_unsupported_media_type(user, user_api_client, only_oauth_scope_p
     assert response.status_code == 200, response.status_code
 
 
-def test_oauth2_authentication_creates_activitystream_entry(unauthenticated_api_client, oauth2_admin_access_token, animal):
+def test_oauth2_authentication_creates_activitystream_entry(unauthenticated_api_client, oauth2_admin_access_token, animal, django_capture_on_commit_callbacks):
     """
     Ensure that authenticating with OAuth2 and making a GET request does NOT
     create spurious activity stream entries (regression test).
@@ -237,15 +237,16 @@ def test_oauth2_authentication_creates_activitystream_entry(unauthenticated_api_
     initial_entry_count = Entry.objects.count()
 
     # Make an authenticated GET request using OAuth2 bearer token
-    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
-    access_token_obj = oauth2_admin_access_token[0]
-    raw_token = oauth2_admin_access_token[1]
-    response = unauthenticated_api_client.get(
-        url,
-        headers={'Authorization': f'Bearer {raw_token}'},
-    )
-    assert response.status_code == 200
-    assert response.data['name'] == animal.name
+    with django_capture_on_commit_callbacks(execute=True):
+        url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
+        access_token_obj = oauth2_admin_access_token[0]
+        raw_token = oauth2_admin_access_token[1]
+        response = unauthenticated_api_client.get(
+            url,
+            headers={'Authorization': f'Bearer {raw_token}'},
+        )
+        assert response.status_code == 200
+        assert response.data['name'] == animal.name
 
     # Verify OAuth2 was actually used by checking the token's last_used field was updated
     access_token_obj.refresh_from_db()

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from oauthlib.common import generate_token
 
+from ansible_base.activitystream.models import Entry
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2AccessToken
 
@@ -222,3 +223,37 @@ def test_oauth2_unsupported_media_type(user, user_api_client, only_oauth_scope_p
     data = b'TESTDATA'
     response = user_api_client.post(url, data=data, content_type='application/octet-stream')
     assert response.status_code == 200, response.status_code
+
+
+def test_oauth2_authentication_creates_activitystream_entry(unauthenticated_api_client, oauth2_admin_access_token, animal):
+    """
+    Ensure that authenticating with OAuth2 and making a GET request does NOT
+    create spurious activity stream entries (regression test).
+
+    This tests that using OAuth2 authentication to simply read data doesn't
+    incorrectly trigger activity stream entry creation.
+    """
+    # Get the count of all activity stream entries before the request
+    initial_entry_count = Entry.objects.count()
+
+    # Make an authenticated GET request using OAuth2 bearer token
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
+    access_token_obj = oauth2_admin_access_token[0]
+    raw_token = oauth2_admin_access_token[1]
+    response = unauthenticated_api_client.get(
+        url,
+        headers={'Authorization': f'Bearer {raw_token}'},
+    )
+    assert response.status_code == 200
+    assert response.data['name'] == animal.name
+
+    # Verify OAuth2 was actually used by checking the token's last_used field was updated
+    access_token_obj.refresh_from_db()
+    assert access_token_obj.last_used is not None
+
+    # Get the count of all activity stream entries after the request
+    final_entry_count = Entry.objects.count()
+
+    # No new activity stream entries should have been created by the GET request
+    # (only the animal creation entry should exist, which was created before this test)
+    assert final_entry_count == initial_entry_count

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -118,8 +118,8 @@ def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_pass
 
 
 @pytest.mark.django_db
-def test_oauth2_access_token_has_non_timestamp_changes_returns_false_for_new_token(admin_user):
-    """Test that _has_non_timestamp_changes returns False for a new token (no pk yet)."""
+def test_oauth2_access_token_has_non_trivial_changes_returns_true_for_new_token(admin_user):
+    """Test that _has_non_trivial_changes returns False for a new token (no pk yet)."""
     token = OAuth2AccessToken(
         user=admin_user,
         application=None,
@@ -127,12 +127,12 @@ def test_oauth2_access_token_has_non_timestamp_changes_returns_false_for_new_tok
         scope='write',
         expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
     )
-    assert token._has_non_timestamp_changes() is False
+    assert token._has_non_trivial_changes() is True
 
 
 @pytest.mark.django_db
-def test_oauth2_access_token_has_non_timestamp_changes_returns_false_for_timestamp_only_changes(admin_user):
-    """Test that _has_non_timestamp_changes returns False when only timestamp fields change."""
+def test_oauth2_access_token_has_non_trivial_changes_returns_false_for_timestamp_only_changes(admin_user):
+    """Test that _has_non_trivial_changes returns False when only timestamp fields change."""
     token = OAuth2AccessToken.objects.create(
         user=admin_user,
         application=None,
@@ -148,12 +148,12 @@ def test_oauth2_access_token_has_non_timestamp_changes_returns_false_for_timesta
 
     # Since we can't directly modify timestamp fields without triggering other changes,
     # we just verify that if we call the method without changing any real fields, it returns False
-    assert token._has_non_timestamp_changes() is False
+    assert token._has_non_trivial_changes() is False
 
 
 @pytest.mark.django_db
-def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_scope_change(admin_user):
-    """Test that _has_non_timestamp_changes returns True when scope changes."""
+def test_oauth2_access_token_has_non_trivial_changes_returns_true_for_scope_change(admin_user):
+    """Test that _has_non_trivial_changes returns True when scope changes."""
     token = OAuth2AccessToken.objects.create(
         user=admin_user,
         application=None,
@@ -165,12 +165,12 @@ def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_scope_ch
     # Change a non-timestamp field
     token.scope = 'read'
 
-    assert token._has_non_timestamp_changes() is True
+    assert token._has_non_trivial_changes() is True
 
 
 @pytest.mark.django_db
-def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_description_change(admin_user):
-    """Test that _has_non_timestamp_changes returns True when description changes."""
+def test_oauth2_access_token_has_non_trivial_changes_returns_true_for_description_change(admin_user):
+    """Test that _has_non_trivial_changes returns True when description changes."""
     token = OAuth2AccessToken.objects.create(
         user=admin_user,
         application=None,
@@ -183,12 +183,12 @@ def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_descript
     # Change a non-timestamp field
     token.description = 'Updated description'
 
-    assert token._has_non_timestamp_changes() is True
+    assert token._has_non_trivial_changes() is True
 
 
 @pytest.mark.django_db
-def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_expires_change(admin_user):
-    """Test that _has_non_timestamp_changes returns True when expires changes."""
+def test_oauth2_access_token_has_non_trivial_changes_returns_true_for_expires_change(admin_user):
+    """Test that _has_non_trivial_changes returns True when expires changes."""
     token = OAuth2AccessToken.objects.create(
         user=admin_user,
         application=None,
@@ -200,12 +200,12 @@ def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_expires_
     # Change a non-timestamp field
     token.expires = datetime(2089, 1, 1, tzinfo=timezone.utc)
 
-    assert token._has_non_timestamp_changes() is True
+    assert token._has_non_trivial_changes() is True
 
 
 @pytest.mark.django_db
-def test_oauth2_refresh_token_has_non_timestamp_changes_returns_false_for_new_token(admin_user):
-    """Test that _has_non_timestamp_changes returns False for a new refresh token."""
+def test_oauth2_refresh_token_has_non_trivial_changes_returns_true_for_new_token(admin_user):
+    """Test that _has_non_trivial_changes returns False for a new refresh token."""
     access_token = OAuth2AccessToken.objects.create(
         user=admin_user,
         token=generate_token(),
@@ -219,12 +219,12 @@ def test_oauth2_refresh_token_has_non_timestamp_changes_returns_false_for_new_to
         access_token=access_token,
     )
 
-    assert refresh_token._has_non_timestamp_changes() is False
+    assert refresh_token._has_non_trivial_changes() is True
 
 
 @pytest.mark.django_db
-def test_oauth2_refresh_token_has_non_timestamp_changes_returns_false_for_no_changes(admin_user, oauth2_application_password):
-    """Test that _has_non_timestamp_changes returns False when nothing changed."""
+def test_oauth2_refresh_token_has_non_trivial_changes_returns_false_for_no_changes(admin_user, oauth2_application_password):
+    """Test that _has_non_trivial_changes returns False when nothing changed."""
     application, _secret = oauth2_application_password
 
     access_token = OAuth2AccessToken.objects.create(
@@ -242,12 +242,12 @@ def test_oauth2_refresh_token_has_non_timestamp_changes_returns_false_for_no_cha
         access_token=access_token,
     )
 
-    assert refresh_token._has_non_timestamp_changes() is False
+    assert refresh_token._has_non_trivial_changes() is False
 
 
 @pytest.mark.django_db
-def test_oauth2_refresh_token_has_non_timestamp_changes_returns_true_for_revoked_change(admin_user, oauth2_application_password):
-    """Test that _has_non_timestamp_changes returns True when revoked status changes."""
+def test_oauth2_refresh_token_has_non_trivial_changes_returns_true_for_revoked_change(admin_user, oauth2_application_password):
+    """Test that _has_non_trivial_changes returns True when revoked status changes."""
     application, _secret = oauth2_application_password
 
     access_token = OAuth2AccessToken.objects.create(
@@ -269,7 +269,7 @@ def test_oauth2_refresh_token_has_non_timestamp_changes_returns_true_for_revoked
     # Change revoked status
     refresh_token.revoked = None
 
-    assert refresh_token._has_non_timestamp_changes() is True
+    assert refresh_token._has_non_trivial_changes() is True
 
 
 @pytest.mark.django_db

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -54,8 +55,8 @@ def test_oauth2_access_token_creation_logs_with_application(mock_logger, oauth2_
     )
 
     # Verify the logger was called with the correct message
-    mock_logger.info.assert_called_once_with(
-        f"Creating OAuth2 access token for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
+    mock_logger.log.assert_called_once_with(
+        logging.INFO, f"Created OAuth2 access token {token.pk} for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
     )
 
     # Verify the token was created
@@ -76,8 +77,8 @@ def test_oauth2_access_token_creation_logs_without_application(mock_logger, admi
     )
 
     # Verify the logger was called with personal access token message
-    mock_logger.info.assert_called_once_with(
-        f"Creating OAuth2 access token for user '{admin_user.username}' with application 'N/A (Personal Access Token)' and scope 'read'"
+    mock_logger.log.assert_called_once_with(
+        logging.INFO, f"Created OAuth2 access token {token.pk} for user '{admin_user.username}' with application 'N/A (Personal Access Token)' and scope 'read'"
     )
 
     # Verify the token was created
@@ -108,7 +109,9 @@ def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_pass
     )
 
     # Verify the logger was called with the correct message
-    mock_logger.info.assert_called_once_with(f"Creating OAuth2 refresh token for user '{admin_user.username}' linked to access token {access_token.pk}")
+    mock_logger.log.assert_called_once_with(
+        logging.INFO, f"Created OAuth2 refresh token for user '{admin_user.username}' linked to access token {access_token.pk}"
+    )
 
     # Verify the refresh token was created
     assert OAuth2RefreshToken.objects.filter(pk=refresh_token.pk).exists()

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -115,3 +115,329 @@ def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_pass
 
     # Verify the refresh token was created
     assert OAuth2RefreshToken.objects.filter(pk=refresh_token.pk).exists()
+
+
+@pytest.mark.django_db
+def test_oauth2_access_token_has_non_timestamp_changes_returns_false_for_new_token(admin_user):
+    """Test that _has_non_timestamp_changes returns False for a new token (no pk yet)."""
+    token = OAuth2AccessToken(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+    assert token._has_non_timestamp_changes() is False
+
+
+@pytest.mark.django_db
+def test_oauth2_access_token_has_non_timestamp_changes_returns_false_for_timestamp_only_changes(admin_user):
+    """Test that _has_non_timestamp_changes returns False when only timestamp fields change."""
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Modify only timestamp fields (these should be ignored)
+    # Note: modified is auto_now, so it will change automatically
+    # created_by and modified_by are also timestamp-related
+    # last_used is explicitly a timestamp field
+
+    # Since we can't directly modify timestamp fields without triggering other changes,
+    # we just verify that if we call the method without changing any real fields, it returns False
+    assert token._has_non_timestamp_changes() is False
+
+
+@pytest.mark.django_db
+def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_scope_change(admin_user):
+    """Test that _has_non_timestamp_changes returns True when scope changes."""
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Change a non-timestamp field
+    token.scope = 'read'
+
+    assert token._has_non_timestamp_changes() is True
+
+
+@pytest.mark.django_db
+def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_description_change(admin_user):
+    """Test that _has_non_timestamp_changes returns True when description changes."""
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+        description='Original description',
+    )
+
+    # Change a non-timestamp field
+    token.description = 'Updated description'
+
+    assert token._has_non_timestamp_changes() is True
+
+
+@pytest.mark.django_db
+def test_oauth2_access_token_has_non_timestamp_changes_returns_true_for_expires_change(admin_user):
+    """Test that _has_non_timestamp_changes returns True when expires changes."""
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Change a non-timestamp field
+    token.expires = datetime(2089, 1, 1, tzinfo=timezone.utc)
+
+    assert token._has_non_timestamp_changes() is True
+
+
+@pytest.mark.django_db
+def test_oauth2_refresh_token_has_non_timestamp_changes_returns_false_for_new_token(admin_user):
+    """Test that _has_non_timestamp_changes returns False for a new refresh token."""
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    refresh_token = OAuth2RefreshToken(
+        user=admin_user,
+        token=generate_token(),
+        access_token=access_token,
+    )
+
+    assert refresh_token._has_non_timestamp_changes() is False
+
+
+@pytest.mark.django_db
+def test_oauth2_refresh_token_has_non_timestamp_changes_returns_false_for_no_changes(admin_user, oauth2_application_password):
+    """Test that _has_non_timestamp_changes returns False when nothing changed."""
+    application, _secret = oauth2_application_password
+
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    refresh_token = OAuth2RefreshToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        access_token=access_token,
+    )
+
+    assert refresh_token._has_non_timestamp_changes() is False
+
+
+@pytest.mark.django_db
+def test_oauth2_refresh_token_has_non_timestamp_changes_returns_true_for_revoked_change(admin_user, oauth2_application_password):
+    """Test that _has_non_timestamp_changes returns True when revoked status changes."""
+    application, _secret = oauth2_application_password
+
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    refresh_token = OAuth2RefreshToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        access_token=access_token,
+        revoked=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Change revoked status
+    refresh_token.revoked = None
+
+    assert refresh_token._has_non_timestamp_changes() is True
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_modification_logs_with_scope_change(mock_logger, admin_user):
+    """Test that OAuth2AccessToken modification logs when scope changes."""
+    # Create an access token
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Modify the scope (a non-timestamp field)
+    token.scope = 'read'
+    token.save()
+
+    # Verify the modification was logged
+    expected_msg = (
+        f"Modified OAuth2 access token {token.pk} for user '{admin_user.username}' " f"with application 'N/A (Personal Access Token)' and scope 'read'"
+    )
+    mock_logger.log.assert_called_once_with(logging.INFO, expected_msg)
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_modification_logs_with_description_change(mock_logger, oauth2_application_password, admin_user):
+    """Test that OAuth2AccessToken modification logs when description changes."""
+    application, _secret = oauth2_application_password
+
+    # Create an access token
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+        description='Original',
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Modify the description (a non-timestamp field)
+    token.description = 'Updated'
+    token.save()
+
+    # Verify the modification was logged
+    mock_logger.log.assert_called_once_with(
+        logging.INFO, f"Modified OAuth2 access token {token.pk} for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
+    )
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_no_modification_log_for_timestamp_only_changes(mock_logger, admin_user):
+    """Test that OAuth2AccessToken does not log modification when only timestamp fields change."""
+    # Create an access token
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Save without changing non-timestamp fields
+    # This will update modified and modified_by, but should not log
+    token.save()
+
+    # Verify no modification log was created
+    mock_logger.log.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_no_modification_log_for_last_used_change(mock_logger, admin_user):
+    """Test that OAuth2AccessToken does not log modification when only last_used changes."""
+    # Create an access token
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Update only last_used (a timestamp field that should be ignored)
+    token.save(update_fields=['last_used'])
+
+    # Verify no modification log was created
+    mock_logger.log.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+def test_oauth2_refresh_token_modification_logs_with_revoked_change(mock_logger, admin_user, oauth2_application_password):
+    """Test that OAuth2RefreshToken modification logs when revoked status changes."""
+    application, _secret = oauth2_application_password
+
+    # Create tokens
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    refresh_token = OAuth2RefreshToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        access_token=access_token,
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Modify the revoked status (a non-timestamp field)
+    refresh_token.revoked = datetime(2088, 6, 1, tzinfo=timezone.utc)
+    refresh_token.save()
+
+    # Verify the modification was logged
+    mock_logger.log.assert_called_once_with(
+        logging.INFO, f"Modified OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
+    )
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+def test_oauth2_refresh_token_no_modification_log_for_timestamp_only_changes(mock_logger, admin_user, oauth2_application_password):
+    """Test that OAuth2RefreshToken does not log modification when only timestamp fields change."""
+    application, _secret = oauth2_application_password
+
+    # Create tokens
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    refresh_token = OAuth2RefreshToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        access_token=access_token,
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Save without changing non-timestamp fields
+    # This will update modified and modified_by, but should not log
+    refresh_token.save()
+
+    # Verify no modification log was created
+    mock_logger.log.assert_not_called()

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -49,6 +50,7 @@ def test_oauth2_access_token_creation_logs_with_application(mock_logger, oauth2_
         application=application,
         token=generate_token(),
         scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
     )
 
     # Verify the logger was called with the correct message
@@ -70,6 +72,7 @@ def test_oauth2_access_token_creation_logs_without_application(mock_logger, admi
         application=None,
         token=generate_token(),
         scope='read',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
     )
 
     # Verify the logger was called with personal access token message
@@ -93,6 +96,7 @@ def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_pass
         application=application,
         token=generate_token(),
         scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
     )
 
     # Create a refresh token linked to the access token

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -1,4 +1,7 @@
+from unittest import mock
+
 import pytest
+from oauthlib.common import generate_token
 
 from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2RefreshToken
 
@@ -32,3 +35,76 @@ def test_oauth2_revoke_refresh_token(oauth2_admin_access_token):
     new_refresh_token = OAuth2RefreshToken.objects.all().first()
     assert refresh_token == new_refresh_token
     assert new_refresh_token.revoked
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_creation_logs_with_application(mock_logger, oauth2_application_password, admin_user):
+    """Test that OAuth2AccessToken creation logs with application name."""
+    application, _secret = oauth2_application_password
+
+    # Create an access token with an application
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+    )
+
+    # Verify the logger was called with the correct message
+    mock_logger.info.assert_called_once_with(
+        f"Creating OAuth2 access token for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
+    )
+
+    # Verify the token was created
+    assert OAuth2AccessToken.objects.filter(pk=token.pk).exists()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_creation_logs_without_application(mock_logger, admin_user):
+    """Test that OAuth2AccessToken creation logs for personal access tokens."""
+    # Create a personal access token (no application)
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='read',
+    )
+
+    # Verify the logger was called with personal access token message
+    mock_logger.info.assert_called_once_with(
+        f"Creating OAuth2 access token for user '{admin_user.username}' with application 'N/A (Personal Access Token)' and scope 'read'"
+    )
+
+    # Verify the token was created
+    assert OAuth2AccessToken.objects.filter(pk=token.pk).exists()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_password, admin_user):
+    """Test that OAuth2RefreshToken creation logs with access token reference."""
+    application, _secret = oauth2_application_password
+
+    # Create an access token first
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+    )
+
+    # Create a refresh token linked to the access token
+    refresh_token = OAuth2RefreshToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        access_token=access_token,
+    )
+
+    # Verify the logger was called with the correct message
+    mock_logger.info.assert_called_once_with(f"Creating OAuth2 refresh token for user '{admin_user.username}' linked to access token {access_token.pk}")
+
+    # Verify the refresh token was created
+    assert OAuth2RefreshToken.objects.filter(pk=refresh_token.pk).exists()

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -441,3 +441,145 @@ def test_oauth2_refresh_token_no_modification_log_for_timestamp_only_changes(moc
 
     # Verify no modification log was created
     mock_logger.log.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_no_modification_log_with_update_fields_timestamp_only(mock_logger, admin_user):
+    """Test that OAuth2AccessToken does not log when update_fields contains only timestamp fields."""
+    # Create an access token
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Save with update_fields containing only timestamp fields
+    token.save(update_fields=['modified', 'modified_by'])
+
+    # Verify no modification log was created
+    mock_logger.log.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_modification_log_with_update_fields_non_timestamp(mock_logger, admin_user):
+    """Test that OAuth2AccessToken logs when update_fields contains non-timestamp fields."""
+    # Create an access token
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+        description='Original',
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Change description and save with update_fields
+    token.description = 'Updated'
+    token.save(update_fields=['description'])
+
+    # Verify the modification was logged
+    expected_msg = (
+        f"Modified OAuth2 access token {token.pk} for user '{admin_user.username}' " f"with application 'N/A (Personal Access Token)' and scope 'write'"
+    )
+    mock_logger.log.assert_called_once_with(logging.INFO, expected_msg)
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+def test_oauth2_access_token_no_modification_log_with_update_fields_unchanged_field(mock_logger, admin_user):
+    """Test that OAuth2AccessToken does not log when update_fields specifies a field that didn't change."""
+    # Create an access token
+    token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=None,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+        description='Same',
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Save with update_fields but without actually changing the field
+    token.save(update_fields=['description'])
+
+    # Verify no modification log was created (field value didn't change)
+    mock_logger.log.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+def test_oauth2_refresh_token_no_modification_log_with_update_fields_timestamp_only(mock_logger, admin_user, oauth2_application_password):
+    """Test that OAuth2RefreshToken does not log when update_fields contains only timestamp fields."""
+    application, _secret = oauth2_application_password
+
+    # Create tokens
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    refresh_token = OAuth2RefreshToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        access_token=access_token,
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Save with update_fields containing only timestamp fields
+    refresh_token.save(update_fields=['modified', 'modified_by'])
+
+    # Verify no modification log was created
+    mock_logger.log.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+def test_oauth2_refresh_token_modification_log_with_update_fields_non_timestamp(mock_logger, admin_user, oauth2_application_password):
+    """Test that OAuth2RefreshToken logs when update_fields contains non-timestamp fields."""
+    application, _secret = oauth2_application_password
+
+    # Create tokens
+    access_token = OAuth2AccessToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        scope='write',
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    refresh_token = OAuth2RefreshToken.objects.create(
+        user=admin_user,
+        application=application,
+        token=generate_token(),
+        access_token=access_token,
+    )
+
+    # Reset the mock to ignore creation log
+    mock_logger.reset_mock()
+
+    # Change revoked status and save with update_fields
+    refresh_token.revoked = datetime(2088, 6, 1, tzinfo=timezone.utc)
+    refresh_token.save(update_fields=['revoked'])
+
+    # Verify the modification was logged
+    mock_logger.log.assert_called_once_with(
+        logging.INFO, f"Modified OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
+    )

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -110,7 +110,7 @@ def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_pass
 
     # Verify the logger was called with the correct message
     mock_logger.log.assert_called_once_with(
-        logging.INFO, f"Created OAuth2 refresh token for user '{admin_user.username}' linked to access token {access_token.pk}"
+        logging.INFO, f"Created OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
     )
 
     # Verify the refresh token was created


### PR DESCRIPTION
This change logs the creation and usage of OAuth2 tokens, logging the OAuth2
application used where applicable.

Co-authored-by: Claude <noreply@anthropic.com>

## Description
- What is being changed? Create logs where OAuth2 tokens are created and used, associating requests with OAuth2 applications where possible.
- Why is this change needed? To make auditability easier for users.
- How does this change address the issue? by adding logs when creating tokens, updating logs when users use tokens.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
  - This one will need to be evaluated for log injection issues, I have yet to do that one myself.
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
- Start test_app
- Create OAuth2 application

### Steps to Test
1. Create an OAuth2 token (both PAT and Application tokens)
2. Use the tokens to authenticate to endpoints in the application

### Expected Results

- On Creation of the token a log should be present noting the user the token was created for and the application it was created for.
- On usage of token, a log should be present noting the user the token was used for, the application it was used for, and the uri it was used to access

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds audit logs for OAuth2 token creation/modification/use and limits activity stream updates to only the fields explicitly updated.
> 
> - **OAuth2**:
>   - **Auth Logging**: Log authenticated API requests with OAuth2, including user, method, path, token, and application id/name in `oauth2_provider/authentication.py`.
>   - **Token Models**: In `OAuth2AccessToken` and `OAuth2RefreshToken`, log on create/modify (skip trivial changes), hash tokens on save, and exclude `last_used/modified/modified_by` from activity stream.
> - **Models/Utils**:
>   - **Change Detection**: Add `ModifiableModel._has_non_trivial_changes()` and `trivial_fields` to detect meaningful updates (supports selective logging).
> - **Activity Stream**:
>   - **Selective Diff**: `_store_activitystream_entry()` accepts `update_fields` and diffs only the intersection with `activity_stream_limit_field_names`; `pre_save` passes `update_fields`.
> - **Tests**:
>   - Add extensive tests for selective activity stream diffs, OAuth2 auth not creating entries on read, and token create/modify logging (including `update_fields` cases).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62abd6dd48a5773659a13fe6794da58c066de051. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->