### PR TITLE
AAP-64507: Fix workload identity client to include trailing slash

### DIFF
--- a/ansible_base/resource_registry/workload_identity_client.py
+++ b/ansible_base/resource_registry/workload_identity_client.py
@@ -137,7 +137,7 @@ class WorkloadIdentityClient(BaseServiceClient):
         """
         Request a workload identity token.
 
-        Makes a POST request to /api/gateway/v1/workload_identity_tokens
+        Makes a POST request to /api/gateway/v1/workload_identity_tokens/
         with the specified claims, scope, and audience.
 
         Args:
@@ -167,7 +167,7 @@ class WorkloadIdentityClient(BaseServiceClient):
         try:
             response = self._make_request(
                 method="POST",
-                path="/api/gateway/v1/workload_identity_tokens",
+                path="/api/gateway/v1/workload_identity_tokens/",
                 data=data,
             )
         except requests.exceptions.RequestException as e:

--- a/test_app/tests/resource_registry/test_workload_identity_client.py
+++ b/test_app/tests/resource_registry/test_workload_identity_client.py
@@ -170,7 +170,7 @@ class TestWorkloadIdentityClient:
         mock_request.assert_called_once()
         call_kwargs = mock_request.call_args[1]
         assert call_kwargs["method"] == "POST"
-        assert call_kwargs["url"] == "https://gateway.example.com/api/gateway/v1/workload_identity_tokens"
+        assert call_kwargs["url"] == "https://gateway.example.com/api/gateway/v1/workload_identity_tokens/"
         assert call_kwargs["json"] == {
             "claims": {"id": 2, "name": "my-example-job"},
             "scope": "aap_controller_automation_job",


### PR DESCRIPTION
## Description
Fix workload identity client to include trailing slash, otherwise the client will throw an error.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

TODO

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
This was discovered upon integrating the client in a real environment.

### Required Actions


### Screenshots/Logs
<img width="1622" height="776" alt="image" src="https://github.com/user-attachments/assets/c92a1daa-d7e9-4fd2-9f5d-0488add33328" />


```
 <pre class="exception_value">You called this URL via POST, but the URL doesn&#x27;t end in a slash and you have APPEND_SLASH set. Django can&#x27;t redirect to the slash URL while maintaining POST data. Change your form to point to myaap/api/gateway/v1/workload_identity_tokens/ (note the trailing slash), or set APPEND_SLASH=False in your Django settings.</pre>
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API endpoint path for workload identity token requests to ensure proper endpoint compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->