### PR TITLE
Try keeping chardet under 6.0.0 to prevent requests installation failure

### DIFF
--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -36,6 +36,8 @@ jobs:
           COPY . /opt/dab/
           RUN pip install -e /opt/dab/
           RUN pip install jq
+          RUN pip install --upgrade tox && pip uninstall -y chardet
+
           EOF
           docker build -t awx-with-dab:latest -f awx-dockerfile/Dockerfile .
 

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -11,6 +11,7 @@ ipython
 isort==6.0.0            # Linting tool, if changed update pyproject.toml as well
 jsonschema
 tox
+chardet<6.0.0           # Dependency of tox, but newer versions break requests
 tox-docker
 typeguard
 openapi-spec-validator>=0.6.1  # Adapted to changing import locations in jsonschema

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -11,7 +11,6 @@ ipython
 isort==6.0.0            # Linting tool, if changed update pyproject.toml as well
 jsonschema
 tox
-chardet<6.0.0           # Dependency of tox, but newer versions break requests
 tox-docker
 typeguard
 openapi-spec-validator>=0.6.1  # Adapted to changing import locations in jsonschema


### PR DESCRIPTION
Not for merging, just checking if upgrading `tox` and removing `chardet` in awx_devel fixes the DAB Consumers check. It does.