### PR TITLE
[AAP-64918] Adds AuditableModel for Role*Assignment

### DIFF
--- a/ansible_base/feature_flags/models/aap_flag.py
+++ b/ansible_base/feature_flags/models/aap_flag.py
@@ -33,9 +33,10 @@ def validate_labels(value):
 
 
 class AAPFlag(NamedCommonModel, _AuditableBase):
-    # Enable audit log for this model (only if activitystream is installed)
+    # When activitystream is installed (_AuditableBase = AuditableModel), these flags
+    # configure AuditableModel to enable audit logging and suppress activity stream entries.
+    # When activitystream is absent, _AuditableBase = object and these flags are inert.
     audit_log_enabled = True
-    # Disable activity stream for this model
     activity_stream_enabled = False
 
     class Meta:

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -434,9 +434,10 @@ class AssignmentBase(ImmutableCommonModel, ObjectRoleFields, _AuditableBase):
     both models are immutable, making caching easy.
     """
 
-    # Enable audit log for this model (only if activitystream is installed)
+    # When activitystream is installed (_AuditableBase = AuditableModel), these flags
+    # configure AuditableModel to enable audit logging and suppress activity stream entries.
+    # When activitystream is absent, _AuditableBase = object and these flags are inert.
     audit_log_enabled = True
-    # Disable activity stream for this model
     activity_stream_enabled = False
 
     object_role = models.ForeignKey(

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -31,6 +31,13 @@ from .content_type import DABContentType
 from .fields import FederatedForeignKey
 from .permission import DABPermission
 
+# Conditionally import AuditableModel if activitystream is installed
+_AuditableBase = object
+if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
+    from ansible_base.activitystream.models import AuditableModel
+
+    _AuditableBase = AuditableModel
+
 logger = logging.getLogger('ansible_base.rbac.models')
 
 
@@ -419,13 +426,18 @@ class ObjectRoleFields(models.Model):
         return RoleEvaluation._meta.get_field('object_id').to_python(self.object_id)
 
 
-class AssignmentBase(ImmutableCommonModel, ObjectRoleFields):
+class AssignmentBase(ImmutableCommonModel, ObjectRoleFields, _AuditableBase):
     """
     This uses some parts of CommonModel to save metadata like documenting
     the user who assigned the permission and timestamp when it happened.
     This caches ObjectRole fields for purposes of serializers,
     both models are immutable, making caching easy.
     """
+
+    # Enable audit log for this model (only if activitystream is installed)
+    audit_log_enabled = True
+    # Disable activity stream for this model
+    activity_stream_enabled = False
 
     object_role = models.ForeignKey(
         'dab_rbac.ObjectRole', on_delete=models.CASCADE, editable=False, null=True, help_text=_("A roll-up of the fields (role_definition, content_type).")

--- a/test_app/tests/rbac/models/test_assignment_audit_logging.py
+++ b/test_app/tests/rbac/models/test_assignment_audit_logging.py
@@ -28,29 +28,21 @@ ACTIVITYSTREAM_INSTALLED = 'ansible_base.activitystream' in settings.INSTALLED_A
 # -----------------------------------------------------------------------------
 
 
-@pytest.mark.django_db
-@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
 def test_role_user_assignment_has_audit_log_enabled():
     """RoleUserAssignment has audit_log_enabled = True to enable audit logging."""
     assert getattr(RoleUserAssignment, "audit_log_enabled", False) is True
 
 
-@pytest.mark.django_db
-@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
 def test_role_user_assignment_has_activity_stream_disabled():
     """RoleUserAssignment has activity_stream_enabled = False to disable activity stream."""
     assert getattr(RoleUserAssignment, "activity_stream_enabled", True) is False
 
 
-@pytest.mark.django_db
-@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
 def test_role_team_assignment_has_audit_log_enabled():
     """RoleTeamAssignment has audit_log_enabled = True to enable audit logging."""
     assert getattr(RoleTeamAssignment, "audit_log_enabled", False) is True
 
 
-@pytest.mark.django_db
-@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
 def test_role_team_assignment_has_activity_stream_disabled():
     """RoleTeamAssignment has activity_stream_enabled = False to disable activity stream."""
     assert getattr(RoleTeamAssignment, "activity_stream_enabled", True) is False

--- a/test_app/tests/rbac/models/test_assignment_audit_logging.py
+++ b/test_app/tests/rbac/models/test_assignment_audit_logging.py
@@ -5,6 +5,8 @@ Ensures that:
 2. Both assignment classes have activity_stream_enabled = False (no activity stream entries)
 3. Create operations generate audit logs at INFO level
 4. Create operations do NOT create activity stream entries
+5. Delete operations generate audit logs at INFO level
+6. Delete operations do NOT create activity stream entries
 """
 
 from unittest import mock
@@ -113,6 +115,86 @@ def test_activity_stream_disabled_on_team_assignment_create(team, inventory, inv
     initial_entry_count = Entry.objects.count()
 
     inv_rd.give_permission(team, inventory)
+
+    # No new activity stream entries should be created
+    assert Entry.objects.count() == initial_entry_count
+
+
+# -----------------------------------------------------------------------------
+# Audit log tests: verify delete generates audit log
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_audit_log_role_user_assignment_delete(rando, inventory, inv_rd):
+    """Deleting a RoleUserAssignment emits an audit log record at INFO."""
+    # Create assignment first
+    inv_rd.give_permission(rando, inventory)
+
+    # Delete and verify audit log
+    with mock.patch(AUDIT_LOG_PATCH) as log_auth_event:
+        inv_rd.remove_permission(rando, inventory)
+
+    log_auth_event.assert_called_once()
+    msg = log_auth_event.call_args[0][0].lower()
+    assert "delete" in msg
+    assert "roleuserassignment" in msg or "assignment" in msg
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_audit_log_role_team_assignment_delete(team, inventory, inv_rd):
+    """Deleting a RoleTeamAssignment emits an audit log record at INFO."""
+    # Create assignment first
+    inv_rd.give_permission(team, inventory)
+
+    # Delete and verify audit log
+    with mock.patch(AUDIT_LOG_PATCH) as log_auth_event:
+        inv_rd.remove_permission(team, inventory)
+
+    log_auth_event.assert_called_once()
+    msg = log_auth_event.call_args[0][0].lower()
+    assert "delete" in msg
+    assert "roleteamassignment" in msg or "assignment" in msg
+
+
+# -----------------------------------------------------------------------------
+# Activity stream tests: verify delete does NOT create entry
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_activity_stream_disabled_on_user_assignment_delete(rando, inventory, inv_rd):
+    """Deleting a RoleUserAssignment does NOT create an activity stream entry."""
+    from ansible_base.activitystream.models import Entry
+
+    # Create assignment first
+    inv_rd.give_permission(rando, inventory)
+
+    initial_entry_count = Entry.objects.count()
+
+    # Delete assignment
+    inv_rd.remove_permission(rando, inventory)
+
+    # No new activity stream entries should be created
+    assert Entry.objects.count() == initial_entry_count
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_activity_stream_disabled_on_team_assignment_delete(team, inventory, inv_rd):
+    """Deleting a RoleTeamAssignment does NOT create an activity stream entry."""
+    from ansible_base.activitystream.models import Entry
+
+    # Create assignment first
+    inv_rd.give_permission(team, inventory)
+
+    initial_entry_count = Entry.objects.count()
+
+    # Delete assignment
+    inv_rd.remove_permission(team, inventory)
 
     # No new activity stream entries should be created
     assert Entry.objects.count() == initial_entry_count

--- a/test_app/tests/rbac/models/test_assignment_audit_logging.py
+++ b/test_app/tests/rbac/models/test_assignment_audit_logging.py
@@ -1,0 +1,118 @@
+"""Unit tests for RoleUserAssignment and RoleTeamAssignment audit logging.
+
+Ensures that:
+1. Both assignment classes have audit_log_enabled = True (generates audit logs)
+2. Both assignment classes have activity_stream_enabled = False (no activity stream entries)
+3. Create operations generate audit logs at INFO level
+4. Create operations do NOT create activity stream entries
+"""
+
+from unittest import mock
+
+import pytest
+from django.conf import settings
+
+from ansible_base.rbac.models import RoleTeamAssignment, RoleUserAssignment
+
+# Patch where DAB activitystream calls it
+AUDIT_LOG_PATCH = "ansible_base.activitystream.signals.log_auth_event"
+
+# Check if activitystream is installed
+ACTIVITYSTREAM_INSTALLED = 'ansible_base.activitystream' in settings.INSTALLED_APPS
+
+
+# -----------------------------------------------------------------------------
+# Verify both assignment classes have correct attribute settings
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_role_user_assignment_has_audit_log_enabled():
+    """RoleUserAssignment has audit_log_enabled = True to enable audit logging."""
+    assert getattr(RoleUserAssignment, "audit_log_enabled", False) is True
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_role_user_assignment_has_activity_stream_disabled():
+    """RoleUserAssignment has activity_stream_enabled = False to disable activity stream."""
+    assert getattr(RoleUserAssignment, "activity_stream_enabled", True) is False
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_role_team_assignment_has_audit_log_enabled():
+    """RoleTeamAssignment has audit_log_enabled = True to enable audit logging."""
+    assert getattr(RoleTeamAssignment, "audit_log_enabled", False) is True
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_role_team_assignment_has_activity_stream_disabled():
+    """RoleTeamAssignment has activity_stream_enabled = False to disable activity stream."""
+    assert getattr(RoleTeamAssignment, "activity_stream_enabled", True) is False
+
+
+# -----------------------------------------------------------------------------
+# Audit log tests: verify create generates audit log
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_audit_log_role_user_assignment_create(rando, inventory, inv_rd):
+    """Creating a RoleUserAssignment emits an audit log record at INFO."""
+    with mock.patch(AUDIT_LOG_PATCH) as log_auth_event:
+        inv_rd.give_permission(rando, inventory)
+
+    log_auth_event.assert_called_once()
+    msg = log_auth_event.call_args[0][0].lower()
+    assert "create" in msg
+    assert "roleuserassignment" in msg or "assignment" in msg
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_audit_log_role_team_assignment_create(team, inventory, inv_rd):
+    """Creating a RoleTeamAssignment emits an audit log record at INFO."""
+    with mock.patch(AUDIT_LOG_PATCH) as log_auth_event:
+        inv_rd.give_permission(team, inventory)
+
+    log_auth_event.assert_called_once()
+    msg = log_auth_event.call_args[0][0].lower()
+    assert "create" in msg
+    assert "roleteamassignment" in msg or "assignment" in msg
+
+
+# -----------------------------------------------------------------------------
+# Activity stream tests: verify create does NOT create entry
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_activity_stream_disabled_on_user_assignment_create(rando, inventory, inv_rd):
+    """Creating a RoleUserAssignment does NOT create an activity stream entry."""
+    from ansible_base.activitystream.models import Entry
+
+    initial_entry_count = Entry.objects.count()
+
+    inv_rd.give_permission(rando, inventory)
+
+    # No new activity stream entries should be created
+    assert Entry.objects.count() == initial_entry_count
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not ACTIVITYSTREAM_INSTALLED, reason="activitystream not installed")
+def test_activity_stream_disabled_on_team_assignment_create(team, inventory, inv_rd):
+    """Creating a RoleTeamAssignment does NOT create an activity stream entry."""
+    from ansible_base.activitystream.models import Entry
+
+    initial_entry_count = Entry.objects.count()
+
+    inv_rd.give_permission(team, inventory)
+
+    # No new activity stream entries should be created
+    assert Entry.objects.count() == initial_entry_count


### PR DESCRIPTION
## Description

Adds AuditableModel to AssignmentBase so that it can be leveraged by RoleUserAssignment and RoleTeamAssignment. This is configured to have audit logs created for these classes without updating the ActivityStream.

These are similar changes to PR 945 , just for the RoleUserAssignment / RoleTeamAssignment (through AssignmentBase).

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my (and Claude's) code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Steps to Test
1. Start an AAP instance with these changes.
2. Create RoleUserAssignment/RoleTeamAssignment objects.
3. Ensure that the Gateway logs have entries indicating that the models were created. Sample log lines are described below.
4. Ensure that no ActivityStream entries are created.

### Expected Results
We should see lines similar to the following in the logs:
```
myaap-gateway-5fc8fd7844-tsl9g api 2026-02-25T14:48:10.022072188-05:00 2026-02-25 19:48:10,021 INFO     3c800b99-b104-428e-8046-eb4fc65d907b aap.auth_audit [10.244.0.1] "Mozilla/5.0 (X11; Linux x86_64; rv:146.0) Gecko/20100101 Firefox/146.0" User: admin create RoleUserAssignment RoleUserAssignment object (18) (18) {'object_role': '4', 'created': '2026-02-25T19:48:10.020024+00:00', 'content_type': '11', 'object_id': '214', 'role_definition': '2', 'id': '18', 'created_by': '2', 'user': '18'}
```

No ActivityStream entries should be created

## Additional Context
As mentioned in the description, this is similar to the approach in PR 945 . 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logging enabled for role assignment operations. Activity stream integration is conditional and remains disabled by default when the activity stream feature isn't available.
* **Tests**
  * Added tests confirming audit logs are emitted on creation and deletion of role assignments and that no activity stream entries are produced whether the activity stream is present or not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->