### PR TITLE
[WIP] AAP-57990 Add visible_teams to support org admins all team view

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -15,7 +15,7 @@ from ansible_base.lib.utils.auth import get_team_model
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.rbac.permission_registry import permission_registry  # careful for circular imports
-from ansible_base.rbac.policies import check_content_obj_permission, visible_users
+from ansible_base.rbac.policies import can_view_all_users, check_content_obj_permission, visible_teams, visible_users
 from ansible_base.rbac.validators import check_locally_managed, validate_permissions_for_model
 
 from ..models import DABContentType, DABPermission
@@ -109,6 +109,9 @@ class BaseAssignmentSerializer(CommonModelSerializer):
             obj = resource.content_object
             if obj._meta.model_name == 'user':
                 if not visible_users(requesting_user).filter(pk=obj.pk).exists():
+                    raise ObjectDoesNotExist
+            elif obj._meta.model_name == 'team':
+                if not visible_teams(requesting_user).filter(pk=obj.pk).exists():
                     raise ObjectDoesNotExist
             elif not requesting_user.has_obj_perm(obj, 'view'):
                 raise ObjectDoesNotExist
@@ -253,7 +256,10 @@ class RoleTeamAssignmentSerializer(BaseAssignmentSerializer):
         fields = ASSIGNMENT_FIELDS + ['team', 'team_ansible_id']
 
     def get_actor_queryset(self, requesting_user):
-        return permission_registry.team_model.access_qs(requesting_user)
+        if can_view_all_users(requesting_user):
+            return visible_teams(requesting_user)
+        else:
+            return permission_registry.team_model.access_qs(requesting_user)
 
 
 class RoleMetadataSerializer(serializers.Serializer):

--- a/ansible_base/rbac/policies.py
+++ b/ansible_base/rbac/policies.py
@@ -51,6 +51,30 @@ def can_view_all_users(request_user):
     )
 
 
+def visible_teams(request_user, queryset=None) -> QuerySet:
+    """Gives a queryset of teams that another user should be able to view"""
+    team_cls = permission_registry.team_model
+
+    if not getattr(request_user, "is_authenticated", False):
+        return team_cls.objects.none()
+
+    org_cls = apps.get_model(settings.ANSIBLE_BASE_ORGANIZATION_MODEL)
+
+    if can_view_all_users(request_user):
+        if queryset is not None:
+            return queryset
+        else:
+            return team_cls.objects.all()
+
+    # Teams belong directly to organizations via ForeignKey, so filter by visible organizations
+    visible_org_ids = org_cls.access_ids_qs(request_user, 'view')
+    if queryset is None:
+        queryset = team_cls.objects
+
+    queryset = queryset.filter(organization_id__in=visible_org_ids)
+    return queryset.distinct()
+
+
 def can_change_user(request_user, target_user) -> bool:
     """Tells if the request user can modify details of the target user"""
     if request_user.is_superuser:

--- a/test_app/tests/rbac/api/test_ansible_id_assignments.py
+++ b/test_app/tests/rbac/api/test_ansible_id_assignments.py
@@ -2,10 +2,12 @@ from uuid import uuid4
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import DABContentType, ObjectRole, RoleEvaluation
 from ansible_base.resource_registry.models import Resource
+from test_app.models import Organization, Team
 
 
 @pytest.mark.django_db
@@ -106,3 +108,49 @@ def test_object_ansible_id_bad_type(admin_api_client, inv_rd, rando, organizatio
     response = admin_api_client.post(url, data=data, format="json")
     assert response.status_code == 400, response.data
     assert 'organization does not match role type of inventory' in str(response.data['object_ansible_id'])
+
+
+@pytest.mark.django_db
+@override_settings(ALLOW_LOCAL_ASSIGNING_JWT_ROLES=True)
+@pytest.mark.parametrize('org_admins_can_see_all_users', [True, False])
+def test_get_by_ansible_id_team_object_org_admins_can_see_all_users(
+    user,
+    user_api_client,
+    organization,
+    org_admin_rd,
+    member_rd,
+    admin_rd,
+    org_admins_can_see_all_users,
+):
+    """get_by_ansible_id uses visible_teams for team objects; ORG_ADMINS_CAN_SEE_ALL_USERS controls whether org admins see all teams.
+
+    When creating a RoleTeamAssignment with object_ansible_id pointing to a team in another org:
+    - ORG_ADMINS_CAN_SEE_ALL_USERS=False: team not in visible_teams → ValidationError (object does not exist)
+    - ORG_ADMINS_CAN_SEE_ALL_USERS=True: team in visible_teams → resolution succeeds (and assignment succeeds if user has change on that team)
+    """
+    org_admin_rd.give_permission(user, organization)
+    actor_team = Team.objects.create(name='actor-team', organization=organization)
+    other_org = Organization.objects.create(name='other-org')
+    target_team = Team.objects.create(name='target-team', organization=other_org)
+
+    target_team_ct = ContentType.objects.get_for_model(target_team)
+    target_team_resource = Resource.objects.get(object_id=target_team.pk, content_type=target_team_ct.pk)
+
+    url = get_relative_url('roleteamassignment-list')
+    data = {
+        'role_definition': member_rd.id,
+        'team': actor_team.id,
+        'object_ansible_id': str(target_team_resource.ansible_id),
+    }
+
+    if org_admins_can_see_all_users:
+        admin_rd.give_permission(user, target_team)
+
+    with override_settings(ORG_ADMINS_CAN_SEE_ALL_USERS=org_admins_can_see_all_users):
+        response = user_api_client.post(url, data=data, format='json')
+
+    if org_admins_can_see_all_users:
+        assert response.status_code == 201, response.data
+    else:
+        assert response.status_code == 400, response.data
+        assert 'object does not exist' in str(response.data.get('object_ansible_id', []))

--- a/test_app/tests/rbac/api/test_user_permissions.py
+++ b/test_app/tests/rbac/api/test_user_permissions.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
-from test_app.models import Organization, Team, User
+from test_app.models import Inventory, Organization, Team, User
 
 
 @pytest.mark.django_db
@@ -215,3 +215,31 @@ class TestRoleBasedAssignment:
         response = user_api_client.post(url, data=data)
         assert response.status_code == 201, response.data
         assert rando.has_obj_perm(inventory, 'change')
+
+    @override_settings(ALLOW_LOCAL_ASSIGNING_JWT_ROLES=True)
+    @pytest.mark.parametrize('org_admins_can_see_all_users', [True, False])
+    def test_org_admin_can_assign_role_to_team_in_other_org(
+        self, user, user_api_client, organization, inv_rd, org_admin_rd, member_rd, org_admins_can_see_all_users
+    ):
+        """Org admins with ORG_ADMINS_CAN_SEE_ALL_USERS=True can assign roles to any team (get_actor_queryset uses visible_teams)."""
+        other_org = Organization.objects.create(name='other-org')
+        inventory_org1 = Inventory.objects.create(name='inv-org1', organization=organization)
+        team_in_other_org = Team.objects.create(name='team-other-org', organization=other_org)
+
+        org_admin_rd.give_permission(user, organization)
+        url = get_relative_url('roleteamassignment-list')
+        data = {
+            'role_definition': inv_rd.id,
+            'object_id': inventory_org1.id,
+            'team': team_in_other_org.id,
+        }
+        with override_settings(ORG_ADMINS_CAN_SEE_ALL_USERS=org_admins_can_see_all_users):
+            response = user_api_client.post(url, data=data)
+        if org_admins_can_see_all_users:
+            assert response.status_code == 201, response.data
+            rando = User.objects.create(username='rando')
+            member_rd.give_permission(rando, team_in_other_org)
+            assert rando.has_obj_perm(inventory_org1, 'change')
+        else:
+            assert response.status_code == 400, response.data
+            assert 'object does not exist' in str(response.data.get('team', []))

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -124,31 +124,59 @@ def test_visible_teams_user_with_view_permission_on_multiple_orgs():
 
 
 @pytest.mark.django_db
-def test_visible_teams_with_custom_queryset():
+@pytest.mark.parametrize(
+    'user_type,org_admins_can_see_all,expected_team1_count,expected_team2_count',
+    [
+        # (user_type, org_admins_can_see_all, expected_team1_count, expected_team2_count)
+        # user_type: 'superuser', 'org_admin', 'regular_viewer'
+        ('superuser', False, 1, 1),  # Superuser sees all teams regardless of setting
+        ('superuser', True, 1, 1),  # Superuser sees all teams regardless of setting
+        ('org_admin', False, 1, 0),  # Org admin only sees teams in their org when setting is False
+        ('org_admin', True, 1, 1),  # Org admin sees all teams when setting is True
+        ('regular_viewer', False, 1, 0),  # Regular viewer only sees teams in orgs they can view
+        ('regular_viewer', True, 1, 0),  # Setting doesn't affect regular viewers without change permission
+    ],
+)
+def test_visible_teams_with_custom_queryset(user_type, org_admins_can_see_all, expected_team1_count, expected_team2_count, org_admin_rd):
     org1 = Organization.objects.create(name='Org 1')
     org2 = Organization.objects.create(name='Org 2')
     team1 = Team.objects.create(name='Team 1', organization=org1)
-    Team.objects.create(name='Team 2', organization=org2)
+    team2 = Team.objects.create(name='Team 2', organization=org2)
 
-    user = User.objects.create(username='viewer')
-    view_org_rd = RoleDefinition.objects.create_from_permissions(
-        permissions=['view_organization'],
-        name='view-org-rd',
-        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
-    )
-    view_org_rd.give_permission(user, org1)
+    # Create user based on type
+    if user_type == 'superuser':
+        user = User.objects.create(username='superuser', is_superuser=True)
+    elif user_type == 'org_admin':
+        user = User.objects.create(username='org-admin')
+        org_admin_rd.give_permission(user, org1)
+    else:  # regular_viewer
+        user = User.objects.create(username='viewer')
+        view_org_rd = RoleDefinition.objects.create_from_permissions(
+            permissions=['view_organization'],
+            name='view-org-rd',
+            content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+        )
+        view_org_rd.give_permission(user, org1)
 
-    # Test with custom queryset that filters by name
-    custom_qs = Team.objects.filter(name='Team 2')
-    qs = visible_teams(user, queryset=custom_qs)
-    # User can only see teams in org1, but queryset filters to team2 (org2), so result should be empty
-    assert not qs.exists()
+    with override_settings(ORG_ADMINS_CAN_SEE_ALL_USERS=org_admins_can_see_all):
+        # Test with custom queryset that filters to team1
+        custom_qs = Team.objects.filter(name='Team 1')
+        qs = visible_teams(user, queryset=custom_qs)
+        assert qs.count() == expected_team1_count
+        if expected_team1_count > 0:
+            assert qs.first().pk == team1.pk
 
-    # Test with custom queryset that matches visible org
-    custom_qs = Team.objects.filter(name='Team 1')
-    qs = visible_teams(user, queryset=custom_qs)
-    assert qs.count() == 1
-    assert qs.first().pk == team1.pk
+        # Test with custom queryset that filters to team2
+        custom_qs = Team.objects.filter(name='Team 2')
+        qs = visible_teams(user, queryset=custom_qs)
+        assert qs.count() == expected_team2_count
+        if expected_team2_count > 0:
+            assert qs.first().pk == team2.pk
+
+        # Test with custom queryset that includes both teams
+        custom_qs = Team.objects.filter(name__in=['Team 1', 'Team 2'])
+        qs = visible_teams(user, queryset=custom_qs)
+        assert qs.count() == expected_team1_count + expected_team2_count
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -1,8 +1,11 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
+from django.test.utils import override_settings
 
-from ansible_base.rbac.policies import can_change_user, visible_users
-from test_app.models import User
+from ansible_base.rbac import permission_registry
+from ansible_base.rbac.models import RoleDefinition
+from ansible_base.rbac.policies import can_change_user, visible_teams, visible_users
+from test_app.models import Organization, Team, User
 
 
 @pytest.mark.django_db
@@ -42,3 +45,133 @@ def test_visible_users_anonymous_user():
 
     qs = visible_users(AnonymousUser())
     assert not qs.exists()
+
+
+@pytest.mark.django_db
+def test_visible_teams_anonymous_user():
+    org = Organization.objects.create(name='Test Org')
+    Team.objects.create(name='Test Team', organization=org)
+
+    qs = visible_teams(AnonymousUser())
+    assert not qs.exists()
+
+
+@pytest.mark.django_db
+def test_visible_teams_superuser(admin_user):
+    org1 = Organization.objects.create(name='Org 1')
+    org2 = Organization.objects.create(name='Org 2')
+    team1 = Team.objects.create(name='Team 1', organization=org1)
+    team2 = Team.objects.create(name='Team 2', organization=org2)
+
+    qs = visible_teams(admin_user)
+    assert qs.count() == 2
+    assert set(qs.values_list('pk', flat=True)) == {team1.pk, team2.pk}
+
+
+@pytest.mark.django_db
+def test_visible_teams_user_with_no_permissions():
+    org = Organization.objects.create(name='Test Org')
+    Team.objects.create(name='Test Team', organization=org)
+
+    user = User.objects.create(username='regular_user')
+    qs = visible_teams(user)
+    assert not qs.exists()
+
+
+@pytest.mark.django_db
+def test_visible_teams_user_with_view_permission_on_one_org():
+    org1 = Organization.objects.create(name='Org 1')
+    org2 = Organization.objects.create(name='Org 2')
+    team1 = Team.objects.create(name='Team 1', organization=org1)
+    team2 = Team.objects.create(name='Team 2', organization=org2)
+
+    user = User.objects.create(username='viewer')
+    view_org_rd = RoleDefinition.objects.create_from_permissions(
+        permissions=['view_organization'],
+        name='view-org-rd',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+    view_org_rd.give_permission(user, org1)
+
+    qs = visible_teams(user)
+    assert qs.count() == 1
+    assert qs.first().pk == team1.pk
+    assert team2.pk not in qs.values_list('pk', flat=True)
+
+
+@pytest.mark.django_db
+def test_visible_teams_user_with_view_permission_on_multiple_orgs():
+    org1 = Organization.objects.create(name='Org 1')
+    org2 = Organization.objects.create(name='Org 2')
+    org3 = Organization.objects.create(name='Org 3')
+    team1 = Team.objects.create(name='Team 1', organization=org1)
+    team2 = Team.objects.create(name='Team 2', organization=org2)
+    team3 = Team.objects.create(name='Team 3', organization=org3)
+
+    user = User.objects.create(username='multi_viewer')
+    view_org_rd = RoleDefinition.objects.create_from_permissions(
+        permissions=['view_organization'],
+        name='view-org-rd',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+    view_org_rd.give_permission(user, org1)
+    view_org_rd.give_permission(user, org2)
+
+    qs = visible_teams(user)
+    assert qs.count() == 2
+    assert set(qs.values_list('pk', flat=True)) == {team1.pk, team2.pk}
+    assert team3.pk not in qs.values_list('pk', flat=True)
+
+
+@pytest.mark.django_db
+def test_visible_teams_with_custom_queryset():
+    org1 = Organization.objects.create(name='Org 1')
+    org2 = Organization.objects.create(name='Org 2')
+    team1 = Team.objects.create(name='Team 1', organization=org1)
+    Team.objects.create(name='Team 2', organization=org2)
+
+    user = User.objects.create(username='viewer')
+    view_org_rd = RoleDefinition.objects.create_from_permissions(
+        permissions=['view_organization'],
+        name='view-org-rd',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+    view_org_rd.give_permission(user, org1)
+
+    # Test with custom queryset that filters by name
+    custom_qs = Team.objects.filter(name='Team 2')
+    qs = visible_teams(user, queryset=custom_qs)
+    # User can only see teams in org1, but queryset filters to team2 (org2), so result should be empty
+    assert not qs.exists()
+
+    # Test with custom queryset that matches visible org
+    custom_qs = Team.objects.filter(name='Team 1')
+    qs = visible_teams(user, queryset=custom_qs)
+    assert qs.count() == 1
+    assert qs.first().pk == team1.pk
+
+
+@pytest.mark.django_db
+def test_visible_teams_org_admin_can_view_all_users_teams(org_admin_rd):
+    org1 = Organization.objects.create(name='Org 1')
+    org2 = Organization.objects.create(name='Org 2')
+    team1 = Team.objects.create(name='Team 1', organization=org1)
+    team2 = Team.objects.create(name='Team 2', organization=org2)
+
+    org_admin = User.objects.create(username='org-admin')
+    org_admin_rd.give_permission(org_admin, org1)
+
+    # Org admin should see all teams (because can_view_all_users returns True for org admins with change permission)
+    # can_view_all_users checks for 'change' permission, and org_admin_rd gives change_organization
+    # So can_view_all_users should return True if ORG_ADMINS_CAN_SEE_ALL_USERS is True
+    # Test both scenarios
+    with override_settings(ORG_ADMINS_CAN_SEE_ALL_USERS=True):
+        qs = visible_teams(org_admin)
+        assert qs.count() == 2
+        assert set(qs.values_list('pk', flat=True)) == {team1.pk, team2.pk}
+
+    with override_settings(ORG_ADMINS_CAN_SEE_ALL_USERS=False):
+        qs = visible_teams(org_admin)
+        # Should only see teams in org1
+        assert qs.count() == 1
+        assert qs.first().pk == team1.pk


### PR DESCRIPTION
## Description
Added a visible_teams alongside visible_users to support making all teams viewable in gateway when ORG_ADMINS_CAN_SEE_ALL_USERS=True


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1.  Run UT
or
1. Grab GW partner PR and start gateway
2. Create two orgs, two teams and one normal user.  Make user admin in one org.  Add one team to org.
3. Set ORG_ADMINS_CAN_SEE_ALL_USERS=True
4. Ensure user who is org admin can see both teams
5. Set ORG_ADMINS_CAN_SEE_ALL_USERS=False
6. Ensure user who is org admin can see only the team in the org

### Expected Results
See above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented team visibility filtering to ensure users only see teams they have permission to access based on their role and organization assignments.

* **Tests**
  * Added comprehensive test coverage for team visibility across different user roles and permission configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->