### PR TITLE
[AAP-64920] Adds audit logging for AAPFlag

### DIFF
--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -101,6 +101,11 @@ class AuditableModel(models.Model):
     A mixin class that provides integration to the activity stream from any
     model. A model should simply inherit from this class to have its
     create/update/delete events sent to the activity stream.
+
+    NOTE: AuditableModel must remain a pure mixin with no database fields.
+    Models conditionally inherit from AuditableModel based on whether
+    activitystream is installed (e.g., AAPFlag). Adding a DB field would
+    create environment-dependent migrations.
     """
 
     class Meta:

--- a/ansible_base/feature_flags/models/aap_flag.py
+++ b/ansible_base/feature_flags/models/aap_flag.py
@@ -1,9 +1,17 @@
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.abstract_models.common import NamedCommonModel
 from ansible_base.resource_registry.fields import AnsibleResourceField
+
+# Conditionally import AuditableModel if activitystream is installed
+_AuditableBase = object
+if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
+    from ansible_base.activitystream.models import AuditableModel
+
+    _AuditableBase = AuditableModel
 
 
 def validate_feature_flag_name(value: str):
@@ -24,7 +32,12 @@ def validate_labels(value):
             raise ValidationError(_("All labels must be strings."))
 
 
-class AAPFlag(NamedCommonModel):
+class AAPFlag(NamedCommonModel, _AuditableBase):
+    # Enable audit log for this model (only if activitystream is installed)
+    audit_log_enabled = True
+    # Disable activity stream for this model
+    activity_stream_enabled = False
+
     class Meta:
         app_label = "dab_feature_flags"
         unique_together = ("name", "condition")

--- a/test_app/tests/activitystream/models/test_entry.py
+++ b/test_app/tests/activitystream/models/test_entry.py
@@ -1,6 +1,8 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.db import models as db_models
 
+from ansible_base.activitystream.models import AuditableModel
 from ansible_base.lib.utils.response import get_relative_url
 
 
@@ -31,3 +33,18 @@ def test_activitystream_auditablemodel_related(admin_api_client, user, organizat
     response = admin_api_client.get(url)
     assert response.status_code == 200
     assert 'activity_stream' not in response.data['related']
+
+
+def test_auditable_model_has_no_db_fields():
+    """
+    AuditableModel must remain a pure mixin with no database fields.
+    Models conditionally inherit from AuditableModel based on whether
+    activitystream is installed (e.g., AAPFlag). Adding a DB field would
+    create environment-dependent migrations.
+    """
+    db_fields = [f.name for f in AuditableModel._meta.local_fields if isinstance(f, db_models.Field)]
+    assert db_fields == [], (
+        f"AuditableModel must not have DB fields (found: {db_fields}). "
+        "This would break models that conditionally inherit from it "
+        "based on whether activitystream is in INSTALLED_APPS."
+    )

--- a/test_app/tests/feature_flags/models/test_aap_flag_audit_logging.py
+++ b/test_app/tests/feature_flags/models/test_aap_flag_audit_logging.py
@@ -1,0 +1,126 @@
+"""Unit tests for AAPFlag audit logging and activity stream behavior.
+
+Ensures that:
+1. AAPFlag has audit_log_enabled = True (generates audit logs)
+2. AAPFlag has activity_stream_enabled = False (no activity stream entries)
+3. Create operations generate audit logs at INFO level (to aap.auth_audit logger)
+4. Create operations do NOT create activity stream entries
+
+Note: Update and delete behavior is covered by base AuditableModel tests in
+test_app/tests/activitystream/test_signals.py. This provides AAPFlag-specific
+regression coverage for the create operation.
+"""
+
+from unittest import mock
+
+import pytest
+from django.conf import settings
+
+from ansible_base.feature_flags.models import AAPFlag
+
+# Patch where DAB activitystream calls it (signals import log_auth_event at load time)
+# log_auth_event writes to the logger specified by ANSIBLE_BASE_AUTH_AUDIT_LOGGER_NAME
+# (default: 'ansible_base.auth_audit', overridden in AAP Gateway to 'aap.auth_audit')
+AUDIT_LOG_PATCH = "ansible_base.activitystream.signals.log_auth_event"
+
+# Check if activitystream is installed
+ACTIVITYSTREAM_INSTALLED = 'ansible_base.activitystream' in settings.INSTALLED_APPS
+
+
+# -----------------------------------------------------------------------------
+# Basic functionality test: verify AAPFlag works without activitystream
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_aap_flag_basic_crud_without_activitystream():
+    """AAPFlag can be created, read, updated, and deleted regardless of activitystream installation."""
+    # Create
+    flag = AAPFlag.objects.create(
+        name="FEATURE_TEST_BASIC_CRUD_ENABLED",
+        ui_name="Test Basic CRUD",
+        condition="boolean",
+        value="False",
+        support_level="DEVELOPER_PREVIEW",
+        description="Test flag for basic CRUD operations",
+    )
+
+    # Read
+    assert flag.name == "FEATURE_TEST_BASIC_CRUD_ENABLED"
+    assert flag.ui_name == "Test Basic CRUD"
+
+    # Update
+    flag.value = "True"
+    flag.save()
+    flag.refresh_from_db()
+    assert flag.value == "True"
+
+
+# -----------------------------------------------------------------------------
+# Verify AAPFlag has correct attribute settings
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_aap_flag_has_audit_log_enabled():
+    """AAPFlag has audit_log_enabled = True to enable audit logging."""
+    assert getattr(AAPFlag, "audit_log_enabled", False) is True
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_aap_flag_has_activity_stream_disabled():
+    """AAPFlag has activity_stream_enabled = False to disable activity stream."""
+    assert getattr(AAPFlag, "activity_stream_enabled", True) is False
+
+
+# -----------------------------------------------------------------------------
+# Audit log test: verify create generates audit log
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_audit_log_aap_flag_create():
+    """Creating an AAPFlag emits an audit log record at INFO."""
+    with mock.patch(AUDIT_LOG_PATCH) as log_auth_event:
+        AAPFlag.objects.create(
+            name="FEATURE_TEST_AUDIT_CREATE_ENABLED",
+            ui_name="Test Audit Create",
+            condition="boolean",
+            value="False",
+            support_level="DEVELOPER_PREVIEW",
+            description="Test flag for audit logging on create",
+        )
+
+    log_auth_event.assert_called_once()
+    msg = log_auth_event.call_args[0][0].lower()
+    assert "create" in msg
+    assert "aapflag" in msg or "feature" in msg or "flag" in msg
+
+
+# -----------------------------------------------------------------------------
+# Activity stream test: verify create does NOT create entry
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_activity_stream_disabled_on_create():
+    """Creating an AAPFlag does NOT create an activity stream entry."""
+    from ansible_base.activitystream.models import Entry
+
+    initial_entry_count = Entry.objects.count()
+
+    AAPFlag.objects.create(
+        name="FEATURE_TEST_STREAM_CREATE_ENABLED",
+        ui_name="Test Stream Create",
+        condition="boolean",
+        value="False",
+        support_level="DEVELOPER_PREVIEW",
+        description="Test flag for activity stream on create",
+    )
+
+    # No new activity stream entries should be created
+    assert Entry.objects.count() == initial_entry_count


### PR DESCRIPTION
## Description
Updates AAPFlag to extend AuditableModel, specifically with:
- audit_log_enabled = True
- activity_stream_enabled = False

At the moment we want to receive audit logs for this, but not create new activity stream entries

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Steps to Test
1. Start up AAP with these changes.
2. Modify FeatureFlag values (create/update/delete)
3. Ensure that **no** ActivityStream entries are created from these modifications
4. Ensure that the audit log contains messages at the INFO level detailing these modifications

## Additional Context
Leverages the work from PR 931 to handle the heavy lifting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature flags now enable audit logging by default while suppressing automatic activity-stream entries.

* **Documentation**
  * Clarified that the audit mixin is a pure mixin with no database fields and should be mixed conditionally to avoid environment-dependent migrations.

* **Tests**
  * Added tests for audit logging behavior, absence of activity-stream entries on create, and verification that the audit mixin has no DB fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->