### PR TITLE
AAP-64919 Mask encrypted fields in audit log/activitystream

### DIFF
--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -322,7 +322,7 @@ def diff(
     # Get any new fields from the new_fields - old_fields
     for field in new_fields_set - old_fields_set:
         val = fields['new'][field]
-        model_diff.added_fields[field] = ENCRYPTED_STRING if _is_sensitive(new, new_model, field, val, sanitize_encrypted) else val
+        model_diff.added_fields[field] = _sanitize_value(new, new_model, field, val, sanitize_encrypted)
 
     # Find any modified fields from the union of the sets
     for field in new_fields_set & old_fields_set:
@@ -330,8 +330,8 @@ def diff(
             old_val = fields['old'][field]
             new_val = fields['new'][field]
             model_diff.changed_fields[field] = (
-                ENCRYPTED_STRING if _is_sensitive(old, old_model, field, old_val, sanitize_encrypted) else old_val,
-                ENCRYPTED_STRING if _is_sensitive(new, new_model, field, new_val, sanitize_encrypted) else new_val,
+                _sanitize_value(old, old_model, field, old_val, sanitize_encrypted),
+                _sanitize_value(new, new_model, field, new_val, sanitize_encrypted),
             )
 
     return model_diff

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -166,6 +166,32 @@ def is_encrypted_field(model, field_name):
     return field_name in getattr(model, 'encrypted_fields', [])
 
 
+def _is_sensitive(instance, model, field_name, value, sanitize_encrypted):
+    """Check whether a field value should be replaced with ENCRYPTED_STRING.
+
+    Extends the class-level ``is_encrypted_field`` check with two additional
+    heuristics so that models with *instance-level* encryption (e.g. a
+    ``Preference`` whose ``raw_value`` is only sometimes encrypted) can
+    participate in sanitization:
+
+    1. **Instance attribute** – if the instance carries an
+       ``_encrypted_field_names`` set/list, fields listed there are treated as
+       encrypted.  Models should populate this in ``from_db()`` / ``save()``
+       when they detect that a particular field holds an encrypted value.
+    2. **Value prefix** – if the string value starts with the well-known
+       ``$encrypted$`` marker, it is replaced regardless of field metadata.
+    """
+    if not sanitize_encrypted:
+        return False
+    if is_encrypted_field(model, field_name):
+        return True
+    if instance is not None and field_name in getattr(instance, '_encrypted_field_names', set()):
+        return True
+    if isinstance(value, str) and value.startswith(ENCRYPTED_STRING):
+        return True
+    return False
+
+
 @dataclass
 class ModelDiff:
     added_fields: dict
@@ -291,18 +317,22 @@ def diff(
 
     # Get any removed fields from the old_fields - new_fields
     for field in old_fields_set - new_fields_set:
-        model_diff.removed_fields[field] = ENCRYPTED_STRING if is_encrypted_field(old_model, field) else fields['old'][field]
+        val = fields['old'][field]
+        model_diff.removed_fields[field] = ENCRYPTED_STRING if _is_sensitive(old, old_model, field, val, sanitize_encrypted) else val
 
     # Get any new fields from the new_fields - old_fields
     for field in new_fields_set - old_fields_set:
-        model_diff.added_fields[field] = ENCRYPTED_STRING if is_encrypted_field(new_model, field) else fields['new'][field]
+        val = fields['new'][field]
+        model_diff.added_fields[field] = ENCRYPTED_STRING if _is_sensitive(new, new_model, field, val, sanitize_encrypted) else val
 
     # Find any modified fields from the union of the sets
     for field in new_fields_set & old_fields_set:
         if fields['old'][field] != fields['new'][field]:
+            old_val = fields['old'][field]
+            new_val = fields['new'][field]
             model_diff.changed_fields[field] = (
-                ENCRYPTED_STRING if is_encrypted_field(old_model, field) else fields['old'][field],
-                ENCRYPTED_STRING if is_encrypted_field(new_model, field) else fields['new'][field],
+                ENCRYPTED_STRING if _is_sensitive(old, old_model, field, old_val, sanitize_encrypted) else old_val,
+                ENCRYPTED_STRING if _is_sensitive(new, new_model, field, new_val, sanitize_encrypted) else new_val,
             )
 
     return model_diff

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -166,30 +166,30 @@ def is_encrypted_field(model, field_name):
     return field_name in getattr(model, 'encrypted_fields', [])
 
 
-def _is_sensitive(instance, model, field_name, value, sanitize_encrypted):
-    """Check whether a field value should be replaced with ENCRYPTED_STRING.
+def _sanitize_value(instance, model, field_name, value, sanitize_encrypted):
+    """Return *value* unchanged or ``ENCRYPTED_STRING`` if the field is sensitive.
 
     Extends the class-level ``is_encrypted_field`` check with two additional
     heuristics so that models with *instance-level* encryption (e.g. a
     ``Preference`` whose ``raw_value`` is only sometimes encrypted) can
     participate in sanitization:
 
-    1. **Instance attribute** – if the instance carries an
+    1. **Instance attribute** -- if the instance carries an
        ``_encrypted_field_names`` set/list, fields listed there are treated as
        encrypted.  Models should populate this in ``from_db()`` / ``save()``
        when they detect that a particular field holds an encrypted value.
-    2. **Value prefix** – if the string value starts with the well-known
+    2. **Value prefix** -- if the string value starts with the well-known
        ``$encrypted$`` marker, it is replaced regardless of field metadata.
     """
     if not sanitize_encrypted:
-        return False
+        return value
     if is_encrypted_field(model, field_name):
-        return True
+        return ENCRYPTED_STRING
     if instance is not None and field_name in getattr(instance, '_encrypted_field_names', set()):
-        return True
+        return ENCRYPTED_STRING
     if isinstance(value, str) and value.startswith(ENCRYPTED_STRING):
-        return True
-    return False
+        return ENCRYPTED_STRING
+    return value
 
 
 @dataclass

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -317,8 +317,7 @@ def diff(
 
     # Get any removed fields from the old_fields - new_fields
     for field in old_fields_set - new_fields_set:
-        val = fields['old'][field]
-        model_diff.removed_fields[field] = ENCRYPTED_STRING if _is_sensitive(old, old_model, field, val, sanitize_encrypted) else val
+        model_diff.removed_fields[field] = _sanitize_value(old, old_model, field, fields['old'][field], sanitize_encrypted)
 
     # Get any new fields from the new_fields - old_fields
     for field in new_fields_set - old_fields_set:

--- a/test_app/tests/lib/utils/test_models.py
+++ b/test_app/tests/lib/utils/test_models.py
@@ -313,6 +313,74 @@ def test_diff_sanitizes_encrypted_fields_removed(disable_activity_stream):
     assert 'message' not in delta.removed_fields
 
 
+@pytest.mark.django_db
+def test_diff_sanitizes_encrypted_value_prefix_changed(disable_activity_stream):
+    """Values starting with '$encrypted$' are sanitized even when the field is not in encrypted_fields."""
+    instance1 = test_app_models.ImmutableLogEntry.objects.create(message='plain_old')
+    instance2 = test_app_models.ImmutableLogEntry.objects.get(pk=instance1.pk)
+    instance2.message = f'{ENCRYPTED_STRING}UTF8$AESCBC$abc123=='
+
+    delta = models.diff(instance1, instance2)
+    assert delta.changed_fields['message'] == ('plain_old', ENCRYPTED_STRING)
+
+
+@pytest.mark.django_db
+def test_diff_sanitizes_encrypted_value_prefix_added(disable_activity_stream):
+    """A new field whose value starts with '$encrypted$' is sanitized in added_fields."""
+    logentry = test_app_models.ImmutableLogEntry.objects.create(message='hello')
+    enc = test_app_models.EncryptionModel.objects.create(name=f'{ENCRYPTED_STRING}UTF8$AESCBC$xyz==', testing1='t1', testing2='t2')
+
+    delta = models.diff(logentry, enc, require_type_match=False)
+    assert delta.added_fields['name'] == ENCRYPTED_STRING
+
+
+@pytest.mark.django_db
+def test_diff_sanitizes_encrypted_value_prefix_removed(disable_activity_stream):
+    """A removed field whose value starts with '$encrypted$' is sanitized in removed_fields."""
+    enc = test_app_models.EncryptionModel.objects.create(name=f'{ENCRYPTED_STRING}UTF8$AESCBC$xyz==', testing1='t1', testing2='t2')
+    logentry = test_app_models.ImmutableLogEntry.objects.create(message='hello')
+
+    delta = models.diff(enc, logentry, require_type_match=False)
+    assert delta.removed_fields['name'] == ENCRYPTED_STRING
+
+
+@pytest.mark.django_db
+def test_diff_sanitizes_instance_encrypted_field_names(disable_activity_stream):
+    """Instance-level _encrypted_field_names causes the field to be sanitized."""
+    instance1 = test_app_models.ImmutableLogEntry.objects.create(message='secret_old')
+    instance2 = test_app_models.ImmutableLogEntry.objects.get(pk=instance1.pk)
+    instance2.message = 'secret_new'
+    instance1._encrypted_field_names = {'message'}
+    instance2._encrypted_field_names = {'message'}
+
+    delta = models.diff(instance1, instance2)
+    assert delta.changed_fields['message'] == (ENCRYPTED_STRING, ENCRYPTED_STRING)
+
+
+@pytest.mark.django_db
+def test_diff_instance_encrypted_field_names_partial(disable_activity_stream):
+    """Only the side with _encrypted_field_names is sanitized; the other keeps its value."""
+    instance1 = test_app_models.ImmutableLogEntry.objects.create(message='plaintext_old')
+    instance2 = test_app_models.ImmutableLogEntry.objects.get(pk=instance1.pk)
+    instance2.message = f'{ENCRYPTED_STRING}UTF8$AESCBC$data=='
+    instance1._encrypted_field_names = {'message'}
+
+    delta = models.diff(instance1, instance2)
+    assert delta.changed_fields['message'] == (ENCRYPTED_STRING, ENCRYPTED_STRING)
+
+
+@pytest.mark.django_db
+def test_diff_no_sanitize_when_disabled(disable_activity_stream):
+    """When sanitize_encrypted=False, neither class-level nor instance-level encryption is sanitized."""
+    instance1 = test_app_models.ImmutableLogEntry.objects.create(message='plain')
+    instance2 = test_app_models.ImmutableLogEntry.objects.get(pk=instance1.pk)
+    instance2.message = f'{ENCRYPTED_STRING}UTF8$AESCBC$data=='
+    instance1._encrypted_field_names = {'message'}
+
+    delta = models.diff(instance1, instance2, sanitize_encrypted=False)
+    assert delta.changed_fields['message'] == ('plain', instance2.message)
+
+
 @pytest.mark.parametrize(
     "username,expected_value",
     [


### PR DESCRIPTION
## Description

GW preferences contain 'raw_value' model field that is not set as encrypted.  They also contain a flag for encryption though, that results in encrypted values being stored in raw_value.  Those were being dumped in the activitystream and audit log looking like

`changed from '' to '$encrypted$UTF8$AESCBC$Z0FBQUFBQnBuTVBFckM5...'`

which isn't really acceptable.

This PR does additional filtering to handle this case and results in

`changed from '$encrypted$' to '$encrypted$'`

 and prevents info leakage.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Run GW
2. Change encrypted preference
3. Examine log

### Expected Results
No more cipher/ciphertext info leaked into log or activitystream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently mask encrypted values in model diffs (added, removed, modified), honoring instance-level encrypted-field hints and values explicitly marked as encrypted; respects the sanitize toggle.
* **Tests**
  * Added tests covering sanitization for prefixed encrypted values, instance-level encrypted-field names, partial-side sanitization, and disabled-sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->