### PR TITLE
AAP-56032 Do not run feature flag logic for partial migrations

### DIFF
--- a/ansible_base/feature_flags/utils.py
+++ b/ansible_base/feature_flags/utils.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from flags.sources import get_flags
 
+from ansible_base.lib.utils.db import migrations_are_complete
+
 logger = logging.getLogger('ansible_base.feature_flags.utils')
 
 
@@ -87,6 +89,10 @@ def purge_feature_flags():
     If a feature flag has been removed from the platform flags list, purge it from the database.
     """
     from ansible_base.resource_registry.signals.handlers import no_reverse_sync
+
+    if not migrations_are_complete():
+        logger.debug('Not running purge_feature_flags logic because migrations not incomplete')
+        return
 
     all_flags = apps.get_model('dab_feature_flags', 'AAPFlag').objects.all()
     for flag in all_flags:

--- a/ansible_base/feature_flags/utils.py
+++ b/ansible_base/feature_flags/utils.py
@@ -57,6 +57,10 @@ def load_feature_flags():
     from ansible_base.resource_registry.models import Resource
     from ansible_base.resource_registry.signals.handlers import no_reverse_sync
 
+    if not migrations_are_complete():
+        logger.debug('Not running load_feature_flags logic because migrations not incomplete')
+        return
+
     feature_flags_model = apps.get_model('dab_feature_flags', 'AAPFlag')
     for flag in feature_flags_list():
         try:


### PR DESCRIPTION
## Description
Trying to test https://github.com/ansible/django-ansible-base/pull/916, I couldn't do this:

```
python manage.py migrate dab_rbac 0001
```

for

```
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/core/management/commands/migrate.py", line 380, in handle
    emit_post_migrate_signal(
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/core/management/sql.py", line 52, in emit_post_migrate_signal
    models.signals.post_migrate.send(
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/repos/django-ansible-base/ansible_base/feature_flags/utils.py", line 34, in create_initial_data
    load_feature_flags()
  File "/home/arominge/repos/django-ansible-base/ansible_base/feature_flags/utils.py", line 64, in load_feature_flags
    if existing_flag:
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 400, in __bool__
    self._fetch_all()
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 1954, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 93, in __iter__
    results = compiler.execute_sql(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/models/sql/compiler.py", line 1623, in execute_sql
    cursor.execute(sql, params)
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 122, in execute
    return super().execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/venvs/awx/lib64/python3.11/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
django.db.utils.ProgrammingError: relation "dab_feature_flags_aapflag" does not exist
LINE 1: ...t_url", "dab_feature_flags_aapflag"."labels" FROM "dab_featu...
```

Because the feature flags failed on non-existing table, which is bad practice.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents feature-flag DB operations during partial migrations.
> 
> - Add `migrations_are_complete()` guard in `load_feature_flags()` and `purge_feature_flags()` to early-return with a debug log
> - Avoids querying `dab_feature_flags.AAPFlag` when schema/tables aren’t ready during partial/incomplete migrations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c3a27c7822fa8556b81a3457fae5a24bfc86028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->