### PR TITLE
[AAP-63312] Add workload_ttl_seconds field to WorkloadIdentityTokenRequestSerializer

### DIFF
--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -1,6 +1,15 @@
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+# Hard ceiling for workload-specific TTL overrides. 24 hours is intentionally
+# generous — workloads needing longer lifetimes should reconsider their design.
+# Terraform Cloud ties exp to the run timeout with no imposed ceiling for workspace
+# runs, but does enforce a max (30 min) for module test tokens. We follow the
+# bounded approach here as a safety net against misconfigured or unlimited timeouts.
+# See: https://developer.hashicorp.com/terraform/cloud-docs/dynamic-provider-credentials/workload-identity-tokens
+# A preference-driven maximum can replace this constant in a follow-up.
+WORKLOAD_TTL_MAX_SECONDS = 24 * 60 * 60  # 86400 or 24 hours
+
 
 class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
     """
@@ -28,11 +37,12 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
     workload_ttl_seconds = serializers.IntegerField(
         required=False,
         allow_null=True,
-        min_value=0,
+        min_value=1,
+        max_value=WORKLOAD_TTL_MAX_SECONDS,
         help_text=_(
-            "Optional workload-specific TTL override in seconds. "
-            "If provided and > 0, overrides the platform default. "
-            "If omitted or 0, uses platform fallback (jwt_default_ttl_seconds). "
+            f"Optional workload-specific TTL override in seconds (1–{WORKLOAD_TTL_MAX_SECONDS}). "
+            "If provided, overrides the platform default for this token. "
+            "Omit or set to null to use the platform fallback (jwt_default_ttl_seconds). "
             "A 60s clock skew offset is automatically added to all JWTs."
         ),
     )

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -3,10 +3,6 @@ from rest_framework import serializers
 
 # Hard ceiling for workload-specific TTL overrides. 24 hours is intentionally
 # generous — workloads needing longer lifetimes should reconsider their design.
-# Terraform Cloud ties exp to the run timeout with no imposed ceiling for workspace
-# runs, but does enforce a max (30 min) for module test tokens. We follow the
-# bounded approach here as a safety net against misconfigured or unlimited timeouts.
-# See: https://developer.hashicorp.com/terraform/cloud-docs/dynamic-provider-credentials/workload-identity-tokens
 # A preference-driven maximum can replace this constant in a follow-up.
 WORKLOAD_TTL_MAX_SECONDS = 24 * 60 * 60  # 86400 or 24 hours
 

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -34,7 +34,7 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
         min_value=1,
-        max_value=WORKLOAD_TTL_MAX_SECONDS,
+        max_value=get_setting('ANSIBLE_BASE_WIT_MAX_TOKEN_TTL', WORKLOAD_TTL_MAX_SECONDS),
         help_text=_(
             "Optional workload-specific TTL override in seconds (1-86400). "
             "If provided, overrides the platform default for this token. "

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -40,7 +40,7 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
         min_value=1,
         max_value=WORKLOAD_TTL_MAX_SECONDS,
         help_text=_(
-            f"Optional workload-specific TTL override in seconds (1–{WORKLOAD_TTL_MAX_SECONDS}). "
+            "Optional workload-specific TTL override in seconds (1-86400). "
             "If provided, overrides the platform default for this token. "
             "Omit or set to null to use the platform fallback (jwt_default_ttl_seconds). "
             "A 60s clock skew offset is automatically added to all JWTs."

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -1,12 +1,13 @@
+from django.core.validators import MinValueValidator
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from ansible_base.lib.utils.settings import get_setting
 
-# Hard ceiling for workload-specific TTL overrides. 24 hours is intentionally
-# generous — workloads needing longer lifetimes should reconsider their design.
-# A preference-driven maximum can replace this constant in a follow-up.
-WORKLOAD_TTL_MAX_SECONDS = 24 * 60 * 60  # 86400 or 24 hours
+# Default ceiling for workload-specific TTL overrides. 24 hours is intentionally
+# generous -- workloads needing longer lifetimes should reconsider their design.
+# Override with the ANSIBLE_BASE_WIT_MAX_TOKEN_TTL Django setting if needed.
+WORKLOAD_TTL_MAX_SECONDS = 24 * 60 * 60  # 86400
 
 
 class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
@@ -35,8 +36,7 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
     workload_ttl_seconds = serializers.IntegerField(
         required=False,
         allow_null=True,
-        min_value=1,
-        max_value=get_setting('ANSIBLE_BASE_WIT_MAX_TOKEN_TTL', WORKLOAD_TTL_MAX_SECONDS),
+        validators=[MinValueValidator(1)],
         help_text=_(
             "Optional workload-specific TTL override in seconds. "
             "If provided, overrides the platform default for this token. "
@@ -44,6 +44,16 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
             "A 60s clock skew offset is automatically added to all JWTs."
         ),
     )
+
+    def validate_workload_ttl_seconds(self, value):
+        if value is not None:
+            max_ttl = get_setting('ANSIBLE_BASE_WIT_MAX_TOKEN_TTL', WORKLOAD_TTL_MAX_SECONDS)
+            if value > max_ttl:
+                raise serializers.ValidationError(
+                    detail=_('Ensure this value is less than or equal to %(max_value)s.') % {'max_value': max_ttl},
+                    code='max_value',
+                )
+        return value
 
 
 class WorkloadIdentityTokenResponseSerializer(serializers.Serializer):

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -1,6 +1,8 @@
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from ansible_base.lib.utils.settings import get_setting
+
 # Hard ceiling for workload-specific TTL overrides. 24 hours is intentionally
 # generous — workloads needing longer lifetimes should reconsider their design.
 # A preference-driven maximum can replace this constant in a follow-up.
@@ -36,7 +38,7 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
         min_value=1,
         max_value=get_setting('ANSIBLE_BASE_WIT_MAX_TOKEN_TTL', WORKLOAD_TTL_MAX_SECONDS),
         help_text=_(
-            "Optional workload-specific TTL override in seconds (1-86400). "
+            "Optional workload-specific TTL override in seconds. "
             "If provided, overrides the platform default for this token. "
             "Omit or set to null to use the platform fallback (jwt_default_ttl_seconds). "
             "A 60s clock skew offset is automatically added to all JWTs."

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -46,6 +46,10 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
     )
 
     def validate_workload_ttl_seconds(self, value):
+        # max_value can't be declared on the field because this module is in
+        # ansible_base/lib/ which must be importable without Django configured
+        # (enforced by the pure-python-imports CI check). Deferring to a
+        # validate method evaluates get_setting() at runtime instead of import time.
         if value is not None:
             max_ttl = get_setting('ANSIBLE_BASE_WIT_MAX_TOKEN_TTL', WORKLOAD_TTL_MAX_SECONDS)
             if value > max_ttl:

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -1,4 +1,3 @@
-from django.core.validators import MinValueValidator
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
@@ -36,7 +35,7 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
     workload_ttl_seconds = serializers.IntegerField(
         required=False,
         allow_null=True,
-        validators=[MinValueValidator(1)],
+        min_value=1,
         help_text=_(
             "Optional workload-specific TTL override in seconds. "
             "If provided, overrides the platform default for this token. "

--- a/ansible_base/lib/workload_identity/workload_identity_tokens.py
+++ b/ansible_base/lib/workload_identity/workload_identity_tokens.py
@@ -25,6 +25,17 @@ class WorkloadIdentityTokenRequestSerializer(serializers.Serializer):
         allow_empty=False,
         help_text=_("Workload details to include in the JWT as claims."),
     )
+    workload_ttl_seconds = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        min_value=0,
+        help_text=_(
+            "Optional workload-specific TTL override in seconds. "
+            "If provided and > 0, overrides the platform default. "
+            "If omitted or 0, uses platform fallback (jwt_default_ttl_seconds). "
+            "A 60s clock skew offset is automatically added to all JWTs."
+        ),
+    )
 
 
 class WorkloadIdentityTokenResponseSerializer(serializers.Serializer):

--- a/test_app/tests/lib/workload_identity/test_serializers.py
+++ b/test_app/tests/lib/workload_identity/test_serializers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ansible_base.lib.workload_identity.workload_identity_tokens import (
+    WORKLOAD_TTL_MAX_SECONDS,
     WorkloadIdentityTokenRequestSerializer,
     WorkloadIdentityTokenResponseSerializer,
 )
@@ -232,19 +233,21 @@ class TestWorkloadIdentityTokenRequestSerializer:
         assert serializer.is_valid(), f"Serializer errors: {serializer.errors}"
         assert serializer.validated_data['workload_ttl_seconds'] == 7200
 
-    def test_workload_ttl_seconds_zero(self):
+    def test_workload_ttl_seconds_zero_fails(self):
         """
-        Test that workload_ttl_seconds = 0 is accepted (means use platform default).
+        Test that workload_ttl_seconds = 0 fails validation (min_value=1).
+        Use null or omit the field to signal "use platform default" instead.
         """
-        valid_data = {
+        invalid_data = {
             'scope': 'openid',
             'audience': 'https://api.example.com',
             'claims': {'job_name': 'test-job'},
             'workload_ttl_seconds': 0,
         }
-        serializer = WorkloadIdentityTokenRequestSerializer(data=valid_data)
-        assert serializer.is_valid(), f"Serializer errors: {serializer.errors}"
-        assert serializer.validated_data['workload_ttl_seconds'] == 0
+        serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
+        assert not serializer.is_valid()
+        assert 'workload_ttl_seconds' in serializer.errors
+        assert serializer.errors['workload_ttl_seconds'][0].code == 'min_value'
 
     def test_workload_ttl_seconds_null(self):
         """
@@ -276,7 +279,7 @@ class TestWorkloadIdentityTokenRequestSerializer:
 
     def test_workload_ttl_seconds_negative_fails(self):
         """
-        Test that negative workload_ttl_seconds fails validation (min_value=0).
+        Test that negative workload_ttl_seconds fails validation (min_value=1).
         """
         invalid_data = {
             'scope': 'openid',
@@ -288,6 +291,21 @@ class TestWorkloadIdentityTokenRequestSerializer:
         assert not serializer.is_valid()
         assert 'workload_ttl_seconds' in serializer.errors
         assert serializer.errors['workload_ttl_seconds'][0].code == 'min_value'
+
+    def test_workload_ttl_seconds_exceeds_max_fails(self):
+        """
+        Test that workload_ttl_seconds > WORKLOAD_TTL_MAX_SECONDS fails validation.
+        """
+        invalid_data = {
+            'scope': 'openid',
+            'audience': 'https://api.example.com',
+            'claims': {'job_name': 'test-job'},
+            'workload_ttl_seconds': WORKLOAD_TTL_MAX_SECONDS + 1,
+        }
+        serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
+        assert not serializer.is_valid()
+        assert 'workload_ttl_seconds' in serializer.errors
+        assert serializer.errors['workload_ttl_seconds'][0].code == 'max_value'
 
     def test_workload_ttl_seconds_not_integer_fails(self):
         """

--- a/test_app/tests/lib/workload_identity/test_serializers.py
+++ b/test_app/tests/lib/workload_identity/test_serializers.py
@@ -285,7 +285,6 @@ class TestWorkloadIdentityTokenRequestSerializer:
         assert 'workload_ttl_seconds' not in serializer.validated_data
 
 
-
 @pytest.mark.django_db
 class TestWorkloadIdentityTokenResponseSerializer:
     """

--- a/test_app/tests/lib/workload_identity/test_serializers.py
+++ b/test_app/tests/lib/workload_identity/test_serializers.py
@@ -233,21 +233,28 @@ class TestWorkloadIdentityTokenRequestSerializer:
         assert serializer.is_valid(), f"Serializer errors: {serializer.errors}"
         assert serializer.validated_data['workload_ttl_seconds'] == 7200
 
-    def test_workload_ttl_seconds_zero_fails(self):
-        """
-        Test that workload_ttl_seconds = 0 fails validation (min_value=1).
-        Use null or omit the field to signal "use platform default" instead.
-        """
+    @pytest.mark.parametrize(
+        "ttl_value, expected_error_code",
+        [
+            pytest.param(0, 'min_value', id="zero"),
+            pytest.param(-100, 'min_value', id="negative"),
+            pytest.param(WORKLOAD_TTL_MAX_SECONDS + 1, 'max_value', id="exceeds_max"),
+            pytest.param('not-a-number', 'invalid', id="string"),
+            pytest.param(3.14, 'invalid', id="float"),
+        ],
+    )
+    def test_workload_ttl_seconds_invalid_values(self, ttl_value, expected_error_code):
+        """Test that invalid workload_ttl_seconds values are rejected."""
         invalid_data = {
             'scope': 'openid',
             'audience': 'https://api.example.com',
             'claims': {'job_name': 'test-job'},
-            'workload_ttl_seconds': 0,
+            'workload_ttl_seconds': ttl_value,
         }
         serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
         assert not serializer.is_valid()
         assert 'workload_ttl_seconds' in serializer.errors
-        assert serializer.errors['workload_ttl_seconds'][0].code == 'min_value'
+        assert serializer.errors['workload_ttl_seconds'][0].code == expected_error_code
 
     def test_workload_ttl_seconds_null(self):
         """
@@ -277,50 +284,6 @@ class TestWorkloadIdentityTokenRequestSerializer:
         # Field not in validated_data when omitted
         assert 'workload_ttl_seconds' not in serializer.validated_data
 
-    def test_workload_ttl_seconds_negative_fails(self):
-        """
-        Test that negative workload_ttl_seconds fails validation (min_value=1).
-        """
-        invalid_data = {
-            'scope': 'openid',
-            'audience': 'https://api.example.com',
-            'claims': {'job_name': 'test-job'},
-            'workload_ttl_seconds': -100,
-        }
-        serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
-        assert not serializer.is_valid()
-        assert 'workload_ttl_seconds' in serializer.errors
-        assert serializer.errors['workload_ttl_seconds'][0].code == 'min_value'
-
-    def test_workload_ttl_seconds_exceeds_max_fails(self):
-        """
-        Test that workload_ttl_seconds > WORKLOAD_TTL_MAX_SECONDS fails validation.
-        """
-        invalid_data = {
-            'scope': 'openid',
-            'audience': 'https://api.example.com',
-            'claims': {'job_name': 'test-job'},
-            'workload_ttl_seconds': WORKLOAD_TTL_MAX_SECONDS + 1,
-        }
-        serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
-        assert not serializer.is_valid()
-        assert 'workload_ttl_seconds' in serializer.errors
-        assert serializer.errors['workload_ttl_seconds'][0].code == 'max_value'
-
-    def test_workload_ttl_seconds_not_integer_fails(self):
-        """
-        Test that non-integer workload_ttl_seconds fails validation.
-        """
-        invalid_data = {
-            'scope': 'openid',
-            'audience': 'https://api.example.com',
-            'claims': {'job_name': 'test-job'},
-            'workload_ttl_seconds': 'not-a-number',
-        }
-        serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
-        assert not serializer.is_valid()
-        assert 'workload_ttl_seconds' in serializer.errors
-        assert serializer.errors['workload_ttl_seconds'][0].code == 'invalid'
 
 
 @pytest.mark.django_db

--- a/test_app/tests/lib/workload_identity/test_serializers.py
+++ b/test_app/tests/lib/workload_identity/test_serializers.py
@@ -218,6 +218,92 @@ class TestWorkloadIdentityTokenRequestSerializer:
         # Extra fields should not appear in validated_data
         assert 'extra_field' not in serializer.validated_data
 
+    def test_workload_ttl_seconds_valid_value(self):
+        """
+        Test that valid workload_ttl_seconds is accepted.
+        """
+        valid_data = {
+            'scope': 'openid',
+            'audience': 'https://api.example.com',
+            'claims': {'job_name': 'test-job'},
+            'workload_ttl_seconds': 7200,
+        }
+        serializer = WorkloadIdentityTokenRequestSerializer(data=valid_data)
+        assert serializer.is_valid(), f"Serializer errors: {serializer.errors}"
+        assert serializer.validated_data['workload_ttl_seconds'] == 7200
+
+    def test_workload_ttl_seconds_zero(self):
+        """
+        Test that workload_ttl_seconds = 0 is accepted (means use platform default).
+        """
+        valid_data = {
+            'scope': 'openid',
+            'audience': 'https://api.example.com',
+            'claims': {'job_name': 'test-job'},
+            'workload_ttl_seconds': 0,
+        }
+        serializer = WorkloadIdentityTokenRequestSerializer(data=valid_data)
+        assert serializer.is_valid(), f"Serializer errors: {serializer.errors}"
+        assert serializer.validated_data['workload_ttl_seconds'] == 0
+
+    def test_workload_ttl_seconds_null(self):
+        """
+        Test that workload_ttl_seconds = None is accepted.
+        """
+        valid_data = {
+            'scope': 'openid',
+            'audience': 'https://api.example.com',
+            'claims': {'job_name': 'test-job'},
+            'workload_ttl_seconds': None,
+        }
+        serializer = WorkloadIdentityTokenRequestSerializer(data=valid_data)
+        assert serializer.is_valid(), f"Serializer errors: {serializer.errors}"
+        assert serializer.validated_data['workload_ttl_seconds'] is None
+
+    def test_workload_ttl_seconds_omitted(self):
+        """
+        Test that omitting workload_ttl_seconds is valid (field is optional).
+        """
+        valid_data = {
+            'scope': 'openid',
+            'audience': 'https://api.example.com',
+            'claims': {'job_name': 'test-job'},
+        }
+        serializer = WorkloadIdentityTokenRequestSerializer(data=valid_data)
+        assert serializer.is_valid(), f"Serializer errors: {serializer.errors}"
+        # Field not in validated_data when omitted
+        assert 'workload_ttl_seconds' not in serializer.validated_data
+
+    def test_workload_ttl_seconds_negative_fails(self):
+        """
+        Test that negative workload_ttl_seconds fails validation (min_value=0).
+        """
+        invalid_data = {
+            'scope': 'openid',
+            'audience': 'https://api.example.com',
+            'claims': {'job_name': 'test-job'},
+            'workload_ttl_seconds': -100,
+        }
+        serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
+        assert not serializer.is_valid()
+        assert 'workload_ttl_seconds' in serializer.errors
+        assert serializer.errors['workload_ttl_seconds'][0].code == 'min_value'
+
+    def test_workload_ttl_seconds_not_integer_fails(self):
+        """
+        Test that non-integer workload_ttl_seconds fails validation.
+        """
+        invalid_data = {
+            'scope': 'openid',
+            'audience': 'https://api.example.com',
+            'claims': {'job_name': 'test-job'},
+            'workload_ttl_seconds': 'not-a-number',
+        }
+        serializer = WorkloadIdentityTokenRequestSerializer(data=invalid_data)
+        assert not serializer.is_valid()
+        assert 'workload_ttl_seconds' in serializer.errors
+        assert serializer.errors['workload_ttl_seconds'][0].code == 'invalid'
+
 
 @pytest.mark.django_db
 class TestWorkloadIdentityTokenResponseSerializer:


### PR DESCRIPTION
 [AAP-63312] Add workload_ttl_seconds field to WorkloadIdentityTokenRequestSerializer

## Description

**What is being changed?**

Adding optional `workload_ttl_seconds` parameter to `WorkloadIdentityTokenRequestSerializer` to support workload-specific JWT TTL overrides.

**Why is this change needed?**

Gateway's AAP-63312 implementation requires the ability to accept workload-specific TTL values from API requests. This serializer change enables the API contract for that feature.

**How does this change address the issue?**

Adds a new optional `IntegerField` to the request serializer that validates TTL override values while maintaining backward compatibility (field is optional).

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] Test update

## Self-Review Checklist

- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Implementation

**Modified:** `ansible_base/lib/workload_identity/workload_identity_tokens.py` (11 lines)  
**Modified:** `test_app/tests/lib/workload_identity/test_serializers.py` (86 lines)

Added optional `workload_ttl_seconds` field with validation (min_value=0, allow_null, not required).

## Testing Instructions

```bash
# Run serializer tests
tox -e py -- test_app/tests/lib/workload_identity/test_serializers.py -v
```

**Expected:** 29 tests pass (22 existing + 7 new)

## Additional Context

**Backward compatible:** Field is optional, existing requests work unchanged.

**Requires coordinated Gateway PR** to implement TTL calculation logic.

**Related:** AAP-63296 (P4.1), ANSTRAT-1019

---

**Development Note:** This implementation was developed with assistance from Claude AI assistant.

https://handbook.eng.ansible.com/proposals/ANSTRAT-1019-Configurable-JWT-Expiration-for-OIDC-Integrations

**Assisted-by:** Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional workload_ttl_seconds parameter to request per-workload token TTL overrides (nullable or omitted to use platform default); accepts a positive integer up to a 24-hour ceiling and applies an automatic 60s clock-skew buffer.

* **Tests**
  * Comprehensive tests covering valid value, zero (rejected), null, omission, negative, exceeding max, and non‑integer inputs to verify behavior and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->