### PR TITLE
fix: change misleading ERROR log to INFO in LDAP group validation

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -394,7 +394,7 @@ class LDAPConfiguration(BaseAuthenticatorConfiguration):
         group_type_class = find_class_in_modules(attrs["GROUP_TYPE"])
         if group_type_class:
             group_type_params = attrs['GROUP_TYPE_PARAMS']
-            logger.error(f"Validating group type params for {attrs['GROUP_TYPE']}")
+            logger.info(f"Validating group type params for {attrs['GROUP_TYPE']}")
             class_args = inspect.getfullargspec(group_type_class.__init__).args[1:]
             invalid_keys = set(group_type_params) - set(class_args)
             missing_keys = set(class_args) - set(group_type_params)


### PR DESCRIPTION
## Summary

Fixes #770 - Changes misleading ERROR log message to INFO level during LDAP authenticator group type parameter validation.

## Changes

- Changed `logger.error()` to `logger.info()` on line 397 of `ansible_base/authentication/authenticator_plugins/ldap.py`
- The log message "Validating group type params for {GROUP_TYPE}" is informational validation logging
- Actual validation errors are properly raised via `ValidationError` later in the function (lines 411-412)

## Rationale

This log message appears during normal LDAP authenticator validation and does not indicate an error condition. Using `ERROR` level causes confusion for administrators who see ERROR logs during successful operations. The message is purely informational - tracking which group type is being validated.

## Testing

- Existing LDAP authenticator tests pass
- No functional changes, only log level adjustment