### PR TITLE
fix(AAP-62151): feature flag restore

### DIFF
--- a/ansible_base/feature_flags/utils.py
+++ b/ansible_base/feature_flags/utils.py
@@ -52,6 +52,7 @@ def load_feature_flags():
     """
     Loads in all feature flags into the database. Updates them if necessary.
     """
+    from ansible_base.resource_registry.models import Resource
     from ansible_base.resource_registry.signals.handlers import no_reverse_sync
 
     feature_flags_model = apps.get_model('dab_feature_flags', 'AAPFlag')
@@ -64,7 +65,12 @@ def load_feature_flags():
                 if hasattr(settings, flag['name']):
                     flag['value'] = getattr(settings, flag['name'])
                 feature_flag = feature_flags_model(**flag)
-            feature_flag.full_clean()
+            try:
+                feature_flag.full_clean()
+            except Resource.DoesNotExist:
+                # Resource may not exist yet during restore scenarios.
+                # This is safe to ignore - the resource will be created when the flag is saved.
+                logger.info(f"Resource not found for feature flag: {flag['name']} during validation, will be created on save")
             with no_reverse_sync():
                 feature_flag.save()
         except ValidationError as e:

--- a/test_app/tests/feature_flags/test_utils.py
+++ b/test_app/tests/feature_flags/test_utils.py
@@ -349,6 +349,77 @@ class TestCreateInitialData:
         mock_created_instance.save.assert_not_called()
 
     @pytest.mark.django_db
+    def test_load_feature_flags_handles_resource_does_not_exist_during_full_clean(
+        self, mock_apps_get_model, mock_aap_flag_model_cls, mock_settings, mock_logger, mock_feature_flags_list, mocker
+    ):
+        """Test that Resource.DoesNotExist during full_clean is caught and logged, allowing save to proceed."""
+        from ansible_base.feature_flags.utils import create_initial_data
+        from ansible_base.resource_registry.models import Resource
+
+        flag_def = {'name': 'RESTORE_FLAG', 'condition': 'restore_cond', 'ui_name': 'Restore Flag'}
+        mock_feature_flags_list.return_value = [flag_def]
+
+        mock_empty_queryset = MagicMock()
+        mock_empty_queryset.first.return_value = None
+        mock_empty_queryset.__bool__ = lambda self: False
+        mock_aap_flag_model_cls.objects.filter.return_value = mock_empty_queryset
+
+        mock_created_instance = MockAAPFlagInstance(**flag_def)
+        # Simulate Resource.DoesNotExist being raised during full_clean (restore scenario)
+        mock_created_instance.full_clean.side_effect = Resource.DoesNotExist("Resource matching query does not exist.")
+
+        mock_aap_flag_model_cls.side_effect = [mock_created_instance]
+
+        mock_aap_flag_model_cls.objects.all.return_value = []
+
+        create_initial_data()
+
+        # Verify the info log was called for the Resource.DoesNotExist case
+        mock_logger.info.assert_called_with("Resource not found for feature flag: RESTORE_FLAG during validation, will be created on save")
+        # Verify that save was still called despite the exception
+        mock_created_instance.save.assert_called_once()
+        # Verify no error was logged
+        mock_logger.error.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_load_feature_flags_handles_resource_does_not_exist_during_update(
+        self, mock_apps_get_model, mock_aap_flag_model_cls, mock_settings, mock_logger, mock_feature_flags_list, mocker
+    ):
+        """Test that Resource.DoesNotExist during full_clean is caught when updating an existing flag."""
+        from ansible_base.feature_flags.utils import create_initial_data
+        from ansible_base.resource_registry.models import Resource
+
+        flag_def = {'name': 'EXISTING_RESTORE_FLAG', 'condition': 'restore_cond', 'ui_name': 'Updated Name'}
+        mock_feature_flags_list.return_value = [flag_def]
+
+        # Create an existing flag in the database
+        existing_db_flag = MockAAPFlagInstance(
+            name='EXISTING_RESTORE_FLAG',
+            condition='restore_cond',
+            ui_name='Old Name',
+        )
+        # Simulate Resource.DoesNotExist being raised during full_clean (restore scenario)
+        existing_db_flag.full_clean.side_effect = Resource.DoesNotExist("Resource matching query does not exist.")
+
+        mock_existing_queryset = MagicMock()
+        mock_existing_queryset.first.return_value = existing_db_flag
+        mock_existing_queryset.__bool__ = lambda self: True
+        mock_aap_flag_model_cls.objects.filter.return_value = mock_existing_queryset
+
+        mock_aap_flag_model_cls.objects.all.return_value = [existing_db_flag]
+
+        create_initial_data()
+
+        # Verify the info log was called for the Resource.DoesNotExist case
+        mock_logger.info.assert_called_with("Resource not found for feature flag: EXISTING_RESTORE_FLAG during validation, will be created on save")
+        # Verify that save was still called despite the exception
+        existing_db_flag.save.assert_called_once()
+        # Verify the flag was updated
+        assert existing_db_flag.ui_name == 'Updated Name'
+        # Verify no error was logged
+        mock_logger.error.assert_not_called()
+
+    @pytest.mark.django_db
     def test_purge_feature_flags_removes_obsolete_flag(self, mock_apps_get_model, mock_aap_flag_model_cls, mock_logger, mock_feature_flags_list):
         from ansible_base.feature_flags.utils import create_initial_data
 


### PR DESCRIPTION
## Description
- What is being changed?
Updates load feature flag method to ensure restore successfully completes.
- Why is this change needed?
AAP Restore is currently broken.
- How does this change address the issue?
Bypasses the exception, so restore can succeed. `full_clean` is not necessary on restore scenarios.

**If I'm not mistaken the AWX CI failure is unrelated here**

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Reproduce Bug using aap-dev
1. `export AAP_VERSION=2.6`
2. `make aap`
3. Deployment succeeds
4. Cancel out of deployment
5. `make aap` again
6. Deployment fails with error -
```
  File "/usr/lib/python3.11/site-packages/ansible_base/feature_flags/utils.py", line 32, in create_initial_data
    load_feature_flags()
  File "/usr/lib/python3.11/site-packages/ansible_base/feature_flags/utils.py", line 67, in load_feature_flags
    feature_flag.full_clean()
  File "/usr/lib/python3.11/site-packages/django/db/models/base.py", line 1470, in full_clean
    self.clean_fields(exclude=exclude)
  File "/usr/lib/python3.11/site-packages/django/db/models/base.py", line 1518, in clean_fields
    raw_value = getattr(self, f.attname)
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/django/db/models/fields/related_descriptors.py", line 236, in __get__
    rel_obj = self.get_object(instance)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/django/db/models/fields/related_descriptors.py", line 366, in get_object
    return super().get_object(instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/django/db/models/fields/related_descriptors.py", line 199, in get_object
    return qs.get(self.field.get_reverse_related_filter(instance))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/django/db/models/query.py", line 639, in get
    raise self.model.DoesNotExist(
ansible_base.resource_registry.models.resource.Resource.DoesNotExist: Resource matching query does not exist.
```

### Steps to test this fix using aap-dev
1. `export AAP_VERSION=2.6`
2. `make configure-sources` and use this DAB branch
3. `make aap`
4. Deployment succeeds
5. Cancel out of deployment
6. `make aap` again
7. Deployment succeeds

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
