### PR TITLE
fix: Handle race condition in RoleDefinition.get_or_create

### DIFF
--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -6,6 +6,7 @@ from uuid import UUID
 # Django
 from django.conf import settings
 from django.db import connection, models, transaction
+from django.db.models import Count
 from django.db.models.functions import Cast
 from django.db.models.query import QuerySet
 from django.db.utils import IntegrityError
@@ -114,17 +115,43 @@ class RoleDefinitionManager(models.Manager):
             return assignment
 
     def get_or_create(self, permissions=(), defaults=None, **kwargs):
-        "Add extra feature on top of existing get_or_create to use permissions list"
+        """Add extra feature on top of existing get_or_create to use permissions list.
+
+        Uses PostgreSQL advisory lock to prevent race conditions when multiple
+        threads attempt to create roles with identical permission sets.
+        """
         if permissions:
             permissions = set(permissions)
-            for existing_rd in self.prefetch_related('permissions'):
+
+            # Generate deterministic lock ID from permission set
+            # Hash collision probability: ~1 in 2^31 (negligible)
+            lock_id = hash(frozenset(permissions)) % (2**31)
+
+            # NOTE: Caller must wrap in transaction.atomic() for advisory lock to work.
+            # pg_advisory_xact_lock is transaction-scoped - releases when transaction ends.
+            # Without outer transaction, lock acquires and releases immediately (no protection).
+            if connection.vendor == 'postgresql':
+                with connection.cursor() as cursor:
+                    cursor.execute('SELECT pg_advisory_xact_lock(%s)', [lock_id])
+            else:
+                logger.debug(f'Advisory lock skipped - {connection.vendor} does not support pg_advisory_xact_lock')
+
+            # Check for existing role with matching permissions
+            # Filter candidates by permission count only - do NOT filter on permissions__codename__in
+            target_count = len(permissions)
+            candidates = self.annotate(perm_count=Count('permissions')).filter(perm_count=target_count).prefetch_related('permissions')
+
+            for existing_rd in candidates:
                 existing_set = {perm.codename for perm in existing_rd.permissions.all()}
                 if existing_set == permissions:
                     return (existing_rd, False)
+
+            # No match found, create new role
             create_kwargs = kwargs.copy()
             if defaults:
                 create_kwargs.update(defaults)
             return (self.create_from_permissions(permissions=permissions, **create_kwargs), True)
+
         return super().get_or_create(defaults=defaults, **kwargs)
 
     def create_from_permissions(self, permissions=(), **kwargs):
@@ -144,8 +171,14 @@ class RoleDefinitionManager(models.Manager):
 
         validate_permissions_for_model(perm_list, ct, managed=kwargs.get('managed', False))
 
-        rd = self.create(**kwargs)
-        rd.permissions.add(*perm_list)
+        # Use get_or_create to handle IntegrityError from concurrent name collisions
+        # This is a safety net - the advisory lock in get_or_create() should prevent
+        # most conflicts, but direct calls to this method may still race.
+        rd, created = super(RoleDefinitionManager, self).get_or_create(**kwargs)
+        if created:
+            rd.permissions.add(*perm_list)
+        else:
+            logger.debug(f'Reused existing RoleDefinition {rd.id} due to name collision')
         return rd
 
 

--- a/test_app/tests/rbac/models/test_role_definition.py
+++ b/test_app/tests/rbac/models/test_role_definition.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from rest_framework.exceptions import ValidationError
 
@@ -5,6 +7,100 @@ from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import DABContentType, DABPermission, ObjectRole, RoleDefinition, RoleEvaluation
 from ansible_base.rbac.validators import validate_permissions_for_model
 from test_app.models import ExampleEvent, Organization
+
+
+@pytest.mark.django_db
+def test_get_or_create_different_permission_count():
+    """Roles with different permission counts should not be matched."""
+    rd1, created1 = RoleDefinition.objects.get_or_create(permissions=['view_inventory', 'change_inventory'], name='two-perm-role')
+    assert created1
+
+    rd2, created2 = RoleDefinition.objects.get_or_create(permissions=['view_inventory', 'change_inventory', 'delete_inventory'], name='three-perm-role')
+    assert created2 and rd2.id != rd1.id
+
+
+@pytest.mark.django_db
+def test_get_or_create_same_count_different_permissions():
+    """Roles with same count but different permissions should not be matched."""
+    rd1, created1 = RoleDefinition.objects.get_or_create(permissions=['view_inventory', 'change_inventory'], name='view-change-role')
+    assert created1
+
+    rd2, created2 = RoleDefinition.objects.get_or_create(permissions=['view_inventory', 'delete_inventory'], name='view-delete-role')
+    assert created2 and rd2.id != rd1.id
+
+
+@pytest.mark.django_db
+def test_create_from_permissions_reuses_on_name_collision():
+    """create_from_permissions reuses existing role on name collision instead of raising IntegrityError."""
+    permissions = ['view_organization', 'change_organization']
+    rd1 = RoleDefinition.objects.create_from_permissions(permissions=permissions, name='collision-test-role')
+
+    rd2 = RoleDefinition.objects.create_from_permissions(permissions=permissions, name='collision-test-role')
+    assert rd2.id == rd1.id
+
+
+@pytest.mark.django_db
+def test_get_or_create_without_permissions_uses_parent():
+    """get_or_create without permissions falls back to standard Django get_or_create by name."""
+    rd1, created1 = RoleDefinition.objects.get_or_create(name='no-perm-role-1')
+    assert created1
+
+    rd2, created2 = RoleDefinition.objects.get_or_create(name='no-perm-role-1')
+    assert (not created2) and rd2.id == rd1.id
+
+
+@pytest.mark.django_db
+def test_get_or_create_with_defaults():
+    """Defaults parameter is properly applied when creating new role."""
+    rd1, created = RoleDefinition.objects.get_or_create(permissions=['view_inventory'], name='defaults-test-role', defaults={'description': 'Test description'})
+    assert created and rd1.description == 'Test description'
+
+
+@pytest.mark.django_db
+def test_get_or_create_non_postgresql_skips_advisory_lock():
+    """Advisory lock is skipped for non-PostgreSQL databases with debug logging."""
+    with patch('ansible_base.rbac.models.role.connection') as mock_connection:
+        mock_connection.vendor = 'sqlite'
+        with patch('ansible_base.rbac.models.role.logger') as mock_logger:
+            rd, created = RoleDefinition.objects.get_or_create(permissions=['view_inventory'], name='sqlite-test-role')
+            assert created
+            # Verify debug log was called for non-PostgreSQL fallback
+            mock_logger.debug.assert_called_once()
+            assert 'sqlite' in str(mock_logger.debug.call_args)
+            assert 'pg_advisory_xact_lock' in str(mock_logger.debug.call_args)
+
+
+@pytest.mark.django_db
+def test_create_from_permissions_logs_reuse():
+    """create_from_permissions logs debug message when reusing existing role."""
+    permissions = ['view_organization', 'change_organization']
+    rd1 = RoleDefinition.objects.create_from_permissions(permissions=permissions, name='log-reuse-test-role')
+
+    with patch('ansible_base.rbac.models.role.logger') as mock_logger:
+        rd2 = RoleDefinition.objects.create_from_permissions(permissions=permissions, name='log-reuse-test-role')
+        assert rd2.id == rd1.id
+        # Verify debug log was called for reuse
+        mock_logger.debug.assert_called()
+        log_message = str(mock_logger.debug.call_args)
+        assert 'Reused existing RoleDefinition' in log_message
+
+
+@pytest.mark.django_db
+def test_get_or_create_generates_deterministic_lock_id():
+    """Lock ID is generated deterministically from permission set (order-independent)."""
+    # Same permissions in different order should generate the same lock ID
+    permissions_a = ['view_inventory', 'change_inventory']
+    permissions_b = ['change_inventory', 'view_inventory']
+
+    # Hash of frozenset should be the same regardless of order
+    lock_id_a = hash(frozenset(permissions_a)) % (2**31)
+    lock_id_b = hash(frozenset(permissions_b)) % (2**31)
+    assert lock_id_a == lock_id_b
+
+    # Different permissions should generate different lock IDs
+    permissions_c = ['view_inventory', 'delete_inventory']
+    lock_id_c = hash(frozenset(permissions_c)) % (2**31)
+    assert lock_id_a != lock_id_c
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Jira Bug: [AAP-60238](https://issues.redhat.com/browse/AAP-60238) Error when creating EDA project by multiple users

## Description
Fixes a race condition in RoleDefinition.get_or_create() that caused duplicate roles with identical names when multiple threads created roles concurrently.
- Add PostgreSQL advisory lock to prevent duplicate roles
- Handle IntegrityError from concurrent name collisions

This is an update to: https://github.com/ansible/django-ansible-base/pull/909

Assisted by: Claude Code

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment