### PR TITLE
[AAP-63314] P4.4: Add workload_ttl_seconds to WorkloadIdentityClient

### DIFF
--- a/ansible_base/resource_registry/workload_identity_client.py
+++ b/ansible_base/resource_registry/workload_identity_client.py
@@ -170,6 +170,8 @@ class WorkloadIdentityClient(BaseServiceClient):
             ...     workload_ttl_seconds=3600,
             ... )
         """
+        if workload_ttl_seconds < 0:
+            raise ValueError(f"workload_ttl_seconds must be >= 0, got {workload_ttl_seconds}")
         request_body = WorkloadIdentityTokenRequest(
             claims=claims,
             scope=scope,

--- a/ansible_base/resource_registry/workload_identity_client.py
+++ b/ansible_base/resource_registry/workload_identity_client.py
@@ -29,11 +29,12 @@ class WorkloadIdentityTokenRequest(NamedTuple):
     audience: str
     """Audience for the token - the external service that will validate it."""
 
-    workload_ttl_seconds: int = 0
+    workload_ttl_seconds: int | None = None
     """Optional workload-specific TTL override in seconds.
 
     If > 0, the Gateway uses this as the base TTL instead of the platform default.
-    Pass 0 (or omit) to use the platform fallback (jwt_default_ttl_seconds).
+    Pass None or omit to use the platform fallback (jwt_default_ttl_seconds).
+    Note: 0 is invalid — Gateway serializer rejects it (min_value=1); use None or omit.
     """
 
 
@@ -140,7 +141,7 @@ class WorkloadIdentityClient(BaseServiceClient):
         claims: dict,
         scope: str,
         audience: str,
-        workload_ttl_seconds: int = 0,
+        workload_ttl_seconds: int | None = None,
     ) -> WorkloadIdentityTokenResponse:
         """
         Request a workload identity token.
@@ -154,13 +155,13 @@ class WorkloadIdentityClient(BaseServiceClient):
             audience: Audience for the token - the external service that will validate it
             workload_ttl_seconds: Optional TTL override in seconds. If > 0, the Gateway
                 uses this as the base TTL instead of the platform default (jwt_default_ttl_seconds).
-                Pass 0 to use the platform fallback.
+                Pass None or omit to use the platform fallback. Note: 0 is invalid (Gateway rejects it).
 
         Returns:
             WorkloadIdentityTokenResponse: Token response with JWT
 
         Raises:
-            ValueError: If workload_ttl_seconds is negative
+            ValueError: If workload_ttl_seconds is 0 or negative
             TokenRequestError: If the request fails
 
         Example:
@@ -171,15 +172,17 @@ class WorkloadIdentityClient(BaseServiceClient):
             ...     workload_ttl_seconds=3600,
             ... )
         """
-        if workload_ttl_seconds < 0:
-            raise ValueError(f"workload_ttl_seconds must be >= 0, got {workload_ttl_seconds}")
-        request_body = WorkloadIdentityTokenRequest(
-            claims=claims,
-            scope=scope,
-            audience=audience,
-            workload_ttl_seconds=workload_ttl_seconds,
-        )
-        data = request_body._asdict()
+        if workload_ttl_seconds is not None and workload_ttl_seconds < 1:
+            raise ValueError(
+                f"workload_ttl_seconds must be None (platform fallback) or >= 1, got {workload_ttl_seconds}"
+            )
+        data = {
+            "claims": claims,
+            "scope": scope,
+            "audience": audience,
+        }
+        if workload_ttl_seconds is not None and workload_ttl_seconds > 0:
+            data["workload_ttl_seconds"] = workload_ttl_seconds
 
         logger.info(f"Requesting workload identity token with scope: {scope}")
         logger.debug(f"Claims: {claims}")

--- a/ansible_base/resource_registry/workload_identity_client.py
+++ b/ansible_base/resource_registry/workload_identity_client.py
@@ -29,6 +29,13 @@ class WorkloadIdentityTokenRequest(NamedTuple):
     audience: str
     """Audience for the token - the external service that will validate it."""
 
+    workload_ttl_seconds: int = 0
+    """Optional workload-specific TTL override in seconds.
+
+    If > 0, the Gateway uses this as the base TTL instead of the platform default.
+    Pass 0 (or omit) to use the platform fallback (jwt_default_ttl_seconds).
+    """
+
 
 class WorkloadIdentityTokenResponse(NamedTuple):
     """Response from workload identity token endpoint."""
@@ -133,6 +140,7 @@ class WorkloadIdentityClient(BaseServiceClient):
         claims: dict,
         scope: str,
         audience: str,
+        workload_ttl_seconds: int = 0,
     ) -> WorkloadIdentityTokenResponse:
         """
         Request a workload identity token.
@@ -144,6 +152,9 @@ class WorkloadIdentityClient(BaseServiceClient):
             claims: Dictionary containing workload details (e.g., job ID, name)
             scope: Token custom scopes string (e.g., 'aap_controller_automation_job')
             audience: Audience for the token - the external service that will validate it
+            workload_ttl_seconds: Optional TTL override in seconds. If > 0, the Gateway
+                uses this as the base TTL instead of the platform default (jwt_default_ttl_seconds).
+                Pass 0 to use the platform fallback.
 
         Returns:
             WorkloadIdentityTokenResponse: Token response with JWT
@@ -155,10 +166,16 @@ class WorkloadIdentityClient(BaseServiceClient):
             >>> response = client.request_workload_jwt(
             ...     claims={"id": 2, "name": "my-example-job"},
             ...     scope="aap_controller_automation_job",
-            ...     audience="https://vault.example.com"
+            ...     audience="https://vault.example.com",
+            ...     workload_ttl_seconds=3600,
             ... )
         """
-        request_body = WorkloadIdentityTokenRequest(claims=claims, scope=scope, audience=audience)
+        request_body = WorkloadIdentityTokenRequest(
+            claims=claims,
+            scope=scope,
+            audience=audience,
+            workload_ttl_seconds=workload_ttl_seconds,
+        )
         data = request_body._asdict()
 
         logger.info(f"Requesting workload identity token with scope: {scope}")

--- a/ansible_base/resource_registry/workload_identity_client.py
+++ b/ansible_base/resource_registry/workload_identity_client.py
@@ -160,6 +160,7 @@ class WorkloadIdentityClient(BaseServiceClient):
             WorkloadIdentityTokenResponse: Token response with JWT
 
         Raises:
+            ValueError: If workload_ttl_seconds is negative
             TokenRequestError: If the request fails
 
         Example:

--- a/ansible_base/resource_registry/workload_identity_client.py
+++ b/ansible_base/resource_registry/workload_identity_client.py
@@ -173,9 +173,7 @@ class WorkloadIdentityClient(BaseServiceClient):
             ... )
         """
         if workload_ttl_seconds is not None and workload_ttl_seconds < 1:
-            raise ValueError(
-                f"workload_ttl_seconds must be None (platform fallback) or >= 1, got {workload_ttl_seconds}"
-            )
+            raise ValueError(f"workload_ttl_seconds must be None (platform fallback) or >= 1, got {workload_ttl_seconds}")
         data = {
             "claims": claims,
             "scope": scope,

--- a/test_app/tests/resource_registry/test_workload_identity_client.py
+++ b/test_app/tests/resource_registry/test_workload_identity_client.py
@@ -232,7 +232,7 @@ class TestWorkloadIdentityClient:
         """Test that workload_ttl_seconds=0 or negative raises ValueError (Gateway rejects 0)."""
         client = WorkloadIdentityClient(base_url="https://gateway.example.com")
 
-        with pytest.raises(ValueError, match="must be None.*or >= 1"):
+        with pytest.raises(ValueError, match=r"must be None.*or >= 1"):
             client.request_workload_jwt(
                 claims={"id": 1, "name": "test-job"},
                 scope="aap_controller_automation_job",

--- a/test_app/tests/resource_registry/test_workload_identity_client.py
+++ b/test_app/tests/resource_registry/test_workload_identity_client.py
@@ -29,6 +29,18 @@ class TestWorkloadIdentityTokenTypes:
         assert request.claims == {"id": 2, "name": "my-example-job"}
         assert request.scope == "aap_controller_automation_job"
         assert request.audience == "https://vault.example.com"
+        assert request.workload_ttl_seconds == 0
+
+    def test_request_type_with_custom_ttl(self):
+        """Test that workload_ttl_seconds can be set on the request type."""
+        request = WorkloadIdentityTokenRequest(
+            claims={"id": 2, "name": "my-example-job"},
+            scope="aap_controller_automation_job",
+            audience="https://vault.example.com",
+            workload_ttl_seconds=3600,
+        )
+
+        assert request.workload_ttl_seconds == 3600
 
     def test_request_type_as_dict(self):
         """Test that WorkloadIdentityTokenRequest can be converted to dict."""
@@ -43,6 +55,7 @@ class TestWorkloadIdentityTokenTypes:
             "claims": {"id": 1, "name": "test-job"},
             "scope": "aap_controller_automation_job",
             "audience": "https://vault.example.com",
+            "workload_ttl_seconds": 0,
         }
 
     def test_response_type_creation(self):
@@ -54,6 +67,17 @@ class TestWorkloadIdentityTokenTypes:
 
 class TestWorkloadIdentityClient:
     """Test the WorkloadIdentityClient class."""
+
+    def _setup_mock_response(self, mock_request, mock_get_service_token, jwt_payload=None):
+        """Configure mocks for a successful HTTP request returning a JWT."""
+        mock_get_service_token.return_value = "service-token"
+        payload = jwt_payload or {"sub": "job_1"}
+        test_jwt = pyjwt.encode(payload, "secret", algorithm="HS256")
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"jwt": test_jwt}
+        mock_request.return_value = mock_response
+        return test_jwt
 
     def test_client_initialization(self):
         """Test that client can be initialized with correct parameters."""
@@ -138,23 +162,13 @@ class TestWorkloadIdentityClient:
     @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
     @mock.patch("ansible_base.resource_registry.service_client.requests.request")
     def test_request_workload_jwt_success(self, mock_request, mock_get_service_token):
-        """Test successful token request."""
-        # Setup mocks
-        mock_get_service_token.return_value = "service-token"
-
-        # Create a valid JWT token for the response
-        test_jwt = pyjwt.encode(
-            {"sub": "job_2", "aud": "https://vault.example.com", "scope": "aap_controller_automation_job"},
-            "secret",
-            algorithm="HS256",
+        """Test successful token request includes all expected fields in the request body."""
+        test_jwt = self._setup_mock_response(
+            mock_request,
+            mock_get_service_token,
+            jwt_payload={"sub": "job_2", "aud": "https://vault.example.com", "scope": "aap_controller_automation_job"},
         )
 
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"jwt": test_jwt}
-        mock_request.return_value = mock_response
-
-        # Make request
         client = WorkloadIdentityClient(base_url="https://gateway.example.com")
         response = client.request_workload_jwt(
             claims={"id": 2, "name": "my-example-job"},
@@ -162,11 +176,9 @@ class TestWorkloadIdentityClient:
             audience="https://vault.example.com",
         )
 
-        # Verify response
         assert isinstance(response, WorkloadIdentityTokenResponse)
         assert response.jwt == test_jwt
 
-        # Verify request was made correctly
         mock_request.assert_called_once()
         call_kwargs = mock_request.call_args[1]
         assert call_kwargs["method"] == "POST"
@@ -175,16 +187,43 @@ class TestWorkloadIdentityClient:
             "claims": {"id": 2, "name": "my-example-job"},
             "scope": "aap_controller_automation_job",
             "audience": "https://vault.example.com",
+            "workload_ttl_seconds": 0,
         }
         assert call_kwargs["headers"]["X-ANSIBLE-SERVICE-AUTH"] == "service-token"
         assert call_kwargs["verify"] is True
+
+    @pytest.mark.parametrize(
+        "workload_ttl_seconds,expected",
+        [
+            (3600, 3600),
+            (0, 0),
+        ],
+        ids=["custom-ttl-sent-to-gateway", "zero-ttl-uses-platform-default"],
+    )
+    @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
+    @mock.patch("ansible_base.resource_registry.service_client.requests.request")
+    def test_request_workload_jwt_workload_ttl_seconds(self, mock_request, mock_get_service_token, workload_ttl_seconds, expected):
+        """Test that workload_ttl_seconds is forwarded verbatim in the request body.
+
+        0 signals the Gateway to use its platform fallback (jwt_default_ttl_seconds).
+        """
+        self._setup_mock_response(mock_request, mock_get_service_token)
+
+        client = WorkloadIdentityClient(base_url="https://gateway.example.com")
+        client.request_workload_jwt(
+            claims={"id": 1, "name": "test-job"},
+            scope="aap_controller_automation_job",
+            audience="https://vault.example.com",
+            workload_ttl_seconds=workload_ttl_seconds,
+        )
+
+        assert mock_request.call_args[1]["json"]["workload_ttl_seconds"] == expected
 
     @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
     @mock.patch("ansible_base.resource_registry.service_client.requests.request")
     def test_request_workload_jwt_http_error(self, mock_request, mock_get_service_token):
         """Test that HTTP errors raise TokenRequestError."""
         mock_get_service_token.return_value = "service-token"
-
         mock_response = mock.Mock()
         mock_response.status_code = 401
         mock_response.text = "Unauthorized"
@@ -207,12 +246,9 @@ class TestWorkloadIdentityClient:
     def test_request_workload_jwt_missing_jwt_field(self, mock_request, mock_get_service_token):
         """Test that missing jwt field in response raises TokenRequestError."""
         mock_get_service_token.return_value = "service-token"
-
         mock_response = mock.Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            # Missing jwt field
-        }
+        mock_response.json.return_value = {}
         mock_request.return_value = mock_response
 
         client = WorkloadIdentityClient(base_url="https://gateway.example.com")
@@ -231,7 +267,6 @@ class TestWorkloadIdentityClient:
     def test_request_workload_jwt_json_parse_error(self, mock_request, mock_get_service_token):
         """Test that JSON parse errors raise TokenRequestError."""
         mock_get_service_token.return_value = "service-token"
-
         mock_response = mock.Mock()
         mock_response.status_code = 200
         mock_response.json.side_effect = ValueError("Invalid JSON")
@@ -270,18 +305,10 @@ class TestWorkloadIdentityClient:
     @mock.patch("ansible_base.resource_registry.service_client.requests.request")
     def test_request_workload_jwt_with_various_scopes(self, mock_request, mock_get_service_token):
         """Test that different scope strings are handled correctly."""
-        mock_get_service_token.return_value = "service-token"
-
-        test_jwt = pyjwt.encode({"sub": "test"}, "secret", algorithm="HS256")
-
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"jwt": test_jwt}
-        mock_request.return_value = mock_response
+        test_jwt = self._setup_mock_response(mock_request, mock_get_service_token)
 
         client = WorkloadIdentityClient(base_url="https://gateway.example.com")
 
-        # Test different scope values
         for scope in ["aap_controller_automation_job", "aap_eda_automation_job", "custom_scope"]:
             response = client.request_workload_jwt(
                 claims={"id": 1, "name": "test"},
@@ -289,27 +316,16 @@ class TestWorkloadIdentityClient:
                 audience="https://vault.example.com",
             )
             assert response.jwt == test_jwt
-
-            # Verify scope was sent in request
-            call_kwargs = mock_request.call_args[1]
-            assert call_kwargs["json"]["scope"] == scope
+            assert mock_request.call_args[1]["json"]["scope"] == scope
 
     @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
     @mock.patch("ansible_base.resource_registry.service_client.requests.request")
     def test_request_workload_jwt_with_various_claims(self, mock_request, mock_get_service_token):
         """Test that different claims dictionaries are handled correctly."""
-        mock_get_service_token.return_value = "service-token"
-
-        test_jwt = pyjwt.encode({"sub": "test"}, "secret", algorithm="HS256")
-
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"jwt": test_jwt}
-        mock_request.return_value = mock_response
+        test_jwt = self._setup_mock_response(mock_request, mock_get_service_token)
 
         client = WorkloadIdentityClient(base_url="https://gateway.example.com")
 
-        # Test different claims
         test_claims = [
             {"id": 1, "name": "job1"},
             {"id": 2, "name": "job2", "project": "test-project"},
@@ -324,10 +340,7 @@ class TestWorkloadIdentityClient:
                 audience="https://vault.example.com",
             )
             assert response.jwt == test_jwt
-
-            # Verify claims were sent in request
-            call_kwargs = mock_request.call_args[1]
-            assert call_kwargs["json"]["claims"] == claims
+            assert mock_request.call_args[1]["json"]["claims"] == claims
 
     @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
     def test_client_with_no_https_verification(self, mock_get_service_token):

--- a/test_app/tests/resource_registry/test_workload_identity_client.py
+++ b/test_app/tests/resource_registry/test_workload_identity_client.py
@@ -203,9 +203,7 @@ class TestWorkloadIdentityClient:
     )
     @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
     @mock.patch("ansible_base.resource_registry.service_client.requests.request")
-    def test_request_workload_jwt_workload_ttl_seconds(
-        self, mock_request, mock_get_service_token, workload_ttl_seconds, expected_in_json
-    ):
+    def test_request_workload_jwt_workload_ttl_seconds(self, mock_request, mock_get_service_token, workload_ttl_seconds, expected_in_json):
         """Test that workload_ttl_seconds is included when set, omitted when None.
 
         None (or omit) signals the Gateway to use its platform fallback (jwt_default_ttl_seconds).

--- a/test_app/tests/resource_registry/test_workload_identity_client.py
+++ b/test_app/tests/resource_registry/test_workload_identity_client.py
@@ -29,7 +29,7 @@ class TestWorkloadIdentityTokenTypes:
         assert request.claims == {"id": 2, "name": "my-example-job"}
         assert request.scope == "aap_controller_automation_job"
         assert request.audience == "https://vault.example.com"
-        assert request.workload_ttl_seconds == 0
+        assert request.workload_ttl_seconds is None
 
     def test_request_type_with_custom_ttl(self):
         """Test that workload_ttl_seconds can be set on the request type."""
@@ -55,7 +55,7 @@ class TestWorkloadIdentityTokenTypes:
             "claims": {"id": 1, "name": "test-job"},
             "scope": "aap_controller_automation_job",
             "audience": "https://vault.example.com",
-            "workload_ttl_seconds": 0,
+            "workload_ttl_seconds": None,
         }
 
     def test_response_type_creation(self):
@@ -183,41 +183,64 @@ class TestWorkloadIdentityClient:
         call_kwargs = mock_request.call_args[1]
         assert call_kwargs["method"] == "POST"
         assert call_kwargs["url"] == "https://gateway.example.com/api/gateway/v1/workload_identity_tokens/"
-        assert call_kwargs["json"] == {
+        expected_json = {
             "claims": {"id": 2, "name": "my-example-job"},
             "scope": "aap_controller_automation_job",
             "audience": "https://vault.example.com",
-            "workload_ttl_seconds": 0,
         }
+        assert call_kwargs["json"] == expected_json
+        assert "workload_ttl_seconds" not in call_kwargs["json"]  # None = omitted (platform fallback)
         assert call_kwargs["headers"]["X-ANSIBLE-SERVICE-AUTH"] == "service-token"
         assert call_kwargs["verify"] is True
 
     @pytest.mark.parametrize(
-        "workload_ttl_seconds,expected",
+        "workload_ttl_seconds,expected_in_json",
         [
             (3600, 3600),
-            (0, 0),
+            (None, None),  # omitted = platform fallback
         ],
-        ids=["custom-ttl-sent-to-gateway", "zero-ttl-uses-platform-default"],
+        ids=["custom-ttl-sent-to-gateway", "none-omitted-platform-fallback"],
     )
     @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
     @mock.patch("ansible_base.resource_registry.service_client.requests.request")
-    def test_request_workload_jwt_workload_ttl_seconds(self, mock_request, mock_get_service_token, workload_ttl_seconds, expected):
-        """Test that workload_ttl_seconds is forwarded verbatim in the request body.
+    def test_request_workload_jwt_workload_ttl_seconds(
+        self, mock_request, mock_get_service_token, workload_ttl_seconds, expected_in_json
+    ):
+        """Test that workload_ttl_seconds is included when set, omitted when None.
 
-        0 signals the Gateway to use its platform fallback (jwt_default_ttl_seconds).
+        None (or omit) signals the Gateway to use its platform fallback (jwt_default_ttl_seconds).
         """
         self._setup_mock_response(mock_request, mock_get_service_token)
 
-        client = WorkloadIdentityClient(base_url="https://gateway.example.com")
-        client.request_workload_jwt(
-            claims={"id": 1, "name": "test-job"},
-            scope="aap_controller_automation_job",
-            audience="https://vault.example.com",
-            workload_ttl_seconds=workload_ttl_seconds,
-        )
+        kwargs = {
+            "claims": {"id": 1, "name": "test-job"},
+            "scope": "aap_controller_automation_job",
+            "audience": "https://vault.example.com",
+        }
+        if workload_ttl_seconds is not None:
+            kwargs["workload_ttl_seconds"] = workload_ttl_seconds
 
-        assert mock_request.call_args[1]["json"]["workload_ttl_seconds"] == expected
+        client = WorkloadIdentityClient(base_url="https://gateway.example.com")
+        client.request_workload_jwt(**kwargs)
+
+        json_body = mock_request.call_args[1]["json"]
+        if expected_in_json is None:
+            assert "workload_ttl_seconds" not in json_body
+        else:
+            assert json_body["workload_ttl_seconds"] == expected_in_json
+
+    @pytest.mark.parametrize("invalid_ttl", [0, -1, -3600])
+    def test_request_workload_jwt_rejects_invalid_ttl(self, invalid_ttl):
+        """Test that workload_ttl_seconds=0 or negative raises ValueError (Gateway rejects 0)."""
+        client = WorkloadIdentityClient(base_url="https://gateway.example.com")
+
+        with pytest.raises(ValueError, match="must be None.*or >= 1"):
+            client.request_workload_jwt(
+                claims={"id": 1, "name": "test-job"},
+                scope="aap_controller_automation_job",
+                audience="https://vault.example.com",
+                workload_ttl_seconds=invalid_ttl,
+            )
 
     @mock.patch("ansible_base.resource_registry.service_client.get_service_token")
     @mock.patch("ansible_base.resource_registry.service_client.requests.request")

--- a/test_app/tests/resource_registry/test_workload_identity_client.py
+++ b/test_app/tests/resource_registry/test_workload_identity_client.py
@@ -215,7 +215,7 @@ class TestWorkloadIdentityClient:
             "scope": "aap_controller_automation_job",
             "audience": "https://vault.example.com",
         }
-        if workload_ttl_seconds is not None:
+        if workload_ttl_seconds:
             kwargs["workload_ttl_seconds"] = workload_ttl_seconds
 
         client = WorkloadIdentityClient(base_url="https://gateway.example.com")


### PR DESCRIPTION
[AAP-63314] P4.4: Add workload_ttl_seconds to WorkloadIdentityClient

## Description

**What is being changed?**

Adding optional `workload_ttl_seconds` parameter to the `WorkloadIdentityClient.request_workload_jwt()` method and `WorkloadIdentityTokenRequest` NamedTuple so callers can pass a workload-specific TTL hint to the Gateway.

**NOTE: 0 → None change:** The client previously used `workload_ttl_seconds: int = 0` for platform fallback. Per the [ANSTRAT-1019 proposal PR#1206](https://github.com/ansible/handbook/pull/1206), `0` is invalid (Gateway serializer rejects it); omit or `null` signals platform fallback. Updated to `int | None = None` and omit the field when `None`.  This is because `0` is the same as **infinite**, which has caused issues in the past.

**Why is this change needed?**

The Gateway (AAP-63312) can now calculate JWT TTL based on workload duration, but it requires the TTL to be sent in the request. This change extends the client library so Controller (AWX) can supply `job.timeout` when requesting JWTs.

**How does this change address the issue?**

- `WorkloadIdentityTokenRequest` NamedTuple: adds `workload_ttl_seconds: int = 0` (default 0 = use platform fallback)
- `request_workload_jwt()`: accepts `workload_ttl_seconds: int = 0` and includes it in the POST body
- Backward compatible — existing callers without the argument send `0`, triggering Gateway's platform-default fallback

**Relationship to other PRs:**

This is the **client half** of a two-part change:
1. **This PR (DAB):** exposes the parameter in the client library
2. **AWX PR (AAP-63314):** calls this method with `job.timeout` — see `awx/AAP-63314.pr.md`

Both depend on AAP-63312 (Gateway + serializer) being merged first so the endpoint accepts the parameter.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] Test update

## Self-Review Checklist

- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Implementation

**Modified:** `ansible_base/resource_registry/workload_identity_client.py` (~20 lines)  
**Modified:** `test_app/tests/resource_registry/test_workload_identity_client.py` (+5 tests)

## Testing Instructions

```bash
tox -e py -- test_app/tests/resource_registry/test_workload_identity_client.py -v
```

**Expected:** All tests pass. New tests:
- `test_request_type_with_custom_ttl`
- `test_request_workload_jwt_workload_ttl_seconds[custom-ttl-sent-to-gateway]`
- `test_request_workload_jwt_workload_ttl_seconds[zero-ttl-uses-platform-default]`

**Related:** AAP-63312 (Gateway TTL calculation), AAP-63296 (P4.1), ANSTRAT-1019

---

**Assisted-by:** Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload identity tokens can include a configurable TTL (seconds); when provided it’s forwarded in requests, otherwise platform default is used.

* **Bug Fixes / Validation**
  * Negative TTL values are rejected to prevent invalid token requests.

* **Documentation**
  * Examples and usage guidance updated to show specifying TTL and its behavior when omitted.

* **Tests**
  * Unit tests added/refactored to cover default (omitted) and custom TTL forwarding and payload assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->