### PR TITLE
[AAP-64480] Add audit logging for activity stream changes

### DIFF
--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -112,6 +112,12 @@ class AuditableModel(models.Model):
     # Adding field names to this list will limit the activity stream changes dictionaries to only include these fields
     activity_stream_limit_field_names = []
 
+    # Controls whether changes to this model are stored in the activity stream
+    activity_stream_enabled = True
+
+    # Controls whether changes to this model are logged to the audit log
+    audit_log_enabled = False
+
     @property
     def activity_stream_entries(self):
         """

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -2,6 +2,8 @@ import logging
 import threading
 from contextlib import contextmanager
 
+from ansible_base.lib.logging import log_auth_info
+
 logger = logging.getLogger('ansible_base.activitystream.signals')
 
 
@@ -66,11 +68,39 @@ def _store_activitystream_entry(old, new, operation, update_fields=None):
     else:
         content_object = new
 
-    return Entry.objects.create(
-        content_object=content_object,
-        operation=operation,
-        changes=delta.dict(),
-    )
+    # Determine the instance to check attributes on (prefer new, fallback to old)
+    instance_for_check = new if new is not None else old
+
+    if getattr(instance_for_check, 'audit_log_enabled', False):
+        model_name = content_object.__class__.__name__
+        obj_str = str(content_object)
+        changes = delta.dict()
+
+        if operation in ('create', 'delete'):
+            # For create/delete, dump the whole object state as a dict
+            all_fields = {}
+            if operation == 'create':
+                all_fields.update(changes.get('added_fields', {}))
+            else:
+                all_fields.update(changes.get('removed_fields', {}))
+            all_fields.update({k: v[1] if operation == 'create' else v[0] for k, v in changes.get('changed_fields', {}).items()})
+            log_auth_info(f"{operation} {model_name} {obj_str} {all_fields}")
+        else:
+            # For update, emit one line per change
+            for field_name, value in changes.get('added_fields', {}).items():
+                log_auth_info(f"{operation} {model_name} {obj_str} added {field_name}='{value}'")
+            for field_name, value in changes.get('removed_fields', {}).items():
+                log_auth_info(f"{operation} {model_name} {obj_str} removed {field_name} (was '{value}')")
+            for field_name, (old_val, new_val) in changes.get('changed_fields', {}).items():
+                log_auth_info(f"{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
+
+    if getattr(instance_for_check, 'activity_stream_enabled', True):
+        return Entry.objects.create(
+            content_object=content_object,
+            operation=operation,
+            changes=delta.dict(),
+        )
+    return None
 
 
 def _store_activitystream_m2m(given_instance, model, operation, pk_set, reverse, field_name):
@@ -88,10 +118,20 @@ def _store_activitystream_m2m(given_instance, model, operation, pk_set, reverse,
     entries = []
 
     for instance in instances:
+        content_object = instance if reverse else given_instance
+        related_object = given_instance if reverse else instance
+
+        # Audit logging for m2m changes
+        if getattr(content_object, 'audit_log_enabled', False):
+            content_model_name = content_object.__class__.__name__
+            related_model_name = related_object.__class__.__name__
+            preposition = 'with' if operation == 'associate' else 'from'
+            log_auth_info(f"{operation} {content_model_name} {content_object} {preposition} {related_model_name} {related_object}")
+
         entry = Entry(
-            content_object=instance if reverse else given_instance,
+            content_object=content_object,
             operation=operation,
-            related_content_object=given_instance if reverse else instance,
+            related_content_object=related_object,
             related_field_name=field_name,
             created_by=user,
         )

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 import logging
 import threading
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Set, Tuple, Type, Union
 
 from ansible_base.lib.logging import log_auth_event
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractUser
+    from django.db.models import Model
 
 logger = logging.getLogger('ansible_base.activitystream.signals')
 
@@ -19,7 +26,7 @@ activitystream_enabled = ActivityStreamEnabled()
 
 
 @contextmanager
-def no_activity_stream():
+def no_activity_stream() -> Generator[None, None, None]:
     previous_value = activitystream_enabled.enabled
     activitystream_enabled.enabled = False
     try:
@@ -28,9 +35,59 @@ def no_activity_stream():
         activitystream_enabled.enabled = previous_value
 
 
-def _store_activitystream_entry(old, new, operation, update_fields=None):
-    if not activitystream_enabled:
+def _get_actor_user_and_username() -> Tuple[Optional[AbstractUser], str]:
+    """Return (current user, username) or (None, 'unknown') if outside request."""
+    from ansible_base.lib.utils.models import current_user_or_system_user
+
+    user = current_user_or_system_user()
+    return (user, user.username if user else "unknown")
+
+
+def _log_audit_entry(
+    *,
+    content_object: Model,
+    operation: str,
+    changes: Union[Dict[str, Any], str],
+) -> None:
+    """Emit audit log lines if content_object has audit_log_enabled.
+    For create/update/delete, changes is a dict (added_fields, removed_fields, changed_fields).
+    For m2m associate/disassociate, changes is the rest of the line as a string (e.g. 'with Team Parent (2)')."""
+    if not getattr(content_object, 'audit_log_enabled', False):
         return
+    model_name = content_object.__class__.__name__
+    obj_str = f"{content_object} ({content_object.pk})"
+    _, actor_username = _get_actor_user_and_username()
+    prefix = f"User: {actor_username} "
+    if isinstance(changes, str):
+        log_auth_event(f"{prefix}{operation} {model_name} {obj_str} {changes}")
+        return
+    if operation in ('create', 'delete'):
+        # For create/delete, dump the whole object state as a dict
+        all_fields = {}
+        if operation == 'create':
+            all_fields.update(changes.get('added_fields', {}))
+        else:
+            all_fields.update(changes.get('removed_fields', {}))
+        all_fields.update({k: v[1] if operation == 'create' else v[0] for k, v in changes.get('changed_fields', {}).items()})
+        log_auth_event(f"{prefix}{operation} {model_name} {obj_str} {all_fields}")
+    else:
+        # For update, emit one line per change
+        for field_name, value in changes.get('added_fields', {}).items():
+            log_auth_event(f"{prefix}{operation} {model_name} {obj_str} added {field_name}='{value}'")
+        for field_name, value in changes.get('removed_fields', {}).items():
+            log_auth_event(f"{prefix}{operation} {model_name} {obj_str} removed {field_name} (was '{value}')")
+        for field_name, (old_val, new_val) in changes.get('changed_fields', {}).items():
+            log_auth_event(f"{prefix}{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
+
+
+def _store_activitystream_entry(
+    old: Optional[Model],
+    new: Optional[Model],
+    operation: str,
+    update_fields: Optional[Any] = None,
+) -> Optional[Any]:
+    if not activitystream_enabled:
+        return None
 
     from ansible_base.activitystream.models import Entry
     from ansible_base.lib.utils.models import diff
@@ -68,33 +125,13 @@ def _store_activitystream_entry(old, new, operation, update_fields=None):
     else:
         content_object = new
 
-    # Determine the instance to check attributes on (prefer new, fallback to old)
-    instance_for_check = new if new is not None else old
+    _log_audit_entry(
+        content_object=content_object,
+        operation=operation,
+        changes=delta.dict(),
+    )
 
-    if getattr(instance_for_check, 'audit_log_enabled', False):
-        model_name = content_object.__class__.__name__
-        obj_str = str(content_object)
-        changes = delta.dict()
-
-        if operation in ('create', 'delete'):
-            # For create/delete, dump the whole object state as a dict
-            all_fields = {}
-            if operation == 'create':
-                all_fields.update(changes.get('added_fields', {}))
-            else:
-                all_fields.update(changes.get('removed_fields', {}))
-            all_fields.update({k: v[1] if operation == 'create' else v[0] for k, v in changes.get('changed_fields', {}).items()})
-            log_auth_event(f"{operation} {model_name} {obj_str} {all_fields}")
-        else:
-            # For update, emit one line per change
-            for field_name, value in changes.get('added_fields', {}).items():
-                log_auth_event(f"{operation} {model_name} {obj_str} added {field_name}='{value}'")
-            for field_name, value in changes.get('removed_fields', {}).items():
-                log_auth_event(f"{operation} {model_name} {obj_str} removed {field_name} (was '{value}')")
-            for field_name, (old_val, new_val) in changes.get('changed_fields', {}).items():
-                log_auth_event(f"{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
-
-    if getattr(instance_for_check, 'activity_stream_enabled', True):
+    if getattr(content_object, 'activity_stream_enabled', True):
         return Entry.objects.create(
             content_object=content_object,
             operation=operation,
@@ -103,18 +140,24 @@ def _store_activitystream_entry(old, new, operation, update_fields=None):
     return None
 
 
-def _store_activitystream_m2m(given_instance, model, operation, pk_set, reverse, field_name):
+def _store_activitystream_m2m(
+    given_instance: Model,
+    model: Type[Model],
+    operation: str,
+    pk_set: Set[Any],
+    reverse: bool,
+    field_name: str,
+) -> None:
     if not activitystream_enabled:
         return
 
     from ansible_base.activitystream.models import Entry
-    from ansible_base.lib.utils.models import current_user_or_system_user
 
     if operation not in ('associate', 'disassociate'):
         raise ValueError("Invalid operation: {}".format(operation))
 
+    user, _ = _get_actor_user_and_username()
     instances = model.objects.filter(pk__in=pk_set)
-    user = current_user_or_system_user()
     entries = []
 
     for instance in instances:
@@ -122,11 +165,14 @@ def _store_activitystream_m2m(given_instance, model, operation, pk_set, reverse,
         related_object = given_instance if reverse else instance
 
         # Audit logging for m2m changes
-        if getattr(content_object, 'audit_log_enabled', False):
-            content_model_name = content_object.__class__.__name__
-            related_model_name = related_object.__class__.__name__
-            preposition = 'with' if operation == 'associate' else 'from'
-            log_auth_event(f"{operation} {content_model_name} {content_object} {preposition} {related_model_name} {related_object}")
+        related_model_name = related_object.__class__.__name__
+        related_str = f"{related_object} ({related_object.pk})"
+        preposition = 'with' if operation == 'associate' else 'from'
+        _log_audit_entry(
+            content_object=content_object,
+            operation=operation,
+            changes=f"{preposition} {related_model_name} {related_str}",
+        )
 
         entry = Entry(
             content_object=content_object,

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -2,7 +2,7 @@ import logging
 import threading
 from contextlib import contextmanager
 
-from ansible_base.lib.logging import log_auth_info
+from ansible_base.lib.logging import log_auth_event
 
 logger = logging.getLogger('ansible_base.activitystream.signals')
 
@@ -84,15 +84,15 @@ def _store_activitystream_entry(old, new, operation, update_fields=None):
             else:
                 all_fields.update(changes.get('removed_fields', {}))
             all_fields.update({k: v[1] if operation == 'create' else v[0] for k, v in changes.get('changed_fields', {}).items()})
-            log_auth_info(f"{operation} {model_name} {obj_str} {all_fields}")
+            log_auth_event(f"{operation} {model_name} {obj_str} {all_fields}")
         else:
             # For update, emit one line per change
             for field_name, value in changes.get('added_fields', {}).items():
-                log_auth_info(f"{operation} {model_name} {obj_str} added {field_name}='{value}'")
+                log_auth_event(f"{operation} {model_name} {obj_str} added {field_name}='{value}'")
             for field_name, value in changes.get('removed_fields', {}).items():
-                log_auth_info(f"{operation} {model_name} {obj_str} removed {field_name} (was '{value}')")
+                log_auth_event(f"{operation} {model_name} {obj_str} removed {field_name} (was '{value}')")
             for field_name, (old_val, new_val) in changes.get('changed_fields', {}).items():
-                log_auth_info(f"{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
+                log_auth_event(f"{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
 
     if getattr(instance_for_check, 'activity_stream_enabled', True):
         return Entry.objects.create(
@@ -126,7 +126,7 @@ def _store_activitystream_m2m(given_instance, model, operation, pk_set, reverse,
             content_model_name = content_object.__class__.__name__
             related_model_name = related_object.__class__.__name__
             preposition = 'with' if operation == 'associate' else 'from'
-            log_auth_info(f"{operation} {content_model_name} {content_object} {preposition} {related_model_name} {related_object}")
+            log_auth_event(f"{operation} {content_model_name} {content_object} {preposition} {related_model_name} {related_object}")
 
         entry = Entry(
             content_object=content_object,

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -272,10 +272,13 @@ def activitystream_m2m_changed(sender, instance, action, reverse, model, pk_set,
             # If we do: user.animal_friends.clear() - the reverse relation - we need to get the PKs of
             # every animal that is being removed from the user's animal_friends.
             # Note that in this case, model is the Animal model, and instance is the user.
-            pk_set = model.objects.filter(**{field_name: instance}).values_list('pk', flat=True)
+            pk_set = set(model.objects.filter(**{field_name: instance}).values_list('pk', flat=True))
         else:
             # If we're not reversing, then we're clearing the forward relation. So it's easy to get the PKs,
             # given we have the field name and the instance.
-            pk_set = getattr(instance, field_name).all().values_list('pk', flat=True)
+            pk_set = set(getattr(instance, field_name).all().values_list('pk', flat=True))
 
+    # Django may pass pk_set as a QuerySet (e.g. for pre_clear); normalize to set for type consistency
+    if not isinstance(pk_set, set):
+        pk_set = set(pk_set)
     _store_activitystream_m2m(instance, model, operation, pk_set, reverse, field_name)

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -80,6 +80,35 @@ def _log_audit_entry(
             log_auth_event(f"{prefix}{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
 
 
+def _get_limit(
+    operation: str,
+    update_fields: Optional[Any],
+    limit_from_model: list,
+) -> Optional[list]:
+    """
+    Return the list of fields to include in the diff, or None to skip storing an entry.
+    For create/delete (or update without update_fields), returns limit_from_model.
+    For update with update_fields: empty update_fields or empty intersection returns None.
+    """
+    # If we are not in an update, return whatever the model limit is.
+    if operation != 'update' or update_fields is None:
+        return limit_from_model
+    # If we are an update but we don't have any update fields, then we don't want to store an entry.
+    if not update_fields:
+        return None
+    # We only want to diff the fields that were updated, so we take the intersection of
+    # the limited fields and the update fields.
+    if not limit_from_model:
+        # If limit is otherwise empty (meaning no pre-existing limit), then we just need
+        # to make the updated fields the limit.
+        return list(update_fields)
+    limit = list(set(limit_from_model).intersection(set(update_fields)))
+    # If only a non-included field is updated, we can be certain that the delta will be
+    # empty; continuing with the diff would introduce a bug where we diff all
+    # non-excluded fields.
+    return limit if limit else None
+
+
 def _store_activitystream_entry(
     old: Optional[Model],
     new: Optional[Model],
@@ -95,36 +124,22 @@ def _store_activitystream_entry(
     if operation not in ('create', 'update', 'delete'):
         raise ValueError("Invalid operation: {}".format(operation))
 
+    # Excluded/limit come from new (for create/update); for delete new is None so getattr returns []
     excluded = getattr(new, 'activity_stream_excluded_field_names', [])
-    limit = getattr(new, 'activity_stream_limit_field_names', [])
+    limit_from_model = getattr(new, 'activity_stream_limit_field_names', [])
 
-    # We only want to diff the fields that were updated, so we have to take the intersection of the limited fields and the update fields
-    if operation == 'update' and update_fields is not None:
-        if not update_fields:
-            return
-        # If limit is otherwise empty (meaning no pre-existing limit), then we just need to make the updated fields the limit
-        if not limit:
-            limit = update_fields
-        else:
-            limit = list(set(limit).intersection(set(update_fields)))
-            # If only a non-included field is updated, we can be certain that the delta will be empty;
-            # Continuing with the diff would introduce a bug where we diff all non-excluded fields.
-            if not limit:
-                return
+    limit = _get_limit(operation, update_fields, limit_from_model)
+    if limit is None:
+        return None
 
     delta = diff(old, new, exclude_fields=excluded, limit_fields=limit, all_values_as_strings=True)
-
     if not delta:
-        # No changes to store
-        return
+        # There were no changes to store, so we return None
+        return None
 
     # If only one of old or new is None, then use the existing one as content_object
     # The case where both are None is handled above (no changes to store)
-    if new is None:
-        content_object = old
-    else:
-        content_object = new
-
+    content_object = new or old
     _log_audit_entry(
         content_object=content_object,
         operation=operation,

--- a/ansible_base/lib/logging/__init__.py
+++ b/ansible_base/lib/logging/__init__.py
@@ -23,10 +23,6 @@ def log_auth_event(message: str, level: Optional[int] = logging.INFO):
     auth_logger.log(level, message)
 
 
-def log_auth_info(message: str):
-    log_auth_event(message, logging.INFO)
-
-
 def log_auth_error(message: str):
     log_auth_event(message, logging.ERROR)
 

--- a/ansible_base/lib/logging/__init__.py
+++ b/ansible_base/lib/logging/__init__.py
@@ -23,6 +23,10 @@ def log_auth_event(message: str, level: Optional[int] = logging.INFO):
     auth_logger.log(level, message)
 
 
+def log_auth_info(message: str):
+    log_auth_event(message, logging.INFO)
+
+
 def log_auth_error(message: str):
     log_auth_event(message, logging.ERROR)
 

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -235,6 +235,37 @@ def test_activitystream__store_activitystream_entry_both_none():
     assert signals._store_activitystream_entry(None, None, 'create') is None
 
 
+@pytest.mark.parametrize(
+    "operation,update_fields,limit_from_model,expected_limit,expected_skip",
+    [
+        ('create', None, [], [], False),
+        ('delete', None, [], [], False),
+        ('update', None, ['a'], ['a'], False),
+        ('update', [], ['a'], [], True),
+        ('update', ['x'], [], ['x'], False),
+        ('update', ['a', 'b'], ['a'], ['a'], False),
+        ('update', ['x'], ['a'], [], True),
+    ],
+    ids=[
+        "create_uses_limit_from_model",
+        "delete_uses_limit_from_model",
+        "update_no_update_fields_uses_limit_from_model",
+        "update_empty_update_fields_skips",
+        "update_no_limit_uses_update_fields",
+        "update_intersection",
+        "update_empty_intersection_skips",
+    ],
+)
+def test_get_limit(operation, update_fields, limit_from_model, expected_limit, expected_skip):
+    """_get_limit returns correct limit list or None (skip) for all operations."""
+    limit = signals._get_limit(operation, update_fields, limit_from_model)
+    if expected_skip:
+        assert limit is None
+    else:
+        assert limit is not None
+        assert set(limit) == set(expected_limit)
+
+
 def test_activitystream__store_activitystream_m2m_invalid_operation():
     """Invalid operation raises ValueError; pass a real model class to satisfy type hints."""
     with pytest.raises(ValueError) as excinfo:

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -576,7 +576,7 @@ def test_audit_log_disabled_by_default():
     """
     Ensure that audit logging is disabled by default (audit_log_enabled=False).
     """
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal = Animal.objects.create(name='Fluffy')
         mock_log.assert_not_called()
 
@@ -601,7 +601,7 @@ def test_audit_log_enabled_on_create_delete(operation, perform_operation):
     if operation == "delete":
         # For delete, we need to create first without audit logging
         animal = Animal.objects.create(name='Fluffy')
-        with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
             animal.audit_log_enabled = True
             animal.delete()
 
@@ -610,7 +610,7 @@ def test_audit_log_enabled_on_create_delete(operation, perform_operation):
             assert call_args.startswith('delete Animal')
             assert 'Fluffy' in call_args
     else:
-        with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
             with mock.patch.object(Animal, 'audit_log_enabled', True):
                 perform_operation()
 
@@ -628,7 +628,7 @@ def test_audit_log_enabled_on_update_changed_field():
     """
     animal = Animal.objects.create(name='Fluffy')
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.audit_log_enabled = True
         animal.name = 'Rocky'
         animal.save()
@@ -649,7 +649,7 @@ def test_audit_log_enabled_on_update_multiple_fields():
     """
     animal = Animal.objects.create(name='Fluffy', kind='dog')
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.audit_log_enabled = True
         animal.name = 'Rocky'
         animal.kind = 'cat'
@@ -679,7 +679,7 @@ def test_audit_log_added_field_format():
     from test_app.models import User
     user = User.objects.create(username='testowner')
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.audit_log_enabled = True
         animal.owner = user
         animal.save()
@@ -701,7 +701,7 @@ def test_audit_log_removed_field_format():
     user = User.objects.create(username='testowner')
     animal = Animal.objects.create(name='Fluffy', owner=user)
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.audit_log_enabled = True
         animal.owner = None
         animal.save()
@@ -722,7 +722,7 @@ def test_audit_log_respects_excluded_fields():
     # Animal has 'age' in activity_stream_excluded_field_names
     animal = Animal.objects.create(name='Fluffy', age=2)
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.audit_log_enabled = True
         animal.name = 'Rocky'
         animal.age = 5  # This should not be logged
@@ -746,7 +746,7 @@ def test_audit_log_with_activity_stream_disabled():
     When activity_stream_enabled=False but audit_log_enabled=True,
     audit logs should still be generated.
     """
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         with mock.patch.object(Animal, 'audit_log_enabled', True):
             with mock.patch.object(Animal, 'activity_stream_enabled', False):
                 animal = Animal.objects.create(name='Fluffy')
@@ -771,7 +771,7 @@ def test_audit_log_message_content(expected_content):
     """
     Ensure the audit log message includes expected content (model name, object str).
     """
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         with mock.patch.object(Animal, 'audit_log_enabled', True):
             Animal.objects.create(name='Fluffy')
 
@@ -792,7 +792,7 @@ def test_audit_log_m2m_associate(user):
     animal = Animal.objects.create(name='Fluffy')
     animal.audit_log_enabled = True
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.people_friends.add(user)
 
         assert mock_log.call_count == 1
@@ -811,7 +811,7 @@ def test_audit_log_m2m_disassociate(user):
     animal.people_friends.add(user)  # First add without logging
     animal.audit_log_enabled = True
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.people_friends.remove(user)
 
         assert mock_log.call_count == 1
@@ -829,7 +829,7 @@ def test_audit_log_m2m_disabled_by_default(user):
     animal = Animal.objects.create(name='Fluffy')
     # audit_log_enabled is False by default
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         animal.people_friends.add(user)
         animal.people_friends.remove(user)
 
@@ -854,7 +854,7 @@ def test_audit_log_m2m_preposition(user, operation, method_name, expected_prepos
         animal.people_friends.add(user)  # Need to add first before removing
     animal.audit_log_enabled = True
 
-    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
         method = getattr(animal.people_friends, method_name)
         method(user)
 

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -1,8 +1,11 @@
+from unittest import mock
+
 import pytest
 
 import ansible_base.activitystream.signals as signals
 from ansible_base.activitystream import no_activity_stream
 from ansible_base.activitystream.models import Entry
+from ansible_base.activitystream.models.entry import AuditableModel
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from test_app.models import Animal, City, SecretColor
 
@@ -477,3 +480,384 @@ def test_activitystream_update_fields_none_with_limit_fields():
     assert 'name' not in entry.changes['changed_fields']
     assert 'population' not in entry.changes['changed_fields']
     assert entry.changes['changed_fields']['country'] == [ENCRYPTED_STRING, ENCRYPTED_STRING]
+
+
+# =============================================================================
+# Tests for AuditableModel class variables
+# =============================================================================
+
+
+class TestAuditableModelClassVariables:
+    """Tests for the AuditableModel class variable defaults."""
+
+    @pytest.mark.parametrize(
+        "attribute,expected",
+        [
+            ("activity_stream_enabled", True),
+            ("audit_log_enabled", False),
+            ("activity_stream_excluded_field_names", []),
+            ("activity_stream_limit_field_names", []),
+        ],
+        ids=[
+            "activity_stream_enabled_defaults_to_true",
+            "audit_log_enabled_defaults_to_false",
+            "excluded_field_names_defaults_to_empty_list",
+            "limit_field_names_defaults_to_empty_list",
+        ],
+    )
+    def test_auditable_model_class_variable_defaults(self, attribute, expected):
+        """Ensure AuditableModel class variables have correct default values."""
+        assert getattr(AuditableModel, attribute) == expected
+
+
+# =============================================================================
+# Tests for activity_stream_enabled flag
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_activity_stream_enabled_false_prevents_entry_creation():
+    """
+    Ensure that setting activity_stream_enabled=False on a model prevents
+    activity stream entries from being created.
+    """
+    # Create an animal with activity stream enabled (default)
+    animal = Animal.objects.create(name='Fluffy')
+    assert animal.activity_stream_entries.count() == 1
+
+    # Now disable activity stream on the instance and update
+    animal.activity_stream_enabled = False
+    animal.name = 'Rocky'
+    animal.save()
+
+    # No new entry should be created
+    assert animal.activity_stream_entries.count() == 1
+
+
+@pytest.mark.django_db
+def test_activity_stream_enabled_false_on_create():
+    """
+    Ensure that creating an object with activity_stream_enabled=False
+    does not create an activity stream entry.
+    """
+    # Create animal, then immediately set flag and check
+    # Note: The flag is checked during signal processing
+    with mock.patch.object(Animal, 'activity_stream_enabled', False):
+        animal = Animal.objects.create(name='Silent')
+
+    assert animal.activity_stream_entries.count() == 0
+
+
+@pytest.mark.django_db
+def test_activity_stream_enabled_false_on_delete():
+    """
+    Ensure that deleting an object with activity_stream_enabled=False
+    does not create an activity stream entry.
+    """
+    animal = Animal.objects.create(name='Fluffy')
+    initial_count = animal.activity_stream_entries.count()
+
+    # Disable activity stream and delete
+    animal.activity_stream_enabled = False
+    entries_qs = animal.activity_stream_entries  # Keep reference
+    animal.delete()
+
+    # No new entry should be created for the delete
+    assert entries_qs.count() == initial_count
+
+
+# =============================================================================
+# Tests for audit_log_enabled flag and log message formatting
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_audit_log_disabled_by_default():
+    """
+    Ensure that audit logging is disabled by default (audit_log_enabled=False).
+    """
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal = Animal.objects.create(name='Fluffy')
+        mock_log.assert_not_called()
+
+        animal.name = 'Rocky'
+        animal.save()
+        mock_log.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "operation,perform_operation",
+    [
+        ("create", lambda: Animal.objects.create(name='Fluffy')),
+        ("delete", None),  # Special case handled in test
+    ],
+    ids=["create_logs_full_state", "delete_logs_full_state"],
+)
+def test_audit_log_enabled_on_create_delete(operation, perform_operation):
+    """
+    Ensure that when audit_log_enabled=True, create/delete operations log the full object state.
+    """
+    if operation == "delete":
+        # For delete, we need to create first without audit logging
+        animal = Animal.objects.create(name='Fluffy')
+        with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+            animal.audit_log_enabled = True
+            animal.delete()
+
+            assert mock_log.call_count == 1
+            call_args = mock_log.call_args[0][0]
+            assert call_args.startswith('delete Animal')
+            assert 'Fluffy' in call_args
+    else:
+        with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+            with mock.patch.object(Animal, 'audit_log_enabled', True):
+                perform_operation()
+
+            assert mock_log.call_count == 1
+            call_args = mock_log.call_args[0][0]
+            assert call_args.startswith(f'{operation} Animal')
+            assert 'Fluffy' in call_args
+            assert 'name' in call_args
+
+
+@pytest.mark.django_db
+def test_audit_log_enabled_on_update_changed_field():
+    """
+    Ensure that when audit_log_enabled=True, update operations log one line per changed field.
+    """
+    animal = Animal.objects.create(name='Fluffy')
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.audit_log_enabled = True
+        animal.name = 'Rocky'
+        animal.save()
+
+        # Should have been called once for the name change
+        assert mock_log.call_count == 1
+        call_args = mock_log.call_args[0][0]
+
+        # Verify message format: "update ModelName obj_str changed field from 'old' to 'new'"
+        assert 'update Animal' in call_args
+        assert "changed name from 'Fluffy' to 'Rocky'" in call_args
+
+
+@pytest.mark.django_db
+def test_audit_log_enabled_on_update_multiple_fields():
+    """
+    Ensure that when multiple fields change, each gets its own log line.
+    """
+    animal = Animal.objects.create(name='Fluffy', kind='dog')
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.audit_log_enabled = True
+        animal.name = 'Rocky'
+        animal.kind = 'cat'
+        animal.save()
+
+        # Should have been called twice (once for each changed field)
+        assert mock_log.call_count == 2
+
+        # Collect all log messages
+        messages = [call[0][0] for call in mock_log.call_args_list]
+
+        # Verify both fields are logged
+        name_logged = any("changed name from 'Fluffy' to 'Rocky'" in msg for msg in messages)
+        kind_logged = any("changed kind from 'dog' to 'cat'" in msg for msg in messages)
+
+        assert name_logged, f"Expected name change in messages: {messages}"
+        assert kind_logged, f"Expected kind change in messages: {messages}"
+
+
+@pytest.mark.django_db
+def test_audit_log_added_field_format():
+    """
+    Ensure added fields (null to value) are logged with correct format.
+    """
+    animal = Animal.objects.create(name='Fluffy', owner=None)
+
+    from test_app.models import User
+    user = User.objects.create(username='testowner')
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.audit_log_enabled = True
+        animal.owner = user
+        animal.save()
+
+        # Find the log call for the added owner field
+        messages = [call[0][0] for call in mock_log.call_args_list]
+        owner_msg = next((msg for msg in messages if 'owner' in msg), None)
+
+        # Could be logged as added or changed depending on diff implementation
+        assert owner_msg is not None, f"Expected owner in messages: {messages}"
+
+
+@pytest.mark.django_db
+def test_audit_log_removed_field_format():
+    """
+    Ensure removed fields (value to null) are logged with correct format.
+    """
+    from test_app.models import User
+    user = User.objects.create(username='testowner')
+    animal = Animal.objects.create(name='Fluffy', owner=user)
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.audit_log_enabled = True
+        animal.owner = None
+        animal.save()
+
+        # Find the log call for the removed owner field
+        messages = [call[0][0] for call in mock_log.call_args_list]
+        owner_msg = next((msg for msg in messages if 'owner' in msg), None)
+
+        # Could be logged as removed or changed depending on diff implementation
+        assert owner_msg is not None, f"Expected owner in messages: {messages}"
+
+
+@pytest.mark.django_db
+def test_audit_log_respects_excluded_fields():
+    """
+    Ensure that excluded fields are not logged to the audit log.
+    """
+    # Animal has 'age' in activity_stream_excluded_field_names
+    animal = Animal.objects.create(name='Fluffy', age=2)
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.audit_log_enabled = True
+        animal.name = 'Rocky'
+        animal.age = 5  # This should not be logged
+        animal.save()
+
+        messages = [call[0][0] for call in mock_log.call_args_list]
+
+        # Name should be logged
+        name_logged = any('name' in msg for msg in messages)
+        assert name_logged, f"Expected name in messages: {messages}"
+
+        # Age should NOT be logged (it's excluded)
+        age_logged = any('age' in msg and 'changed age' in msg for msg in messages)
+        assert not age_logged, f"Age should not be logged: {messages}"
+
+
+@pytest.mark.django_db
+def test_audit_log_with_activity_stream_disabled():
+    """
+    Ensure audit logging works independently of activity stream.
+    When activity_stream_enabled=False but audit_log_enabled=True,
+    audit logs should still be generated.
+    """
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        with mock.patch.object(Animal, 'audit_log_enabled', True):
+            with mock.patch.object(Animal, 'activity_stream_enabled', False):
+                animal = Animal.objects.create(name='Fluffy')
+
+        # Audit log should still be called
+        assert mock_log.call_count == 1
+
+    # But no activity stream entry
+    assert animal.activity_stream_entries.count() == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "expected_content",
+    [
+        "Animal",  # Model name
+        "Fluffy",  # Object name (part of __str__)
+    ],
+    ids=["includes_model_name", "includes_object_str"],
+)
+def test_audit_log_message_content(expected_content):
+    """
+    Ensure the audit log message includes expected content (model name, object str).
+    """
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        with mock.patch.object(Animal, 'audit_log_enabled', True):
+            Animal.objects.create(name='Fluffy')
+
+        call_args = mock_log.call_args[0][0]
+        assert expected_content in call_args
+
+
+# =============================================================================
+# Tests for M2M audit logging
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_audit_log_m2m_associate(user):
+    """
+    Ensure that M2M associations are logged when audit_log_enabled=True.
+    """
+    animal = Animal.objects.create(name='Fluffy')
+    animal.audit_log_enabled = True
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.people_friends.add(user)
+
+        assert mock_log.call_count == 1
+        call_args = mock_log.call_args[0][0]
+        assert 'associate' in call_args
+        assert 'Animal' in call_args
+        assert 'with' in call_args
+
+
+@pytest.mark.django_db
+def test_audit_log_m2m_disassociate(user):
+    """
+    Ensure that M2M disassociations are logged when audit_log_enabled=True.
+    """
+    animal = Animal.objects.create(name='Fluffy')
+    animal.people_friends.add(user)  # First add without logging
+    animal.audit_log_enabled = True
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.people_friends.remove(user)
+
+        assert mock_log.call_count == 1
+        call_args = mock_log.call_args[0][0]
+        assert 'disassociate' in call_args
+        assert 'Animal' in call_args
+        assert 'from' in call_args
+
+
+@pytest.mark.django_db
+def test_audit_log_m2m_disabled_by_default(user):
+    """
+    Ensure that M2M operations are not logged when audit_log_enabled=False (default).
+    """
+    animal = Animal.objects.create(name='Fluffy')
+    # audit_log_enabled is False by default
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        animal.people_friends.add(user)
+        animal.people_friends.remove(user)
+
+        mock_log.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "operation,method_name,expected_preposition",
+    [
+        ("associate", "add", "with"),
+        ("disassociate", "remove", "from"),
+    ],
+    ids=["associate_uses_with", "disassociate_uses_from"],
+)
+def test_audit_log_m2m_preposition(user, operation, method_name, expected_preposition):
+    """
+    Ensure that associate uses 'with' and disassociate uses 'from' in log messages.
+    """
+    animal = Animal.objects.create(name='Fluffy')
+    if method_name == "remove":
+        animal.people_friends.add(user)  # Need to add first before removing
+    animal.audit_log_enabled = True
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_info') as mock_log:
+        method = getattr(animal.people_friends, method_name)
+        method(user)
+
+        call_args = mock_log.call_args[0][0]
+        assert expected_preposition in call_args
+        assert operation in call_args

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -1,3 +1,4 @@
+import re
 from unittest import mock
 
 import pytest
@@ -516,10 +517,10 @@ class TestAuditableModelClassVariables:
 
 
 @pytest.mark.django_db
-def test_activity_stream_enabled_false_prevents_entry_creation():
+def test_activity_stream_enabled_false_on_update():
     """
     Ensure that setting activity_stream_enabled=False on a model prevents
-    activity stream entries from being created.
+    activity stream entries from being created on update.
     """
     # Create an animal with activity stream enabled (default)
     animal = Animal.objects.create(name='Fluffy')
@@ -677,6 +678,7 @@ def test_audit_log_added_field_format():
     animal = Animal.objects.create(name='Fluffy', owner=None)
 
     from test_app.models import User
+
     user = User.objects.create(username='testowner')
 
     with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
@@ -698,6 +700,7 @@ def test_audit_log_removed_field_format():
     Ensure removed fields (value to null) are logged with correct format.
     """
     from test_app.models import User
+
     user = User.objects.create(username='testowner')
     animal = Animal.objects.create(name='Fluffy', owner=user)
 
@@ -715,9 +718,15 @@ def test_audit_log_removed_field_format():
 
 
 @pytest.mark.django_db
-def test_audit_log_respects_excluded_fields():
+def test_audit_log_respects_excluded_fields(user):
     """
     Ensure that excluded fields are not logged to the audit log.
+
+    Excluded fields (e.g. age, last_login) must never appear in audit messages.
+    This helps ensure sensitive or irrelevant data is not logged. In real
+    deployments, models should exclude passwords, tokens, API keys, and other
+    secrets via activity_stream_excluded_field_names; DAB test_app has
+    User.last_login and Animal.age as examples.
     """
     # Animal has 'age' in activity_stream_excluded_field_names
     animal = Animal.objects.create(name='Fluffy', age=2)
@@ -737,6 +746,46 @@ def test_audit_log_respects_excluded_fields():
         # Age should NOT be logged (it's excluded)
         age_logged = any('age' in msg and 'changed age' in msg for msg in messages)
         assert not age_logged, f"Age should not be logged: {messages}"
+
+        # Disallowed content: no raw password hashes (pbkdf2, sha, argon2, etc.) in messages
+        for msg in messages:
+            assert 'pbkdf2_sha256$' not in msg, "Audit log must not contain password hashes"
+            assert 'sha1$' not in msg and 'argon2$' not in msg, "Audit log must not contain raw hash algorithms"
+
+    # User password change: if password is ever logged, both old and new must appear as $encrypted$
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
+        user.audit_log_enabled = True
+        user.set_password('NewSecurePass1!')
+        user.save()
+
+        messages = [call[0][0] for call in mock_log.call_args_list]
+        for msg in messages:
+            assert (
+                'pbkdf2_sha256$' not in msg and 'sha1$' not in msg and 'argon2$' not in msg
+            ), "Audit log must not contain password hashes or raw hash algorithms"
+            if 'changed password' in msg:
+                assert re.search(r"changed password from '\$encrypted\$' to '\$encrypted\$'", msg), (
+                    "Password change must show both old and new as $encrypted$: " + msg
+                )
+            if 'added password' in msg:
+                assert "'$encrypted$'" in msg, "Added password must show as $encrypted$: " + msg
+
+    # User has 'last_login' in activity_stream_excluded_field_names
+    from django.utils import timezone
+
+    with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
+        user.audit_log_enabled = True
+        user.first_name = 'Audit'
+        user.last_login = timezone.now()
+        user.save()
+
+        messages = [call[0][0] for call in mock_log.call_args_list]
+        # first_name should be logged
+        first_name_logged = any('first_name' in msg for msg in messages)
+        assert first_name_logged, f"Expected first_name in messages: {messages}"
+        # last_login should NOT be logged (it's excluded)
+        last_login_logged = any('last_login' in msg and ('changed last_login' in msg or 'added last_login' in msg) for msg in messages)
+        assert not last_login_logged, f"last_login should not be logged: {messages}"
 
 
 @pytest.mark.django_db

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -236,8 +236,9 @@ def test_activitystream__store_activitystream_entry_both_none():
 
 
 def test_activitystream__store_activitystream_m2m_invalid_operation():
+    """Invalid operation raises ValueError; pass a real model class to satisfy type hints."""
     with pytest.raises(ValueError) as excinfo:
-        signals._store_activitystream_m2m(None, None, 'invalid', [], False, 'field')
+        signals._store_activitystream_m2m(None, Animal, 'invalid', set(), False, 'field')
 
     assert 'Invalid operation: invalid' in str(excinfo.value)
 
@@ -608,7 +609,7 @@ def test_audit_log_enabled_on_create_delete(operation, perform_operation):
 
             assert mock_log.call_count == 1
             call_args = mock_log.call_args[0][0]
-            assert call_args.startswith('delete Animal')
+            assert 'delete Animal' in call_args
             assert 'Fluffy' in call_args
     else:
         with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
@@ -617,7 +618,7 @@ def test_audit_log_enabled_on_create_delete(operation, perform_operation):
 
             assert mock_log.call_count == 1
             call_args = mock_log.call_args[0][0]
-            assert call_args.startswith(f'{operation} Animal')
+            assert f'{operation} Animal' in call_args
             assert 'Fluffy' in call_args
             assert 'name' in call_args
 


### PR DESCRIPTION
## Description

- **What is being changed?**
  Add audit logging capability to the activity stream that logs model changes to a configurable audit logger.

- **Why is this change needed?**
  To provide comprehensive audit logging for AAP entities, enabling compliance and security auditing requirements.

- **How does this change address the issue?**
  Implements audit logging infrastructure in the AuditableModel signal handlers that can be enabled per-model.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- Development environment with DAB test_app

### Steps to Test
1. Run the test suite: `tox -e py312 -- -k "test_audit" -v`
2. All new audit logging tests should pass

### Expected Results
- All tests pass
- No regressions in existing activity stream functionality

## Changes Summary

### New class variables on AuditableModel
- `audit_log_enabled` (default False) - enables/disables audit log messages
- `activity_stream_enabled` (default True) - enables/disables activity stream DB entries

### New logging helper
- Added `log_auth_info()` function for INFO level audit logging

### Audit log message formats
- **create/delete**: Logs full object state as dict
- **update**: Logs one line per changed field with old/new values
- **associate/disassociate**: Logs M2M relationship changes

### Example log output
```
2026-02-06 15:15:02,744 INFO 550e8400-e29b-41d4-a716-446655440000 aap.auth_audit [172.18.0.1] "curl/8.7.1" update User admin changed last_name from 'OldValue' to 'NewValue'
```

---
**Note:** This PR was developed with assistance from Claude AI assistant.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-model toggles added to control activity stream and audit logging behavior
  * Many-to-many relationship changes are now recorded and logged

* **Bug Fixes**
  * Activity stream entries are only created when activity stream is enabled
  * Better handling of update-field limits and defensive normalization for m2m changes

* **Tests**
  * Extensive tests added for activity stream and audit logging scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->