### PR TITLE
AAP-60514 Add pinned lxml into requirements file for Konflux

### DIFF
--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -72,6 +72,7 @@ ldap-filter==1.0.1
     # via -r requirements/requirements_authentication.in
 lxml==6.0.2
     # via
+    #   -r requirements/requirements_authentication.in
     #   python3-saml
     #   xmlsec
 netaddr==1.3.0

--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -13,7 +13,8 @@ ldap-filter
 python3-saml
 tacacs_plus
 
-xmlsec>=1.3.17  # Required for python 3.12
+xmlsec>=1.3.17  # Required for python 3.12, pinned for Konflux
+lxml>=6.0.2     # Required for python 3.12, pinned for Konflux
 
 # RADIUS Authenticator Plugin
 pyrad


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
 - Added lxml into requirements file
- Why is this change needed?
  - In order for Konflux to notice the version, otherwise it will keep using older one, despite xmlsec having `lxml==6.0.2` in their requirements.txt.
- How does this change address the issue?
  - Konflux only reads the .in files and this will force it to use correct lxml version

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions

No testing required.