### PR TITLE
AAP-62532 Add service authorization support to workload identity scopes

### DIFF
--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -10,9 +10,13 @@ class BaseWorkloadIdentityScope:
     Base class for OIDC workload identity scopes.
     """
 
+    SERVICE_TYPE_CONTROLLER = "controller"
+    SERVICE_TYPE_EDA = "eda"
+    SERVICE_TYPE_HUB = "hub"
+    SERVICE_TYPE_GATEWAY = "gateway"
+
     name = ""
     description = ""
-    allowed_services = set()
 
     @classmethod
     @abstractmethod
@@ -36,6 +40,34 @@ class BaseWorkloadIdentityScope:
         """
         raise NotImplementedError("Subclasses must implement get_target_claim_names_to_sub_stubs()")
 
+    @abstractmethod
+    def populate_claims(self, workload_data: dict) -> dict:
+        """
+        Populate claims based on the provided workload data.
+
+        :param workload_data: The workload_data dictionary used to populate claim values.
+                        This workload_data identifies the AAP workload that is requesting a scope.
+        :type workload_data: dict
+        :return: A dictionary mapping claim names to their corresponding values generated from the workload_data.
+        :rtype: dict
+        """
+        raise NotImplementedError("Subclasses will implement populate_claims() in future iterations")
+
+    @classmethod
+    def is_service_allowed(cls, service_name: str) -> bool:
+        """
+        Check if a service is authorized to request this scope.
+
+        Subclasses MUST override this method to authorize specific services.
+        The default implementation returns False (deny all services).
+
+        :param service_name: The name of the service requesting the scope.
+        :type service_name: str
+        :return: True if the service is allowed, False otherwise.
+        :rtype: bool
+        """
+        return False
+
     @classmethod
     def generate_sub_claim(cls, workload_claims: dict) -> str:
         """
@@ -55,16 +87,3 @@ class BaseWorkloadIdentityScope:
         """
         target_claim_names_to_sub_stubs = cls.get_target_claim_names_to_sub_stubs()
         return ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
-
-    @abstractmethod
-    def populate_claims(self, workload_data: dict) -> dict:
-        """
-        Populate claims based on the provided workload data.
-
-        :param workload_data: The workload_data dictionary used to populate claim values.
-                        This workload_data identifies the AAP workload that is requesting a scope.
-        :type workload_data: dict
-        :return: A dictionary mapping claim names to their corresponding values generated from the workload_data.
-        :rtype: dict
-        """
-        raise NotImplementedError("Subclasses will implement populate_claims() in future iterations")

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -12,6 +12,7 @@ class BaseWorkloadIdentityScope:
 
     name = ""
     description = ""
+    allowed_services = set()
 
     @classmethod
     @abstractmethod

--- a/ansible_base/lib/workload_identity/controller.py
+++ b/ansible_base/lib/workload_identity/controller.py
@@ -17,6 +17,7 @@ class AutomationControllerJobScope(BaseWorkloadIdentityScope):
 
     name = "aap_controller_automation_job"
     description = "Default AAP Controller automation job workload identity"
+    allowed_services = {"controller"}
 
     CLAIM_JOB_ID = 'aap_controller_job_id'
     CLAIM_JOB_NAME = 'aap_controller_job_name'

--- a/ansible_base/lib/workload_identity/controller.py
+++ b/ansible_base/lib/workload_identity/controller.py
@@ -17,7 +17,6 @@ class AutomationControllerJobScope(BaseWorkloadIdentityScope):
 
     name = "aap_controller_automation_job"
     description = "Default AAP Controller automation job workload identity"
-    allowed_services = {"controller"}
 
     CLAIM_JOB_ID = 'aap_controller_job_id'
     CLAIM_JOB_NAME = 'aap_controller_job_name'
@@ -53,3 +52,7 @@ class AutomationControllerJobScope(BaseWorkloadIdentityScope):
             cls.CLAIM_PROJECT_NAME: "project",
             cls.CLAIM_JOB_TEMPLATE_NAME: "job_template",
         }
+
+    @classmethod
+    def is_service_allowed(cls, service_name: str) -> bool:
+        return service_name == cls.SERVICE_TYPE_CONTROLLER

--- a/test_app/tests/lib/workload_identity/test_base.py
+++ b/test_app/tests/lib/workload_identity/test_base.py
@@ -27,3 +27,12 @@ def test_populate_claims():
     scope = BaseWorkloadIdentityScope()
     with pytest.raises(NotImplementedError, match="Subclasses will implement populate_claims\\(\\) in future iterations"):
         scope.populate_claims({})
+
+
+def test_is_service_allowed_default():
+    """
+    Test that the base Scope class returns False by default for is_service_allowed().
+    """
+    assert BaseWorkloadIdentityScope.is_service_allowed(BaseWorkloadIdentityScope.SERVICE_TYPE_CONTROLLER) is False
+    assert BaseWorkloadIdentityScope.is_service_allowed(BaseWorkloadIdentityScope.SERVICE_TYPE_EDA) is False
+    assert BaseWorkloadIdentityScope.is_service_allowed("any_service") is False

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -103,3 +103,20 @@ def test_generate_sub_claim(workload_claims, expected_sub_claim):
     """
     actual_sub_claim = AutomationControllerJobScope.generate_sub_claim(workload_claims)
     assert actual_sub_claim == expected_sub_claim
+
+
+@pytest.mark.parametrize(
+    "service_name,expected_result",
+    [
+        (AutomationControllerJobScope.SERVICE_TYPE_CONTROLLER, True),
+        (AutomationControllerJobScope.SERVICE_TYPE_EDA, False),
+        (AutomationControllerJobScope.SERVICE_TYPE_HUB, False),
+        (AutomationControllerJobScope.SERVICE_TYPE_GATEWAY, False),
+        ("unknown", False),
+    ],
+)
+def test_is_service_allowed(service_name, expected_result):
+    """
+    Test that is_service_allowed correctly validates service authorization.
+    """
+    assert AutomationControllerJobScope.is_service_allowed(service_name) == expected_result


### PR DESCRIPTION
AAP-62532

## Description               
Add service authorization support to workload identity scopes for AAP-62532.

- Added SERVICE_TYPE_* constants to BaseWorkloadIdentityScope (controller, eda, hub, gateway)
- Added `is_service_allowed(service_name: str)` method to BaseWorkloadIdentityScope (returns False by default - deny all services)
- AutomationControllerJobScope overrides `is_service_allowed()` to allow only controller service

`is_service_allowed` is called here: https://github.com/ansible-automation-platform/aap-gateway/pull/1262   

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
