### PR TITLE
AAP-62534 Add get_target_claim_names_to_sub_stubs() classmethod to BaseWorkloadIdentityScope and  AutomationControllerJobScope            

### DIFF
--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -24,15 +24,12 @@ class BaseWorkloadIdentityScope:
         """
         raise NotImplementedError("Subclasses must implement list_claims()")
 
-    @abstractmethod
-    def populate_claims(self, workload_data: dict) -> dict:
+    @classmethod
+    def get_target_claim_names_to_sub_stubs(cls) -> dict[str, str]:
         """
-        Populate claims based on the provided workload data.
+        Return a mapping of claim names to their corresponding sub claim stubs.
 
-        :param workload_data: The workload_data dictionary used to populate claim values.
-                        This workload_data identifies the AAP workload that is requesting a scope.
-        :type workload_data: dict
-        :return: A dictionary mapping claim names to their corresponding values generated from the workload_data.
-        :rtype: dict
+        :return: A dictionary mapping claim names to sub claim stubs.
+        :rtype: dict[str, str]
         """
-        raise NotImplementedError("Subclasses will implement populate_claims() in future iterations")
+        raise NotImplementedError("Subclasses must implement get_target_claim_names_to_sub_stubs()")

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -25,6 +25,7 @@ class BaseWorkloadIdentityScope:
         raise NotImplementedError("Subclasses must implement list_claims()")
 
     @classmethod
+    @abstractmethod
     def get_target_claim_names_to_sub_stubs(cls) -> dict[str, str]:
         """
         Return a mapping of claim names to their corresponding sub claim stubs.

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -34,3 +34,36 @@ class BaseWorkloadIdentityScope:
         :rtype: dict[str, str]
         """
         raise NotImplementedError("Subclasses must implement get_target_claim_names_to_sub_stubs()")
+
+    @classmethod
+    def generate_sub_claim(cls, workload_details: dict) -> str:
+        """
+        Generate a sub claim string from workload details using the scope's claim mapping.
+
+        Given a dictionary with the details of a workload, generates a sub claim string with the following format:
+        "job:<job_name>:organization:<organization_name>:project:<project_name>:job_template:<job_template_name>"
+
+        Note: The specified claim names are included in the output sub claim value even if they
+        are empty. Claim validation is expected to take care of doing these checks before this
+        function is called.
+
+        :param workload_details: A dictionary containing the workload details (claim names to values)
+        :type workload_details: dict
+        :return: A string containing the sub claim
+        :rtype: str
+        """
+        target_claim_names_to_sub_stubs = cls.get_target_claim_names_to_sub_stubs()
+        return ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_details.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
+
+    @abstractmethod
+    def populate_claims(self, workload_data: dict) -> dict:
+        """
+        Populate claims based on the provided workload data.
+
+        :param workload_data: The workload_data dictionary used to populate claim values.
+                        This workload_data identifies the AAP workload that is requesting a scope.
+        :type workload_data: dict
+        :return: A dictionary mapping claim names to their corresponding values generated from the workload_data.
+        :rtype: dict
+        """
+        raise NotImplementedError("Subclasses will implement populate_claims() in future iterations")

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -36,24 +36,24 @@ class BaseWorkloadIdentityScope:
         raise NotImplementedError("Subclasses must implement get_target_claim_names_to_sub_stubs()")
 
     @classmethod
-    def generate_sub_claim(cls, workload_details: dict) -> str:
+    def generate_sub_claim(cls, workload_claims: dict) -> str:
         """
-        Generate a sub claim string from workload details using the scope's claim mapping.
+        Generate a sub claim string from workload claims using the scope's claim mapping.
 
-        Given a dictionary with the details of a workload, generates a sub claim string with the following format:
+        Given a dictionary with the claims of a workload, generates a sub claim string with the following format:
         "job:<job_name>:organization:<organization_name>:project:<project_name>:job_template:<job_template_name>"
 
         Note: The specified claim names are included in the output sub claim value even if they
         are empty. Claim validation is expected to take care of doing these checks before this
         function is called.
 
-        :param workload_details: A dictionary containing the workload details (claim names to values)
-        :type workload_details: dict
+        :param workload_claims: A dictionary containing the workload claims (claim names to values)
+        :type workload_claims: dict
         :return: A string containing the sub claim
         :rtype: str
         """
         target_claim_names_to_sub_stubs = cls.get_target_claim_names_to_sub_stubs()
-        return ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_details.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
+        return ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
 
     @abstractmethod
     def populate_claims(self, workload_data: dict) -> dict:

--- a/ansible_base/lib/workload_identity/controller.py
+++ b/ansible_base/lib/workload_identity/controller.py
@@ -43,3 +43,12 @@ class AutomationControllerJobScope(BaseWorkloadIdentityScope):
     @classmethod
     def list_claims(cls) -> list[str]:
         return [getattr(cls, attr) for attr in dir(cls) if attr.startswith('CLAIM_')]
+
+    @classmethod
+    def get_target_claim_names_to_sub_stubs(cls) -> dict[str, str]:
+        return {
+            cls.CLAIM_JOB_NAME: "job",
+            cls.CLAIM_ORGANIZATION_NAME: "organization",
+            cls.CLAIM_PROJECT_NAME: "project",
+            cls.CLAIM_JOB_TEMPLATE_NAME: "job_template",
+        }

--- a/ansible_base/lib/workload_identity/controller.py
+++ b/ansible_base/lib/workload_identity/controller.py
@@ -10,9 +10,6 @@ from .base import BaseWorkloadIdentityScope
 class AutomationControllerJobScope(BaseWorkloadIdentityScope):
     """
     Default scope for AAP Controller automation job workload identity.
-
-    Note: populate_claims() is not yet implemented and will be added
-    in a future iteration.
     """
 
     name = "aap_controller_automation_job"

--- a/ansible_base/lib/workload_identity/controller.py
+++ b/ansible_base/lib/workload_identity/controller.py
@@ -10,6 +10,9 @@ from .base import BaseWorkloadIdentityScope
 class AutomationControllerJobScope(BaseWorkloadIdentityScope):
     """
     Default scope for AAP Controller automation job workload identity.
+
+    Note: populate_claims() is not yet implemented and will be added
+    in a future iteration.
     """
 
     name = "aap_controller_automation_job"

--- a/test_app/tests/lib/workload_identity/test_base.py
+++ b/test_app/tests/lib/workload_identity/test_base.py
@@ -12,10 +12,9 @@ def test_list_claims():
         scope.list_claims()
 
 
-def test_populate_claims():
+def test_get_target_claim_names_to_sub_stubs():
     """
-    Test that the base Scope class raises NotImplementedError for populate_claims().
+    Test that the base Scope class raises NotImplementedError for get_target_claim_names_to_sub_stubs().
     """
-    scope = BaseWorkloadIdentityScope()
-    with pytest.raises(NotImplementedError, match="Subclasses will implement populate_claims\\(\\) in future iterations"):
-        scope.populate_claims({})
+    with pytest.raises(NotImplementedError, match="Subclasses must implement get_target_claim_names_to_sub_stubs\\(\\)"):
+        BaseWorkloadIdentityScope.get_target_claim_names_to_sub_stubs()

--- a/test_app/tests/lib/workload_identity/test_base.py
+++ b/test_app/tests/lib/workload_identity/test_base.py
@@ -18,3 +18,12 @@ def test_get_target_claim_names_to_sub_stubs():
     """
     with pytest.raises(NotImplementedError, match="Subclasses must implement get_target_claim_names_to_sub_stubs\\(\\)"):
         BaseWorkloadIdentityScope.get_target_claim_names_to_sub_stubs()
+
+
+def test_populate_claims():
+    """
+    Test that the base Scope class raises NotImplementedError for populate_claims().
+    """
+    scope = BaseWorkloadIdentityScope()
+    with pytest.raises(NotImplementedError, match="Subclasses will implement populate_claims\\(\\) in future iterations"):
+        scope.populate_claims({})

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -67,7 +67,7 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
 
 
 @pytest.mark.parametrize(
-    "workload_details,expected_sub_claim",
+    "workload_claims,expected_sub_claim",
     [
         (
             {
@@ -96,10 +96,10 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
         ),
     ],
 )
-def test_generate_sub_claim(workload_details, expected_sub_claim):
+def test_generate_sub_claim(workload_claims, expected_sub_claim):
     """
     Test that generate_sub_claim produces the correct sub claim string
     with full values, empty values, and missing keys.
     """
-    actual_sub_claim = AutomationControllerJobScope.generate_sub_claim(workload_details)
+    actual_sub_claim = AutomationControllerJobScope.generate_sub_claim(workload_claims)
     assert actual_sub_claim == expected_sub_claim

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ansible_base.lib.workload_identity.controller import AutomationControllerJobScope
 
 
@@ -62,3 +64,42 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
 
     for claim_name in mapping.keys():
         assert claim_name in all_claims, f"{claim_name} is not a valid claim in AutomationControllerJobScope"
+
+
+@pytest.mark.parametrize(
+    "workload_details,expected_sub_claim",
+    [
+        (
+            {
+                'aap_controller_job_name': 'my-job',
+                'aap_controller_organization_name': 'my-org',
+                'aap_controller_project_name': 'my-project',
+                'aap_controller_job_template_name': 'my-template',
+            },
+            "job:my-job:organization:my-org:project:my-project:job_template:my-template",
+        ),
+        (
+            {
+                'aap_controller_job_name': 'my-job',
+                'aap_controller_organization_name': '',
+                'aap_controller_project_name': 'my-project',
+                'aap_controller_job_template_name': '',
+            },
+            "job:my-job:organization::project:my-project:job_template:",
+        ),
+        (
+            {
+                'aap_controller_job_name': 'my-job',
+                'aap_controller_project_name': 'my-project',
+            },
+            "job:my-job:organization::project:my-project:job_template:",
+        ),
+    ],
+)
+def test_generate_sub_claim(workload_details, expected_sub_claim):
+    """
+    Test that generate_sub_claim produces the correct sub claim string
+    with full values, empty values, and missing keys.
+    """
+    actual_sub_claim = AutomationControllerJobScope.generate_sub_claim(workload_details)
+    assert actual_sub_claim == expected_sub_claim

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -33,3 +33,32 @@ def test_list_claims():
     actual_claims = set(scope.list_claims())
 
     assert actual_claims == expected_claims
+
+
+def test_get_target_claim_names_to_sub_stubs():
+    """
+    Test that get_target_claim_names_to_sub_stubs returns the correct mapping
+    of claim names to their sub claim stubs.
+    """
+    expected_mapping = {
+        'aap_controller_job_name': 'job',
+        'aap_controller_organization_name': 'organization',
+        'aap_controller_project_name': 'project',
+        'aap_controller_job_template_name': 'job_template',
+    }
+
+    actual_mapping = AutomationControllerJobScope.get_target_claim_names_to_sub_stubs()
+
+    assert actual_mapping == expected_mapping
+
+
+def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
+    """
+    Test that all keys in the target claim names mapping are valid claims
+    defined in the scope.
+    """
+    mapping = AutomationControllerJobScope.get_target_claim_names_to_sub_stubs()
+    all_claims = set(AutomationControllerJobScope.list_claims())
+
+    for claim_name in mapping.keys():
+        assert claim_name in all_claims, f"{claim_name} is not a valid claim in AutomationControllerJobScope"


### PR DESCRIPTION
These changes were requested by @john-westcott-iv and @dleehr in [#1250](https://github.com/ansible-automation-platform/aap-gateway/pull/1250/changes#r2799953039) under AAP-62534

## Description
What is being changed?
  - Added `generate_sub_claim()` classmethod to BaseWorkloadIdentityScope that encapsulates sub claim generation logic
  - Added `get_target_claim_names_to_sub_stubs()` classmethod to BaseWorkloadIdentityScope and AutomationControllerJobScope
  - The mapping method returns claim names (e.g., CLAIM_JOB_NAME) to their corresponding sub claim stubs (e.g., "job")
  - The generation method uses this mapping to produce the formatted sub claim string (e.g., "job:my-job:organization:my-org:...")

Why is this change needed?
  - Per feedback from @john-westcott-iv in [#1250](https://github.com/ansible-automation-platform/aap-gateway/pull/1250/changes#r2799953039), we should:
    a. Use the claim constants defined in DAB (e.g., AutomationControllerJobScope.CLAIM_JOB_NAME) instead of hardcoded strings
    b. Encapsulate the sub claim generation logic within scope classes rather than spreading it across two repos
    c. Make it automatically extensible when new scopes are added to DAB

How does this change address the issue?
  - Each scope class now defines its own claim-to-stub mapping using class constants
  - The base class provides `generate_sub_claim()` that uses the scope's mapping to build the sub claim string
  - Gateway's JWT creation code can simply call `scope_class.generate_sub_claim(workload_claims)` instead of implementing the logic itself
  - All sub claim generation logic is now encapsulated within django-ansible-base
  - Changes to scope claims in DAB automatically propagate without requiring Gateway code updates


## Type of Change
- [x] New feature (non-breaking change which adds functionality)


## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
Run the new tests:
```bash
tox -e py312 -- test_app/tests/lib/workload_identity/test_base.py::test_get_target_claim_names_to_sub_stubs test_app/tests/lib/workload_identity/test_controller.py -k "get_target_claim_names_to_sub_stubs or
generate_sub_claim"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workload-identity scope API to support mapping claim names to sub-stub keys and to produce consistent colon-delimited sub-claim strings for identity claims.

* **Tests**
  * Added and updated tests to validate the claim-to-sub-stub mapping, key validity, and sub-claim generation across full, empty, and missing-value scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->