### PR TITLE
[AAP-66890] Re-order subject claim in workload identity token to be org->job

### DIFF
--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -56,9 +56,7 @@ class BaseWorkloadIdentityScope:
         target_claim_names_to_sub_stubs = cls.get_target_claim_names_to_sub_stubs()
         base_sub = ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
 
-        if cls.name:
-            return f"workload_type:{cls.name}:{base_sub}"
-        return base_sub
+        return f"workload_type:{cls.name}:{base_sub}"
 
     @abstractmethod
     def populate_claims(self, workload_data: dict) -> dict:

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -40,7 +40,7 @@ class BaseWorkloadIdentityScope:
         """
         Generate a sub claim string from workload claims using the scope's claim mapping.
 
-        Constructs a colon-delimited string prefixed with "service:{service_name}:" followed by
+        Constructs a colon-delimited string prefixed with "workload_type:{scope_name}:" followed by
         the claim names and values specified by the scope's get_target_claim_names_to_sub_stubs()
         method. The order is determined by the subclass implementation.
 
@@ -50,15 +50,14 @@ class BaseWorkloadIdentityScope:
 
         :param workload_claims: A dictionary containing the workload claims (claim names to values)
         :type workload_claims: dict
-        :return: A string containing the sub claim prefixed with service identifier
+        :return: A string containing the sub claim prefixed with workload type
         :rtype: str
         """
         target_claim_names_to_sub_stubs = cls.get_target_claim_names_to_sub_stubs()
         base_sub = ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
 
-        if cls.name and '_' in cls.name:
-            service_name = cls.name.split('_')[1]
-            return f"service:{service_name}:{base_sub}"
+        if cls.name:
+            return f"workload_type:{cls.name}:{base_sub}"
         return base_sub
 
     @abstractmethod

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -40,9 +40,9 @@ class BaseWorkloadIdentityScope:
         """
         Generate a sub claim string from workload claims using the scope's claim mapping.
 
-        Constructs a colon-delimited string using the claim names and values specified by
-        the scope's get_target_claim_names_to_sub_stubs() method. The order is determined
-        by the subclass implementation.
+        Constructs a colon-delimited string prefixed with "service:{service_name}:" followed by
+        the claim names and values specified by the scope's get_target_claim_names_to_sub_stubs()
+        method. The order is determined by the subclass implementation.
 
         Note: The specified claim names are included in the output sub claim value even if they
         are empty. Claim validation is expected to take care of doing these checks before this
@@ -50,11 +50,16 @@ class BaseWorkloadIdentityScope:
 
         :param workload_claims: A dictionary containing the workload claims (claim names to values)
         :type workload_claims: dict
-        :return: A string containing the sub claim
+        :return: A string containing the sub claim prefixed with service identifier
         :rtype: str
         """
         target_claim_names_to_sub_stubs = cls.get_target_claim_names_to_sub_stubs()
-        return ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
+        base_sub = ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
+
+        if cls.name and '_' in cls.name:
+            service_name = cls.name.split('_')[1]
+            return f"service:{service_name}:{base_sub}"
+        return base_sub
 
     @abstractmethod
     def populate_claims(self, workload_data: dict) -> dict:

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -40,8 +40,9 @@ class BaseWorkloadIdentityScope:
         """
         Generate a sub claim string from workload claims using the scope's claim mapping.
 
-        Given a dictionary with the claims of a workload, generates a sub claim string with the following format:
-        "job:<job_name>:organization:<organization_name>:project:<project_name>:job_template:<job_template_name>"
+        Constructs a colon-delimited string using the claim names and values specified by
+        the scope's get_target_claim_names_to_sub_stubs() method. The order is determined
+        by the subclass implementation.
 
         Note: The specified claim names are included in the output sub claim value even if they
         are empty. Claim validation is expected to take care of doing these checks before this

--- a/ansible_base/lib/workload_identity/base.py
+++ b/ansible_base/lib/workload_identity/base.py
@@ -54,9 +54,10 @@ class BaseWorkloadIdentityScope:
         :rtype: str
         """
         target_claim_names_to_sub_stubs = cls.get_target_claim_names_to_sub_stubs()
-        base_sub = ":".join([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
+        base_sub = [f"workload_type:{cls.name}"]
+        base_sub.extend([f"{target_claim_names_to_sub_stubs[key]}:{workload_claims.get(key, '')}" for key in target_claim_names_to_sub_stubs.keys()])
 
-        return f"workload_type:{cls.name}:{base_sub}"
+        return ":".join(base_sub)
 
     @abstractmethod
     def populate_claims(self, workload_data: dict) -> dict:

--- a/ansible_base/lib/workload_identity/controller.py
+++ b/ansible_base/lib/workload_identity/controller.py
@@ -47,8 +47,6 @@ class AutomationControllerJobScope(BaseWorkloadIdentityScope):
     @classmethod
     def get_target_claim_names_to_sub_stubs(cls) -> dict[str, str]:
         return {
-            cls.CLAIM_JOB_NAME: "job",
             cls.CLAIM_ORGANIZATION_NAME: "organization",
-            cls.CLAIM_PROJECT_NAME: "project",
             cls.CLAIM_JOB_TEMPLATE_NAME: "job_template",
         }

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -81,11 +81,18 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
             },
             "organization::job_template:",
         ),
+        (
+            {
+                'aap_controller_job_template_name': 'my-template'
+            },
+            "organization::job_template:my-template",
+        ),
     ],
 )
 def test_generate_sub_claim(workload_claims, expected_sub_claim):
     """
-    Test that generate_sub_claim produces the correct sub claim string.
+    Test that generate_sub_claim produces the correct sub claim string
+    with full values, empty values, and missing keys.
     """
     actual_sub_claim = AutomationControllerJobScope.generate_sub_claim(workload_claims)
     assert actual_sub_claim == expected_sub_claim

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -72,18 +72,18 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
                 'aap_controller_organization_name': 'my-org',
                 'aap_controller_job_template_name': 'my-template',
             },
-            "service:controller:organization:my-org:job_template:my-template",
+            "workload_type:aap_controller_automation_job:organization:my-org:job_template:my-template",
         ),
         (
             {
                 'aap_controller_organization_name': '',
                 'aap_controller_job_template_name': '',
             },
-            "service:controller:organization::job_template:",
+            "workload_type:aap_controller_automation_job:organization::job_template:",
         ),
         (
             {'aap_controller_job_template_name': 'my-template'},
-            "service:controller:organization::job_template:my-template",
+            "workload_type:aap_controller_automation_job:organization::job_template:my-template",
         ),
     ],
 )

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -43,9 +43,7 @@ def test_get_target_claim_names_to_sub_stubs():
     of claim names to their sub claim stubs.
     """
     expected_mapping = {
-        'aap_controller_job_name': 'job',
         'aap_controller_organization_name': 'organization',
-        'aap_controller_project_name': 'project',
         'aap_controller_job_template_name': 'job_template',
     }
 
@@ -71,35 +69,23 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
     [
         (
             {
-                'aap_controller_job_name': 'my-job',
                 'aap_controller_organization_name': 'my-org',
-                'aap_controller_project_name': 'my-project',
                 'aap_controller_job_template_name': 'my-template',
             },
-            "job:my-job:organization:my-org:project:my-project:job_template:my-template",
+            "organization:my-org:job_template:my-template",
         ),
         (
             {
-                'aap_controller_job_name': 'my-job',
                 'aap_controller_organization_name': '',
-                'aap_controller_project_name': 'my-project',
                 'aap_controller_job_template_name': '',
             },
-            "job:my-job:organization::project:my-project:job_template:",
-        ),
-        (
-            {
-                'aap_controller_job_name': 'my-job',
-                'aap_controller_project_name': 'my-project',
-            },
-            "job:my-job:organization::project:my-project:job_template:",
+            "organization::job_template:",
         ),
     ],
 )
 def test_generate_sub_claim(workload_claims, expected_sub_claim):
     """
-    Test that generate_sub_claim produces the correct sub claim string
-    with full values, empty values, and missing keys.
+    Test that generate_sub_claim produces the correct sub claim string.
     """
     actual_sub_claim = AutomationControllerJobScope.generate_sub_claim(workload_claims)
     assert actual_sub_claim == expected_sub_claim

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -82,9 +82,7 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
             "organization::job_template:",
         ),
         (
-            {
-                'aap_controller_job_template_name': 'my-template'
-            },
+            {'aap_controller_job_template_name': 'my-template'},
             "organization::job_template:my-template",
         ),
     ],

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -72,18 +72,18 @@ def test_get_target_claim_names_to_sub_stubs_keys_are_valid_claims():
                 'aap_controller_organization_name': 'my-org',
                 'aap_controller_job_template_name': 'my-template',
             },
-            "organization:my-org:job_template:my-template",
+            "service:controller:organization:my-org:job_template:my-template",
         ),
         (
             {
                 'aap_controller_organization_name': '',
                 'aap_controller_job_template_name': '',
             },
-            "organization::job_template:",
+            "service:controller:organization::job_template:",
         ),
         (
             {'aap_controller_job_template_name': 'my-template'},
-            "organization::job_template:my-template",
+            "service:controller:organization::job_template:my-template",
         ),
     ],
 )


### PR DESCRIPTION
[AAP-66890](https://issues.redhat.com/browse/AAP-66890)

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
**What is being changed?**
  - Reordering the workload identity token `sub` claim to `workload_type:<workload>organization:<org>:job_template:<template>`
  - Removed controller-specific examples from base class docstrings
  
**Why is this change needed?**
  - The sub claim should identify the immutable principal identity, not mutable attributes
  - Mutable attributes like project, inventory, job_type remain available as separate claims for use in Vault bound claims
  
**How does this change address the issue?**
  - Implements minimal principal identity pattern: organization -> job_template
  - Aligns with team decision after discussion in [Slack thread](https://redhat-internal.slack.com/archives/C0A048CSKHP/p1772659828705009)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test update


## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment


### Steps to Test
Unit tests:
  1. Run workload identity tests: python -m pytest test_app/tests/lib/workload_identity/test_controller.py -v
  2. Verify all tests pass
  3. Check that generate_sub_claim produces format: organization:<org>:job_template:<template>
End to end tests see Jira ticket



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shortened workload identity sub-claims by removing job and project components, producing more concise claim strings.
  * Sub-claim values now consistently prefixed with "workload_type:{name}:" and enforce a stable segment order.

* **Tests**
  * Updated unit tests to align with the new sub-claim formats and mappings.

* **Documentation**
  * Updated claim-generation docs to reflect the new prefixing and simplified mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->