### PR TITLE
AAP-68986 Move activity stream registry to setting

### DIFF
--- a/ansible_base/activitystream/__init__.py
+++ b/ansible_base/activitystream/__init__.py
@@ -1,3 +1,36 @@
 from ansible_base.activitystream.signals import no_activity_stream
 
-__all__ = ['no_activity_stream']
+__all__ = ['no_activity_stream', 'activity_stream_entries']
+
+
+def activity_stream_entries():
+    """
+    Return a GenericRelation to the activity stream Entry model.
+
+    The returned relation does not cascade-delete entries when the parent
+    object is deleted, since activity stream records are an audit trail
+    that must survive object deletion.
+
+    Use this on your model to add a reverse relation for querying
+    activity stream entries::
+
+        from ansible_base.activitystream import activity_stream_entries
+
+        class MyModel(CommonModel):
+            activity_stream = activity_stream_entries()
+    """
+    from django.contrib.contenttypes.fields import GenericRelation
+
+    class NonCascadingGenericRelation(GenericRelation):
+        """A GenericRelation that does not cascade-delete related objects."""
+
+        def bulk_related_objects(self, objs, using='default'):
+            # Return an empty queryset so Django's deletion collector
+            # never picks up (and deletes) the related entries.
+            return self.remote_field.model._base_manager.db_manager(using).none()
+
+    return NonCascadingGenericRelation(
+        'dab_activitystream.Entry',
+        content_type_field='content_type',
+        object_id_field='object_id',
+    )

--- a/ansible_base/activitystream/apps.py
+++ b/ansible_base/activitystream/apps.py
@@ -1,9 +1,46 @@
+import logging
+import warnings
 from functools import partial
 
 from django.apps import AppConfig
 from django.db.models.signals import m2m_changed, post_save, pre_delete, pre_save
 
 from ansible_base.activitystream.signals import activitystream_create, activitystream_delete, activitystream_m2m_changed, activitystream_update
+
+logger = logging.getLogger('ansible_base.activitystream')
+
+# Registry of models tracked by the activity stream, populated in ready().
+_registered_models = set()
+
+
+def get_activity_stream_entries(instance):
+    """Return activity stream entries for a model instance."""
+    from django.contrib.contenttypes.models import ContentType
+
+    from ansible_base.activitystream.models import Entry
+
+    return Entry.objects.filter(content_type=ContentType.objects.get_for_model(instance), object_id=instance.pk).order_by('created')
+
+
+def get_activity_stream_related_url(instance):
+    """Return the activity stream related URL dict for a model instance, or empty dict if not registered."""
+    if type(instance) not in _registered_models:
+        return {}
+
+    from django.contrib.contenttypes.models import ContentType
+    from django.utils.http import urlencode
+
+    from ansible_base.lib.utils.response import get_relative_url
+
+    content_type = ContentType.objects.get_for_model(instance)
+    query_kwargs = {
+        'content_type': content_type.pk,
+        'object_id': instance.pk,
+    }
+    activity_stream_url = get_relative_url('activitystream-list') + '?' + urlencode(query_kwargs)
+    return {
+        'activity_stream': activity_stream_url,
+    }
 
 
 def connect_activitystream_signals(cls):
@@ -13,7 +50,7 @@ def connect_activitystream_signals(cls):
 
     # Connect to m2m_changed signal for all m2m fields
     for field in cls._meta.many_to_many:
-        if field.name in cls.activity_stream_excluded_field_names:
+        if field.name in getattr(cls, 'activity_stream_excluded_field_names', []):
             continue
 
         fn = partial(activitystream_m2m_changed, field_name=field.name)
@@ -32,12 +69,36 @@ class ActivitystreamConfig(AppConfig):
     verbose_name = 'Activity Stream'
 
     def ready(self):
-        # Iterate models and look for ones that inherit from AuditableModel.
-        # If found, connect the signal to the model by calling its static connect_signals().
         from django.apps import apps
+        from django.conf import settings
 
         from ansible_base.activitystream.models import AuditableModel
 
+        # Register models from the ACTIVITY_STREAM_MODELS setting (preferred)
+        for app_label, model_name in getattr(settings, 'ACTIVITY_STREAM_MODELS', []):
+            try:
+                model = apps.get_model(app_label, model_name)
+            except LookupError:
+                logger.warning(f"ACTIVITY_STREAM_MODELS references '{app_label}.{model_name}', but this model was not found.")
+                continue
+
+            connect_activitystream_signals(model)
+            _registered_models.add(model)
+
+        # Backward compatibility: also detect AuditableModel subclasses not
+        # already covered by the setting and register them with loud warnings.
         for model in apps.get_models():
+            if model in _registered_models:
+                continue
             if issubclass(model, AuditableModel):
+                msg = (
+                    f"DEPRECATED: Model '{model._meta.label}' inherits from AuditableModel. "
+                    f"Remove AuditableModel from the base classes and add "
+                    f"('{model._meta.app_label}', '{model.__name__}') to the "
+                    f"ACTIVITY_STREAM_MODELS setting instead. "
+                    f"AuditableModel inheritance will stop being detected in a future release."
+                )
+                warnings.warn(msg, DeprecationWarning, stacklevel=1)
+                logger.warning(msg)
                 connect_activitystream_signals(model)
+                _registered_models.add(model)

--- a/ansible_base/activitystream/models/entry.py
+++ b/ansible_base/activitystream/models/entry.py
@@ -1,13 +1,12 @@
 import functools
+import warnings
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.abstract_models import ImmutableCommonModel
-from ansible_base.lib.utils.response import get_relative_url
 
 
 class Entry(ImmutableCommonModel):
@@ -98,45 +97,42 @@ class Entry(ImmutableCommonModel):
 
 class AuditableModel(models.Model):
     """
-    A mixin class that provides integration to the activity stream from any
-    model. A model should simply inherit from this class to have its
-    create/update/delete events sent to the activity stream.
+    DEPRECATED: Do not inherit from this class for new models.
 
-    NOTE: AuditableModel must remain a pure mixin with no database fields.
-    Models conditionally inherit from AuditableModel based on whether
-    activitystream is installed (e.g., AAPFlag). Adding a DB field would
-    create environment-dependent migrations.
+    Instead, add your model to the ACTIVITY_STREAM_MODELS setting as a
+    (app_label, model_name) tuple. Signals will be connected automatically
+    in the activitystream app's ready() method.
+
+    This class is retained only for backward compatibility and will be
+    removed in a future release.
     """
 
     class Meta:
         abstract = True
 
-    # Adding field names to this list will exclude them from the activity stream changes dictionaries
     activity_stream_excluded_field_names = []
-
-    # Adding field names to this list will limit the activity stream changes dictionaries to only include these fields
     activity_stream_limit_field_names = []
-
-    # Controls whether changes to this model are stored in the activity stream
     activity_stream_enabled = True
-
-    # Controls whether changes to this model are logged to the audit log
     audit_log_enabled = False
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        warnings.warn(
+            f"DEPRECATED: '{cls.__qualname__}' inherits from AuditableModel. "
+            f"Remove AuditableModel from its base classes and add the model to "
+            f"the ACTIVITY_STREAM_MODELS setting instead. "
+            f"AuditableModel will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     @property
     def activity_stream_entries(self):
-        """
-        A helper property that returns the activity stream entries for this object.
-        """
-        return Entry.objects.filter(content_type=ContentType.objects.get_for_model(self), object_id=self.pk).order_by('created')
+        from ansible_base.activitystream.apps import get_activity_stream_entries
+
+        return get_activity_stream_entries(self)
 
     def extra_related_fields(self, request):
-        content_type = ContentType.objects.get_for_model(self)
-        query_kwargs = {
-            'content_type': content_type.pk,
-            'object_id': self.pk,
-        }
-        activity_stream_url = get_relative_url('activitystream-list') + '?' + urlencode(query_kwargs)
-        return {
-            'activity_stream': activity_stream_url,
-        }
+        from ansible_base.activitystream.apps import get_activity_stream_related_url
+
+        return get_activity_stream_related_url(self)

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -204,9 +204,8 @@ def _store_activitystream_m2m(
 # post_save
 def activitystream_create(sender, instance, created, **kwargs):
     """
-    This signal is registered via the activity stream AuditableModel abstract
-    model/class. It is called after save() of any model that inherits from
-    AuditableModel. (It is registered as a post_save signal.)
+    This signal is connected for any model registered in the
+    ACTIVITY_STREAM_MODELS setting. It is registered as a post_save signal.
 
     This signal only handles creation of new objects (created=True). For
     updates, use the activitystream_update signal, where we can compare the
@@ -223,9 +222,8 @@ def activitystream_create(sender, instance, created, **kwargs):
 # pre_save
 def activitystream_update(sender, instance, raw, using, update_fields, **kwargs):
     """
-    This signal is registered via the activity stream AuditableModel abstract
-    model/class. It is called before save() of any model that inherits from
-    AuditableModel. (It is registered as a pre_save signal.)
+    This signal is connected for any model registered in the
+    ACTIVITY_STREAM_MODELS setting. It is registered as a pre_save signal.
 
     This signal only handles updates of existing objects. For creation of
     objects, see the above activitystream_create().
@@ -246,9 +244,8 @@ def activitystream_update(sender, instance, raw, using, update_fields, **kwargs)
 # pre_delete
 def activitystream_delete(sender, instance, using, origin, **kwargs):
     """
-    This signal is registered via the activity stream AuditableModel abstract
-    model/class. It is called before delete() of any model that inherits from
-    AuditableModel. (It is registered as a pre_delete signal.)
+    This signal is connected for any model registered in the
+    ACTIVITY_STREAM_MODELS setting. It is registered as a pre_delete signal.
     """
     if instance.pk is None:
         return
@@ -259,10 +256,10 @@ def activitystream_delete(sender, instance, using, origin, **kwargs):
 # m2m_changed
 def activitystream_m2m_changed(sender, instance, action, reverse, model, pk_set, **kwargs):
     """
-    This signal is registered via the activity stream AuditableModel abstract
-    model/class. It is called when a many-to-many relationship is changed
-    (added or removed) for any model that inherits from AuditableModel. (It is
-    registered as a m2m_changed signal.)
+    This signal is connected for any model registered in the
+    ACTIVITY_STREAM_MODELS setting. It is called when a many-to-many
+    relationship is changed (added or removed). It is registered as an
+    m2m_changed signal.
     """
     if action not in ('post_add', 'post_remove', 'pre_clear'):
         return

--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -253,6 +253,11 @@ class AbstractCommonModel(models.Model):
         if hasattr(self, 'extra_related_fields'):
             response.update(self.extra_related_fields(request))
 
+        if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
+            from ansible_base.activitystream.apps import get_activity_stream_related_url
+
+            response.update(get_activity_stream_related_url(self))
+
         sorted_response = OrderedDict()
         sorted_keys = list(response.keys())
         sorted_keys.sort()

--- a/ansible_base/oauth2_provider/models/access_token.py
+++ b/ansible_base/oauth2_provider/models/access_token.py
@@ -30,14 +30,7 @@ def validate_scope(value):
             raise ValidationError(_('Invalid scope: %(scope)s. Must be one of: %(scopes)s') % {'scope': scope, 'scopes': ', '.join(SCOPES)})
 
 
-activitystream = object
-if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
-    from ansible_base.activitystream.models import AuditableModel
-
-    activitystream = AuditableModel
-
-
-class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken, activitystream):
+class OAuth2AccessToken(CommonModel, oauth2_models.AbstractAccessToken):
     router_basename = 'token'
     ignore_relations = ['refresh_token']
     activity_stream_excluded_field_names = ['last_used', "modified", "modified_by"]

--- a/ansible_base/oauth2_provider/models/application.py
+++ b/ansible_base/oauth2_provider/models/application.py
@@ -8,14 +8,8 @@ from ansible_base.lib.abstract_models.common import NamedCommonModel
 from ansible_base.lib.utils.models import prevent_search
 from ansible_base.lib.utils.response import get_relative_url
 
-activitystream = object
-if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
-    from ansible_base.activitystream.models import AuditableModel
 
-    activitystream = AuditableModel
-
-
-class OAuth2Application(NamedCommonModel, oauth2_models.AbstractApplication, activitystream):
+class OAuth2Application(NamedCommonModel, oauth2_models.AbstractApplication):
     router_basename = 'application'
     ignore_relations = ['oauth2idtoken', 'grant', 'oauth2refreshtoken']
     # We do NOT add client_secret to encrypted_fields because it is hashed by Django OAuth Toolkit

--- a/ansible_base/oauth2_provider/models/id_token.py
+++ b/ansible_base/oauth2_provider/models/id_token.py
@@ -1,17 +1,10 @@
 import oauth2_provider.models as oauth2_models
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.abstract_models.common import CommonModel
 
-activitystream = object
-if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
-    from ansible_base.activitystream.models import AuditableModel
 
-    activitystream = AuditableModel
-
-
-class OAuth2IDToken(CommonModel, oauth2_models.AbstractIDToken, activitystream):
+class OAuth2IDToken(CommonModel, oauth2_models.AbstractIDToken):
     class Meta(oauth2_models.AbstractIDToken.Meta):
         verbose_name = _('id token')
         swappable = "OAUTH2_PROVIDER_ID_TOKEN_MODEL"

--- a/ansible_base/oauth2_provider/models/refresh_token.py
+++ b/ansible_base/oauth2_provider/models/refresh_token.py
@@ -2,7 +2,6 @@ import hashlib
 import logging
 
 import oauth2_provider.models as oauth2_models
-from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -13,14 +12,8 @@ from ansible_base.lib.utils.models import prevent_search
 
 logger = logging.getLogger('ansible_base.oauth2_provider.models.refresh_token')
 
-activitystream = object
-if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
-    from ansible_base.activitystream.models import AuditableModel
 
-    activitystream = AuditableModel
-
-
-class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken, activitystream):
+class OAuth2RefreshToken(CommonModel, oauth2_models.AbstractRefreshToken):
     class Meta(oauth2_models.AbstractRefreshToken.Meta):
         verbose_name = _('refresh token')
         ordering = ('id',)

--- a/docs/apps/activitystream.md
+++ b/docs/apps/activitystream.md
@@ -8,18 +8,47 @@ that happen to models within the system.
 To make use of `activitystream` in your application, first add
 `ansible_base.activitystream` to your `INSTALLED_APPS`.
 
-Now in your models you can:
+Then, add an `ACTIVITY_STREAM_MODELS` setting listing the models you want to
+track. Each entry is a tuple of `(app_label, model_name)`:
 
 ```python
-from ansible_base.activitystream.models import AuditableModel
+ACTIVITY_STREAM_MODELS = [
+    ('myapp', 'MyModel'),
+    ('myapp', 'AnotherModel'),
+]
 ```
 
-... and make your model inherit from `AuditableModel`. In theory, this is all
-that is required. When your application starts up, `activitystream` will ask
-Django to list all the models it knows about. It will then filter this list for
-ones that inherit from `AuditableModel` and call the
-`AuditableModel::connect_signals` class method which registers the appropriate
-signals.
+When your application starts up, `activitystream` will look up each model in
+this list and connect the appropriate signals to track create, update, delete,
+and many-to-many changes. Registered models will automatically get an
+`activity_stream` link in their API `related` fields.
+
+To query entries for a specific object, use the utility function:
+
+```python
+from ansible_base.activitystream.apps import get_activity_stream_entries
+
+entries = get_activity_stream_entries(my_instance)
+```
+
+#### Adding an `activity_stream` relation to your model
+
+If you want a reverse relation on your model so you can query activity stream
+entries directly from an instance, import the pre-configured `GenericRelation`
+factory and add it as a field:
+
+```python
+from ansible_base.activitystream import activity_stream_entries
+
+class MyModel(CommonModel):
+    activity_stream = activity_stream_entries()
+```
+
+This gives you a standard Django reverse generic relation, so you can do
+things like `my_obj.activity_stream.filter(operation='update')`.
+
+Note: since this is a `GenericRelation`, Django's contenttypes framework
+handles the content type and object ID lookups automatically.
 
 #### Excluding Fields
 

--- a/test_app/defaults.py
+++ b/test_app/defaults.py
@@ -204,4 +204,15 @@ RESOURCE_SERVER_SYNC_ENABLED = False
 
 RENAMED_USERNAME_PREFIX = "dab:"
 
+ACTIVITY_STREAM_MODELS = [
+    ('test_app', 'User'),
+    ('test_app', 'Animal'),
+    ('test_app', 'City'),
+    ('test_app', 'SecretColor'),
+    ('dab_oauth2_provider', 'OAuth2AccessToken'),
+    ('dab_oauth2_provider', 'OAuth2RefreshToken'),
+    ('dab_oauth2_provider', 'OAuth2Application'),
+    ('dab_oauth2_provider', 'OAuth2IDToken'),
+]
+
 JUST_A_TEST = 41

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -5,7 +5,7 @@ from django.db.models import JSONField
 from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
-from ansible_base.activitystream.models import AuditableModel
+from ansible_base.activitystream import activity_stream_entries
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.abstract_models import (
     AbstractDABUser,
@@ -32,7 +32,7 @@ class Organization(AbstractOrganization):
     extra_field = models.CharField(max_length=100, null=True)
 
 
-class User(AbstractDABUser, CommonModel, AuditableModel):
+class User(AbstractDABUser, CommonModel):
     class Meta(AbstractDABUser.Meta):
         ordering = ['id']
 
@@ -364,7 +364,7 @@ class MultipleFieldsModel(NamedCommonModel):
     bool_field = models.BooleanField(default=True)
 
 
-class Animal(NamedCommonModel, AuditableModel):
+class Animal(NamedCommonModel):
     class Meta:
         app_label = "test_app"
         ordering = ['id']
@@ -381,9 +381,10 @@ class Animal(NamedCommonModel, AuditableModel):
     kind = models.CharField(max_length=4, choices=ANIMAL_KINDS, default='dog')
     age = models.PositiveIntegerField(null=True, default=1)
     people_friends = models.ManyToManyField(User, related_name='animal_friends', blank=True)
+    activity_stream = activity_stream_entries()
 
 
-class City(NamedCommonModel, AuditableModel):
+class City(NamedCommonModel):
     class Meta:
         app_label = "test_app"
         ordering = ['id']
@@ -396,9 +397,9 @@ class City(NamedCommonModel, AuditableModel):
     state = models.CharField(max_length=100, null=True, editable=False)
 
 
-class SecretColor(AuditableModel):
+class SecretColor(models.Model):
     """
-    An AuditableModel that also has encrypted fields.
+    A model that has encrypted fields and is tracked in the activity stream.
     """
 
     class Meta:

--- a/test_app/tests/activitystream/models/test_entry.py
+++ b/test_app/tests/activitystream/models/test_entry.py
@@ -3,6 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models as db_models
 
 from ansible_base.activitystream.models import AuditableModel
+from ansible_base.activitystream.apps import get_activity_stream_entries
 from ansible_base.lib.utils.response import get_relative_url
 
 
@@ -10,7 +11,7 @@ def test_activitystream_entry_immutable(system_user, animal):
     """
     Trying to modify an Entry object should raise an exception.
     """
-    entry = animal.activity_stream_entries.first()
+    entry = get_activity_stream_entries(animal).first()
     entry.operation = "delete"
     with pytest.raises(ValueError) as excinfo:
         entry.save()
@@ -18,7 +19,7 @@ def test_activitystream_entry_immutable(system_user, animal):
     assert "Entry is immutable" in str(excinfo.value)
 
 
-def test_activitystream_auditablemodel_related(admin_api_client, user, organization):
+def test_activitystream_registered_model_related(admin_api_client, user, organization):
     url = get_relative_url('user-detail', kwargs={'pk': user.pk})
     response = admin_api_client.get(url)
     assert response.status_code == 200
@@ -28,7 +29,7 @@ def test_activitystream_auditablemodel_related(admin_api_client, user, organizat
     assert f'object_id={user.pk}' in activity_stream_url
     assert f'content_type={content_type.pk}' in activity_stream_url
 
-    # organization isn't an AuditableModel, so it shouldn't show AS in related
+    # organization isn't in ACTIVITY_STREAM_MODELS, so it shouldn't show AS in related
     url = get_relative_url('organization-detail', kwargs={'pk': organization.pk})
     response = admin_api_client.get(url)
     assert response.status_code == 200

--- a/test_app/tests/activitystream/models/test_entry.py
+++ b/test_app/tests/activitystream/models/test_entry.py
@@ -2,8 +2,8 @@ import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.db import models as db_models
 
-from ansible_base.activitystream.models import AuditableModel
 from ansible_base.activitystream.apps import get_activity_stream_entries
+from ansible_base.activitystream.models import AuditableModel
 from ansible_base.lib.utils.response import get_relative_url
 
 

--- a/test_app/tests/activitystream/test_api.py
+++ b/test_app/tests/activitystream/test_api.py
@@ -5,6 +5,7 @@ from crum import impersonate
 from django.contrib.contenttypes.models import ContentType
 from django.utils.http import urlencode
 
+from ansible_base.activitystream.apps import get_activity_stream_entries
 from ansible_base.activitystream.models import Entry
 from ansible_base.lib.utils.response import get_relative_url
 
@@ -190,7 +191,7 @@ def test_activitystream_api_related_fks_in_detail_view(admin_api_client, animal,
     """
     animal.owner = random_user
     animal.save()
-    url = get_relative_url("activitystream-detail", args=[animal.activity_stream_entries.last().id])
+    url = get_relative_url("activitystream-detail", args=[get_activity_stream_entries(animal).last().id])
     response = admin_api_client.get(url)
     assert response.status_code == 200
     entry = response.data
@@ -206,7 +207,7 @@ def test_activitystream_api_related_fks_refused_for_bad_time_delta(admin_api_cli
     animal.owner = random_user
     animal.save()
 
-    last_entry = animal.activity_stream_entries.last()
+    last_entry = get_activity_stream_entries(animal).last()
     random_user.created = last_entry.created + timedelta(days=1)
     random_user.save()
 
@@ -223,7 +224,7 @@ def test_activitystream_api_related_content_object(admin_api_client, animal):
     """
     Ensure that we can link to the thing we're an entry for.
     """
-    url = get_relative_url("activitystream-detail", args=[animal.activity_stream_entries.last().id])
+    url = get_relative_url("activitystream-detail", args=[get_activity_stream_entries(animal).last().id])
     response = admin_api_client.get(url)
     assert response.status_code == 200
     entry = response.data
@@ -239,7 +240,7 @@ def test_activitystream_api_related_related_content_object(admin_api_client, ani
     Should show in both list and detail views.
     """
     animal.people_friends.add(random_user)
-    db_entry = animal.activity_stream_entries.last()
+    db_entry = get_activity_stream_entries(animal).last()
 
     # sanity assertions that entry links models we expect
     assert db_entry.related_content_type == ContentType.objects.get_for_model(random_user)
@@ -277,7 +278,7 @@ def test_activitystream_api_summary_fields(admin_api_client, animal, admin_user,
     with impersonate(user):
         animal.save()
 
-    url = get_relative_url("activitystream-detail", args=[animal.activity_stream_entries.last().id])
+    url = get_relative_url("activitystream-detail", args=[get_activity_stream_entries(animal).last().id])
     query_params = {
         'page_size': 100,
     }
@@ -302,7 +303,7 @@ def test_activitystream_api_summary_fields_after_patch(admin_api_client, animal,
     response = admin_api_client.patch(url, data={"owner": random_user.id})
     assert response.status_code == 200
 
-    stream_id = animal.activity_stream_entries.last().id
+    stream_id = get_activity_stream_entries(animal).last().id
     url = get_relative_url("activitystream-detail", args=[stream_id])
     response = admin_api_client.get(url)
     assert response.status_code == 200
@@ -325,7 +326,7 @@ def test_activitystream_api_no_fatal_with_invalid_fks(admin_api_client, animal):
     We should never fatal, even if we point to bad FKs.
     Just don't show the related objects.
     """
-    entry = animal.activity_stream_entries.last()
+    entry = get_activity_stream_entries(animal).last()
     entry.object_id = '31337'
     entry.changes['changed_fields']['owner'] = ['31337', '99999']
     Entry.objects.bulk_update([entry], ['object_id', 'changes'])
@@ -343,7 +344,7 @@ def test_activitystream_api_deleted_object(admin_api_client, animal, user):
     """
     animal.owner = user
     animal.save()
-    entries = animal.activity_stream_entries
+    entries = get_activity_stream_entries(animal)
     animal.delete()
     entry = entries.last()
     assert entry.operation == "delete"

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -976,3 +976,38 @@ def test_audit_log_m2m_preposition(user, operation, method_name, expected_prepos
         call_args = mock_log.call_args[0][0]
         assert expected_preposition in call_args
         assert operation in call_args
+
+
+# =============================================================================
+# Tests for NonCascadingGenericRelation
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_non_cascading_generic_relation_prevents_cascade_delete():
+    """
+    NonCascadingGenericRelation overrides bulk_related_objects to return an
+    empty queryset, preventing Django's deletion collector from cascade-deleting
+    activity stream entries when a parent object is deleted.
+
+    This verifies that audit trail data survives object deletion.
+    """
+    animal = Animal.objects.create(name='CascadeTest')
+    entry_qs = Entry.objects.filter(
+        content_type__app_label='test_app',
+        content_type__model='animal',
+        object_id=str(animal.pk),
+    )
+    # The create signal should have produced an entry
+    assert entry_qs.count() >= 1, "Expected at least a 'create' entry for the animal"
+    entry_pks = list(entry_qs.values_list('pk', flat=True))
+
+    # Delete the animal
+    animal.delete()
+
+    # Activity stream entries must survive the parent deletion
+    surviving = Entry.objects.filter(pk__in=entry_pks)
+    assert surviving.count() == len(entry_pks), (
+        "Activity stream entries were cascade-deleted when the parent object was deleted. "
+        "NonCascadingGenericRelation.bulk_related_objects should prevent this."
+    )

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -5,19 +5,51 @@ import pytest
 
 import ansible_base.activitystream.signals as signals
 from ansible_base.activitystream import no_activity_stream
+from ansible_base.activitystream.apps import get_activity_stream_entries
 from ansible_base.activitystream.models import Entry
-from ansible_base.activitystream.models.entry import AuditableModel
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from test_app.models import Animal, City, SecretColor
+
+
+def test_activitystream_generic_relation(system_user, animal, random_user):
+    """
+    Ensure that the GenericRelation field (activity_stream_entries()) works
+    as a standard Django reverse relation for querying entries.
+    """
+    # Creation entry should be visible via the relation
+    assert animal.activity_stream.count() == 1
+    entry = animal.activity_stream.first()
+    assert entry.operation == 'create'
+
+    # Update should produce a second entry
+    animal.name = 'Buddy'
+    animal.save()
+    assert animal.activity_stream.count() == 2
+    assert animal.activity_stream.last().operation == 'update'
+
+    # Filtering works like a normal queryset
+    creates = animal.activity_stream.filter(operation='create')
+    assert creates.count() == 1
+    updates = animal.activity_stream.filter(operation='update')
+    assert updates.count() == 1
+
+    # M2M association shows up too
+    animal.people_friends.add(random_user)
+    assert animal.activity_stream.filter(operation='associate').count() == 1
+
+    # Delete entry is visible via the saved queryset reference
+    qs = animal.activity_stream.all()
+    animal.delete()
+    assert qs.filter(operation='delete').count() == 1
 
 
 def test_activitystream_create(system_user, animal):
     """
     Ensure that an activity stream entry is created when an object is created.
 
-    Also ensure that AuditableModel.activity_stream_entries returns the correct entries.
+    Also ensure that activity_stream_entries returns the correct entries.
     """
-    entries = animal.activity_stream_entries
+    entries = get_activity_stream_entries(animal)
     assert len(entries) == 1
     entry = entries[0]
     assert entry == Entry.objects.last()
@@ -41,7 +73,7 @@ def test_activitystream_update(system_user, animal, random_user):
     animal.owner = random_user
     animal.save()
 
-    entries = animal.activity_stream_entries
+    entries = get_activity_stream_entries(animal)
     assert len(entries) == 2
     entry = entries.last()
     assert entry.created_by == system_user
@@ -60,7 +92,7 @@ def test_activitystream_m2m(system_user, animal, user, random_user):
     """
     Ensure that an activity stream entry is created when an object's m2m fields change.
     """
-    entries_qs = animal.activity_stream_entries
+    entries_qs = get_activity_stream_entries(animal)
 
     # Add an association
     animal.people_friends.add(user)
@@ -89,7 +121,7 @@ def test_activitystream_m2m_reverse(system_user, animal, animal_2, animal_3, use
     """
     Ensure that an activity stream entry is created when an object's reverse m2m fields change.
     """
-    entries_qs = animal_3.activity_stream_entries
+    entries_qs = get_activity_stream_entries(animal_3)
 
     # Add an association
     user.animal_friends.add(animal_3)
@@ -106,15 +138,15 @@ def test_activitystream_m2m_reverse_clear(system_user, animal, animal_2, animal_
     user.animal_friends.clear()
 
     for animal in (animal, animal_2, animal_3):
-        assert animal.activity_stream_entries.last().operation == 'disassociate'
-        assert animal.activity_stream_entries.count() == 3  # create, associate, disassociate
+        assert get_activity_stream_entries(animal).last().operation == 'disassociate'
+        assert get_activity_stream_entries(animal).count() == 3  # create, associate, disassociate
 
 
 def test_activitystream_m2m_clear(system_user, animal, user, random_user):
     """
     Ensure that an activity stream entry is created for each association removed by clear().
     """
-    entries_qs = animal.activity_stream_entries
+    entries_qs = get_activity_stream_entries(animal)
     entries_count = entries_qs.count()
 
     # add two associations
@@ -145,7 +177,7 @@ def test_activitystream_m2m_forward_bulk(django_assert_max_num_queries, django_u
     inserts = len([q for q in captured.connection.queries if q['sql'].startswith('INSERT')])
     assert inserts == 2  # 1 for the assocations, 1 for the activity stream entries
 
-    entries = animal.activity_stream_entries.all()
+    entries = get_activity_stream_entries(animal).all()
     assert len(entries) == 101  # create + 100 associates
 
     # The first entry is the create, so start at 1
@@ -181,12 +213,12 @@ def test_activitystream_m2m_reverse_bulk(django_assert_max_num_queries, django_u
     inserts = len([q for q in captured.connection.queries if q['sql'].startswith('INSERT')])
     assert inserts == 2  # 1 for the assocations, 1 for the activity stream entries
 
-    user_entries = user.activity_stream_entries.all()
+    user_entries = get_activity_stream_entries(user).all()
     assert len(user_entries) == 1  # The entries are always on the forward relation, so the user only has their creation entry
 
     # But we can check the animals
     for animal in animals:
-        entries = animal.activity_stream_entries.all()
+        entries = get_activity_stream_entries(animal).all()
         assert len(entries) == 1  # associate (no create because the animals were bulk created)
         assert entries[0].operation == 'associate'
         assert entries[0].related_content_object == user
@@ -201,7 +233,7 @@ def test_activitystream_m2m_reverse_bulk(django_assert_max_num_queries, django_u
     # Even though django_assert_max_num_queries is a context manager the earlier inserts still seem to count
     assert disassoc_inserts == inserts + 1
     for animal in animals:
-        entries = animal.activity_stream_entries.all()
+        entries = get_activity_stream_entries(animal).all()
         assert len(entries) == 2  # associate, disassociate
         assert entries.last().operation == 'disassociate'
 
@@ -211,7 +243,7 @@ def test_activitystream_delete(system_user, animal):
     Ensure that an activity stream entry is created when an object is deleted.
     """
     # Kind of a hack/trick, grab a reference to the queryset before the delete
-    entries = animal.activity_stream_entries
+    entries = get_activity_stream_entries(animal)
     animal.delete()
     entry = entries.last()
     assert entry.created_by == system_user
@@ -280,7 +312,7 @@ def test_activitystream_excluded_fields():
     Ensure that limit fields (specified by the model's activity_stream_limit_field_names) are the only ones included in the activity stream entry.
     """
     city = City.objects.create(name='New York', country='USA')
-    entry = city.activity_stream_entries.last()
+    entry = get_activity_stream_entries(city).last()
     assert entry.operation == 'create'  # sanity check
     assert 'country' in entry.changes['added_fields']
     assert len(entry.changes['added_fields']) == 1
@@ -289,7 +321,7 @@ def test_activitystream_excluded_fields():
 
     city.country = 'Canada'
     city.save()
-    entry = city.activity_stream_entries.last()
+    entry = get_activity_stream_entries(city).last()
     assert entry.operation == 'update'  # sanity check
     assert 'country' in entry.changes['changed_fields']
     assert len(entry.changes['changed_fields']) == 1
@@ -306,7 +338,7 @@ def test_activitystream_context_manager():
     """
     with no_activity_stream():
         city = City.objects.create(name='New York', country='USA')
-    entries = city.activity_stream_entries
+    entries = get_activity_stream_entries(city)
     assert entries.count() == 0
 
     city.country = 'Canada'
@@ -330,7 +362,7 @@ def test_activitystream_nested_context_manager():
         with no_activity_stream():
             city = City.objects.create(name='New York', country='USA')
 
-    entries = city.activity_stream_entries
+    entries = get_activity_stream_entries(city)
     assert entries.count() == 0
 
     city.country = 'Canada'
@@ -347,7 +379,7 @@ def test_activitystream_nested_context_manager():
 @pytest.mark.django_db
 def test_activitystream_encrypted_fields_are_sanitized():
     color = SecretColor.objects.create(color='red')
-    entries = color.activity_stream_entries
+    entries = get_activity_stream_entries(color)
     assert entries.last().changes['added_fields']['color'] == ENCRYPTED_STRING
 
     color.color = 'orange'
@@ -360,7 +392,7 @@ def test_activitystream_encrypted_fields_are_sanitized():
 
 @pytest.mark.django_db
 def test_activitystream_user_password_sanitized(user):
-    entries = user.activity_stream_entries
+    entries = get_activity_stream_entries(user)
     assert entries.last().changes['added_fields']['password'] == ENCRYPTED_STRING
 
     user.set_password('new_password')
@@ -377,14 +409,14 @@ def test_activitystream_update_fields_limits_diff():
     from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 
     city = City.objects.create(name='New York', country='USA', population=1000)
-    initial_entry_count = city.activity_stream_entries.count()
+    initial_entry_count = get_activity_stream_entries(city).count()
 
     # Update both name and country, but only save country via update_fields
     city.name = 'Albany'
     city.country = 'Canada'
     city.save(update_fields=['country'])
 
-    entries = city.activity_stream_entries
+    entries = get_activity_stream_entries(city)
     assert entries.count() == initial_entry_count + 1
     entry = entries.last()
     assert entry.operation == 'update'
@@ -405,7 +437,7 @@ def test_activitystream_update_fields_no_entry_when_only_excluded_fields():
     no activity stream entry is created.
     """
     city = City.objects.create(name='New York', country='USA')
-    initial_entry_count = city.activity_stream_entries.count()
+    initial_entry_count = get_activity_stream_entries(city).count()
 
     # Update name but not country, and save only name via update_fields
     # Since City has activity_stream_limit_field_names = ['country'],
@@ -413,7 +445,7 @@ def test_activitystream_update_fields_no_entry_when_only_excluded_fields():
     city.name = 'Albany'
     city.save(update_fields=['name'])
 
-    entries = city.activity_stream_entries
+    entries = get_activity_stream_entries(city)
     # No new entry should be created because 'name' is not in the limit_fields
     assert entries.count() == initial_entry_count
 
@@ -425,7 +457,7 @@ def test_activitystream_update_fields_with_limit_fields_intersection():
     are provided, only the intersection of those fields is diffed.
     """
     city = City.objects.create(name='New York', country='USA')
-    initial_entry_count = city.activity_stream_entries.count()
+    initial_entry_count = get_activity_stream_entries(city).count()
 
     # City has activity_stream_limit_field_names = ['country']
     # If we update both name and country with update_fields=['name', 'country']
@@ -434,7 +466,7 @@ def test_activitystream_update_fields_with_limit_fields_intersection():
     city.country = 'Canada'
     city.save(update_fields=['name', 'country'])
 
-    entries = city.activity_stream_entries
+    entries = get_activity_stream_entries(city)
     assert entries.count() == initial_entry_count + 1
     entry = entries.last()
 
@@ -451,12 +483,12 @@ def test_activitystream_update_fields_empty_delta_no_entry():
     actually changed, no activity stream entry is created (empty delta).
     """
     animal = Animal.objects.create(name='Fluffy')
-    initial_entry_count = animal.activity_stream_entries.count()
+    initial_entry_count = get_activity_stream_entries(animal).count()
 
     # Save with update_fields but without actually changing the value
     animal.save(update_fields=['name'])
 
-    entries = animal.activity_stream_entries
+    entries = get_activity_stream_entries(animal)
     # No new entry should be created because there's no actual change
     assert entries.count() == initial_entry_count
 
@@ -468,7 +500,7 @@ def test_activitystream_update_fields_multiple_fields():
     appear in the activity stream entry.
     """
     animal = Animal.objects.create(name='Fluffy', age=2)
-    initial_entry_count = animal.activity_stream_entries.count()
+    initial_entry_count = get_activity_stream_entries(animal).count()
 
     # Update multiple fields
     # Note: 'age' is in activity_stream_excluded_field_names, so it won't show up
@@ -476,7 +508,7 @@ def test_activitystream_update_fields_multiple_fields():
     animal.age = 3
     animal.save(update_fields=['name', 'age'])
 
-    entries = animal.activity_stream_entries
+    entries = get_activity_stream_entries(animal)
     assert entries.count() == initial_entry_count + 1
     entry = entries.last()
 
@@ -495,7 +527,7 @@ def test_activitystream_update_fields_none_with_limit_fields():
     from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 
     city = City.objects.create(name='New York', country='USA', population=1000)
-    initial_entry_count = city.activity_stream_entries.count()
+    initial_entry_count = get_activity_stream_entries(city).count()
 
     # City has activity_stream_limit_field_names = ['country']
     # So only changes to country should be tracked
@@ -504,7 +536,7 @@ def test_activitystream_update_fields_none_with_limit_fields():
     city.population = 2000
     city.save()
 
-    entries = city.activity_stream_entries
+    entries = get_activity_stream_entries(city)
     assert entries.count() == initial_entry_count + 1
     entry = entries.last()
 
@@ -516,15 +548,15 @@ def test_activitystream_update_fields_none_with_limit_fields():
 
 
 # =============================================================================
-# Tests for AuditableModel class variables
+# Tests for activity stream attribute defaults in signal handlers
 # =============================================================================
 
 
-class TestAuditableModelClassVariables:
-    """Tests for the AuditableModel class variable defaults."""
+class TestActivityStreamAttributeDefaults:
+    """Tests that signal handlers use correct defaults for optional model attributes."""
 
     @pytest.mark.parametrize(
-        "attribute,expected",
+        "attribute,expected_default",
         [
             ("activity_stream_enabled", True),
             ("audit_log_enabled", False),
@@ -538,9 +570,11 @@ class TestAuditableModelClassVariables:
             "limit_field_names_defaults_to_empty_list",
         ],
     )
-    def test_auditable_model_class_variable_defaults(self, attribute, expected):
-        """Ensure AuditableModel class variables have correct default values."""
-        assert getattr(AuditableModel, attribute) == expected
+    def test_signal_handler_uses_correct_defaults(self, attribute, expected_default):
+        """Ensure signal handlers fall back to the correct defaults when a model lacks an attribute."""
+        # SecretColor doesn't define these attributes (except what it inherits),
+        # so getattr with defaults should match expectations.
+        assert getattr(SecretColor, attribute, expected_default) == expected_default
 
 
 # =============================================================================
@@ -556,7 +590,7 @@ def test_activity_stream_enabled_false_on_update():
     """
     # Create an animal with activity stream enabled (default)
     animal = Animal.objects.create(name='Fluffy')
-    assert animal.activity_stream_entries.count() == 1
+    assert get_activity_stream_entries(animal).count() == 1
 
     # Now disable activity stream on the instance and update
     animal.activity_stream_enabled = False
@@ -564,7 +598,7 @@ def test_activity_stream_enabled_false_on_update():
     animal.save()
 
     # No new entry should be created
-    assert animal.activity_stream_entries.count() == 1
+    assert get_activity_stream_entries(animal).count() == 1
 
 
 @pytest.mark.django_db
@@ -575,10 +609,10 @@ def test_activity_stream_enabled_false_on_create():
     """
     # Create animal, then immediately set flag and check
     # Note: The flag is checked during signal processing
-    with mock.patch.object(Animal, 'activity_stream_enabled', False):
+    with mock.patch.object(Animal, 'activity_stream_enabled', False, create=True):
         animal = Animal.objects.create(name='Silent')
 
-    assert animal.activity_stream_entries.count() == 0
+    assert get_activity_stream_entries(animal).count() == 0
 
 
 @pytest.mark.django_db
@@ -588,11 +622,11 @@ def test_activity_stream_enabled_false_on_delete():
     does not create an activity stream entry.
     """
     animal = Animal.objects.create(name='Fluffy')
-    initial_count = animal.activity_stream_entries.count()
+    initial_count = get_activity_stream_entries(animal).count()
 
     # Disable activity stream and delete
     animal.activity_stream_enabled = False
-    entries_qs = animal.activity_stream_entries  # Keep reference
+    entries_qs = get_activity_stream_entries(animal)  # Keep reference
     animal.delete()
 
     # No new entry should be created for the delete
@@ -644,7 +678,7 @@ def test_audit_log_enabled_on_create_delete(operation, perform_operation):
             assert 'Fluffy' in call_args
     else:
         with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
-            with mock.patch.object(Animal, 'audit_log_enabled', True):
+            with mock.patch.object(Animal, 'audit_log_enabled', True, create=True):
                 perform_operation()
 
             assert mock_log.call_count == 1
@@ -828,15 +862,15 @@ def test_audit_log_with_activity_stream_disabled():
     audit logs should still be generated.
     """
     with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
-        with mock.patch.object(Animal, 'audit_log_enabled', True):
-            with mock.patch.object(Animal, 'activity_stream_enabled', False):
+        with mock.patch.object(Animal, 'audit_log_enabled', True, create=True):
+            with mock.patch.object(Animal, 'activity_stream_enabled', False, create=True):
                 animal = Animal.objects.create(name='Fluffy')
 
         # Audit log should still be called
         assert mock_log.call_count == 1
 
     # But no activity stream entry
-    assert animal.activity_stream_entries.count() == 0
+    assert get_activity_stream_entries(animal).count() == 0
 
 
 @pytest.mark.django_db
@@ -853,7 +887,7 @@ def test_audit_log_message_content(expected_content):
     Ensure the audit log message includes expected content (model name, object str).
     """
     with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
-        with mock.patch.object(Animal, 'audit_log_enabled', True):
+        with mock.patch.object(Animal, 'audit_log_enabled', True, create=True):
             Animal.objects.create(name='Fluffy')
 
         call_args = mock_log.call_args[0][0]

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from oauthlib.common import generate_token
 
+from ansible_base.activitystream.apps import get_activity_stream_entries
 from ansible_base.activitystream.models import Entry
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2AccessToken
@@ -174,7 +175,7 @@ def test_oauth2_bearer_no_activitystream(unauthenticated_api_client, oauth2_admi
     """
     url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
     token = oauth2_admin_access_token[1]
-    existing_as_count = len(oauth2_admin_access_token[0].activity_stream_entries)
+    existing_as_count = len(get_activity_stream_entries(oauth2_admin_access_token[0]))
 
     response = unauthenticated_api_client.get(
         url,
@@ -184,7 +185,7 @@ def test_oauth2_bearer_no_activitystream(unauthenticated_api_client, oauth2_admi
     assert response.data['name'] == animal.name
 
     updated_token = OAuth2AccessToken.objects.get(token=oauth2_admin_access_token[0].token)
-    assert len(updated_token.activity_stream_entries) == existing_as_count
+    assert len(get_activity_stream_entries(updated_token)) == existing_as_count
 
 
 @pytest.mark.parametrize(

--- a/test_app/tests/oauth2_provider/views/test_application.py
+++ b/test_app/tests/oauth2_provider/views/test_application.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib.auth.hashers import check_password
 
+from ansible_base.activitystream.apps import get_activity_stream_entries
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2Application, OAuth2RefreshToken
@@ -380,5 +381,5 @@ def test_oauth2_application_prevent_search_client_secret(oauth2_application, adm
     assert 'Filtering on client_secret is not allowed' in response.data['detail']
 
     # Also ensure we don't leak the client_secret in activity stream
-    creation_entry = oauth2_application[0].activity_stream_entries.first()
+    creation_entry = get_activity_stream_entries(oauth2_application[0]).first()
     assert creation_entry.changes['added_fields']['client_secret'] == ENCRYPTED_STRING


### PR DESCRIPTION
## Description
Technical refactor item:

Making activitystream app follow the philosophy of "outside looking in" regarding handling of the ultimate app that is using it. Everything in activitystream uses GenericForeignKey, and as things stand, it is completely consistent with this philosophy.

A concern was expressed that adding a field to `AditableModel` will trigger migrations in apps. That is a question that I don't think should exist, and it won't with these changes.

I also find this to be something that will ease its introduction to AWX and other apps. We do not want to add more parent classes to the models there.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [x] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [ ] I have performed a self-review of ~my~ Claude's code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how activity-stream signals are connected (now setting-driven with a runtime registry), so misconfiguration could silently stop auditing or change related links. Also adds a custom non-cascading `GenericRelation`, affecting delete behavior around audit records.
> 
> **Overview**
> Shifts activity-stream tracking from `AuditableModel` inheritance to an explicit `ACTIVITY_STREAM_MODELS` setting: `ActivitystreamConfig.ready()` now connects create/update/delete/m2m signals only for configured models, while still auto-detecting `AuditableModel` subclasses with deprecation warnings.
> 
> Adds public helpers `get_activity_stream_entries()` / `get_activity_stream_related_url()` and automatically injects an `activity_stream` related link for registered models via `CommonModel.related_fields()`. Introduces `activity_stream_entries()` (a non-cascading `GenericRelation`) so models can optionally expose a reverse relation without risking audit entry deletion when the parent object is deleted.
> 
> Updates test app models, OAuth2 models, docs, and tests to remove required `AuditableModel` inheritance, rely on the new setting-based registration, and validate the new reverse relation and non-cascading delete behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a2fad36b6be864a14fa72cd20c9d3ebda7cb26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Activity stream tracking now uses configuration-based model registration via `ACTIVITY_STREAM_MODELS` setting instead of class inheritance
  - New helper functions for querying activity stream entries
  - Models can include reverse activity stream relations for direct entry access

* **Deprecations**
  - `AuditableModel` inheritance approach is now deprecated; migrate to `ACTIVITY_STREAM_MODELS` setting

* **Changes**
  - OAuth2 models no longer automatically tracked in activity stream by default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->