### PR TITLE
cleanup: remove unused sanitize_encrypted param from diff function

### DIFF
--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -203,7 +203,7 @@ def is_encrypted_field(model, field_name):
     return field_name in getattr(model, 'encrypted_fields', [])
 
 
-def _sanitize_value(instance, model, field_name, value, sanitize_encrypted):
+def _sanitize_value(instance, model, field_name, value):
     """Return *value* unchanged or ``ENCRYPTED_STRING`` if the field is sensitive.
 
     Extends the class-level ``is_encrypted_field`` check with two additional
@@ -218,8 +218,6 @@ def _sanitize_value(instance, model, field_name, value, sanitize_encrypted):
     2. **Value prefix** -- if the string value starts with the well-known
        ``$encrypted$`` marker, it is replaced regardless of field metadata.
     """
-    if not sanitize_encrypted:
-        return value
     if is_encrypted_field(model, field_name):
         return ENCRYPTED_STRING
     if instance is not None and field_name in getattr(instance, '_encrypted_field_names', set()):
@@ -253,7 +251,6 @@ def diff(
     include_m2m=False,
     exclude_fields=[],
     limit_fields=[],
-    sanitize_encrypted=True,
     all_values_as_strings=False,
 ):
     """
@@ -278,11 +275,9 @@ def diff(
         useful, for example, when update_fields is passed to a model's save
         method and you only want to diff the fields that were updated.
         (default: [])
-    :param sanitize_encrypted: If True, encrypted fields will be replaced with
-        a constant value (ENCRYPTED_STRING) in the diff. (default: True)
     :param all_values_as_strings: If True, all values will be converted to
         strings after diffing, using Field.value_to_string. (default: False)
-    :return: A dictionary with the following
+    :return: A ModelDiff object with the following attributes
         - added_fields: A dictionary of fields that were added between old and
           new. Importantly, if old and new are the same type of model, this
           should always be empty. An "added field" does not mean that the field
@@ -358,12 +353,12 @@ def diff(
 
     # Get any removed fields from the old_fields - new_fields
     for field in old_fields_set - new_fields_set:
-        model_diff.removed_fields[field] = _sanitize_value(old, old_model, field, fields['old'][field], sanitize_encrypted)
+        model_diff.removed_fields[field] = _sanitize_value(old, old_model, field, fields['old'][field])
 
     # Get any new fields from the new_fields - old_fields
     for field in new_fields_set - old_fields_set:
         val = fields['new'][field]
-        model_diff.added_fields[field] = _sanitize_value(new, new_model, field, val, sanitize_encrypted)
+        model_diff.added_fields[field] = _sanitize_value(new, new_model, field, val)
 
     # Find any modified fields from the union of the sets
     for field in new_fields_set & old_fields_set:
@@ -371,8 +366,8 @@ def diff(
             old_val = fields['old'][field]
             new_val = fields['new'][field]
             model_diff.changed_fields[field] = (
-                _sanitize_value(old, old_model, field, old_val, sanitize_encrypted),
-                _sanitize_value(new, new_model, field, new_val, sanitize_encrypted),
+                _sanitize_value(old, old_model, field, old_val),
+                _sanitize_value(new, new_model, field, new_val),
             )
 
     return model_diff

--- a/test_app/tests/lib/utils/test_models.py
+++ b/test_app/tests/lib/utils/test_models.py
@@ -369,18 +369,6 @@ def test_diff_instance_encrypted_field_names_partial(disable_activity_stream):
     assert delta.changed_fields['message'] == (ENCRYPTED_STRING, ENCRYPTED_STRING)
 
 
-@pytest.mark.django_db
-def test_diff_no_sanitize_when_disabled(disable_activity_stream):
-    """When sanitize_encrypted=False, neither class-level nor instance-level encryption is sanitized."""
-    instance1 = test_app_models.ImmutableLogEntry.objects.create(message='plain')
-    instance2 = test_app_models.ImmutableLogEntry.objects.get(pk=instance1.pk)
-    instance2.message = f'{ENCRYPTED_STRING}UTF8$AESCBC$data=='
-    instance1._encrypted_field_names = {'message'}
-
-    delta = models.diff(instance1, instance2, sanitize_encrypted=False)
-    assert delta.changed_fields['message'] == ('plain', instance2.message)
-
-
 @pytest.mark.parametrize(
     "username,expected_value",
     [


### PR DESCRIPTION
Fixes #688. This PR removes the unused \sanitize_encrypted\ parameter from the \diff\ utility and its helper \_sanitize_value\, and corrects the return type in the docstring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Diff/comparison now always detects and masks encrypted field values, and the option to disable this behavior has been removed.
  * Encryption-aware sanitization is applied consistently to removed, added, and changed diff results.

* **Documentation**
  * Updated documentation to clarify that diffs return a structured diff object rather than a generic dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->