### PR TITLE
AAP-63560 Allow not checking permission of remote objects, and do check in service-index

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -249,6 +249,8 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
         # API clients can create custom roles that change shared resources
         'ALLOW_SHARED_RESOURCE_CUSTOM_ROLES': False,
         'MANAGE_ORGANIZATION_AUTH': True,
+        # Enforce local permission checks for RemoteObject role assignments
+        'ANSIBLE_BASE_ENFORCE_REMOTE_OBJECT_PERMISSIONS': True,
         # Alternative to permission_registry.register
         'ANSIBLE_BASE_RBAC_MODEL_REGISTRY': {},
         'ORG_ADMINS_CAN_SEE_ALL_USERS': True,

--- a/ansible_base/rbac/policies.py
+++ b/ansible_base/rbac/policies.py
@@ -84,6 +84,8 @@ def check_content_obj_permission(request_user, obj) -> None:
     If that is not available, then we check all object-level permissions.
     """
     if isinstance(obj, RemoteObject):
+        if not get_setting('ANSIBLE_BASE_ENFORCE_REMOTE_OBJECT_PERMISSIONS', True):
+            return
         permissions = DABPermission.objects.filter(content_type=obj.content_type)
         for permission in permissions:
             if permission.codename.startswith('change'):

--- a/ansible_base/rbac/service_api/serializers.py
+++ b/ansible_base/rbac/service_api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 
 from ..api.fields import ActorAnsibleIdField
 from ..models import DABContentType, DABPermission, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
+from ..policies import check_content_obj_permission
 from ..remote import RemoteObject
 
 
@@ -113,6 +114,7 @@ class BaseAssignmentSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         rd = validated_data['role_definition']
         actor = validated_data[self.actor_field]
+        requesting_user = self.context['view'].request.user
 
         as_user = None
         if 'created_by' in validated_data:
@@ -140,6 +142,8 @@ class BaseAssignmentSerializer(serializers.ModelSerializer):
                 # Object role assignment
                 if not obj:
                     raise serializers.ValidationError({'object_id': _('Object must be specified for this role assignment')})
+
+                check_content_obj_permission(requesting_user, obj)
 
                 with transaction.atomic():
                     assignment = rd.give_permission(actor, obj)

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -201,6 +201,7 @@ def test_unassign_endpoint_for_team(team, org_inv_rd, inventory, admin_api_clien
 @pytest.mark.django_db
 def test_service_user_assignment_requires_object_permission(inv_rd, inventory, rando):
     requester = User.objects.create(username='service-requester')
+    rando.resource_api_actions = "*"  # specific to internal requests
     client = APIClient()
     client.force_authenticate(user=requester)
 
@@ -211,7 +212,7 @@ def test_service_user_assignment_requires_object_permission(inv_rd, inventory, r
     assert response.status_code == 403, response.data
 
     # Should still get a 403 even if assignment already exists
-    inv_rd.give_permission(requester, inventory)
+    inv_rd.give_permission(rando, inventory)
     response = client.post(url, data=data)
     assert response.status_code == 403, response.data
 

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import pytest
+from rest_framework.test import APIClient
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition
@@ -195,6 +196,24 @@ def test_unassign_endpoint_for_team(team, org_inv_rd, inventory, admin_api_clien
     response = admin_api_client.post(url, data)
     assert response.status_code == 200, response.data
     assert not rando.has_obj_perm(inventory, 'change')
+
+
+@pytest.mark.django_db
+def test_service_user_assignment_requires_object_permission(inv_rd, inventory, rando):
+    requester = User.objects.create(username='service-requester')
+    client = APIClient()
+    client.force_authenticate(user=requester)
+
+    url = get_relative_url('serviceuserassignment-assign')
+    data = {"role_definition": inv_rd.name, "user_ansible_id": str(rando.resource.ansible_id), "object_id": inventory.pk}
+
+    response = client.post(url, data=data)
+    assert response.status_code == 403, response.data
+
+    # Should still get a 403 even if assignment already exists
+    inv_rd.give_permission(requester, inventory)
+    response = client.post(url, data=data)
+    assert response.status_code == 403, response.data
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
I didn't want to create this PR here. I wanted to work on in the release branch and then forward-port. However, technical issues block that workflow from happening.

So I had to create this PR so that it can be a "Requires" of another PR. I have a more complete writeup of what this does in the Jira and the original PR but I have to have this so that it can be a dependency of other `devel` content here.

In language appropriate for devel, this gives the "resource server" sufficient knobs to defer checking permission on a remote object, if it intends to defer that check to a service it is interacting with. For this to work, the /service-index/ endpoint must check permissions when it receives a change to sync. This might also be good to make configurable, but I have not thought that far ahead yet.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authorization for service-index role assignment writes and introduces a new enforcement toggle; misconfiguration or unexpected permission denials could impact cross-service sync flows.
> 
> **Overview**
> Adds a new RBAC setting, `ANSIBLE_BASE_ENFORCE_REMOTE_OBJECT_PERMISSIONS`, defaulting to `True`, to allow deployments to skip *local* permission checks when assigning roles on `RemoteObject` instances.
> 
> Updates `service_api` role-assignment creation to explicitly run `check_content_obj_permission()` against the requesting user for object-scoped assignments, and adds a regression test ensuring `serviceuserassignment-assign` returns `403` when the requester lacks object permission (even if the assignment already exists).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca74689a21b25ec2cc2af23bf8e0dbcb55851e06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->