### PR TITLE
AAP-60703 Pin lxml and xmlsec to versions compatible with ubi9

### DIFF
--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -70,7 +70,7 @@ jwcrypto==1.5.6
     # via django-oauth-toolkit
 ldap-filter==1.0.1
     # via -r requirements/requirements_authentication.in
-lxml==6.0.2
+lxml==5.3.0
     # via
     #   -r requirements/requirements_authentication.in
     #   python3-saml
@@ -157,7 +157,7 @@ urllib3==2.6.1
     # via
     #   -r requirements/requirements_resource_registry.in
     #   requests
-xmlsec==1.3.17
+xmlsec==1.3.13
     # via
     #   -r requirements/requirements_authentication.in
     #   python3-saml

--- a/requirements/requirements_authentication.in
+++ b/requirements/requirements_authentication.in
@@ -13,8 +13,8 @@ ldap-filter
 python3-saml
 tacacs_plus
 
-xmlsec>=1.3.17  # Required for python 3.12, pinned for Konflux
-lxml>=6.0.2     # Required for python 3.12, pinned for Konflux
+xmlsec==1.3.13  # Required for python 3.12, pinned for compatibility with ubi9 base image
+lxml==5.3.0     # Required for python 3.12, pinned for compatibility with ubi9 base image
 
 # RADIUS Authenticator Plugin
 pyrad


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - Python dependencies lxml and xmlsec are pinned to versions that were tested and working in container based on  UBI9 base image
- Why is this change needed?
  - Using newer versions of these would require moving up to UBI10 image which also would force us to upgrade other dependencies like nginx, nodejs and postgresql!
- How does this change address the issue?
  - The specific versions of lxml and xmlsec have been tested and found working with container based on UBI9

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
Testing can only be done in components that depend on DAB and build a container.

