### PR TITLE
[AAP-43413] FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED feature flag and OIDC endpoints

### DIFF
--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -52,3 +52,14 @@
   support_url: ''
   labels:
     - platform
+- name: FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED
+  ui_name: OIDC Workload Identity
+  visibility: False
+  condition: boolean
+  value: 'False'
+  support_level: TECHNOLOGY_PREVIEW
+  description: Enable identity provision of workloads using OIDC
+  support_url: ''
+  toggle_type: install-time
+  labels:
+    - platform

--- a/ansible_base/feature_flags/migrations/0003_manual_20260113.py
+++ b/ansible_base/feature_flags/migrations/0003_manual_20260113.py
@@ -1,0 +1,16 @@
+###
+# Addition of FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED
+###
+
+# FileHash: 53968cb50a7e8250c60abc96733d40c927fefd4ecd6389a2a5d3b121d07216a1
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+     dependencies = [
+         ('dab_feature_flags', '0002_manual_20251222'),
+     ]
+
+     operations = [
+     ]

--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path, re_path
+from flags.urls import flagged_re_path
 from oauth2_provider import views as oauth_views
 
 from ansible_base.lib.routers import AssociationResourceRouter
@@ -28,9 +29,25 @@ api_version_urls = [
     path('', include(router.urls)),
 ]
 
+FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED = 'FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'
+
+oauth_urls = [
+    re_path(r'^$', oauth2_provider_views.ApiOAuthAuthorizationRootView.as_view(), name='oauth_authorization_root_view'),
+    re_path(r"^authorize/$", oauth_views.AuthorizationView.as_view(), name="authorize"),
+    re_path(r"^token/$", oauth2_provider_views.TokenView.as_view(), name="token"),
+    re_path(r"^revoke_token/$", oauth_views.RevokeTokenView.as_view(), name="revoke-token"),
+    # OIDC endpoints - flag is checked at request time, returns 404 when disabled
+    flagged_re_path(
+        FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED,
+        r"^\.well-known/openid-configuration$",
+        oauth_views.ConnectDiscoveryInfoView.as_view(),
+        name="oidc-connect-discovery-info",
+    ),
+    flagged_re_path(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED, r"^\.well-known/jwks\.json$", oauth_views.JwksInfoView.as_view(), name="jwks-info"),
+    flagged_re_path(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED, r"^userinfo$", oauth_views.UserInfoView.as_view(), name="user-info"),
+]
+
+
 root_urls = [
-    re_path(r'^o/$', oauth2_provider_views.ApiOAuthAuthorizationRootView.as_view(), name='oauth_authorization_root_view'),
-    re_path(r"^o/authorize/$", oauth_views.AuthorizationView.as_view(), name="authorize"),
-    re_path(r"^o/token/$", oauth2_provider_views.TokenView.as_view(), name="token"),
-    re_path(r"^o/revoke_token/$", oauth_views.RevokeTokenView.as_view(), name="revoke-token"),
+    re_path(r"^o/", include((oauth_urls, 'oauth2_provider'))),
 ]

--- a/ansible_base/oauth2_provider/views/authorization_root.py
+++ b/ansible_base/oauth2_provider/views/authorization_root.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 
 from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import extend_schema
+from flags.state import flag_enabled
 from rest_framework import permissions
 from rest_framework.response import Response
 
@@ -8,6 +10,7 @@ from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 
 
+@extend_schema(exclude=True)
 class ApiOAuthAuthorizationRootView(AnsibleBaseDjangoAppApiView):
     permission_classes = (permissions.AllowAny,)
     name = _("API OAuth 2 Authorization Root")
@@ -16,7 +19,10 @@ class ApiOAuthAuthorizationRootView(AnsibleBaseDjangoAppApiView):
 
     def get(self, request, format=None):
         data = OrderedDict()
-        data['authorize'] = get_relative_url('authorize')
-        data['revoke_token'] = get_relative_url('revoke-token')
-        data['token'] = get_relative_url('token')
+        data['authorize'] = get_relative_url('oauth2_provider:authorize')
+        data['revoke_token'] = get_relative_url('oauth2_provider:revoke-token')
+        data['token'] = get_relative_url('oauth2_provider:token')
+        if flag_enabled("FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED"):
+            data['oidc-connect-discovery-info'] = get_relative_url('oauth2_provider:oidc-connect-discovery-info')
+            data['jwks-info'] = get_relative_url('oauth2_provider:jwks-info')
         return Response(data)

--- a/test_app/tests/oauth2_provider/views/test_authorization_root.py
+++ b/test_app/tests/oauth2_provider/views/test_authorization_root.py
@@ -1,3 +1,6 @@
+import pytest
+from flags.state import disable_flag, enable_flag
+
 from ansible_base.lib.utils.response import get_relative_url
 
 
@@ -5,8 +8,23 @@ def test_oauth2_provider_authorization_root_view(admin_api_client, unauthenticat
     """
     As an admin, accessing /o/ gives an index of oauth endpoints.
     """
-    url = get_relative_url("oauth_authorization_root_view")
+    url = get_relative_url("oauth2_provider:oauth_authorization_root_view")
     for client in (admin_api_client, unauthenticated_api_client, user_api_client):
         response = admin_api_client.get(url)
         assert response.status_code == 200
         assert 'authorize' in response.data
+
+
+@pytest.mark.django_db
+def test_oidc_endpoints_shown_when_flag_enabled(admin_api_client):
+    """
+    OIDC endpoints are shown when feature flag is enabled.
+    """
+    enable_flag("FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED")
+    try:
+        url = get_relative_url("oauth2_provider:oauth_authorization_root_view")
+        response = admin_api_client.get(url)
+        assert 'oidc-connect-discovery-info' in response.data
+        assert 'jwks-info' in response.data
+    finally:
+        disable_flag("FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED")

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -7,7 +7,7 @@ def test_oauth2_provider_authorize_view_as_admin(admin_api_client):
     """
     As an admin, accessing /o/authorize/ without client_id parameter should return a 400 error.
     """
-    url = get_relative_url("authorize")
+    url = get_relative_url("oauth2_provider:authorize")
     response = admin_api_client.get(url)
 
     assert response.status_code == 400
@@ -18,7 +18,7 @@ def test_oauth2_provider_authorize_view_anon(client, settings):
     """
     As an anonymous user, accessing /o/authorize/ should redirect to the login page.
     """
-    url = get_relative_url("authorize")
+    url = get_relative_url("oauth2_provider:authorize")
     response = client.get(url)
 
     assert response.status_code == 302
@@ -30,7 +30,7 @@ def test_oauth2_provider_authorize_view_flow(user_api_client, oauth2_application
     As a user, I should be able to complete the authorization flow and get an authorization code.
     """
     oauth2_application = oauth2_application[0]
-    url = get_relative_url("authorize")
+    url = get_relative_url("oauth2_provider:authorize")
     query_params = {
         'client_id': oauth2_application.client_id,
         'response_type': 'code',

--- a/test_app/tests/oauth2_provider/views/test_token.py
+++ b/test_app/tests/oauth2_provider/views/test_token.py
@@ -33,7 +33,7 @@ def test_oauth2_token_creation_disabled_for_external_accounts(
     AuthenticatorUser.objects.get_or_create(uid=user.username, user=user, provider=local_authenticator)
     app = oauth2_application_password[0]
     secret = oauth2_application_password[1]
-    url = get_relative_url('token')
+    url = get_relative_url('oauth2_provider:token')
     settings.ALLOW_OAUTH2_FOR_EXTERNAL_USERS = allow_oauth
     data = {
         'grant_type': 'password',
@@ -68,7 +68,7 @@ def test_oauth2_existing_token_enabled_for_external_accounts(
     AuthenticatorUser.objects.get_or_create(uid=user.username, user=user, provider=local_authenticator)
     app = oauth2_application_password[0]
     secret = oauth2_application_password[1]
-    url = get_relative_url('token')
+    url = get_relative_url('oauth2_provider:token')
     settings.ALLOW_OAUTH2_FOR_EXTERNAL_USERS = True
     data = {
         'grant_type': 'password',
@@ -125,7 +125,7 @@ def test_oauth2_pat_create_and_list(request, client_fixture, user_fixture):
 def test_oauth2_pat_creation(oauth2_application_password, user, unauthenticated_api_client):
     app = oauth2_application_password[0]
     secret = oauth2_application_password[1]
-    url = get_relative_url('token')
+    url = get_relative_url('oauth2_provider:token')
     data = {
         "grant_type": "password",
         "username": "user",
@@ -349,7 +349,7 @@ def test_oauth2_refresh_access_token(oauth2_application, oauth2_admin_access_tok
     refresh_token = oauth2_admin_access_token[2]
     refresh_token_obj = oauth2_admin_access_token[0].refresh_token
 
-    url = get_relative_url('token')
+    url = get_relative_url('oauth2_provider:token')
     data = {
         'grant_type': 'refresh_token',
         'refresh_token': refresh_token,
@@ -398,7 +398,7 @@ def test_oauth2_refresh_token_expiration_is_respected(oauth2_application, oauth2
     settings.OAUTH2_PROVIDER['AUTHORIZATION_CODE_EXPIRE_SECONDS'] = 1
     time.sleep(1)
 
-    url = get_relative_url('token')
+    url = get_relative_url('oauth2_provider:token')
     data = {
         'grant_type': 'refresh_token',
         'refresh_token': refresh_token,


### PR DESCRIPTION
## Description

* Support in DAB for a new feature flag `FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED`, disabled by default.
* View under `/o/` updated to display `/o/.well-known/jwks.json` and `/o/.well-known/openid-configuration` when the feature flag is enabled.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)


## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
See instructions under https://github.com/ansible-automation-platform/aap-gateway/pull/1200



