### PR TITLE
Add typing to inform spectacular of field details

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TypedDict
 
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
@@ -260,6 +261,16 @@ class RoleMetadataSerializer(serializers.Serializer):
     allowed_permissions = serializers.DictField(help_text=_('A List of permissions allowed for a role definition, given its content type.'))
 
 
+class RoleDefinitionSummary(TypedDict):
+    name: str
+    url: str
+
+
+class AssignmentSummary(TypedDict):
+    type: str
+    role_definition: RoleDefinitionSummary
+
+
 class AccessListMixin:
 
     def _get_related(self, obj) -> dict[str, str]:
@@ -286,11 +297,11 @@ class AccessListMixin:
         return related_fields
 
     @staticmethod
-    def summarize_role_definition(role_definition):
+    def summarize_role_definition(role_definition) -> RoleDefinitionSummary:
         return {"name": role_definition.name, "url": get_url_for_object(role_definition)}
 
     @staticmethod
-    def summarize_assignment_list(assignment_qs, obj_ct):
+    def summarize_assignment_list(assignment_qs, obj_ct) -> list[AssignmentSummary]:
         assignment_list = []
         team_ct = DABContentType.objects.get_for_model(get_team_model())
         for assignment in assignment_qs.distinct():
@@ -306,7 +317,7 @@ class AccessListMixin:
 
         return assignment_list
 
-    def get_object_role_assignments(self, actor):
+    def get_object_role_assignments(self, actor) -> list[AssignmentSummary]:
         obj = self.context.get("related_object")
         permission = self.context.get("permission")
         ct = self.context.get("content_type")
@@ -325,26 +336,26 @@ class AccessListMixin:
 class UserAccessListMixin(AccessListMixin, serializers.ModelSerializer):
     "controller uses auth.User model so this needs to be as compatible as possible, thus ModelSerializer"
 
-    object_role_assignments = serializers.SerializerMethodField()
+    object_role_assignments: list[AssignmentSummary] = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     related = serializers.SerializerMethodField('_get_related')
     _expected_fields = ['id', 'url', 'related', 'username', 'is_superuser', 'first_name', 'last_name', 'object_role_assignments']
 
 
 class TeamAccessListMixin(AccessListMixin, AbstractCommonModelSerializer):
-    object_role_assignments = serializers.SerializerMethodField()
+    object_role_assignments: list[AssignmentSummary] = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     related = serializers.SerializerMethodField('_get_related')
     _expected_fields = ['id', 'url', 'related', 'name', 'organization', 'object_role_assignments']
 
 
 class UserAccessAssignmentSerializer(RoleUserAssignmentSerializer):
-    intermediary_roles = serializers.SerializerMethodField()
+    intermediary_roles: list[AssignmentSummary] = serializers.SerializerMethodField()
 
     class Meta(RoleUserAssignmentSerializer.Meta):
         fields = RoleUserAssignmentSerializer.Meta.fields + ['intermediary_roles']
 
-    def get_intermediary_roles(self, assignment):
+    def get_intermediary_roles(self, assignment: RoleUserAssignment) -> list[AssignmentSummary]:
         team_ct = DABContentType.objects.get_for_model(get_team_model())
 
         permission = self.context.get("permission")


### PR DESCRIPTION
## Description
Working on https://github.com/ansible/django-ansible-base/pull/919

Saw

```
/home/arominge/repos/django-ansible-base/ansible_base/rbac/api/serializers.py:341: Warning [UserAccessAssignmentViewSet > UserAccessAssignmentSerializer]: unable to resolve type hint for function "get_intermediary_roles". Consider using a type hint or @extend_schema_field. Defaulting to string.
```

for later sanity

```
$ python manage.py spectacular 2>&1 | grep 'UserAccessAssignmentViewSet' | wc -l
4
```

after this change the warning goes away. And to wrap this up:

```
$ python manage.py spectacular 2>&1 | grep 'UserAccessAssignmentViewSet' | wc -l
3
```

formally addresses 1 warning. How many are left? For posterity:

```
$ python manage.py spectacular 2>&1 | wc -l
18718
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit typing to RBAC serializers to aid drf-spectacular and remove a schema warning.
> 
> - Introduces `TypedDict` types `RoleDefinitionSummary` and `AssignmentSummary` in `serializers.py`
> - Annotates return types for helpers like `summarize_role_definition`, `summarize_assignment_list`, and `get_object_role_assignments`
> - Adds typed `SerializerMethodField`s for `object_role_assignments` and `intermediary_roles`
> - Types `get_intermediary_roles(self, assignment: RoleUserAssignment) -> list[AssignmentSummary]`, addressing the prior unresolved type hint warning
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d7747e5977a4f5c836ab80a8fbccc5435d86064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->