### PR TITLE
AAP-60514 Pin xmlsec to 1.3.17 for python 3.12

### DIFF
--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -13,7 +13,7 @@ ldap-filter
 python3-saml
 tacacs_plus
 
-xmlsec
+xmlsec>=1.3.17  # Required for python 3.12
 
 # RADIUS Authenticator Plugin
 pyrad


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - The dependency xmlsec is pinned so it can be picked up by Konflux build
- Why is this change needed?
  - Konflux only reads the .in files and will not pickup latest version without pinning. Without pinning, Konflux will continue using previously used version.
- How does this change address the issue?
  - Konflux will pick the pinned version.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

No testing required.