### PR TITLE
[AAP-65392] Fix OIDC issuer in discovery view

### DIFF
--- a/ansible_base/lib/testing/util.py
+++ b/ansible_base/lib/testing/util.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from pathlib import Path
 
-from flags.state import disable_flag, enable_flag
+from flags.state import disable_flag, enable_flag, flag_state
 from requests import Response
 
 from ansible_base.resource_registry.rest_client import ResourceAPIClient
@@ -79,8 +79,10 @@ class StaticResourceAPIClient(ResourceAPIClient):
 @contextmanager
 def feature_flag_enabled(flag_name):
     """Context manager to temporarily enable a feature flag"""
+    was_enabled = flag_state(flag_name)
     enable_flag(flag_name)
     try:
         yield
     finally:
-        disable_flag(flag_name)
+        if not was_enabled:
+            disable_flag(flag_name)

--- a/ansible_base/lib/testing/util.py
+++ b/ansible_base/lib/testing/util.py
@@ -77,12 +77,27 @@ class StaticResourceAPIClient(ResourceAPIClient):
 
 
 @contextmanager
-def feature_flag_enabled(flag_name):
-    """Context manager to temporarily enable a feature flag"""
+def _feature_flag_state(flag_name, desired_state):
+    """Context manager to temporarily set a feature flag to a desired state"""
     was_enabled = flag_state(flag_name)
-    enable_flag(flag_name)
+    if desired_state:
+        enable_flag(flag_name)
+    else:
+        disable_flag(flag_name)
     try:
         yield
     finally:
-        if not was_enabled:
+        if was_enabled:
+            enable_flag(flag_name)
+        else:
             disable_flag(flag_name)
+
+
+def feature_flag_enabled(flag_name):
+    """Context manager to temporarily enable a feature flag"""
+    return _feature_flag_state(flag_name, desired_state=True)
+
+
+def feature_flag_disabled(flag_name):
+    """Context manager to temporarily disable a feature flag"""
+    return _feature_flag_state(flag_name, desired_state=False)

--- a/ansible_base/lib/testing/util.py
+++ b/ansible_base/lib/testing/util.py
@@ -1,5 +1,7 @@
+from contextlib import contextmanager
 from pathlib import Path
 
+from flags.state import disable_flag, enable_flag
 from requests import Response
 
 from ansible_base.resource_registry.rest_client import ResourceAPIClient
@@ -72,3 +74,13 @@ class StaticResourceAPIClient(ResourceAPIClient):
             response.status_code = 404
 
         return response
+
+
+@contextmanager
+def feature_flag_enabled(flag_name):
+    """Context manager to temporarily enable a feature flag"""
+    enable_flag(flag_name)
+    try:
+        yield
+    finally:
+        disable_flag(flag_name)

--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -39,6 +39,8 @@ oauth_urls = [
     # OIDC endpoints - flag is checked at request time, returns 404 when disabled
     flagged_re_path(
         FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED,
+        # URL patterns below must match installed django-oauth-toolkit version, otherwise discovery fails
+        # See https://github.com/django-oauth/django-oauth-toolkit/blob/2.3.0/oauth2_provider/urls.py#L35
         r"^\.well-known/openid-configuration/$",
         oauth_views.ConnectDiscoveryInfoView.as_view(),
         name="oidc-connect-discovery-info",

--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -39,7 +39,7 @@ oauth_urls = [
     # OIDC endpoints - flag is checked at request time, returns 404 when disabled
     flagged_re_path(
         FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED,
-        r"^\.well-known/openid-configuration$",
+        r"^\.well-known/openid-configuration/$",
         oauth_views.ConnectDiscoveryInfoView.as_view(),
         name="oidc-connect-discovery-info",
     ),

--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -46,7 +46,7 @@ oauth_urls = [
         name="oidc-connect-discovery-info",
     ),
     flagged_re_path(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED, r"^\.well-known/jwks\.json$", oauth_views.JwksInfoView.as_view(), name="jwks-info"),
-    flagged_re_path(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED, r"^userinfo$", oauth_views.UserInfoView.as_view(), name="user-info"),
+    flagged_re_path(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED, r"^userinfo/$", oauth_views.UserInfoView.as_view(), name="user-info"),
 ]
 
 

--- a/test_app/tests/oauth2_provider/test_oidc_urlpatterns.py
+++ b/test_app/tests/oauth2_provider/test_oidc_urlpatterns.py
@@ -1,0 +1,19 @@
+import pytest
+
+from oauth2_provider.urls import oidc_urlpatterns as dot_oidc_urlpatterns
+from ansible_base.oauth2_provider.urls import oauth_urls
+
+dot_oidc_names = {p.name for p in dot_oidc_urlpatterns}
+dab_oidc_names = {
+    getattr(p, 'name', None) for p in oauth_urls
+} & dot_oidc_names
+
+@pytest.mark.parametrize("name", sorted(dab_oidc_names))
+def test_oidc_url_patterns_match_dot(name):
+    """Ensure our OIDC URL patterns stay aligned with the pinned DOT version."""
+    dot_pattern = next(p for p in dot_oidc_urlpatterns if p.name == name)
+    dab_pattern = next(p for p in oauth_urls if getattr(p, 'name', None) == name)
+    assert dab_pattern.pattern._regex == dot_pattern.pattern._regex, (
+        f"URL pattern for '{name}' differs from django-oauth-toolkit. "
+        f"DAB: {dab_pattern.pattern._regex}, DOT: {dot_pattern.pattern._regex}"
+    )

--- a/test_app/tests/oauth2_provider/test_oidc_urlpatterns.py
+++ b/test_app/tests/oauth2_provider/test_oidc_urlpatterns.py
@@ -1,12 +1,34 @@
-import pytest
+"""
+This module tests that the OIDC url patterns defined in ansible_base.oauth2_provider
+align with the OIDC url patterns in django-oauth-toolkit.
 
+The ansible_base.oauth2_provider re-implements these URL patterns so that they can
+be feature-flagged. At the time of this writing, the patterns align with the pinned version
+of django-oauth-toolkit. This is necessary because we rely on internal behaviors
+of django-oauth-toolkit (e.g. oidc_issuer()) that require them to match.
+
+The tests below are a canary. When we upgrade django-oauth-toolkit, the tests will fail.
+We'll then need to update our URL patterns to fix them.
+"""
+
+import pytest
+from oauth2_provider import __version__ as dot_version
 from oauth2_provider.urls import oidc_urlpatterns as dot_oidc_urlpatterns
+from packaging.version import parse
+
 from ansible_base.oauth2_provider.urls import oauth_urls
 
 dot_oidc_names = {p.name for p in dot_oidc_urlpatterns}
-dab_oidc_names = {
-    getattr(p, 'name', None) for p in oauth_urls
-} & dot_oidc_names
+dab_oidc_names = {getattr(p, 'name', None) for p in oauth_urls} & dot_oidc_names
+
+
+if parse(dot_version) < parse("3.0.0"):
+    # Prior to django-oauth-toolkit 3.0.0, the 'jwks-info' URL is incorrectly defined as
+    # re_path(r"^\.well-known/jwks.json$". The unescaped '.' in jwks.json would match any
+    # single character. Our implementation uses '\.', which is correct but doesn't match
+    # django-oauth-toolkit in older versions, so we skip this check.
+    dab_oidc_names.remove('jwks-info')
+
 
 @pytest.mark.parametrize("name", sorted(dab_oidc_names))
 def test_oidc_url_patterns_match_dot(name):
@@ -14,6 +36,5 @@ def test_oidc_url_patterns_match_dot(name):
     dot_pattern = next(p for p in dot_oidc_urlpatterns if p.name == name)
     dab_pattern = next(p for p in oauth_urls if getattr(p, 'name', None) == name)
     assert dab_pattern.pattern._regex == dot_pattern.pattern._regex, (
-        f"URL pattern for '{name}' differs from django-oauth-toolkit. "
-        f"DAB: {dab_pattern.pattern._regex}, DOT: {dot_pattern.pattern._regex}"
+        f"URL pattern for '{name}' differs from django-oauth-toolkit. " f"DAB: {dab_pattern.pattern._regex}, DOT: {dot_pattern.pattern._regex}"
     )

--- a/test_app/tests/oauth2_provider/views/test_authorization_root.py
+++ b/test_app/tests/oauth2_provider/views/test_authorization_root.py
@@ -1,6 +1,6 @@
 import pytest
-from flags.state import disable_flag, enable_flag
 
+from ansible_base.lib.testing.util import feature_flag_enabled
 from ansible_base.lib.utils.response import get_relative_url
 
 
@@ -20,11 +20,8 @@ def test_oidc_endpoints_shown_when_flag_enabled(admin_api_client):
     """
     OIDC endpoints are shown when feature flag is enabled.
     """
-    enable_flag("FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED")
-    try:
+    with feature_flag_enabled("FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED"):
         url = get_relative_url("oauth2_provider:oauth_authorization_root_view")
         response = admin_api_client.get(url)
         assert 'oidc-connect-discovery-info' in response.data
         assert 'jwks-info' in response.data
-    finally:
-        disable_flag("FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED")

--- a/test_app/tests/oauth2_provider/views/test_openid_configuration.py
+++ b/test_app/tests/oauth2_provider/views/test_openid_configuration.py
@@ -2,8 +2,8 @@ import pytest
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.test import override_settings
-from flags.state import disable_flag, enable_flag
 
+from ansible_base.lib.testing.util import feature_flag_enabled
 from ansible_base.lib.utils.response import get_relative_url
 
 
@@ -14,13 +14,10 @@ def test_oauth2_provider_openid_configuration_valid_issuer_url(client):
     an issuer URL that ends with /o
     """
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
-    enable_flag('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED')
-    try:
-        with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True, 'OIDC_OIDC_RSA_PRIVATE_KEY': private_key}):
+    with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True, 'OIDC_OIDC_RSA_PRIVATE_KEY': private_key}):
+        with feature_flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
             url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
             response_json = client.get(url).json()
             assert response_json['issuer'].endswith(
                 '/o'
             ), "issuer in discovery metadata is expected to end with /o and match the authorization root view, otherwise discovery will fail!"
-    finally:
-        disable_flag('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED')

--- a/test_app/tests/oauth2_provider/views/test_openid_configuration.py
+++ b/test_app/tests/oauth2_provider/views/test_openid_configuration.py
@@ -14,7 +14,9 @@ def test_oauth2_provider_openid_configuration_valid_issuer_url(client):
     with feature_flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
         with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True}):
             url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
-            response_json = client.get(url).json()
+            response = client.get(url)
+            assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+            response_json = response.json()
             assert response_json['issuer'].endswith(
                 '/o'
             ), "issuer in discovery metadata is expected to end with /o and match the authorization root view, otherwise discovery will fail!"

--- a/test_app/tests/oauth2_provider/views/test_openid_configuration.py
+++ b/test_app/tests/oauth2_provider/views/test_openid_configuration.py
@@ -1,0 +1,26 @@
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from django.test import override_settings
+from flags.state import disable_flag, enable_flag
+
+from ansible_base.lib.utils.response import get_relative_url
+
+
+@pytest.mark.django_db
+def test_oauth2_provider_openid_configuration_valid_issuer_url(client):
+    """
+    As an anonymous user, accessing /o/.well-known/openid-configuration/ should include
+    an issuer URL that ends with /o
+    """
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
+    enable_flag('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED')
+    try:
+        with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True, 'OIDC_OIDC_RSA_PRIVATE_KEY': private_key}):
+            url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
+            response_json = client.get(url).json()
+            assert response_json['issuer'].endswith(
+                '/o'
+            ), "issuer in discovery metadata is expected to end with /o and match the authorization root view, otherwise discovery will fail!"
+    finally:
+        disable_flag('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED')

--- a/test_app/tests/oauth2_provider/views/test_openid_configuration.py
+++ b/test_app/tests/oauth2_provider/views/test_openid_configuration.py
@@ -11,8 +11,8 @@ def test_oauth2_provider_openid_configuration_valid_issuer_url(client):
     As an anonymous user, accessing /o/.well-known/openid-configuration/ should include
     an issuer URL that ends with /o
     """
-    with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True}):
-        with feature_flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
+    with feature_flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
+        with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True}):
             url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
             response_json = client.get(url).json()
             assert response_json['issuer'].endswith(

--- a/test_app/tests/oauth2_provider/views/test_openid_configuration.py
+++ b/test_app/tests/oauth2_provider/views/test_openid_configuration.py
@@ -1,6 +1,4 @@
 import pytest
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa
 from django.test import override_settings
 
 from ansible_base.lib.testing.util import feature_flag_enabled
@@ -13,8 +11,7 @@ def test_oauth2_provider_openid_configuration_valid_issuer_url(client):
     As an anonymous user, accessing /o/.well-known/openid-configuration/ should include
     an issuer URL that ends with /o
     """
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
-    with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True, 'OIDC_OIDC_RSA_PRIVATE_KEY': private_key}):
+    with override_settings(OAUTH2_PROVIDER={'OIDC_ENABLED': True}):
         with feature_flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
             url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
             response_json = client.get(url).json()

--- a/test_app/tests/oauth2_provider/views/test_openid_configuration.py
+++ b/test_app/tests/oauth2_provider/views/test_openid_configuration.py
@@ -1,7 +1,7 @@
 import pytest
 from django.test import override_settings
 
-from ansible_base.lib.testing.util import feature_flag_enabled
+from ansible_base.lib.testing.util import feature_flag_disabled, feature_flag_enabled
 from ansible_base.lib.utils.response import get_relative_url
 
 
@@ -20,3 +20,15 @@ def test_oauth2_provider_openid_configuration_valid_issuer_url(client):
             assert response_json['issuer'].endswith(
                 '/o'
             ), "issuer in discovery metadata is expected to end with /o and match the authorization root view, otherwise discovery will fail!"
+
+
+@pytest.mark.django_db
+def test_oauth2_provider_openid_configuration_404_without_feature_flag(client):
+    """
+    As an anonymous user, accessing /o/.well-known/openid-configuration/ should fail
+    with 404 if the feature is not enabled
+    """
+    with feature_flag_disabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
+        url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
+        response = client.get(url)
+        assert response.status_code == 404, f"Expected 404, got {response.status_code}"


### PR DESCRIPTION
## Description

This PR changes the url pattern for the ConnectDiscoveryInfoView (`.well-known/openid-configuration`) to end with a trailing slash `/`, which matches the implementation in [django-oauth-toolkit 2.3.0](https://github.com/django-oauth/django-oauth-toolkit/blob/2.3.0/oauth2_provider/urls.py#L35), (pinned [here](https://github.com/ansible/django-ansible-base/blob/devel/requirements/requirements_oauth2_provider.in)).

The change is needed to fix a bug where the view returned an invalid issuer and causes OIDC Discovery to fail. Specifically, the `ConnectDiscoveryInfoView` uses a helper function `oidc_issuer()` to derive the issuer URL. In 2.3.0, this function assumes the URL ends with a trailing slash https://github.com/django-oauth/django-oauth-toolkit/blob/2.3.0/oauth2_provider/settings.py#L297 and uses that length. So if ours doesn't include the `/`, that count is off by one and the issuer ends with `/` instead of `/o`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

This can be tested in aap-dev using https://github.com/ansible/aap-dev/pull/448. See section "k8s-vault with aap-dev"

## Additional Context

This URL pattern was discussed in #915: https://github.com/ansible/django-ansible-base/pull/915/changes#r2709849119. I'd prefer without the trailing slash, I'd recommend upgrading django-oauth-toolkit to address that. Since that's a more complex effort I added comments and tests to make sure we consider this when we do upgrade that dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC discovery and UserInfo endpoints now require trailing slashes for compatibility with the OAuth2 provider.

* **Tests**
  * Added tests validating OpenID discovery behavior, issuer formatting, 404 behavior when feature flag is off, and URL pattern alignment with the upstream provider.

* **Chores**
  * Added scoped context-manager utilities to temporarily enable or disable feature flags in tests.

* **Refactor**
  * Updated tests to use scoped feature-flag context managers instead of manual enable/disable calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->