### PR TITLE
Replace tox/tox-docker with nox for test and lint execution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@
 **/.gitignore
 **/.venv
 **/venv
-**/.tox
+**/.nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
 jobs:
-  tox:
+  nox:
     name: django-ansible-base - ${{ matrix.tests.env }}
     runs-on: ubuntu-latest
     permissions:
@@ -67,13 +67,13 @@ jobs:
         with:
           python-version: ${{ matrix.tests.python-version }}
 
-      - name: Install tox
-        run: pip${{ matrix.tests.python-version }} install tox tox-docker
+      - name: Install nox
+        run: pip${{ matrix.tests.python-version }} install nox
 
-      - name: Run tox
+      - name: Run nox
         run: |
           echo "::remove-matcher owner=python::"  # Disable annoying annotations from setup-python
-          tox --colored yes -e ${{ matrix.tests.env }}
+          nox -s ${{ matrix.tests.env }} --no-reuse-existing-virtualenvs
 
       - name: Inject PR number into coverage.xml
         if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ coverage.xml
 coverage.json
 django-ansible-base-test-results.xml
 htmlcov
-*.tox
+*.nox
+.nox
 venv/
 .venv/
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ PYTHON := $(notdir $(shell for i in python3.12 python3; do command -v $$i; done|
 CHECK_SYNTAX_FILES ?= .
 RM ?= /bin/rm
 UID := $(shell id -u)
-TOX_ARGS ?= ""
 COMPOSE_OPTS ?=
 COMPOSE_UP_OPTS ?=
 DOCKER_COMPOSE ?= docker compose
@@ -31,23 +30,23 @@ clean:
 
 ## Run test suite
 check:
-	tox
+	nox
 
 ## Run linters (and modify files if necessary)
 lint:
-	tox -m lint
+	nox -s flake8 black isort
 
 ## Run black syntax check
 check_black:
-	tox -e black -- --check $(CHECK_SYNTAX_FILES)
+	nox -s black -- --check $(CHECK_SYNTAX_FILES)
 
 ## Run flake8 syntax check
 check_flake8:
-	tox -e flake8 -- $(CHECK_SYNTAX_FILES)
+	nox -s flake8 -- $(CHECK_SYNTAX_FILES)
 
 ## Run isort syntax check
 check_isort:
-	tox -e isort -- --check $(CHECK_SYNTAX_FILES)
+	nox -s isort -- --check $(CHECK_SYNTAX_FILES)
 
 
 ## Starts a postgres container in the background if one is not running

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,20 +13,39 @@ pip install -r requirements/requirements_dev.txt
 ```
 
 ### Run
-To run the test suite locally you can use tox. By default, with no arguments, tox will attempt to run the tests in various version of python. To run a specific version you can add the `-e` parameter like:
+To run the test suite locally you can use nox. By default, with no arguments, nox will run all sessions. To run a specific session you can use the `-s` parameter like:
 ```
-tox -e 311
+nox -s py312
+```
+
+Available test sessions (for each of 3.11 and 3.12):
+- `py311` / `py312` - Main test suite
+- `py311-check` / `py312-check` - Django system checks and migration verification
+- `py311-sqlite` / `py312-sqlite` - Test suite with SQLite backend
+- `py311-django4` / `py312-django4` - Test suite pinned to Django 4.2
+- `py311-in-files` / `py312-in-files` - Test suite using individual `.in` requirement files
+
+Available lint/utility sessions:
+- `flake8` - Flake8 linter
+- `black` - Black code formatter
+- `isort` - isort import sorter
+- `lint` - Run all linters at once
+- `stop_db` - Stop the test PostgreSQL container
+
+You can list all available sessions with:
+```
+nox -l
 ```
 
 ### Test database
 
 Tests require PostgreSQL running in order to pass.
 
-tox will automatically create/start and stop/destroy the postgres container.  If you want the container to remain after test execution, add **--docker-dont-stop=db**.
+nox will automatically create a fresh PostgreSQL container (`dab-test-postgres`) before running tests and destroy it when the session finishes. This ensures a clean database state for every run.
 
 ## Checking code coverage locally
 
-Tox will also create code coverage reports when run. These can be found in various places. For example, git ignored, `coverage.xml` and `coverage.json` will be crated in the root folders. For human consumption you will also see an `htmlcov` folder in which is an index.html file. If you open this file in a browser you will be presented with a coverage report. If you change the tests, run again and reload the file the report should be updated.
+nox will also create code coverage reports when run. These can be found in various places. For example, git ignored, `coverage.xml` and `coverage.json` will be crated in the root folders. For human consumption you will also see an `htmlcov` folder in which is an index.html file. If you open this file in a browser you will be presented with a coverage report. If you change the tests, run again and reload the file the report should be updated.
 
 
 # OS X SAML python library issue
@@ -50,7 +69,7 @@ brew edit $USER/local/libxmlsec1@1.2.37
 	Change any occurrences of "openssl@1.1" to "openssl@3"
 
 brew install $USER/local/libxmlsec1@1.2.37
-tox -e 311
+nox -s py311
 
 unset HOMEBREW_NO_INSTALL_FROM_API
 brew untap homebrew/core

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,325 @@
+"""Nox configuration for django-ansible-base.
+
+Replaces tox for test execution, linting, and Docker lifecycle management.
+Session names match the legacy tox environment names.
+
+Usage examples:
+    nox -s py312                    # Run main test suite (Python 3.12)
+    nox -s py311                    # Run main test suite (Python 3.11)
+    nox -s py312-check              # Django check + migration check
+    nox -s py312-sqlite             # Run tests with SQLite backend
+    nox -s py312-django4            # Run tests pinned to Django 4.2
+    nox -s py312-in-files           # Run tests using .in requirement files
+    nox -s flake8                   # Run flake8 linter
+    nox -s black                    # Run black formatter
+    nox -s isort                    # Run isort import sorter
+    nox -s lint                     # Run all linters
+    nox -s stop_db                  # Stop the test postgres container (if still running)
+"""
+
+import os
+import subprocess
+import time
+
+import nox
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+POSTGRES_CONTAINER_NAME = "dab-test-postgres"
+POSTGRES_IMAGE_NAME = "dab-test-postgres:latest"
+POSTGRES_PORT = 55432
+POSTGRES_DOCKERFILE = "tools/dev_postgres/Dockerfile"
+POSTGRES_HEALTH_TIMEOUT = 60  # seconds
+
+PYTHON_VERSIONS = ["3.11", "3.12"]
+
+REQUIREMENTS_ALL = "requirements/requirements_all.txt"
+REQUIREMENTS_DEV = "requirements/requirements_dev.txt"
+
+PYTEST_CMD = [
+    "pytest",
+    "-n", "auto",
+    "--color=yes",
+    "--cov=.",
+    "--cov-report=xml:coverage.xml",
+    "--cov-report=html",
+    "--cov-report=json",
+    "--cov-branch",
+    "--junit-xml=django-ansible-base-test-results.xml",
+]
+
+IN_FILE_REQUIREMENTS = [
+    "requirements/requirements.in",
+    "requirements/requirements_activitystream.in",
+    "requirements/requirements_authentication.in",
+    "requirements/requirements_api_documentation.in",
+    "requirements/requirements_rest_filters.in",
+    "requirements/requirements_rbac.in",
+    "requirements/requirements_channels.in",
+    "requirements/requirements_jwt_consumer.in",
+    "requirements/requirements_redis_client.in",
+    "requirements/requirements_oauth2_provider.in",
+    "requirements/requirements_resource_registry.in",
+    "requirements/requirements_feature_flags.in",
+    "requirements/requirements_testing.txt",
+    REQUIREMENTS_DEV,
+]
+
+# Default to reuse venvs for speed; CI can override with --no-reuse-existing-virtualenvs
+nox.options.reuse_existing_virtualenvs = True
+
+
+# ---------------------------------------------------------------------------
+# Docker helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_container_running(name: str) -> bool:
+    """Check if a Docker container with the given name is running."""
+    result = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", name],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _container_exists(name: str) -> bool:
+    """Check if a Docker container with the given name exists (running or stopped)."""
+    result = subprocess.run(
+        ["docker", "inspect", name],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _start_postgres(session: nox.Session) -> None:
+    """Start a fresh PostgreSQL container for a test run.
+
+    Any existing container with the same name is removed first to ensure
+    a clean database state. The container is destroyed after the test run
+    by ``_destroy_postgres``.
+    """
+    # Always remove any existing container to guarantee a clean database
+    if _container_exists(POSTGRES_CONTAINER_NAME):
+        session.log(f"Removing existing container '{POSTGRES_CONTAINER_NAME}'...")
+        subprocess.run(["docker", "rm", "-f", POSTGRES_CONTAINER_NAME], check=True)
+
+    # Build the image
+    session.log("Building PostgreSQL Docker image...")
+    subprocess.run(
+        ["docker", "build", "-t", POSTGRES_IMAGE_NAME, "-f", POSTGRES_DOCKERFILE, os.path.dirname(POSTGRES_DOCKERFILE)],
+        check=True,
+    )
+
+    # Run the container
+    session.log(f"Starting PostgreSQL container on port {POSTGRES_PORT}...")
+    subprocess.run(
+        [
+            "docker", "run",
+            "-d",
+            "--name", POSTGRES_CONTAINER_NAME,
+            "-p", f"{POSTGRES_PORT}:5432",
+            POSTGRES_IMAGE_NAME,
+        ],
+        check=True,
+    )
+
+    # Wait for healthy
+    session.log("Waiting for PostgreSQL to become ready...")
+    deadline = time.time() + POSTGRES_HEALTH_TIMEOUT
+    while time.time() < deadline:
+        result = subprocess.run(
+            ["docker", "exec", POSTGRES_CONTAINER_NAME, "pg_isready", "-U", "dab", "-d", "dab_db"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            session.log("PostgreSQL is ready.")
+            return
+        time.sleep(1)
+
+    session.error(f"PostgreSQL did not become ready within {POSTGRES_HEALTH_TIMEOUT}s")
+
+
+def _destroy_postgres(session: nox.Session) -> None:
+    """Stop and remove the PostgreSQL container."""
+    if _container_exists(POSTGRES_CONTAINER_NAME):
+        session.log(f"Destroying container '{POSTGRES_CONTAINER_NAME}'...")
+        subprocess.run(["docker", "rm", "-f", POSTGRES_CONTAINER_NAME], check=True)
+
+
+def _set_postgres_env(session: nox.Session) -> None:
+    """Set environment variables so Django connects to the test postgres."""
+    session.env["DB_HOST"] = "127.0.0.1"
+    session.env["DB_PORT"] = str(POSTGRES_PORT)
+    session.env["DB_USER"] = "dab"
+    session.env["DB_PASSWORD"] = "dabing"
+    session.env["DB_NAME"] = "dab_db"
+
+
+def _pytest_args(session: nox.Session) -> list[str]:
+    """Build the full pytest argument list, incorporating env vars and posargs."""
+    args = list(PYTEST_CMD)
+
+    extra = os.environ.get("ANSIBLE_BASE_PYTEST_ARGS", "")
+    if extra:
+        args.extend(extra.split())
+
+    test_dirs = os.environ.get("ANSIBLE_BASE_TEST_DIRS", "test_app/tests")
+    args.append(test_dirs)
+
+    if session.posargs:
+        args.extend(session.posargs)
+
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Test session implementations
+# ---------------------------------------------------------------------------
+
+
+def _run_tests(session: nox.Session) -> None:
+    """Run the main test suite with PostgreSQL."""
+    _start_postgres(session)
+    try:
+        _set_postgres_env(session)
+        session.install("-r", REQUIREMENTS_ALL, "-r", REQUIREMENTS_DEV)
+        session.run(*_pytest_args(session))
+    finally:
+        _destroy_postgres(session)
+
+
+def _run_check(session: nox.Session) -> None:
+    """Run Django system checks and verify no pending migrations."""
+    _start_postgres(session)
+    try:
+        _set_postgres_env(session)
+        session.install("-r", REQUIREMENTS_ALL, "-r", REQUIREMENTS_DEV)
+        session.run("python3", "manage.py", "check")
+        session.run("python3", "manage.py", "makemigrations", "--check")
+    finally:
+        _destroy_postgres(session)
+
+
+def _run_tests_sqlite(session: nox.Session) -> None:
+    """Run the test suite with SQLite backend."""
+    _start_postgres(session)
+    try:
+        _set_postgres_env(session)
+        session.env["DJANGO_SETTINGS_MODULE"] = "test_app.sqlite3settings"
+        session.install("-r", REQUIREMENTS_ALL, "-r", REQUIREMENTS_DEV)
+        session.run(*_pytest_args(session))
+    finally:
+        _destroy_postgres(session)
+
+
+def _run_tests_django4(session: nox.Session) -> None:
+    """Run the test suite pinned to Django 4.2."""
+    _start_postgres(session)
+    try:
+        _set_postgres_env(session)
+        session.install("-r", REQUIREMENTS_ALL, "-r", REQUIREMENTS_DEV)
+        session.install("--upgrade", "Django>=4.2.21,<4.3.0")
+        session.run(*_pytest_args(session))
+    finally:
+        _destroy_postgres(session)
+
+
+def _run_tests_in_files(session: nox.Session) -> None:
+    """Run the test suite using individual .in requirement files."""
+    _start_postgres(session)
+    try:
+        _set_postgres_env(session)
+        install_args = []
+        for req in IN_FILE_REQUIREMENTS:
+            install_args.extend(["-r", req])
+        session.install(*install_args)
+        session.run(*_pytest_args(session))
+    finally:
+        _destroy_postgres(session)
+
+
+# ---------------------------------------------------------------------------
+# Register test sessions with tox-compatible names (py311, py312-check, etc.)
+# ---------------------------------------------------------------------------
+
+# Mapping of suffix -> implementation function.
+# Empty string suffix means the base session (e.g. "py311", "py312").
+_TEST_VARIANTS = {
+    "": _run_tests,
+    "-check": _run_check,
+    "-sqlite": _run_tests_sqlite,
+    "-django4": _run_tests_django4,
+    "-in-files": _run_tests_in_files,
+}
+
+for _py_version in PYTHON_VERSIONS:
+    _py_tag = f"py{_py_version.replace('.', '')}"
+
+    for _suffix, _impl in _TEST_VARIANTS.items():
+        _session_name = f"{_py_tag}{_suffix}"
+
+        # Use default arguments to capture loop variables by value
+        def _make_session(_name=_session_name, _python=_py_version, _fn=_impl):
+            @nox.session(name=_name, python=_python)
+            def _session(session: nox.Session) -> None:
+                _fn(session)
+
+            _session.__doc__ = _fn.__doc__
+
+        _make_session()
+
+
+# ---------------------------------------------------------------------------
+# Lint sessions
+# ---------------------------------------------------------------------------
+
+
+@nox.session(python="3.12", reuse_venv=True)
+def flake8(session: nox.Session) -> None:
+    """Run flake8 linter."""
+    session.install("flake8==7.1.1", "Flake8-pyproject==1.2.3")
+    args = session.posargs or ["."]
+    session.run("flake8", *args)
+
+
+@nox.session(python="3.12", reuse_venv=True)
+def black(session: nox.Session) -> None:
+    """Run black code formatter."""
+    session.install("black==25.1.0")
+    args = session.posargs or ["."]
+    session.run("black", "--version")
+    session.run("black", *args)
+
+
+@nox.session(python="3.12", reuse_venv=True)
+def isort(session: nox.Session) -> None:
+    """Run isort import sorter."""
+    session.install("isort==6.0.0")
+    args = session.posargs or ["."]
+    session.run("isort", *args)
+
+
+@nox.session(python="3.12", reuse_venv=True)
+def lint(session: nox.Session) -> None:
+    """Run all linters (flake8, black --check, isort --check)."""
+    session.install("flake8==7.1.1", "Flake8-pyproject==1.2.3", "black==25.1.0", "isort==6.0.0")
+    session.run("flake8", ".")
+    session.run("black", "--check", ".")
+    session.run("isort", "--check", ".")
+
+
+# ---------------------------------------------------------------------------
+# Utility sessions
+# ---------------------------------------------------------------------------
+
+
+@nox.session(python=False)
+def stop_db(session: nox.Session) -> None:
+    """Stop and remove the test PostgreSQL container (if still running)."""
+    _destroy_postgres(session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,104 +84,11 @@ skip_glob = [ "ansible_base/*/migrations" ]
 [tool.flake8]
 max-line-length = 160
 extend-ignore = [ "E203" ]
-exclude = [ 'ansible_base/*/migrations/*', 'test_app/migrations/*', '.tox', 'build', '.venv', 'venv']
+exclude = [ 'ansible_base/*/migrations/*', 'test_app/migrations/*', '.nox', 'build', '.venv', 'venv']
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "test_app.settings"
 addopts = "--strict-markers --reuse-db --migrations -vvv"
-
-[tool.tox]
-legacy_tox_ini = """
-    [tox]
-    min_version = 4.0
-    no_package = true
-    env_list =
-        py311-check
-        py312-check
-        py311
-        py312
-        py311-sqlite
-        py312-sqlite
-        py311-django4
-        py312-django4
-        py311-in-files
-        py312-in-files
-    labels =
-        test = py311-check, py312-check, py311, py312, py311-sqlite, py312-sqlite, py312-django4, py311-in-files, py312-in-files
-        lint = flake8, black, isort
-
-    [testenv]
-    deps =
-        -r{toxinidir}/requirements/requirements_all.txt
-        -r{toxinidir}/requirements/requirements_dev.txt
-    allowlist_externals = sh
-    commands = pytest -n auto --color=yes --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch --junit-xml=django-ansible-base-test-results.xml {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}
-    docker = db
-
-    [testenv:py311-check,py312-check]
-    deps =
-        -r{toxinidir}/requirements/requirements_all.txt
-        -r{toxinidir}/requirements/requirements_dev.txt
-    docker = db
-    commands =
-        python3 manage.py check
-        python3 manage.py makemigrations --check
-
-    [testenv:py311-sqlite,py312-sqlite]
-    docker = db
-    setenv =
-        DJANGO_SETTINGS_MODULE = test_app.sqlite3settings
-
-    [testenv:py311-django4,py312-django4]
-    deps =
-        -r{toxinidir}/requirements/requirements_all.txt
-        -r{toxinidir}/requirements/requirements_dev.txt
-    commands_pre =
-        python -m pip install --upgrade "Django>=4.2.21,<4.3.0"
-    docker = db
-
-    [testenv:py311-in-files,py312-in-files]
-    deps =
-        -r{toxinidir}/requirements/requirements.in
-        -r{toxinidir}/requirements/requirements_activitystream.in
-        -r{toxinidir}/requirements/requirements_authentication.in
-        -r{toxinidir}/requirements/requirements_api_documentation.in
-        -r{toxinidir}/requirements/requirements_rest_filters.in
-        -r{toxinidir}/requirements/requirements_rbac.in
-        -r{toxinidir}/requirements/requirements_channels.in
-        -r{toxinidir}/requirements/requirements_jwt_consumer.in
-        -r{toxinidir}/requirements/requirements_redis_client.in
-        -r{toxinidir}/requirements/requirements_oauth2_provider.in
-        -r{toxinidir}/requirements/requirements_resource_registry.in
-        -r{toxinidir}/requirements/requirements_feature_flags.in
-        -r{toxinidir}/requirements/requirements_testing.txt
-        -r{toxinidir}/requirements/requirements_dev.txt
-
-    [docker:db]
-    dockerfile = {toxinidir}/tools/dev_postgres/Dockerfile
-    expose =
-        DB_PORT=5432/tcp
-
-    [testenv:flake8]
-    deps =
-        flake8==7.1.1
-        Flake8-pyproject==1.2.3
-    docker =
-    commands = flake8 {posargs:.}
-
-    [testenv:black]
-    deps =
-        black==25.1.0
-    allowlist_externals = sh
-    docker =
-    commands = sh -c 'black --version && black {posargs:.}'
-
-    [testenv:isort]
-    deps =
-        isort==6.0.0
-    docker =
-    commands = isort {posargs:.}
-"""
 
 [tool.coverage.run]
 omit = ["test_app/*", "manage.py"]

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -10,8 +10,7 @@ Flake8-pyproject==1.2.3 # Linting tool, if changed update pyproject.toml as well
 ipython
 isort==6.0.0            # Linting tool, if changed update pyproject.toml as well
 jsonschema
-tox
-tox-docker
+nox
 typeguard
 openapi-spec-validator>=0.6.1  # Adapted to changing import locations in jsonschema
 pytest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -84,7 +84,7 @@ sonar.exclusions=\
     **/dist/**,\
     **/*.egg-info/**,\
     **/htmlcov/**,\
-    **/.tox/**,\
+    **/.nox/**,\
     **/node_modules/**,\
     **/.git/**,\
     **/reports/**,\
@@ -100,7 +100,7 @@ sonar.exclusions=\
 sonar.coverage.exclusions=\
     **/tests/**,\
     test_app/**,\
-    **/.tox/**,\
+    **/.nox/**,\
     **/test_*.py,\
     **/*_test.py,\
     **/conftest.py,\

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+no_package = true
+
+[testenv]
+skip_install = true
+deps =
+allowlist_externals = sh
+commands = sh -c 'echo ""; echo "ERROR: tox has been replaced by nox in this project."; echo "  Instead of:  tox -e {envname}"; echo "  Run:         nox -s {envname}"; echo ""; echo "  To list all sessions: nox -l"; echo "  Install nox with:     pip install nox"; echo ""; exit 1'


### PR DESCRIPTION
- Remove tox and tox-docker dependencies, add nox
- Create noxfile.py with all test/lint sessions using tox-compatible names (py311, py312, py311-check, py312-sqlite, etc.)
- Manage PostgreSQL Docker container lifecycle directly in nox: fresh container per run, destroyed on completion (even on failure)
- Add stub tox.ini that prints migration message if someone runs tox
- Update CI workflow, Makefile, docs, and ignore files for nox
- Session names are a drop-in match for old tox env names


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure with new test runner configuration and dependencies.
  * Enhanced PostgreSQL database container lifecycle management and cleanup for test execution.
  * Updated CI/CD pipeline workflows to use new test runner.
  * Updated project build and linting tool configurations.

* **Documentation**
  * Revised testing documentation with updated test session descriptions and execution commands for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->