### PR TITLE
AAP-67028 Move scope_registry to DAB

### DIFF
--- a/ansible_base/lib/workload_identity/__init__.py
+++ b/ansible_base/lib/workload_identity/__init__.py
@@ -1,0 +1,18 @@
+"""
+Workload Identity module.
+
+Provides scope definitions and registry for workload identity tokens.
+"""
+
+from .base import BaseWorkloadIdentityScope
+from .controller import AutomationControllerJobScope
+
+SCOPE_REGISTRY = {
+    AutomationControllerJobScope.name: AutomationControllerJobScope,
+}
+
+__all__ = [
+    'BaseWorkloadIdentityScope',
+    'AutomationControllerJobScope',
+    'SCOPE_REGISTRY',
+]

--- a/test_app/tests/lib/workload_identity/test_controller.py
+++ b/test_app/tests/lib/workload_identity/test_controller.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansible_base.lib.workload_identity.controller import AutomationControllerJobScope
+from ansible_base.lib.workload_identity import AutomationControllerJobScope
 
 
 def test_list_claims():

--- a/test_app/tests/lib/workload_identity/test_scope_registry.py
+++ b/test_app/tests/lib/workload_identity/test_scope_registry.py
@@ -1,0 +1,21 @@
+from ansible_base.lib.workload_identity import SCOPE_REGISTRY, AutomationControllerJobScope
+
+
+def test_scope_registry_contains_controller_scope():
+    """Test that SCOPE_REGISTRY contains the AutomationControllerJobScope."""
+    assert "aap_controller_automation_job" in SCOPE_REGISTRY
+    assert SCOPE_REGISTRY["aap_controller_automation_job"] == AutomationControllerJobScope
+
+
+def test_scope_registry_lookup():
+    """Test that we can look up scopes by name."""
+    scope_class = SCOPE_REGISTRY.get("aap_controller_automation_job")
+    assert scope_class is not None
+    assert scope_class.name == "aap_controller_automation_job"
+    assert scope_class == AutomationControllerJobScope
+
+
+def test_scope_registry_unknown_scope():
+    """Test that looking up an unknown scope returns None."""
+    scope_class = SCOPE_REGISTRY.get("unknown_scope")
+    assert scope_class is None


### PR DESCRIPTION
[AAP-67028](https://issues.redhat.com/browse/AAP-67028)

## Description
- What is being changed?
Moved `SCOPE_REGISTRY` to ansible_base/lib/workload_identity/__init__.py
- Why is this change needed?
Consolidates OAuth2/OIDC infrastructure in DAB following consistent architectural patterns. 
Keeps all workload identity infrastructure (base classes, scope definitions, scope registry) in one module

## Type of Change
- [x] Refactoring (no functional changes)


## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
Run unit tests in workload identity
E2E testing see [AAP-67028](https://issues.redhat.com/browse/AAP-67028) description




### Screenshots/Logs
<img width="610" height="57" alt="image" src="https://github.com/user-attachments/assets/52b6802d-f587-4277-9bbe-aab78bb7868c" />
<img width="597" height="624" alt="image" src="https://github.com/user-attachments/assets/d1ae1b63-88ad-4ae9-a7b6-9bc11ad10e99" />
<img width="444" height="603" alt="image" src="https://github.com/user-attachments/assets/ac82370f-62ec-4cb9-8a79-dd213ddee05a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload identity scope registry is now publicly available for integrations and external use.

* **Tests**
  * Added validation tests for scope registry functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->