### PR TITLE
AAP-53741: Add and use more auth log functions

### DIFF
--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -6,7 +6,7 @@ from django.contrib.auth.backends import ModelBackend
 
 from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin
 from ansible_base.authentication.models import Authenticator
-from ansible_base.lib.logging import log_auth_event
+from ansible_base.lib.logging import log_auth_event, log_auth_exception, log_auth_warning
 
 logger = logging.getLogger('ansible_base.authentication.backend')
 
@@ -41,7 +41,7 @@ class AnsibleBaseAuth(ModelBackend):
             try:
                 user = authenticator_object.authenticate(request, *args, **kwargs)
             except Exception:
-                logger.exception(f"Exception raised while trying to authenticate with {authenticator_object.database_instance.name}")
+                log_auth_exception(f"Exception raised while trying to authenticate with {authenticator_object.database_instance.name}", logger)
                 continue
 
             # Social Auth pipeline can return status string when update_user_claims fails (authentication maps deny access)
@@ -51,12 +51,13 @@ class AnsibleBaseAuth(ModelBackend):
             if user:
                 # The local authenticator handles this but we want to check this for other authentication types
                 if not getattr(user, 'is_active', True):
-                    logger.warning(
-                        f'User {user.username} attempted to login from authenticator with ID "{authenticator_id}" their user is inactive, denying permission'
+                    log_auth_warning(
+                        f'User {user.username} attempted to login from authenticator with ID "{authenticator_id}" their user is inactive, denying permission',
+                        logger,
                     )
                     return None
 
-                log_auth_event(f'User {user.username} logged in from authenticator with ID "{authenticator_id}"', logger)
+                log_auth_event(f'User {user.username} logged in from {authenticator_object.type} authenticator with ID "{authenticator_id}"', logger)
                 if hasattr(user, "last_login_from"):
                     user.last_login_from = authenticator_object.database_instance
                     user.save(update_fields=['last_login_from'])

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -19,6 +19,7 @@ from rest_framework.serializers import DateTimeField
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap, AuthenticatorUser
 from ansible_base.authentication.utils.authenticator_map import check_role_type, expand_syntax
 from ansible_base.lib.abstract_models import AbstractOrganization, AbstractTeam, CommonModel
+from ansible_base.lib.logging import log_auth_warning
 from ansible_base.lib.utils.apps import is_rbac_installed
 from ansible_base.lib.utils.auth import get_organization_model, get_team_model
 from ansible_base.lib.utils.string import is_empty
@@ -623,7 +624,7 @@ def update_user_claims(user: Optional[AbstractUser], database_authenticator: Aut
         authenticator_user.save(update_fields=["extra_data"])
 
     if results['access_allowed'] is not True:
-        logger.warning(f"User {user.username} failed an allow map and was denied access")
+        log_auth_warning(f"User {user.username} failed an allow map and was denied access via authenticator {database_authenticator.name}", logger)
         return None
 
     # Make the orgs and the teams as necessary ...

--- a/ansible_base/lib/logging/__init__.py
+++ b/ansible_base/lib/logging/__init__.py
@@ -18,18 +18,14 @@ def get_auth_logger() -> logging.Logger:
     return auth_logger
 
 
-def log_auth_event(message: str, second_logger: Optional[logging.Logger] = None):
+def log_auth_event(message: str, second_logger: Optional[logging.Logger] = None, level: Optional[int] = logging.INFO):
     auth_logger = get_auth_logger()
-    auth_logger.info(message)
+    auth_logger.log(level, message)
     if second_logger:
-        second_logger.info(message)
-
+        second_logger.log(level, message)
 
 def log_auth_warning(message: str, second_logger: Optional[logging.Logger] = None):
-    auth_logger = get_auth_logger()
-    auth_logger.warning(message)
-    if second_logger:
-        second_logger.warning(message)
+    log_auth_event(message, second_logger, logging.WARNING)
 
 
 def log_auth_exception(message: str, second_logger: Optional[logging.Logger] = None):

--- a/ansible_base/lib/logging/__init__.py
+++ b/ansible_base/lib/logging/__init__.py
@@ -9,12 +9,31 @@ thread_local = threading.local()
 auth_logger = None
 
 
-def log_auth_event(message: str, second_logger: Optional[logging.Logger] = None):
+def get_auth_logger() -> logging.Logger:
     global auth_logger
     if not auth_logger:
         AUTH_AUDIT_LOGGER_NAME = get_setting('ANSIBLE_BASE_AUTH_AUDIT_LOGGER_NAME', 'ansible_base.auth_audit')
         auth_logger = logging.getLogger(AUTH_AUDIT_LOGGER_NAME)
 
+    return auth_logger
+
+
+def log_auth_event(message: str, second_logger: Optional[logging.Logger] = None):
+    auth_logger = get_auth_logger()
     auth_logger.info(message)
     if second_logger:
         second_logger.info(message)
+
+
+def log_auth_warning(message: str, second_logger: Optional[logging.Logger] = None):
+    auth_logger = get_auth_logger()
+    auth_logger.warning(message)
+    if second_logger:
+        second_logger.warning(message)
+
+
+def log_auth_exception(message: str, second_logger: Optional[logging.Logger] = None):
+    auth_logger = get_auth_logger()
+    auth_logger.exception(message)
+    if second_logger:
+        second_logger.exception(message)

--- a/ansible_base/lib/logging/__init__.py
+++ b/ansible_base/lib/logging/__init__.py
@@ -24,6 +24,7 @@ def log_auth_event(message: str, second_logger: Optional[logging.Logger] = None,
     if second_logger:
         second_logger.log(level, message)
 
+
 def log_auth_warning(message: str, second_logger: Optional[logging.Logger] = None):
     log_auth_event(message, second_logger, logging.WARNING)
 

--- a/test_app/tests/authentication/test_backend.py
+++ b/test_app/tests/authentication/test_backend.py
@@ -1,3 +1,4 @@
+import logging
 from random import shuffle
 from types import SimpleNamespace
 from unittest import mock
@@ -193,12 +194,14 @@ def test_last_login_from_with_attribute(local_authenticator, random_user, expect
             return_value={local_authenticator.id: mock_authenticator_plugin},
         ):
             # Expected log message when user logs in
-            with expected_log(
-                'ansible_base.authentication.backend.logger',
-                "info",
-                f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}',
-            ):
+            with mock.patch(
+                'ansible_base.authentication.backend.logger.log',
+            ) as log_mock:
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
+                log_mock.assert_called_once_with(
+                    logging.INFO,
+                    f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}"',
+                )
 
             # Verify the user is returned
             assert auth_return == random_user
@@ -229,12 +232,14 @@ def test_last_login_from_without_attribute(local_authenticator, random_user, exp
             "ansible_base.authentication.backend.get_authentication_backends",
             return_value={local_authenticator.id: mock_authenticator_plugin},
         ):
-            with expected_log(
-                'ansible_base.authentication.backend.logger',
-                "info",
-                f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}',
-            ):
+            with mock.patch(
+                'ansible_base.authentication.backend.logger.log',
+            ) as log_mock:
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
+                log_mock.assert_called_once_with(
+                    logging.INFO,
+                    f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}"',
+                )
 
             # Verify the user is returned
             assert auth_return == random_user
@@ -266,12 +271,13 @@ def test_last_login_from_multiple_authenticators(local_authenticator, github_ent
             return_value={github_enterprise_authenticator.id: mock_github_plugin, local_authenticator.id: mock_local_plugin},
         ):
             # Expected log message when user logs in
-            with expected_log(
-                'ansible_base.authentication.backend.logger',
-                "info",
-                f'User {random_user.username} logged in from {mock_local_plugin.type} authenticator with ID "{local_authenticator.id}',
-            ):
+            with mock.patch(
+                'ansible_base.authentication.backend.logger.log',
+            ) as log_mock:
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
+                log_mock.assert_called_once_with(
+                    logging.INFO, f'User {random_user.username} logged in from {mock_local_plugin.type} authenticator with ID "{local_authenticator.id}"'
+                )
 
             # Verify the user is returned
             assert auth_return == random_user

--- a/test_app/tests/authentication/test_backend.py
+++ b/test_app/tests/authentication/test_backend.py
@@ -184,6 +184,7 @@ def test_last_login_from_with_attribute(local_authenticator, random_user, expect
     mock_authenticator_plugin = mock.MagicMock()
     mock_authenticator_plugin.authenticate.return_value = random_user
     mock_authenticator_plugin.database_instance = local_authenticator
+    mock_authenticator_plugin.type = "local"
 
     # Mock the save method to track calls
     with mock.patch.object(random_user, 'save') as mock_save:
@@ -195,7 +196,7 @@ def test_last_login_from_with_attribute(local_authenticator, random_user, expect
             with expected_log(
                 'ansible_base.authentication.backend.logger',
                 "info",
-                f'User {random_user.username} logged in from authenticator with ID "{local_authenticator.id}"',
+                f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}',
             ):
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
 
@@ -220,6 +221,7 @@ def test_last_login_from_without_attribute(local_authenticator, random_user, exp
     mock_authenticator_plugin = mock.MagicMock()
     mock_authenticator_plugin.authenticate.return_value = random_user
     mock_authenticator_plugin.database_instance = local_authenticator
+    mock_authenticator_plugin.type = "local"
 
     # Mock the save method to track calls
     with mock.patch.object(random_user, 'save') as mock_save:
@@ -230,7 +232,7 @@ def test_last_login_from_without_attribute(local_authenticator, random_user, exp
             with expected_log(
                 'ansible_base.authentication.backend.logger',
                 "info",
-                f'User {random_user.username} logged in from authenticator with ID "{local_authenticator.id}"',
+                f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}',
             ):
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
 
@@ -255,6 +257,7 @@ def test_last_login_from_multiple_authenticators(local_authenticator, github_ent
     mock_local_plugin = mock.MagicMock()
     mock_local_plugin.authenticate.return_value = random_user
     mock_local_plugin.database_instance = local_authenticator
+    mock_local_plugin.type = "local"
 
     # Mock the save method to track calls
     with mock.patch.object(random_user, 'save') as mock_save:
@@ -266,7 +269,7 @@ def test_last_login_from_multiple_authenticators(local_authenticator, github_ent
             with expected_log(
                 'ansible_base.authentication.backend.logger',
                 "info",
-                f'User {random_user.username} logged in from authenticator with ID "{local_authenticator.id}"',
+                f'User {random_user.username} logged in from {mock_local_plugin.type} authenticator with ID "{local_authenticator.id}',
             ):
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
 

--- a/test_app/tests/lib/logging/test_logging.py
+++ b/test_app/tests/lib/logging/test_logging.py
@@ -259,7 +259,7 @@ class TestLogAuthEvent:
 
         log_auth_event("Test event message")
 
-        mock_auth_logger.info.assert_called_once_with("Test event message")
+        mock_auth_logger.log.assert_called_once_with(logging.INFO, "Test event message")
 
     @mock.patch("ansible_base.lib.logging.get_auth_logger")
     def test_logs_to_second_logger_mock(self, mock_get_auth_logger):
@@ -270,8 +270,8 @@ class TestLogAuthEvent:
 
         log_auth_event("Test event message", second_logger=mock_second_logger)
 
-        mock_auth_logger.info.assert_called_once_with("Test event message")
-        mock_second_logger.info.assert_called_once_with("Test event message")
+        mock_auth_logger.log.assert_called_once_with(logging.INFO, "Test event message")
+        mock_second_logger.log.assert_called_once_with(logging.INFO, "Test event message")
 
 
 class TestLogAuthWarning:
@@ -285,7 +285,7 @@ class TestLogAuthWarning:
 
         log_auth_warning("Test warning message")
 
-        mock_auth_logger.warning.assert_called_once_with("Test warning message")
+        mock_auth_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
 
     @mock.patch("ansible_base.lib.logging.get_auth_logger")
     def test_logs_to_second_logger(self, mock_get_auth_logger):
@@ -296,8 +296,8 @@ class TestLogAuthWarning:
 
         log_auth_warning("Test warning message", second_logger=mock_second_logger)
 
-        mock_auth_logger.warning.assert_called_once_with("Test warning message")
-        mock_second_logger.warning.assert_called_once_with("Test warning message")
+        mock_auth_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
+        mock_second_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
 
     @mock.patch("ansible_base.lib.logging.get_auth_logger")
     def test_only_logs_to_auth_logger_when_no_second_logger(self, mock_get_auth_logger):
@@ -307,7 +307,7 @@ class TestLogAuthWarning:
 
         log_auth_warning("Test warning message", second_logger=None)
 
-        mock_auth_logger.warning.assert_called_once_with("Test warning message")
+        mock_auth_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
 
     @mock.patch("ansible_base.lib.logging.get_auth_logger")
     def test_with_empty_message(self, mock_get_auth_logger):
@@ -317,7 +317,7 @@ class TestLogAuthWarning:
 
         log_auth_warning("")
 
-        mock_auth_logger.warning.assert_called_once_with("")
+        mock_auth_logger.log.assert_called_once_with(logging.WARNING, "")
 
     @mock.patch("ansible_base.lib.logging.get_auth_logger")
     def test_with_multiline_message(self, mock_get_auth_logger):
@@ -328,7 +328,7 @@ class TestLogAuthWarning:
 
         log_auth_warning(multiline_message)
 
-        mock_auth_logger.warning.assert_called_once_with(multiline_message)
+        mock_auth_logger.log.assert_called_once_with(logging.WARNING, multiline_message)
 
     @mock.patch("ansible_base.lib.logging.get_auth_logger")
     def test_with_special_characters(self, mock_get_auth_logger):
@@ -339,7 +339,7 @@ class TestLogAuthWarning:
 
         log_auth_warning(special_message)
 
-        mock_auth_logger.warning.assert_called_once_with(special_message)
+        mock_auth_logger.log.assert_called_once_with(logging.WARNING, special_message)
 
 
 class TestLogAuthException:

--- a/test_app/tests/lib/logging/test_logging.py
+++ b/test_app/tests/lib/logging/test_logging.py
@@ -1,10 +1,11 @@
 import logging
+from unittest import mock
 
 import pytest
 from django.test import override_settings
 
 import ansible_base.lib.logging as logging_module
-from ansible_base.lib.logging import log_auth_event
+from ansible_base.lib.logging import get_auth_logger, log_auth_event, log_auth_exception, log_auth_warning
 
 
 @pytest.fixture(autouse=True)
@@ -15,8 +16,40 @@ def reset_auth_logger():
     logging_module.auth_logger = None
 
 
-class TestLogAuthEventBasicFunctionality:
-    """Tests for basic logging functionality of log_auth_event."""
+class TestGetAuthLogger:
+    """Tests for get_auth_logger function."""
+
+    @mock.patch("ansible_base.lib.logging.get_setting")
+    @mock.patch("ansible_base.lib.logging.logging.getLogger")
+    def test_uses_configured_logger_name(self, mock_get_logger, mock_get_setting):
+        """Test that get_auth_logger uses the configured logger name from settings."""
+        mock_get_setting.return_value = "custom.auth.logger"
+        mock_logger = mock.Mock()
+        mock_get_logger.return_value = mock_logger
+
+        result = get_auth_logger()
+
+        mock_get_setting.assert_called_once_with('ANSIBLE_BASE_AUTH_AUDIT_LOGGER_NAME', 'ansible_base.auth_audit')
+        mock_get_logger.assert_called_once_with("custom.auth.logger")
+        assert result == mock_logger
+
+    @mock.patch("ansible_base.lib.logging.get_setting")
+    @mock.patch("ansible_base.lib.logging.logging.getLogger")
+    def test_uses_default_logger_name(self, mock_get_logger, mock_get_setting):
+        """Test that get_auth_logger uses the default logger name when not configured."""
+        mock_get_setting.return_value = 'ansible_base.auth_audit'
+        mock_logger = mock.Mock()
+        mock_get_logger.return_value = mock_logger
+
+        result = get_auth_logger()
+
+        mock_get_setting.assert_called_once_with('ANSIBLE_BASE_AUTH_AUDIT_LOGGER_NAME', 'ansible_base.auth_audit')
+        mock_get_logger.assert_called_once_with('ansible_base.auth_audit')
+        assert result == mock_logger
+
+
+class TestLogAuthEvent:
+    """Tests for log_auth_event function."""
 
     def test_logs_message_to_auth_logger(self, caplog):
         """Verify that the message is logged to the auth_logger at INFO level."""
@@ -53,16 +86,11 @@ class TestLogAuthEventBasicFunctionality:
 
         assert message in caplog.text
 
-
-class TestLogAuthEventLoggerInitialization:
-    """Tests for auth_logger initialization behavior."""
-
     def test_uses_default_logger_name_when_setting_not_configured(self, caplog):
         """Verify default logger name 'ansible_base.auth_audit' is used when no setting is configured."""
         with caplog.at_level(logging.INFO):
             log_auth_event("Test message")
 
-        # The log should be captured under the default logger name
         assert any(r.name == 'ansible_base.auth_audit' for r in caplog.records)
 
     def test_uses_custom_logger_name_from_setting(self, caplog):
@@ -73,49 +101,37 @@ class TestLogAuthEventLoggerInitialization:
             with caplog.at_level(logging.INFO):
                 log_auth_event("Custom logger test")
 
-        # The log should be captured under the custom logger name
         assert any(r.name == custom_logger_name for r in caplog.records)
 
     def test_auth_logger_is_cached_after_first_call(self, caplog):
         """Verify that auth_logger is initialized once and reused on subsequent calls."""
-        # First call initializes the logger
         with caplog.at_level(logging.INFO):
             log_auth_event("First message")
 
-        # Capture the logger reference
         first_logger = logging_module.auth_logger
 
-        # Second call should reuse the same logger
         with caplog.at_level(logging.INFO):
             log_auth_event("Second message")
 
         second_logger = logging_module.auth_logger
 
-        # Both should be the same object
         assert first_logger is second_logger
         assert first_logger is not None
 
     def test_auth_logger_caching_ignores_subsequent_setting_changes(self, caplog):
         """Verify that once auth_logger is initialized, setting changes don't affect it."""
-        # First call with default settings
         with caplog.at_level(logging.INFO):
             log_auth_event("Initial message")
 
         initial_logger = logging_module.auth_logger
         initial_logger_name = initial_logger.name
 
-        # Now change the setting - but logger is already cached
         with override_settings(ANSIBLE_BASE_AUTH_AUDIT_LOGGER_NAME='different_logger'):
             with caplog.at_level(logging.INFO):
                 log_auth_event("After setting change")
 
-        # Logger should still be the same (cached)
         assert logging_module.auth_logger is initial_logger
         assert logging_module.auth_logger.name == initial_logger_name
-
-
-class TestLogAuthEventSecondLogger:
-    """Tests for the optional second_logger parameter."""
 
     def test_logs_to_second_logger_when_provided(self, caplog):
         """Verify that message is logged to both auth_logger and second_logger."""
@@ -124,12 +140,10 @@ class TestLogAuthEventSecondLogger:
         with caplog.at_level(logging.INFO):
             log_auth_event("Dual logger message", second_logger=second_logger)
 
-        # Should have logs from both loggers
         logger_names = [r.name for r in caplog.records]
         assert 'ansible_base.auth_audit' in logger_names
         assert 'test.second.logger' in logger_names
 
-        # Both should have the same message
         messages = [r.message for r in caplog.records]
         assert messages.count("Dual logger message") == 2
 
@@ -138,7 +152,6 @@ class TestLogAuthEventSecondLogger:
         with caplog.at_level(logging.INFO):
             log_auth_event("Single logger message", second_logger=None)
 
-        # Should only have one log record
         assert len(caplog.records) == 1
         assert caplog.records[0].name == 'ansible_base.auth_audit'
 
@@ -147,7 +160,6 @@ class TestLogAuthEventSecondLogger:
         with caplog.at_level(logging.INFO):
             log_auth_event("Default single logger message")
 
-        # Should only have one log record
         assert len(caplog.records) == 1
         assert caplog.records[0].name == 'ansible_base.auth_audit'
 
@@ -173,14 +185,9 @@ class TestLogAuthEventSecondLogger:
 
         logger_names = [r.name for r in caplog.records]
 
-        # Should have auth_logger twice plus each second logger once
         assert logger_names.count('ansible_base.auth_audit') == 2
         assert logger_names.count('logger.a') == 1
         assert logger_names.count('logger.b') == 1
-
-
-class TestLogAuthEventEdgeCases:
-    """Tests for edge cases and boundary conditions."""
 
     def test_multiple_calls_all_logged(self, caplog):
         """Verify that multiple consecutive calls all result in logged messages."""
@@ -195,7 +202,7 @@ class TestLogAuthEventEdgeCases:
 
     def test_logs_long_message(self, caplog):
         """Verify that very long messages are logged correctly."""
-        long_message = "A" * 10000  # 10,000 character message
+        long_message = "A" * 10000
 
         with caplog.at_level(logging.INFO, logger='ansible_base.auth_audit'):
             log_auth_event(long_message)
@@ -204,20 +211,13 @@ class TestLogAuthEventEdgeCases:
 
     def test_auth_logger_global_state_isolation(self):
         """Verify the global auth_logger can be properly reset for test isolation."""
-        # The autouse fixture should have reset it
         assert logging_module.auth_logger is None
 
-        # After a call, it should be set
         log_auth_event("Test")
         assert logging_module.auth_logger is not None
 
-        # Manually reset (simulating what the fixture does)
         logging_module.auth_logger = None
         assert logging_module.auth_logger is None
-
-
-class TestLogAuthEventIntegration:
-    """Integration tests combining multiple features."""
 
     def test_custom_logger_name_with_second_logger(self, caplog):
         """Verify custom logger name works correctly with second_logger."""
@@ -250,3 +250,161 @@ class TestLogAuthEventIntegration:
 
         for msg in test_messages:
             assert msg in caplog.text
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_logs_to_auth_logger_mock(self, mock_get_auth_logger):
+        """Test that log_auth_event logs info to the auth logger using mocks."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+
+        log_auth_event("Test event message")
+
+        mock_auth_logger.info.assert_called_once_with("Test event message")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_logs_to_second_logger_mock(self, mock_get_auth_logger):
+        """Test that log_auth_event logs info to both auth logger and second logger using mocks."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+        mock_second_logger = mock.Mock()
+
+        log_auth_event("Test event message", second_logger=mock_second_logger)
+
+        mock_auth_logger.info.assert_called_once_with("Test event message")
+        mock_second_logger.info.assert_called_once_with("Test event message")
+
+
+class TestLogAuthWarning:
+    """Tests for log_auth_warning function."""
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_logs_to_auth_logger(self, mock_get_auth_logger):
+        """Test that log_auth_warning logs warning to the auth logger."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+
+        log_auth_warning("Test warning message")
+
+        mock_auth_logger.warning.assert_called_once_with("Test warning message")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_logs_to_second_logger(self, mock_get_auth_logger):
+        """Test that log_auth_warning logs warning to both auth logger and second logger."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+        mock_second_logger = mock.Mock()
+
+        log_auth_warning("Test warning message", second_logger=mock_second_logger)
+
+        mock_auth_logger.warning.assert_called_once_with("Test warning message")
+        mock_second_logger.warning.assert_called_once_with("Test warning message")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_only_logs_to_auth_logger_when_no_second_logger(self, mock_get_auth_logger):
+        """Test that log_auth_warning only logs to auth logger when second_logger is None."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+
+        log_auth_warning("Test warning message", second_logger=None)
+
+        mock_auth_logger.warning.assert_called_once_with("Test warning message")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_with_empty_message(self, mock_get_auth_logger):
+        """Test that log_auth_warning handles empty messages."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+
+        log_auth_warning("")
+
+        mock_auth_logger.warning.assert_called_once_with("")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_with_multiline_message(self, mock_get_auth_logger):
+        """Test that log_auth_warning handles multiline messages."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+        multiline_message = "Line 1\nLine 2\nLine 3"
+
+        log_auth_warning(multiline_message)
+
+        mock_auth_logger.warning.assert_called_once_with(multiline_message)
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_with_special_characters(self, mock_get_auth_logger):
+        """Test that log_auth_warning handles messages with special characters."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+        special_message = "Warning: User 'admin@example.com' failed auth {attempt: 3}"
+
+        log_auth_warning(special_message)
+
+        mock_auth_logger.warning.assert_called_once_with(special_message)
+
+
+class TestLogAuthException:
+    """Tests for log_auth_exception function."""
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_logs_to_auth_logger(self, mock_get_auth_logger):
+        """Test that log_auth_exception logs exception to the auth logger."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+
+        log_auth_exception("Test exception message")
+
+        mock_auth_logger.exception.assert_called_once_with("Test exception message")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_logs_to_second_logger(self, mock_get_auth_logger):
+        """Test that log_auth_exception logs exception to both auth logger and second logger."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+        mock_second_logger = mock.Mock()
+
+        log_auth_exception("Test exception message", second_logger=mock_second_logger)
+
+        mock_auth_logger.exception.assert_called_once_with("Test exception message")
+        mock_second_logger.exception.assert_called_once_with("Test exception message")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_only_logs_to_auth_logger_when_no_second_logger(self, mock_get_auth_logger):
+        """Test that log_auth_exception only logs to auth logger when second_logger is None."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+
+        log_auth_exception("Test exception message", second_logger=None)
+
+        mock_auth_logger.exception.assert_called_once_with("Test exception message")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_with_empty_message(self, mock_get_auth_logger):
+        """Test that log_auth_exception handles empty messages."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+
+        log_auth_exception("")
+
+        mock_auth_logger.exception.assert_called_once_with("")
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_with_multiline_message(self, mock_get_auth_logger):
+        """Test that log_auth_exception handles multiline messages."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+        multiline_message = "Error occurred:\nTraceback details\nMore info"
+
+        log_auth_exception(multiline_message)
+
+        mock_auth_logger.exception.assert_called_once_with(multiline_message)
+
+    @mock.patch("ansible_base.lib.logging.get_auth_logger")
+    def test_with_special_characters(self, mock_get_auth_logger):
+        """Test that log_auth_exception handles messages with special characters."""
+        mock_auth_logger = mock.Mock()
+        mock_get_auth_logger.return_value = mock_auth_logger
+        special_message = "Exception: Token 'abc-123' @ /api/v1/users/"
+
+        log_auth_exception(special_message)
+
+        mock_auth_logger.exception.assert_called_once_with(special_message)


### PR DESCRIPTION
adds more auth logs for the different log levels

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? add `log_auth_warning` and `log_auth_exception` logs.
- Why is this change needed? To maintain log levels of auth failures at what they were before and log to the unified auth logger

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
tox and tox-docker installed

### Steps to Test
1.  tox -e py311
2. 
3. 

### Expected Results
tests in `test_logging.py` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce centralized auth logging (info/warn/exception) with a configurable logger and update authentication to use it, adjusting messages and tests accordingly.
> 
> - **Logging**:
>   - Add `get_auth_logger()` and refactor `log_auth_event()` to support levels and optional `second_logger`.
>   - Introduce `log_auth_warning()` and `log_auth_exception()` helpers.
> - **Authentication**:
>   - Replace direct logger calls with `log_auth_warning`/`log_auth_exception` in `authentication/backend.py`.
>   - Update login success message to include authenticator `type`.
> - **Claims**:
>   - Use `log_auth_warning` when access is denied in `update_user_claims()` with authenticator context.
> - **Tests**:
>   - Add extensive tests for `get_auth_logger`, `log_auth_event`, `log_auth_warning`, and `log_auth_exception`.
>   - Update backend tests to assert new login message format and logging behavior; set mock authenticator `type` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ab0212a7ce828b3d55e8a676d3214e2609bbd57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->