### PR TITLE
AAP-65704 Define TOX_DOCKER_GATEWAY to fix failing CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         run: pip${{ matrix.tests.python-version }} install tox tox-docker
 
       - name: Run tox
+        env:
+          TOX_DOCKER_GATEWAY: "127.0.0.1"
         run: |
           echo "::remove-matcher owner=python::"  # Disable annoying annotations from setup-python
           tox --colored yes -e ${{ matrix.tests.env }}


### PR DESCRIPTION
## Description
- What is being changed?
Defines TOX_DOCKER_GATEWAY in CI to ensure failing CI checks can pass.
- Why is this change needed?
Without this change, tox-docker fails to get off the ground -
```
File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/tox_docker/plugin.py", line 53, in get_gateway_ip
    ip = container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'Gateway'
  py311-check: FAIL code 2 (86.24 seconds)
  evaluation failed :( (86.37 seconds)
```
- How does this change address the issue?
Defines environment variable to prevent tox-docker from going down problematic code path.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

### Steps to Test
1. Validate CI passes
