### PR TITLE
[AAP-55910] Corrects OAuth2_Authentication securityScheme in openapi spec

### DIFF
--- a/ansible_base/api_documentation/apps.py
+++ b/ansible_base/api_documentation/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
-from ansible_base.api_documentation.customizations import apply_authentication_customizations
+from ansible_base.api_documentation.customizations import apply_authentication_customizations, apply_oauth2_customizations
 
 
 class ApiDocumentationConfig(AppConfig):
@@ -13,6 +13,9 @@ class ApiDocumentationConfig(AppConfig):
 
         if 'ansible_base.authentication' in settings.INSTALLED_APPS:
             apply_authentication_customizations()
+
+        if 'ansible_base.oauth2_provider' in settings.INSTALLED_APPS:
+            apply_oauth2_customizations()
 
         # Import filter extensions to register them with drf-spectacular
         if 'ansible_base.rest_filters' in settings.INSTALLED_APPS and 'ansible_base.api_documentation' in settings.INSTALLED_APPS:

--- a/ansible_base/api_documentation/customizations.py
+++ b/ansible_base/api_documentation/customizations.py
@@ -14,3 +14,43 @@ def apply_authentication_customizations() -> None:
     class MyAuthenticationScheme(SessionScheme):
         target_class = SessionAuthentication
         name = 'SessionAuthentication'
+
+
+def apply_oauth2_customizations() -> None:
+    """Register OAuth2 authentication extension for schema generation"""
+    try:
+        from drf_spectacular.extensions import OpenApiAuthenticationExtension
+        from drf_spectacular.openapi import AutoSchema
+        from drf_spectacular.settings import spectacular_settings
+
+        from ansible_base.oauth2_provider.authentication import LoggedOAuth2Authentication
+
+    except ImportError:
+        # If dependencies aren't available, skip OAuth2 schema registration
+        return
+
+    class OAuth2Scheme(OpenApiAuthenticationExtension):
+        """OAuth2 authentication scheme for LoggedOAuth2Authentication
+
+        We must define a custom OpenApiAuthenticationExtension subclass, as
+        drf-spectacular's built-in OAuth2 extension only targets the base OAuth2Authentication class
+        Reads configuration from SPECTACULAR_SETTINGS OAUTH2_* keys.
+        """
+
+        target_class = LoggedOAuth2Authentication
+        name = 'OAuth2_Authentication'
+        priority = 1  # Needed to prevent built-in extensions overwriting the definition
+
+        def get_security_definition(self, auto_schema: AutoSchema):
+            flows = {}
+            for flow_type in spectacular_settings.OAUTH2_FLOWS:
+                flows[flow_type] = {}
+                if flow_type in ('implicit', 'authorizationCode'):
+                    flows[flow_type]['authorizationUrl'] = spectacular_settings.OAUTH2_AUTHORIZATION_URL
+                if flow_type in ('password', 'clientCredentials', 'authorizationCode'):
+                    flows[flow_type]['tokenUrl'] = spectacular_settings.OAUTH2_TOKEN_URL
+                if spectacular_settings.OAUTH2_REFRESH_URL:
+                    flows[flow_type]['refreshUrl'] = spectacular_settings.OAUTH2_REFRESH_URL
+                flows[flow_type]['scopes'] = spectacular_settings.OAUTH2_SCOPES or {}
+
+            return {'type': 'oauth2', 'flows': flows}

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -20,13 +20,6 @@ DEFAULT_SPECTACULAR_SETTINGS = {
     'PREPROCESSING_HOOKS': [
         'ansible_base.api_documentation.preprocessing_hooks.collect_ai_description_metadata',
     ],
-    'OAUTH2_FLOWS': ['authorizationCode', 'password'],
-    'OAUTH2_AUTHORIZATION_URL': '/o/authorize/',
-    'OAUTH2_TOKEN_URL': '/o/token/',
-    'OAUTH2_SCOPES': {
-        'read': 'Read access to resources',
-        'write': 'Write access to resources (includes read)',
-    },
     'POSTPROCESSING_HOOKS': [
         'ansible_base.api_documentation.postprocessing_hooks.add_x_ai_description',
     ],
@@ -298,6 +291,18 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
         oauth2_authentication_class = 'ansible_base.oauth2_provider.authentication.LoggedOAuth2Authentication'
         if oauth2_authentication_class not in rest_framework['DEFAULT_AUTHENTICATION_CLASSES']:
             rest_framework['DEFAULT_AUTHENTICATION_CLASSES'].insert(0, oauth2_authentication_class)
+
+        # OAuth2 OpenAPI schema settings (only apply when oauth2_provider is installed)
+        spectacular_settings.setdefault('OAUTH2_FLOWS', ['authorizationCode', 'password'])
+        spectacular_settings.setdefault('OAUTH2_AUTHORIZATION_URL', '/o/authorize/')
+        spectacular_settings.setdefault('OAUTH2_TOKEN_URL', '/o/token/')
+        spectacular_settings.setdefault(
+            'OAUTH2_SCOPES',
+            {
+                'read': 'Read access to resources',
+                'write': 'Write access to resources (includes read)',
+            },
+        )
 
         # These have to be defined for the migration to function
         dab_data['OAUTH2_PROVIDER_APPLICATION_MODEL'] = DEFAULT_OAUTH2_APPLICATION_MODEL

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -20,6 +20,13 @@ DEFAULT_SPECTACULAR_SETTINGS = {
     'PREPROCESSING_HOOKS': [
         'ansible_base.api_documentation.preprocessing_hooks.collect_ai_description_metadata',
     ],
+    'OAUTH2_FLOWS': ['authorizationCode', 'password'],
+    'OAUTH2_AUTHORIZATION_URL': '/o/authorize/',
+    'OAUTH2_TOKEN_URL': '/o/token/',
+    'OAUTH2_SCOPES': {
+        'read': 'Read access to resources',
+        'write': 'Write access to resources (includes read)',
+    },
     'POSTPROCESSING_HOOKS': [
         'ansible_base.api_documentation.postprocessing_hooks.add_x_ai_description',
     ],

--- a/test_app/tests/api_documentation/test_customizations.py
+++ b/test_app/tests/api_documentation/test_customizations.py
@@ -20,7 +20,7 @@ def test_oauth2_scheme_type_is_oauth2_not_apikey():
 
     from ansible_base.oauth2_provider.authentication import LoggedOAuth2Authentication
 
-    # Find the OAuth2 scheme registered by apps.py
+    # Intentionally access _registry to verify OAuth2Scheme is registered with expected attributes
     oauth2_schemes = [
         ext for ext in OpenApiAuthenticationExtension._registry if hasattr(ext, 'target_class') and ext.target_class == LoggedOAuth2Authentication
     ]
@@ -47,6 +47,7 @@ def test_oauth2_scheme_includes_configured_flows():
 
     from ansible_base.oauth2_provider.authentication import LoggedOAuth2Authentication
 
+    # Intentionally access _registry to verify OAuth2Scheme is registered with expected attributes
     oauth2_schemes = [
         ext for ext in OpenApiAuthenticationExtension._registry if hasattr(ext, 'target_class') and ext.target_class == LoggedOAuth2Authentication
     ]

--- a/test_app/tests/api_documentation/test_customizations.py
+++ b/test_app/tests/api_documentation/test_customizations.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for api_documentation customizations.
+
+Tests the OAuth2 security scheme customization that allows the
+LoggedOAuth2Authentication to leverage the OAuth2 customization settings.
+These change allow the OAuth2Authentication securityScheme to be listed as
+'oauth2' instead of 'apiKey'.
+"""
+
+from unittest.mock import MagicMock
+
+
+def test_oauth2_scheme_type_is_oauth2_not_apikey():
+    """Test OAuth2Scheme returns type 'oauth2' instead of 'apiKey'.
+
+    drf-spectacular auto-detects OAuth2Authentication as 'apiKey',
+    but the method overrides it to the correct definition.
+    """
+    from drf_spectacular.extensions import OpenApiAuthenticationExtension
+
+    from ansible_base.oauth2_provider.authentication import LoggedOAuth2Authentication
+
+    # Find the OAuth2 scheme registered by apps.py
+    oauth2_schemes = [
+        ext for ext in OpenApiAuthenticationExtension._registry if hasattr(ext, 'target_class') and ext.target_class == LoggedOAuth2Authentication
+    ]
+    assert len(oauth2_schemes) >= 1, "OAuth2_Authentication should be registered"
+
+    # Get the first matching scheme
+    oauth2_scheme_cls = oauth2_schemes[0]
+    assert oauth2_scheme_cls.name == 'OAuth2_Authentication'
+
+    # Instantiate and get security definition
+    oauth2_scheme = oauth2_scheme_cls(target=LoggedOAuth2Authentication)
+    # Use MagicMock for auto_schema parameter
+    security_def = oauth2_scheme.get_security_definition(auto_schema=MagicMock())
+
+    # CRITICAL: Must be 'oauth2', not 'apiKey'
+    assert security_def['type'] == 'oauth2', "OAuth2 security scheme must have type 'oauth2', not 'apiKey'"
+    assert 'flows' in security_def
+
+
+def test_oauth2_scheme_includes_configured_flows():
+    """Test get_security_definition includes flows from SPECTACULAR_SETTINGS."""
+    from django.conf import settings
+    from drf_spectacular.extensions import OpenApiAuthenticationExtension
+
+    from ansible_base.oauth2_provider.authentication import LoggedOAuth2Authentication
+
+    oauth2_schemes = [
+        ext for ext in OpenApiAuthenticationExtension._registry if hasattr(ext, 'target_class') and ext.target_class == LoggedOAuth2Authentication
+    ]
+    oauth2_scheme = oauth2_schemes[0](target=LoggedOAuth2Authentication)
+    security_def = oauth2_scheme.get_security_definition(auto_schema=MagicMock())
+
+    flows = security_def['flows']
+    configured_flows = settings.SPECTACULAR_SETTINGS['OAUTH2_FLOWS']
+
+    for flow_type in configured_flows:
+        assert flow_type in flows
+        assert 'scopes' in flows[flow_type]
+
+        # Verify flow-specific URLs
+        if flow_type in ('implicit', 'authorizationCode'):
+            assert 'authorizationUrl' in flows[flow_type]
+        if flow_type in ('password', 'clientCredentials', 'authorizationCode'):
+            assert 'tokenUrl' in flows[flow_type]


### PR DESCRIPTION
Updates the OAuth2 securityScheme in the generated OpenAPI spec to more accurately the OAuth flow. It also includes the necessary endpoints for the authentication flow.

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
Introduces customizations so that our LoggedOAuth2Authentication class can be utilized with the drf-spectacular environment variables for OAuth2 settings. 

This change is requested as our specs are increasingly important as sources of truth for functionality, and as these specs are being ingested for AI related tooling. Being explicit with these endpoints and their uses should assist this tooling.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
I tested this with the local Gateway instance, but any component should be able to reproduce.

### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Start an instance of the server with this commit.
2. Navigate to the generated spec.
3. Confirm that the OAuth2_Authentication securityScheme (near the bottom of the file) shows `oauth2` as its type instead of `apiKey`. In addition, confirm that it includes the supported OAuth2 flows (authorizationCode and password).

### Expected Results
The OAuth2_Authentication flow in the generated OpenAPI spec should be correct

## Additional Context
At one point this PR was to also introduce the /o/* endpoints in the spec. After discussion with additional users, this was seen as less valuable. As such, that piece has been dropped from the PR. This PR is now focused solely on updating the OAuth2_Authentication securityScheme to include the proper type and flows.