### PR TITLE
AAP-65704 Abandon tox-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ jobs:
     permissions:
       packages: write
       contents: read
+    services:
+      postgres:
+        image: mirror.gcr.io/library/postgres:15
+        env:
+          POSTGRES_DB: dab_db
+          POSTGRES_USER: dab
+          POSTGRES_PASSWORD: dabing
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U dab -d dab_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
@@ -68,9 +82,12 @@ jobs:
           python-version: ${{ matrix.tests.python-version }}
 
       - name: Install tox
-        run: pip${{ matrix.tests.python-version }} install tox tox-docker
+        run: pip${{ matrix.tests.python-version }} install tox
 
       - name: Run tox
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 5432
         run: |
           echo "::remove-matcher owner=python::"  # Disable annoying annotations from setup-python
           tox --colored yes -e ${{ matrix.tests.env }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,19 +116,16 @@ legacy_tox_ini = """
         -r{toxinidir}/requirements/requirements_dev.txt
     allowlist_externals = sh
     commands = pytest -n auto --color=yes --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch --junit-xml=django-ansible-base-test-results.xml {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}
-    docker = db
 
     [testenv:py311-check,py312-check]
     deps =
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
-    docker = db
     commands =
         python3 manage.py check
         python3 manage.py makemigrations --check
 
     [testenv:py311-sqlite,py312-sqlite]
-    docker = db
     setenv =
         DJANGO_SETTINGS_MODULE = test_app.sqlite3settings
 
@@ -138,7 +135,6 @@ legacy_tox_ini = """
         -r{toxinidir}/requirements/requirements_dev.txt
     commands_pre =
         python -m pip install --upgrade "Django>=4.2.21,<4.3.0"
-    docker = db
 
     [testenv:py311-in-files,py312-in-files]
     deps =
@@ -157,29 +153,21 @@ legacy_tox_ini = """
         -r{toxinidir}/requirements/requirements_testing.txt
         -r{toxinidir}/requirements/requirements_dev.txt
 
-    [docker:db]
-    dockerfile = {toxinidir}/tools/dev_postgres/Dockerfile
-    expose =
-        DB_PORT=5432/tcp
-
     [testenv:flake8]
     deps =
         flake8==7.1.1
         Flake8-pyproject==1.2.3
-    docker =
     commands = flake8 {posargs:.}
 
     [testenv:black]
     deps =
         black==25.1.0
     allowlist_externals = sh
-    docker =
     commands = sh -c 'black --version && black {posargs:.}'
 
     [testenv:isort]
     deps =
         isort==6.0.0
-    docker =
     commands = isort {posargs:.}
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ legacy_tox_ini = """
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
     allowlist_externals = sh
+    passenv =
+        DB_HOST
+        DB_PORT
     commands = pytest -n auto --color=yes --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch --junit-xml=django-ansible-base-test-results.xml {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}
 
     [testenv:py311-check,py312-check]

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -11,7 +11,6 @@ ipython
 isort==6.0.0            # Linting tool, if changed update pyproject.toml as well
 jsonschema
 tox
-tox-docker
 typeguard
 openapi-spec-validator>=0.6.1  # Adapted to changing import locations in jsonschema
 pytest


### PR DESCRIPTION
## Description
Proof that checks are failing

https://github.com/ansible/django-ansible-base/pull/936

I don't know what else to do. We kind of thought we would have to move off tox-docker eventually, so went to nuclear option here.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect CI/test database provisioning and environment wiring; risk is mainly build instability if DB connectivity assumptions differ across tox envs.
> 
> **Overview**
> CI is updated to stop using `tox-docker` and instead provision PostgreSQL via a GitHub Actions `services.postgres` container (with health checks) for the tox job.
> 
> Tox execution now receives `DB_HOST`/`DB_PORT` from CI, and `pyproject.toml` is adjusted to pass these env vars while removing the tox `docker = db` configuration; `tox-docker` is also removed from dev requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40f8a2d934d7c4a8d806fbe0e603b021f72cb8f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs a PostgreSQL service for tests and exposes DB host/port to the test run.
  * Removed the previous docker-based test orchestration and dependency used solely for Docker integration.
  * Test environment forwards DB-related environment variables so test processes connect to the local DB service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->