### PR TITLE
[AAP-60826] Fix serializer accessing DB when generating schema

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -87,7 +87,10 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         """
         super().__init__(*args, **kwargs)
         request = self.context.get('request')
-        if request:
+        # To satisfy schema generator (drf-spectacular) when database is not available
+        if self.context.get('swagger_fake_view', False):
+            qs = self.Meta.model._meta.get_field(self.actor_field).model.objects.none()
+        elif request:
             qs = self.get_actor_queryset(request.user)
         else:
             qs = self.Meta.model._meta.get_field(self.actor_field).model.objects.all()

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -176,6 +176,13 @@ class BaseAssignmentViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
         model = self.serializer_class.Meta.model
         return model.objects.prefetch_related(*self.prefetch_related, *assignment_prefetch_base)
 
+    def get_serializer_context(self):
+        """Add swagger_fake_view flag to context for serializer to use during schema generation."""
+        context = super().get_serializer_context()
+        if getattr(self, 'swagger_fake_view', False):
+            context['swagger_fake_view'] = True
+        return context
+
     def filter_queryset(self, qs):
         model = self.serializer_class.Meta.model
         if has_super_permission(self.request.user, 'view'):


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/AAP-60826

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
### What is being changed?
Fixes isses when generating openapi schema for controller. Specifically, when generating the schema without a live database, spectacular logs contained:

`Error [RoleUserAssignmentViewSet]: exception raised while getting serializer...(Exception: no such table: dab_rbac_dabcontenttype)`

The fix involves adding a serializer context field called "swagger_fake_view", and when initializing BaseAssignmentSerializer, return early when this field is set.

### Why is this change needed?
awx CI generates schema without a live, migrated database
`docker run --rm --workdir=/awx_devel ghcr.io/ansible/awx_devel:devel /start_tests.sh genschema`

### How does this change address the issue?
BaseAssignmentSerializer's init does queries. The fix is to return early if we are in the context of generating schema.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [x] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes drf-spectacular schema generation when no database is available.
> 
> - In `BaseAssignmentSerializer.__init__`, when `swagger_fake_view` is set in context, use `.objects.none()` for the actor field queryset to avoid DB hits
> - In `BaseAssignmentViewSet.get_serializer_context`, propagate `swagger_fake_view` to serializer context during schema generation
> - Minor docstrings/comments to clarify schema-generation behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee1a5d2bf98e3a3cbf03151819b389523032e51f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->