### PR TITLE
Add docs index view and move Swagger to /docs/swagger/

### DIFF
--- a/ansible_base/api_documentation/urls.py
+++ b/ansible_base/api_documentation/urls.py
@@ -2,10 +2,12 @@ from django.urls import path
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 from ansible_base.api_documentation.apps import ApiDocumentationConfig
+from ansible_base.api_documentation.views import DocsRootView
 
 app_name = ApiDocumentationConfig.label
 api_version_urls = [
-    path('docs/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('docs/', DocsRootView.as_view(), name='docs-root'),
+    path('docs/swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('docs/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+    path('docs/schema/', SpectacularAPIView.as_view(), name='schema'),
 ]

--- a/ansible_base/api_documentation/views.py
+++ b/ansible_base/api_documentation/views.py
@@ -1,0 +1,19 @@
+from collections import OrderedDict
+
+from rest_framework import permissions
+from rest_framework.response import Response
+
+from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
+
+
+class DocsRootView(AnsibleBaseDjangoAppApiView):
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request, format=None):
+        '''Index of API documentation endpoints'''
+        data = OrderedDict()
+        data['swagger'] = get_relative_url('swagger-ui')
+        data['redoc'] = get_relative_url('redoc')
+        data['schema'] = get_relative_url('schema')
+        return Response(data)

--- a/docs/apps/api_documentation.md
+++ b/docs/apps/api_documentation.md
@@ -54,6 +54,12 @@ see the instructions in the [x_ai_description_guide](./ai_documentation/x_ai_des
 
 This feature includes URLs which you will get if you are using [dynamic urls](../..//Installation.md)
 
+The following endpoints are provided:
+- `docs/` - Index page listing available documentation endpoints
+- `docs/swagger/` - Swagger UI
+- `docs/redoc/` - ReDoc UI
+- `docs/schema/` - OpenAPI schema export
+
 If you want to manually add the urls without dynamic urls add the following to your urls.py:
 ```
 from ansible_base.api_documentation import urls

--- a/test_app/tests/api_documentation/test_views.py
+++ b/test_app/tests/api_documentation/test_views.py
@@ -1,0 +1,46 @@
+"""
+Tests for API documentation views.
+"""
+
+
+def test_docs_root_view_returns_index(unauthenticated_api_client):
+    """Test that the docs root endpoint returns an index of documentation endpoints."""
+    url = '/api/v1/docs/'
+    response = unauthenticated_api_client.get(url)
+
+    assert response.status_code == 200
+    data = response.data
+
+    # Verify all expected keys are present
+    assert 'swagger' in data
+    assert 'redoc' in data
+    assert 'schema' in data
+
+    # Verify URLs point to the correct endpoints
+    assert '/docs/swagger/' in data['swagger']
+    assert '/docs/redoc/' in data['redoc']
+    assert '/docs/schema/' in data['schema']
+
+
+def test_docs_root_view_allows_unauthenticated_access(unauthenticated_api_client):
+    """Test that the docs root endpoint is accessible without authentication."""
+    url = '/api/v1/docs/'
+    response = unauthenticated_api_client.get(url)
+
+    assert response.status_code == 200
+
+
+def test_swagger_ui_accessible(unauthenticated_api_client):
+    """Test that Swagger UI is accessible at the new URL."""
+    url = '/api/v1/docs/swagger/'
+    response = unauthenticated_api_client.get(url)
+
+    assert response.status_code == 200
+
+
+def test_redoc_accessible(unauthenticated_api_client):
+    """Test that ReDoc is accessible."""
+    url = '/api/v1/docs/redoc/'
+    response = unauthenticated_api_client.get(url)
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Description
- What is being changed?
  - Reorganized the API documentation URL structure so `/docs/` serves as an index page listing available documentation endpoints, rather than directly showing Swagger UI.
  - Swagger UI moved from `/docs/` to `/docs/swagger/`
  - Added a new `DocsRootView` that returns a DRF-style JSON response with links to swagger, redoc, and schema endpoints.

- Why is this change needed?
  - The previous URL structure was inconsistent - `/docs/` went directly to Swagger UI while `/docs/redoc/` and `/docs/schema/` were nested under it. This was confusing for API consumers.

- How does this change address the issue?
  - Now `/docs/` serves as a proper index/root endpoint that lists all available documentation options, making the URL hierarchy more intuitive and discoverable.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- A running instance of the test app with `ansible_base.api_documentation` enabled

### Steps to Test
1. Start the development server: `python manage.py runserver`
2. Navigate to `/api/v1/docs/`
3. Verify it returns a JSON response with links to swagger, redoc, and schema
4. Navigate to `/api/v1/docs/swagger/` and verify Swagger UI loads
5. Navigate to `/api/v1/docs/redoc/` and verify ReDoc loads
6. Navigate to `/api/v1/docs/schema/` and verify the OpenAPI schema is returned

### Expected Results
- `/api/v1/docs/` returns JSON: `{"swagger": "/api/v1/docs/swagger/", "redoc": "/api/v1/docs/redoc/", "schema": "/api/v1/docs/schema/"}`
- `/api/v1/docs/swagger/` displays Swagger UI
- `/api/v1/docs/redoc/` displays ReDoc
- `/api/v1/docs/schema/` returns OpenAPI schema

## Additional Context

### Required Actions
- [ ] Requires downstream repository changes
  - Any services that hardcode `/api/v1/docs/` expecting Swagger UI will need to update to `/api/v1/docs/swagger/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public API documentation routes (notably moving Swagger off `/docs/`), which may break consumers that hardcode the old URL; logic changes are otherwise small and covered by new tests.
> 
> **Overview**
> Reworks API documentation routing so `GET /docs/` is now a new unauthenticated JSON index (`DocsRootView`) linking to Swagger, ReDoc, and the OpenAPI schema.
> 
> Moves Swagger UI from `/docs/` to `/docs/swagger/` while keeping `/docs/redoc/` and `/docs/schema/` intact, and updates docs plus adds tests asserting the new endpoints and index response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c180ab7fd9e90472196de3fb20578b18b522ff74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured API documentation endpoints for improved accessibility and organization
  * New documentation root endpoint provides an index of available documentation resources
  * Separate dedicated endpoints for Swagger UI, ReDoc, and raw API schema

* **Documentation**
  * Updated API documentation guide with new endpoint information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->