### PR TITLE
AAP-58540 Remove the dispatcherd feature flag

### DIFF
--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -30,18 +30,6 @@
   toggle_type: install-time
   labels:
     - gateway
-- name: FEATURE_DISPATCHERD_ENABLED
-  ui_name: AAP Dispatcherd background tasking system
-  visibility: False
-  condition: boolean
-  value: 'False'
-  support_level: TECHNOLOGY_PREVIEW
-  description: A service to run python tasks in subprocesses, designed specifically to work well with pg_notify, but intended to be extensible to other message delivery means.
-  support_url: ''
-  toggle_type: install-time
-  labels:
-    - eda
-    - controller
 - name: FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED
   ui_name: Case Insensitive Authentication Maps
   visibility: False

--- a/ansible_base/feature_flags/migrations/0003_remove_dispatcherd_feature_flag.py
+++ b/ansible_base/feature_flags/migrations/0003_remove_dispatcherd_feature_flag.py
@@ -1,0 +1,17 @@
+###
+# Noop migration due to removal of FEATURE_DISPATCHERD_ENABLED
+###
+
+# FileHash: c86a753d9bf5999274a78c771e5fc23d9dde2fd6c6f630440d28477a658dcf7f
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dab_feature_flags', '0002_manual_20251222'),
+    ]
+
+    operations = [
+    ]

--- a/ansible_base/feature_flags/migrations/0004_remove_dispatcherd_feature_flag.py
+++ b/ansible_base/feature_flags/migrations/0004_remove_dispatcherd_feature_flag.py
@@ -2,7 +2,7 @@
 # Noop migration due to removal of FEATURE_DISPATCHERD_ENABLED
 ###
 
-# FileHash: c86a753d9bf5999274a78c771e5fc23d9dde2fd6c6f630440d28477a658dcf7f
+# FileHash: a85e30c0d37e6aeac8dc04b9dd37e7dc0d06a9793e85af00f01bef100165df6f
 
 from django.db import migrations
 

--- a/ansible_base/feature_flags/migrations/0004_remove_dispatcherd_feature_flag.py
+++ b/ansible_base/feature_flags/migrations/0004_remove_dispatcherd_feature_flag.py
@@ -10,7 +10,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dab_feature_flags', '0002_manual_20251222'),
+        ('dab_feature_flags', '0003_manual_20260113'),
     ]
 
     operations = [

--- a/test_app/tests/feature_flags/test_utils.py
+++ b/test_app/tests/feature_flags/test_utils.py
@@ -1,10 +1,15 @@
 import json
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 import yaml
+from django.apps import apps as django_apps
 from django.core.exceptions import ValidationError
+from django.db.models.signals import post_migrate
 from jsonschema import validate
+
+from ansible_base.feature_flags.models import AAPFlag
+from ansible_base.feature_flags.utils import create_initial_data, feature_flags_list
 
 MODULE_PATH = "ansible_base.feature_flags.utils"
 
@@ -137,6 +142,47 @@ def test_validate_flags_yaml_against_json_schema():
     except Exception as e:
         # If any other exception occurs (like a ValidationError), fail the test.
         pytest.fail(f"Validation failed unexpectedly for a valid file: {e}")
+
+
+@pytest.mark.django_db
+def test_dispatcherd_feature_flag_removed_after_post_migrate():
+    flag_name = 'FEATURE_DISPATCHERD_ENABLED'
+    removed_flag_def = {
+        'name': flag_name,
+        'ui_name': 'AAP Dispatcherd background tasking system',
+        'visibility': False,
+        'condition': 'boolean',
+        'value': 'False',
+        'support_level': 'TECHNOLOGY_PREVIEW',
+        'description': (
+            'A service to run python tasks in subprocesses, designed specifically to work well '
+            'with pg_notify, but intended to be extensible to other message delivery means.'
+        ),
+        'support_url': '',
+        'toggle_type': 'install-time',
+        'labels': ['eda', 'controller'],
+    }
+
+    current_flags = feature_flags_list()
+    assert not any(flag['name'] == flag_name for flag in current_flags)  # Sanity, we removed the flag from mainifest
+
+    with patch(f"{MODULE_PATH}.feature_flags_list", return_value=list(current_flags) + [removed_flag_def]):
+        create_initial_data()
+
+    assert AAPFlag.objects.filter(name=flag_name).exists()
+
+    # Run the normal post_migrate logic in the feature flags app
+    app_config = django_apps.get_app_config('dab_feature_flags')
+    post_migrate.send(
+        sender=app_config,
+        app_config=app_config,
+        apps=django_apps,
+        verbosity=0,
+        interactive=False,
+        using='default',
+    )
+
+    assert not AAPFlag.objects.filter(name=flag_name).exists()
 
 
 class TestCreateInitialData:


### PR DESCRIPTION
## Description
Blocked by https://github.com/ansible/awx/pull/16209

Will have its hashes ruffled up by https://github.com/ansible/django-ansible-base/pull/915

But that's just normal merge order of operations. Otherwise I think this looks to be in good shape.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the obsolete `FEATURE_DISPATCHERD_ENABLED` feature flag and verifies cleanup behavior.
> 
> - Deletes `FEATURE_DISPATCHERD_ENABLED` from `feature_flags.yaml`
> - Adds noop migration `0004_remove_dispatcherd_feature_flag.py` to reflect the removal
> - Adds a Django test that seeds the removed flag via `create_initial_data()` and asserts it’s purged on `post_migrate`; minor test scaffolding updates (imports/patching)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f032a8ab9dfa59a72cb7db2fdd1b9ebecf4bd2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->