### PR TITLE
[AAP-64481] Remove double logging by eliminating second_logger parameter

### DIFF
--- a/ansible_base/authentication/backend.py
+++ b/ansible_base/authentication/backend.py
@@ -41,7 +41,7 @@ class AnsibleBaseAuth(ModelBackend):
             try:
                 user = authenticator_object.authenticate(request, *args, **kwargs)
             except Exception:
-                log_auth_exception(f"Exception raised while trying to authenticate with {authenticator_object.database_instance.name}", logger)
+                log_auth_exception(f"Exception raised while trying to authenticate with {authenticator_object.database_instance.name}")
                 continue
 
             # Social Auth pipeline can return status string when update_user_claims fails (authentication maps deny access)
@@ -52,16 +52,15 @@ class AnsibleBaseAuth(ModelBackend):
                 # The local authenticator handles this but we want to check this for other authentication types
                 if not getattr(user, 'is_active', True):
                     log_auth_warning(
-                        f'User {user.username} attempted to login from authenticator with ID "{authenticator_id}" their user is inactive, denying permission',
-                        logger,
+                        f'User {user.username} attempted to login from authenticator with ID "{authenticator_id}" their user is inactive, denying permission'
                     )
                     return None
 
-                log_auth_event(f'User {user.username} logged in from {authenticator_object.type} authenticator with ID "{authenticator_id}"', logger)
+                log_auth_event(f'User {user.username} logged in from {authenticator_object.type} authenticator with ID "{authenticator_id}"')
                 if hasattr(user, "last_login_from"):
                     user.last_login_from = authenticator_object.database_instance
                     user.save(update_fields=['last_login_from'])
                 return user
         provided_username = kwargs.get('username', 'Unknown')
-        log_auth_event(f"Authentication failed for username: {provided_username}", logger)
+        log_auth_event(f"Authentication failed for username: {provided_username}")
         return None

--- a/ansible_base/authentication/middleware.py
+++ b/ansible_base/authentication/middleware.py
@@ -50,5 +50,5 @@ class SocialExceptionHandlerMiddleware(SocialAuthExceptionMiddleware):
         error_url = strategy.setting("LOGIN_ERROR_URL")
         backend = getattr(request, "backend", None)
         backend_name = getattr(backend, "name", "unknown-backend")
-        log_auth_error(f"Auth failure for backend {backend_name} - {repr(exception)}, redirecting to {error_url}", logger)
+        log_auth_error(f"Auth failure for backend {backend_name} - {repr(exception)}, redirecting to {error_url}")
         return error_url

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -160,8 +160,7 @@ class SocialAuthMixin:
             # Strip URL parameters from the auth URL for logging
             auth_url_without_params = auth_url.split('?')[0] if auth_url else auth_url
             log_auth_event(
-                f"Starting SSO redirect to {auth_url_without_params} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})",
-                second_logger=logger,
+                f"Starting SSO redirect to {auth_url_without_params} with authenticator '{self.database_instance.name}' (slug: {self.database_instance.slug})"
             )
 
         return super().start()

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -14,7 +14,7 @@ from social_django.strategy import DjangoStrategy
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_class, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator, AuthenticatorUser
 from ansible_base.authentication.utils.user import normalize_and_get_email
-from ansible_base.lib.logging import log_auth_event
+from ansible_base.lib.logging import log_auth_error, log_auth_event
 from ansible_base.lib.utils.response import get_fully_qualified_url
 
 logger = logging.getLogger('ansible_base.authentication.social_auth')
@@ -151,7 +151,7 @@ class SocialAuthMixin:
     def start(self):
         # This will be run on the /login call and we want to return a 404 if the authenticator is not enabled.
         if not self.database_instance.enabled:
-            logger.error(f"Authentication attempted with disabled authenticator {self.database_instance.name}")
+            log_auth_error(f"Authentication attempted with disabled authenticator {self.database_instance.name}")
             return HttpResponseNotFound()
 
         # Before calling BaseAuth.start, we need to log any expected redirects from the parent function.

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -624,7 +624,7 @@ def update_user_claims(user: Optional[AbstractUser], database_authenticator: Aut
         authenticator_user.save(update_fields=["extra_data"])
 
     if results['access_allowed'] is not True:
-        log_auth_warning(f"User {user.username} failed an allow map and was denied access via authenticator {database_authenticator.name}", logger)
+        log_auth_warning(f"User {user.username} failed an allow map and was denied access via authenticator {database_authenticator.name}")
         return None
 
     # Make the orgs and the teams as necessary ...

--- a/ansible_base/lib/logging/__init__.py
+++ b/ansible_base/lib/logging/__init__.py
@@ -18,23 +18,19 @@ def get_auth_logger() -> logging.Logger:
     return auth_logger
 
 
-def log_auth_event(message: str, second_logger: Optional[logging.Logger] = None, level: Optional[int] = logging.INFO):
+def log_auth_event(message: str, level: Optional[int] = logging.INFO):
     auth_logger = get_auth_logger()
     auth_logger.log(level, message)
-    if second_logger:
-        second_logger.log(level, message)
 
 
-def log_auth_error(message: str, second_logger: Optional[logging.Logger] = None):
-    log_auth_event(message, second_logger, logging.ERROR)
+def log_auth_error(message: str):
+    log_auth_event(message, logging.ERROR)
 
 
-def log_auth_warning(message: str, second_logger: Optional[logging.Logger] = None):
-    log_auth_event(message, second_logger, logging.WARNING)
+def log_auth_warning(message: str):
+    log_auth_event(message, logging.WARNING)
 
 
-def log_auth_exception(message: str, second_logger: Optional[logging.Logger] = None):
+def log_auth_exception(message: str):
     auth_logger = get_auth_logger()
     auth_logger.exception(message)
-    if second_logger:
-        second_logger.exception(message)

--- a/ansible_base/oauth2_provider/authentication.py
+++ b/ansible_base/oauth2_provider/authentication.py
@@ -50,8 +50,7 @@ class LoggedOAuth2Authentication(OAuth2Authentication):
                     u"User {} performed a {} to {} through the API using OAuth 2 token {} for OAuth2 application {} ({}).".format(
                         username, request.method, request.path, token.pk, oauth2_application_pk, oauth2_application_name
                     )
-                ),
-                logger,
+                )
             )
             # TODO: check oauth_scopes when we have RBAC in Gateway
             setattr(user, 'oauth_scopes', [x for x in token.scope.split() if x])

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -109,7 +109,4 @@ class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activity
         app_name = self.application.name if self.application else "N/A (Personal Access Token)"
         user_name = self.user.username if self.user else "N/A"
         if has_non_trivial_fields:
-            log_auth_event(
-                f"{logging_verb} OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'",
-                second_logger=logger,
-            )
+            log_auth_event(f"{logging_verb} OAuth2 access token {self.pk} for user '{user_name}' with application '{app_name}' and scope '{self.scope}'")

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -40,6 +40,4 @@ class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activi
         access_token_id = self.access_token.pk if hasattr(self, 'access_token') and self.access_token else "N/A"
         user_name = self.user.username if self.user else "N/A"
         if has_non_trivial_fields:
-            log_auth_event(
-                f"{logging_verb} OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}", second_logger=logger
-            )
+            log_auth_event(f"{logging_verb} OAuth2 refresh token {self.pk} for user '{user_name}' linked to access token {access_token_id}")

--- a/test_app/tests/authentication/test_backend.py
+++ b/test_app/tests/authentication/test_backend.py
@@ -1,4 +1,3 @@
-import logging
 from random import shuffle
 from types import SimpleNamespace
 from unittest import mock
@@ -158,7 +157,8 @@ def test_authenticate(request, local_authenticator, github_enterprise_authentica
 
 
 @pytest.mark.django_db
-def test_authentication_exception(expected_log):
+@mock.patch("ansible_base.authentication.backend.log_auth_exception")
+def test_authentication_exception(mock_log_exception):
     class MockAuthenticator:
         database_instance = SimpleNamespace(name='testing')
 
@@ -170,9 +170,10 @@ def test_authentication_exception(expected_log):
         "ansible_base.authentication.backend.get_authentication_backends",
         return_value={1: MockAuthenticator()},
     ):
-        # Expect the log we emit
-        with expected_log('ansible_base.authentication.backend.logger', "exception", "Exception raised while trying to authenticate with"):
-            backend.AnsibleBaseAuth().authenticate(None)
+        backend.AnsibleBaseAuth().authenticate(None)
+
+        # Verify that log_auth_exception was called with the expected message
+        mock_log_exception.assert_called_once_with("Exception raised while trying to authenticate with testing")
 
 
 @pytest.mark.django_db
@@ -195,11 +196,10 @@ def test_last_login_from_with_attribute(local_authenticator, random_user, expect
         ):
             # Expected log message when user logs in
             with mock.patch(
-                'ansible_base.authentication.backend.logger.log',
+                'ansible_base.authentication.backend.log_auth_event',
             ) as log_mock:
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
                 log_mock.assert_called_once_with(
-                    logging.INFO,
                     f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}"',
                 )
 
@@ -233,11 +233,10 @@ def test_last_login_from_without_attribute(local_authenticator, random_user, exp
             return_value={local_authenticator.id: mock_authenticator_plugin},
         ):
             with mock.patch(
-                'ansible_base.authentication.backend.logger.log',
+                'ansible_base.authentication.backend.log_auth_event',
             ) as log_mock:
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
                 log_mock.assert_called_once_with(
-                    logging.INFO,
                     f'User {random_user.username} logged in from {mock_authenticator_plugin.type} authenticator with ID "{local_authenticator.id}"',
                 )
 
@@ -272,11 +271,11 @@ def test_last_login_from_multiple_authenticators(local_authenticator, github_ent
         ):
             # Expected log message when user logs in
             with mock.patch(
-                'ansible_base.authentication.backend.logger.log',
+                'ansible_base.authentication.backend.log_auth_event',
             ) as log_mock:
                 auth_return = backend.AnsibleBaseAuth().authenticate(None)
                 log_mock.assert_called_once_with(
-                    logging.INFO, f'User {random_user.username} logged in from {mock_local_plugin.type} authenticator with ID "{local_authenticator.id}"'
+                    f'User {random_user.username} logged in from {mock_local_plugin.type} authenticator with ID "{local_authenticator.id}"'
                 )
 
             # Verify the user is returned

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -1,4 +1,3 @@
-import logging
 from unittest import mock
 
 import pytest
@@ -51,7 +50,7 @@ class SubstringMatcher:
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.authentication.social_auth.logger")
+@mock.patch("ansible_base.authentication.social_auth.log_auth_event")
 def test_authenticator_strategy_redirect_logging(mock_logger):
     """Test that SSO redirect logging happens in the start() method."""
     from ansible_base.authentication.models import Authenticator
@@ -85,9 +84,7 @@ def test_authenticator_strategy_redirect_logging(mock_logger):
         result = backend.start()
 
         # Verify the logger was called with the SSO redirect message (without URL parameters)
-        mock_logger.log.assert_called_once_with(
-            logging.INFO, "Starting SSO redirect to https://example.com/oauth/callback with authenticator 'Test OIDC' (slug: test-oidc)"
-        )
+        mock_logger.assert_called_once_with("Starting SSO redirect to https://example.com/oauth/callback with authenticator 'Test OIDC' (slug: test-oidc)")
 
         # Verify that the result is an HttpResponseRedirect with the correct URL (with parameters)
         assert isinstance(result, HttpResponseRedirect)
@@ -95,8 +92,9 @@ def test_authenticator_strategy_redirect_logging(mock_logger):
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.authentication.social_auth.logger")
-def test_social_auth_mixin_start_enabled_authenticator(mock_logger):
+@mock.patch("ansible_base.authentication.social_auth.log_auth_error")
+@mock.patch("ansible_base.authentication.social_auth.log_auth_event")
+def test_social_auth_mixin_start_enabled_authenticator(mock_log_event, mock_log_error):
     """Test that SocialAuthMixin.start logs when authentication is attempted with an enabled authenticator."""
 
     from ansible_base.authentication.models import Authenticator
@@ -129,15 +127,16 @@ def test_social_auth_mixin_start_enabled_authenticator(mock_logger):
     backend.start()
 
     # Verify info logging for starting SSO redirect (URL parameters stripped)
-    mock_logger.log.assert_any_call(logging.INFO, "Starting SSO redirect to https://example.com/auth with authenticator 'Test OIDC' (slug: test-oidc)")
+    mock_log_event.assert_any_call("Starting SSO redirect to https://example.com/auth with authenticator 'Test OIDC' (slug: test-oidc)")
 
     # Verify error was not called (since authenticator is enabled)
-    assert not mock_logger.error.called
+    assert not mock_log_error.called
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.authentication.social_auth.logger")
-def test_social_auth_mixin_start_disabled_authenticator(mock_logger):
+@mock.patch("ansible_base.authentication.social_auth.log_auth_event")
+@mock.patch("ansible_base.authentication.social_auth.log_auth_error")
+def test_social_auth_mixin_start_disabled_authenticator(mock_log_error, mock_log_event):
     """Test that SocialAuthMixin.start logs an error and returns 404 for disabled authenticator."""
     from ansible_base.authentication.models import Authenticator
 
@@ -159,10 +158,10 @@ def test_social_auth_mixin_start_disabled_authenticator(mock_logger):
     result = backend.start()
 
     # Verify error logging for disabled authenticator
-    mock_logger.error.assert_called_once_with("Authentication attempted with disabled authenticator Disabled OIDC")
+    mock_log_error.assert_called_once_with("Authentication attempted with disabled authenticator Disabled OIDC")
 
     # Verify info logging was not called (since authenticator is disabled)
-    assert not mock_logger.log.called
+    assert not mock_log_event.called
 
     # Verify that a 404 response was returned
     assert isinstance(result, HttpResponseNotFound)
@@ -217,7 +216,7 @@ def test_social_auth_mixin_start_disabled_authenticator(mock_logger):
         ),
     ],
 )
-@mock.patch("ansible_base.authentication.social_auth.logger")
+@mock.patch("ansible_base.authentication.social_auth.log_auth_event")
 def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_type, authenticator_name, minimal_config):
     """
     Test that all SSO authenticators log both the start message and redirect message during auth flow.
@@ -257,7 +256,7 @@ def test_sso_authenticators_log_redirect_and_start(mock_logger, authenticator_ty
         assert isinstance(result, HttpResponseRedirect), f"{authenticator_type} did not return HttpResponseRedirect"
 
         # Verify we got the SSO redirect log message (which includes both start and redirect info)
-        sso_log_calls = [call for call in mock_logger.log.call_args_list if "Starting SSO redirect" in str(call)]
+        sso_log_calls = [call for call in mock_logger.call_args_list if "Starting SSO redirect" in str(call)]
         assert len(sso_log_calls) >= 1, f"{authenticator_type} did not log SSO redirect message"
 
         # Verify the message contains the authenticator name, slug, and redirect URL (without parameters)
@@ -571,7 +570,7 @@ def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, user
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.authentication.social_auth.logger")
+@mock.patch("ansible_base.authentication.social_auth.log_auth_event")
 def test_social_auth_mixin_start_no_redirect(mock_logger):
     """Test that SocialAuthMixin.start returns HTML when uses_redirect() returns False."""
     from ansible_base.authentication.models import Authenticator
@@ -612,12 +611,12 @@ def test_social_auth_mixin_start_no_redirect(mock_logger):
     backend.start()
 
     # Verify that we didn't log the SSO redirect message (since this doesn't use redirect)
-    sso_log_calls = [call for call in mock_logger.log.call_args_list if "Starting SSO redirect" in str(call)]
+    sso_log_calls = [call for call in mock_logger.call_args_list if "Starting SSO redirect" in str(call)]
     assert len(sso_log_calls) == 0, "Should not log SSO redirect when uses_redirect() is False"
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.authentication.social_auth.logger")
+@mock.patch("ansible_base.authentication.social_auth.log_auth_error")
 def test_social_auth_mixin_start_no_redirect_disabled_authenticator(mock_logger):
     """Test that SocialAuthMixin.start returns 404 for disabled authenticator even when uses_redirect() is False."""
     from ansible_base.authentication.models import Authenticator
@@ -650,10 +649,7 @@ def test_social_auth_mixin_start_no_redirect_disabled_authenticator(mock_logger)
     result = backend.start()
 
     # Verify error logging for disabled authenticator
-    mock_logger.error.assert_called_once_with("Authentication attempted with disabled authenticator Disabled HTML Auth")
-
-    # Verify that no SSO redirect logging happened
-    assert not mock_logger.log.called
+    mock_logger.assert_called_once_with("Authentication attempted with disabled authenticator Disabled HTML Auth")
 
     # Verify that a 404 response was returned (not HTML)
     assert isinstance(result, HttpResponseNotFound)

--- a/test_app/tests/lib/logging/test_logging.py
+++ b/test_app/tests/lib/logging/test_logging.py
@@ -133,61 +133,13 @@ class TestLogAuthEvent:
         assert logging_module.auth_logger is initial_logger
         assert logging_module.auth_logger.name == initial_logger_name
 
-    def test_logs_to_second_logger_when_provided(self, caplog):
-        """Verify that message is logged to both auth_logger and second_logger."""
-        second_logger = logging.getLogger('test.second.logger')
-
-        with caplog.at_level(logging.INFO):
-            log_auth_event("Dual logger message", second_logger=second_logger)
-
-        logger_names = [r.name for r in caplog.records]
-        assert 'ansible_base.auth_audit' in logger_names
-        assert 'test.second.logger' in logger_names
-
-        messages = [r.message for r in caplog.records]
-        assert messages.count("Dual logger message") == 2
-
-    def test_does_not_log_to_second_logger_when_none(self, caplog):
-        """Verify that only auth_logger receives message when second_logger is None."""
-        with caplog.at_level(logging.INFO):
-            log_auth_event("Single logger message", second_logger=None)
-
-        assert len(caplog.records) == 1
-        assert caplog.records[0].name == 'ansible_base.auth_audit'
-
-    def test_does_not_log_to_second_logger_when_not_provided(self, caplog):
-        """Verify default behavior (no second_logger) only logs to auth_logger."""
+    def test_default_behavior_logs_to_auth_logger_only(self, caplog):
+        """Verify default behavior logs only to auth_logger."""
         with caplog.at_level(logging.INFO):
             log_auth_event("Default single logger message")
 
         assert len(caplog.records) == 1
         assert caplog.records[0].name == 'ansible_base.auth_audit'
-
-    def test_second_logger_receives_info_level_message(self, caplog):
-        """Verify that second_logger receives message at INFO level."""
-        second_logger = logging.getLogger('test.level.logger')
-
-        with caplog.at_level(logging.INFO):
-            log_auth_event("Level test message", second_logger=second_logger)
-
-        second_logger_records = [r for r in caplog.records if r.name == 'test.level.logger']
-        assert len(second_logger_records) == 1
-        assert second_logger_records[0].levelno == logging.INFO
-
-    def test_different_second_loggers_on_consecutive_calls(self, caplog):
-        """Verify that different second_loggers can be used on consecutive calls."""
-        logger_a = logging.getLogger('logger.a')
-        logger_b = logging.getLogger('logger.b')
-
-        with caplog.at_level(logging.INFO):
-            log_auth_event("Message A", second_logger=logger_a)
-            log_auth_event("Message B", second_logger=logger_b)
-
-        logger_names = [r.name for r in caplog.records]
-
-        assert logger_names.count('ansible_base.auth_audit') == 2
-        assert logger_names.count('logger.a') == 1
-        assert logger_names.count('logger.b') == 1
 
     def test_multiple_calls_all_logged(self, caplog):
         """Verify that multiple consecutive calls all result in logged messages."""
@@ -219,20 +171,6 @@ class TestLogAuthEvent:
         logging_module.auth_logger = None
         assert logging_module.auth_logger is None
 
-    def test_custom_logger_name_with_second_logger(self, caplog):
-        """Verify custom logger name works correctly with second_logger."""
-        custom_name = 'custom.auth.audit'
-        second_logger = logging.getLogger('integration.second')
-
-        with override_settings(ANSIBLE_BASE_AUTH_AUDIT_LOGGER_NAME=custom_name):
-            with caplog.at_level(logging.INFO):
-                log_auth_event("Integration test message", second_logger=second_logger)
-
-        logger_names = [r.name for r in caplog.records]
-        assert custom_name in logger_names
-        assert 'integration.second' in logger_names
-        assert len(caplog.records) == 2
-
     def test_realistic_auth_event_messages(self, caplog):
         """Test with realistic authentication event messages."""
         test_messages = [
@@ -261,18 +199,6 @@ class TestLogAuthEvent:
 
         mock_auth_logger.log.assert_called_once_with(logging.INFO, "Test event message")
 
-    @mock.patch("ansible_base.lib.logging.get_auth_logger")
-    def test_logs_to_second_logger_mock(self, mock_get_auth_logger):
-        """Test that log_auth_event logs info to both auth logger and second logger using mocks."""
-        mock_auth_logger = mock.Mock()
-        mock_get_auth_logger.return_value = mock_auth_logger
-        mock_second_logger = mock.Mock()
-
-        log_auth_event("Test event message", second_logger=mock_second_logger)
-
-        mock_auth_logger.log.assert_called_once_with(logging.INFO, "Test event message")
-        mock_second_logger.log.assert_called_once_with(logging.INFO, "Test event message")
-
 
 class TestLogAuthWarning:
     """Tests for log_auth_warning function."""
@@ -284,28 +210,6 @@ class TestLogAuthWarning:
         mock_get_auth_logger.return_value = mock_auth_logger
 
         log_auth_warning("Test warning message")
-
-        mock_auth_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
-
-    @mock.patch("ansible_base.lib.logging.get_auth_logger")
-    def test_logs_to_second_logger(self, mock_get_auth_logger):
-        """Test that log_auth_warning logs warning to both auth logger and second logger."""
-        mock_auth_logger = mock.Mock()
-        mock_get_auth_logger.return_value = mock_auth_logger
-        mock_second_logger = mock.Mock()
-
-        log_auth_warning("Test warning message", second_logger=mock_second_logger)
-
-        mock_auth_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
-        mock_second_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
-
-    @mock.patch("ansible_base.lib.logging.get_auth_logger")
-    def test_only_logs_to_auth_logger_when_no_second_logger(self, mock_get_auth_logger):
-        """Test that log_auth_warning only logs to auth logger when second_logger is None."""
-        mock_auth_logger = mock.Mock()
-        mock_get_auth_logger.return_value = mock_auth_logger
-
-        log_auth_warning("Test warning message", second_logger=None)
 
         mock_auth_logger.log.assert_called_once_with(logging.WARNING, "Test warning message")
 
@@ -352,28 +256,6 @@ class TestLogAuthException:
         mock_get_auth_logger.return_value = mock_auth_logger
 
         log_auth_exception("Test exception message")
-
-        mock_auth_logger.exception.assert_called_once_with("Test exception message")
-
-    @mock.patch("ansible_base.lib.logging.get_auth_logger")
-    def test_logs_to_second_logger(self, mock_get_auth_logger):
-        """Test that log_auth_exception logs exception to both auth logger and second logger."""
-        mock_auth_logger = mock.Mock()
-        mock_get_auth_logger.return_value = mock_auth_logger
-        mock_second_logger = mock.Mock()
-
-        log_auth_exception("Test exception message", second_logger=mock_second_logger)
-
-        mock_auth_logger.exception.assert_called_once_with("Test exception message")
-        mock_second_logger.exception.assert_called_once_with("Test exception message")
-
-    @mock.patch("ansible_base.lib.logging.get_auth_logger")
-    def test_only_logs_to_auth_logger_when_no_second_logger(self, mock_get_auth_logger):
-        """Test that log_auth_exception only logs to auth logger when second_logger is None."""
-        mock_auth_logger = mock.Mock()
-        mock_get_auth_logger.return_value = mock_auth_logger
-
-        log_auth_exception("Test exception message", second_logger=None)
 
         mock_auth_logger.exception.assert_called_once_with("Test exception message")
 

--- a/test_app/tests/oauth2_provider/test_models.py
+++ b/test_app/tests/oauth2_provider/test_models.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -40,7 +39,7 @@ def test_oauth2_revoke_refresh_token(oauth2_admin_access_token):
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_creation_logs_with_application(mock_logger, oauth2_application_password, admin_user):
     """Test that OAuth2AccessToken creation logs with application name."""
     application, _secret = oauth2_application_password
@@ -55,8 +54,8 @@ def test_oauth2_access_token_creation_logs_with_application(mock_logger, oauth2_
     )
 
     # Verify the logger was called with the correct message
-    mock_logger.log.assert_called_once_with(
-        logging.INFO, f"Created OAuth2 access token {token.pk} for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
+    mock_logger.assert_called_once_with(
+        f"Created OAuth2 access token {token.pk} for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
     )
 
     # Verify the token was created
@@ -64,7 +63,7 @@ def test_oauth2_access_token_creation_logs_with_application(mock_logger, oauth2_
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_creation_logs_without_application(mock_logger, admin_user):
     """Test that OAuth2AccessToken creation logs for personal access tokens."""
     # Create a personal access token (no application)
@@ -77,8 +76,8 @@ def test_oauth2_access_token_creation_logs_without_application(mock_logger, admi
     )
 
     # Verify the logger was called with personal access token message
-    mock_logger.log.assert_called_once_with(
-        logging.INFO, f"Created OAuth2 access token {token.pk} for user '{admin_user.username}' with application 'N/A (Personal Access Token)' and scope 'read'"
+    mock_logger.assert_called_once_with(
+        f"Created OAuth2 access token {token.pk} for user '{admin_user.username}' with application 'N/A (Personal Access Token)' and scope 'read'"
     )
 
     # Verify the token was created
@@ -86,7 +85,7 @@ def test_oauth2_access_token_creation_logs_without_application(mock_logger, admi
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.log_auth_event")
 def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_password, admin_user):
     """Test that OAuth2RefreshToken creation logs with access token reference."""
     application, _secret = oauth2_application_password
@@ -109,8 +108,8 @@ def test_oauth2_refresh_token_creation_logs(mock_logger, oauth2_application_pass
     )
 
     # Verify the logger was called with the correct message
-    mock_logger.log.assert_called_once_with(
-        logging.INFO, f"Created OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
+    mock_logger.assert_called_once_with(
+        f"Created OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
     )
 
     # Verify the refresh token was created
@@ -273,7 +272,7 @@ def test_oauth2_refresh_token_has_non_trivial_changes_returns_true_for_revoked_c
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_modification_logs_with_scope_change(mock_logger, admin_user):
     """Test that OAuth2AccessToken modification logs when scope changes."""
     # Create an access token
@@ -296,11 +295,11 @@ def test_oauth2_access_token_modification_logs_with_scope_change(mock_logger, ad
     expected_msg = (
         f"Modified OAuth2 access token {token.pk} for user '{admin_user.username}' " f"with application 'N/A (Personal Access Token)' and scope 'read'"
     )
-    mock_logger.log.assert_called_once_with(logging.INFO, expected_msg)
+    mock_logger.assert_called_once_with(expected_msg)
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_modification_logs_with_description_change(mock_logger, oauth2_application_password, admin_user):
     """Test that OAuth2AccessToken modification logs when description changes."""
     application, _secret = oauth2_application_password
@@ -323,13 +322,13 @@ def test_oauth2_access_token_modification_logs_with_description_change(mock_logg
     token.save()
 
     # Verify the modification was logged
-    mock_logger.log.assert_called_once_with(
-        logging.INFO, f"Modified OAuth2 access token {token.pk} for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
+    mock_logger.assert_called_once_with(
+        f"Modified OAuth2 access token {token.pk} for user '{admin_user.username}' with application '{application.name}' and scope 'write'"
     )
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_no_modification_log_for_timestamp_only_changes(mock_logger, admin_user):
     """Test that OAuth2AccessToken does not log modification when only timestamp fields change."""
     # Create an access token
@@ -349,11 +348,11 @@ def test_oauth2_access_token_no_modification_log_for_timestamp_only_changes(mock
     token.save()
 
     # Verify no modification log was created
-    mock_logger.log.assert_not_called()
+    mock_logger.assert_not_called()
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_no_modification_log_for_last_used_change(mock_logger, admin_user):
     """Test that OAuth2AccessToken does not log modification when only last_used changes."""
     # Create an access token
@@ -372,11 +371,11 @@ def test_oauth2_access_token_no_modification_log_for_last_used_change(mock_logge
     token.save(update_fields=['last_used'])
 
     # Verify no modification log was created
-    mock_logger.log.assert_not_called()
+    mock_logger.assert_not_called()
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.log_auth_event")
 def test_oauth2_refresh_token_modification_logs_with_revoked_change(mock_logger, admin_user, oauth2_application_password):
     """Test that OAuth2RefreshToken modification logs when revoked status changes."""
     application, _secret = oauth2_application_password
@@ -405,13 +404,13 @@ def test_oauth2_refresh_token_modification_logs_with_revoked_change(mock_logger,
     refresh_token.save()
 
     # Verify the modification was logged
-    mock_logger.log.assert_called_once_with(
-        logging.INFO, f"Modified OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
+    mock_logger.assert_called_once_with(
+        f"Modified OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
     )
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.log_auth_event")
 def test_oauth2_refresh_token_no_modification_log_for_timestamp_only_changes(mock_logger, admin_user, oauth2_application_password):
     """Test that OAuth2RefreshToken does not log modification when only timestamp fields change."""
     application, _secret = oauth2_application_password
@@ -440,11 +439,11 @@ def test_oauth2_refresh_token_no_modification_log_for_timestamp_only_changes(moc
     refresh_token.save()
 
     # Verify no modification log was created
-    mock_logger.log.assert_not_called()
+    mock_logger.assert_not_called()
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_no_modification_log_with_update_fields_timestamp_only(mock_logger, admin_user):
     """Test that OAuth2AccessToken does not log when update_fields contains only timestamp fields."""
     # Create an access token
@@ -463,11 +462,11 @@ def test_oauth2_access_token_no_modification_log_with_update_fields_timestamp_on
     token.save(update_fields=['modified', 'modified_by'])
 
     # Verify no modification log was created
-    mock_logger.log.assert_not_called()
+    mock_logger.assert_not_called()
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_modification_log_with_update_fields_non_timestamp(mock_logger, admin_user):
     """Test that OAuth2AccessToken logs when update_fields contains non-timestamp fields."""
     # Create an access token
@@ -491,11 +490,11 @@ def test_oauth2_access_token_modification_log_with_update_fields_non_timestamp(m
     expected_msg = (
         f"Modified OAuth2 access token {token.pk} for user '{admin_user.username}' " f"with application 'N/A (Personal Access Token)' and scope 'write'"
     )
-    mock_logger.log.assert_called_once_with(logging.INFO, expected_msg)
+    mock_logger.assert_called_once_with(expected_msg)
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.access_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.access_token.log_auth_event")
 def test_oauth2_access_token_no_modification_log_with_update_fields_unchanged_field(mock_logger, admin_user):
     """Test that OAuth2AccessToken does not log when update_fields specifies a field that didn't change."""
     # Create an access token
@@ -515,11 +514,11 @@ def test_oauth2_access_token_no_modification_log_with_update_fields_unchanged_fi
     token.save(update_fields=['description'])
 
     # Verify no modification log was created (field value didn't change)
-    mock_logger.log.assert_not_called()
+    mock_logger.assert_not_called()
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.log_auth_event")
 def test_oauth2_refresh_token_no_modification_log_with_update_fields_timestamp_only(mock_logger, admin_user, oauth2_application_password):
     """Test that OAuth2RefreshToken does not log when update_fields contains only timestamp fields."""
     application, _secret = oauth2_application_password
@@ -547,11 +546,11 @@ def test_oauth2_refresh_token_no_modification_log_with_update_fields_timestamp_o
     refresh_token.save(update_fields=['modified', 'modified_by'])
 
     # Verify no modification log was created
-    mock_logger.log.assert_not_called()
+    mock_logger.assert_not_called()
 
 
 @pytest.mark.django_db
-@mock.patch("ansible_base.oauth2_provider.models.refresh_token.logger")
+@mock.patch("ansible_base.oauth2_provider.models.refresh_token.log_auth_event")
 def test_oauth2_refresh_token_modification_log_with_update_fields_non_timestamp(mock_logger, admin_user, oauth2_application_password):
     """Test that OAuth2RefreshToken logs when update_fields contains non-timestamp fields."""
     application, _secret = oauth2_application_password
@@ -580,6 +579,6 @@ def test_oauth2_refresh_token_modification_log_with_update_fields_non_timestamp(
     refresh_token.save(update_fields=['revoked'])
 
     # Verify the modification was logged
-    mock_logger.log.assert_called_once_with(
-        logging.INFO, f"Modified OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
+    mock_logger.assert_called_once_with(
+        f"Modified OAuth2 refresh token {refresh_token.pk} for user '{admin_user.username}' linked to access token {access_token.pk}"
     )


### PR DESCRIPTION
## Summary
Fixes AAP-64481: Remove instances of double logging in OCP and containerized environments to prevent duplicate log entries in RPM files and container stdout logs.

## Dependencies
- **Requires**:  https://github.com/ansible-automation-platform/aap-gateway/pull/1235
- **Related**: AAP-64481 Jira ticket

## Changes Made
- **Remove second_logger parameter** from all auth logging functions in `lib/logging`:
  - `log_auth_event()`
  - `log_auth_error()` 
  - `log_auth_warning()`
  - `log_auth_exception()`

- **Updated 12 call sites** across the codebase:
  - OAuth2 provider modules (authentication.py, access_token.py, refresh_token.py)
  - Authentication modules (backend.py, social_auth.py, middleware.py, claims.py)
  - Removed tests for second_logger functionality while preserving core auth logging tests

## Result
- Auth events now only log to the central audit logger (`ansible_base.auth_audit`)
- Eliminates duplicate log entries that were causing issues in OCP and containerized environments
- No more hair-pulling for PDEs! 🎉

## Test Plan
- [x] All auth logging functions only accept message parameter
- [x] All call sites updated to remove second_logger parameter
- [x] Tests updated to remove second_logger functionality
- [x] Code formatting and linting checks pass
- [x] Manual verification: no remaining double logging patterns in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)