### PR TITLE
Configure DAB so custom OIDC scopes and claims are supported

### DIFF
--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -8,7 +8,12 @@ from ansible_base.lib.routers import AssociationResourceRouter
 from ansible_base.oauth2_provider import views as oauth2_provider_views
 from ansible_base.oauth2_provider.apps import Oauth2ProviderConfig
 
-if importlib.util.find_spec("aap_gateway_api.views.oidc_discovery") is not None:
+try:
+    _gateway_spec = importlib.util.find_spec("aap_gateway_api.views.oidc_discovery")
+except ModuleNotFoundError:
+    _gateway_spec = None
+
+if _gateway_spec is not None:
     from aap_gateway_api.views.oidc_discovery import ConnectDiscoveryInfoView
 else:
     ConnectDiscoveryInfoView = oauth_views.ConnectDiscoveryInfoView

--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -6,6 +6,11 @@ from ansible_base.lib.routers import AssociationResourceRouter
 from ansible_base.oauth2_provider import views as oauth2_provider_views
 from ansible_base.oauth2_provider.apps import Oauth2ProviderConfig
 
+try:
+    from aap_gateway_api.views.oidc_discovery import ConnectDiscoveryInfoView
+except ImportError:
+    ConnectDiscoveryInfoView = oauth_views.ConnectDiscoveryInfoView
+
 app_name = Oauth2ProviderConfig.label
 
 router = AssociationResourceRouter()
@@ -42,7 +47,7 @@ oauth_urls = [
         # URL patterns below must match installed django-oauth-toolkit version, otherwise discovery fails
         # See https://github.com/django-oauth/django-oauth-toolkit/blob/2.3.0/oauth2_provider/urls.py#L35
         r"^\.well-known/openid-configuration/$",
-        oauth_views.ConnectDiscoveryInfoView.as_view(),
+        ConnectDiscoveryInfoView.as_view(),  # Uses custom gateway view if available
         name="oidc-connect-discovery-info",
     ),
     flagged_re_path(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED, r"^\.well-known/jwks\.json$", oauth_views.JwksInfoView.as_view(), name="jwks-info"),

--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 from django.urls import include, path, re_path
 from flags.urls import flagged_re_path
 from oauth2_provider import views as oauth_views
@@ -6,9 +8,9 @@ from ansible_base.lib.routers import AssociationResourceRouter
 from ansible_base.oauth2_provider import views as oauth2_provider_views
 from ansible_base.oauth2_provider.apps import Oauth2ProviderConfig
 
-try:
+if importlib.util.find_spec("aap_gateway_api.views.oidc_discovery") is not None:
     from aap_gateway_api.views.oidc_discovery import ConnectDiscoveryInfoView
-except ImportError:
+else:
     ConnectDiscoveryInfoView = oauth_views.ConnectDiscoveryInfoView
 
 app_name = Oauth2ProviderConfig.label


### PR DESCRIPTION
AAP-60507

## Description
### What is being changed?                                                                                                                                                                                            
The OIDC discovery endpoint URL pattern now uses a custom ConnectDiscoveryInfoView (if available) instead of always using the default django-oauth-toolkit view. Falls back to the default view when custom view is not present.                                                                                                                                                                                           
                  
### Why is this change needed?
Gateway needs to extend the OIDC discovery endpoint to dynamically populate scopes_supported and claims_supported with workload identity scopes and claims. Since DAB owns the OAuth2/OIDC URL routing, the custom view must be wired up here.

### How does this change address the issue?
Allows Gateway to override the discovery view to include workload identity data in the response, while maintaining backwards compatibility for standalone DAB usage via the try/except fallback.


## Type of Change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
See testing in corresponding PR for AAP-60507




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * OAuth2/OpenID Connect discovery endpoint now prefers a custom gateway discovery view when available, with an automatic fallback to the standard provider. This adds runtime flexibility so deployments with a gateway use its discovery behavior without impacting others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->