### PR TITLE
AAP-68990 Switch from typeguard to mypy

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,6 +25,8 @@ jobs:
             command: check_black
           - name: api-isort
             command: check_isort
+          - name: api-mypy
+            command: check_mypy
           - name: pure-python-imports
             command: check_pure_python_imports
     steps:
@@ -41,8 +43,16 @@ jobs:
         with:
           python-version: 3.12
 
+      - name: Install build requirements for mypy
+        if: matrix.tests.name == 'api-mypy'
+        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
+
       - name: Install requirments
         run: pip3.12 install -r requirements/requirements_dev.txt
+
+      - name: Install all dependencies for mypy
+        if: matrix.tests.name == 'api-mypy'
+        run: pip3.12 install -r requirements/requirements_all.txt
 
       - name: Install test dependencies for pure-python-imports
         if: matrix.tests.name == 'pure-python-imports'

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ COMPOSE_UP_OPTS ?=
 DOCKER_COMPOSE ?= docker compose
 
 .PHONY: PYTHON_VERSION clean build\
-	check lint check_black check_flake8 check_isort git_hooks_config
+	check lint check_black check_flake8 check_isort check_mypy git_hooks_config
 
 PYTHON_VERSION:
 	@echo "$(subst python,,$(PYTHON))"
@@ -48,6 +48,10 @@ check_flake8:
 ## Run isort syntax check
 check_isort:
 	tox -e isort -- --check $(CHECK_SYNTAX_FILES)
+
+## Run mypy type checking
+check_mypy:
+	tox -e mypy
 
 
 ## Starts a postgres container in the background if one is not running

--- a/ansible_base/activitystream/serializers.py
+++ b/ansible_base/activitystream/serializers.py
@@ -32,10 +32,12 @@ class EntrySerializer(ImmutableCommonModelSerializer):
     def get_content_type_model(self, obj) -> Optional[str]:
         if obj.content_type:
             return obj.content_type.model
+        return None
 
     def get_related_content_type_model(self, obj) -> Optional[str]:
         if obj.related_content_type:
             return obj.related_content_type.model
+        return None
 
     def _field_value_to_python(self, entry, field_name, value):
         model = entry.content_type.model_class()

--- a/ansible_base/authentication/authenticator_plugins/ldap.py
+++ b/ansible_base/authentication/authenticator_plugins/ldap.py
@@ -466,7 +466,7 @@ class LDAPSettings(BaseLDAPSettings):
 
         # Group type needs to be an object instead of a String so instantiate it
         group_type_class = find_class_in_modules(defaults["GROUP_TYPE"])
-        setattr(self, 'GROUP_TYPE', group_type_class(**defaults['GROUP_TYPE_PARAMS']))
+        setattr(self, 'GROUP_TYPE', group_type_class(**defaults['GROUP_TYPE_PARAMS']))  # type: ignore[operator]
 
 
 class AuthenticatorPlugin(LDAPBackend, AbstractAuthenticatorPlugin):
@@ -482,9 +482,9 @@ class AuthenticatorPlugin(LDAPBackend, AbstractAuthenticatorPlugin):
         self.configuration_encrypted_fields = ['BIND_PASSWORD']
         self.set_logger(logger)
 
-    def authenticate(self, request, username=None, password=None, **kwargs) -> (object, dict, list):
+    def authenticate(self, request, username=None, password=None, **kwargs):
         if not username or not password:
-            return
+            return None
         users_groups = []
 
         if not self.database_instance:

--- a/ansible_base/authentication/models/authenticator.py
+++ b/ansible_base/authentication/models/authenticator.py
@@ -18,7 +18,7 @@ def get_next_authenticator_order():
     return largest_order_authenticator['order'] + 1 if largest_order_authenticator else 1
 
 
-class Authenticator(UniqueNamedCommonModel):
+class Authenticator(UniqueNamedCommonModel):  # type: ignore[django-manager-missing]
     ignore_relations = ['authenticator_users']
     enabled = fields.BooleanField(default=False, help_text="Should this authenticator be enabled.")
     create_objects = fields.BooleanField(default=True, help_text="Allow authenticator to create objects (users, teams, organizations).")

--- a/ansible_base/authentication/models/authenticator_map.py
+++ b/ansible_base/authentication/models/authenticator_map.py
@@ -14,11 +14,11 @@ class AuthenticatorMap(NamedCommonModel):
         constraints = [
             models.CheckConstraint(
                 name="%(app_label)s_%(class)s_require_org_team_if_team_map",
-                check=(~models.Q(map_type='team') | models.Q(team__isnull=False) & models.Q(organization__isnull=False)),
+                check=(~models.Q(map_type='team') | models.Q(team__isnull=False) & models.Q(organization__isnull=False)),  # type: ignore[call-arg]
             ),
             models.CheckConstraint(
                 name="%(app_label)s_%(class)s_require_org_if_org_map",
-                check=(~models.Q(map_type='organization') | models.Q(organization__isnull=False)),
+                check=(~models.Q(map_type='organization') | models.Q(organization__isnull=False)),  # type: ignore[call-arg]
             ),
         ]
         unique_together = ['name', 'authenticator']

--- a/ansible_base/authentication/models/authenticator_user.py
+++ b/ansible_base/authentication/models/authenticator_user.py
@@ -23,7 +23,7 @@ def b64_encode_binary_data_in_dict(obj: Any) -> Any:
     return obj
 
 
-class AuthenticatorUser(AbstractUserSocialAuth, AbstractCommonModel):
+class AuthenticatorUser(AbstractUserSocialAuth, AbstractCommonModel):  # type: ignore[django-manager-missing]
     """
     This appends extra information on the local user model that includes extra data returned by
     the authenticators and links the user to the authenticator that they used to login.

--- a/ansible_base/authentication/utils/authentication.py
+++ b/ansible_base/authentication/utils/authentication.py
@@ -71,7 +71,7 @@ def migrate_from_existing_authenticator(
     )
 
     if len(migrate_users) == 0:
-        return
+        return None
 
     try:
         main_user = AuthenticatorUser.objects.get(uid=uid, provider=authenticator).user

--- a/ansible_base/authentication/utils/authenticator_map.py
+++ b/ansible_base/authentication/utils/authenticator_map.py
@@ -37,6 +37,7 @@ def check_expansion_syntax(value: Optional[str]) -> Optional[TranslatedString]:
 
     if has_expansion(value) and not _EXPANSION_RE.search(value):
         return _("Expansion only supports the format {% for_attr_value(attribute) %}")
+    return None
 
 
 def expand_syntax(attributes: dict, auth_map: AuthenticatorMap) -> list[Dict[str, str]]:
@@ -191,7 +192,7 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
 
     if not _is_rbac_installed():
         errors['role'] = _("You specified a role without RBAC installed ")
-        return errors
+        return errors  # type: ignore[return-value]
 
     from ansible_base.rbac.models import RoleDefinition
 
@@ -201,7 +202,7 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
 
         # system role is allowed for map type == role without further conditions
         if is_system_role and map_type == 'role':
-            return errors
+            return errors  # type: ignore[return-value]
 
         is_org_role, is_team_role = False, False
         if not is_system_role:
@@ -227,4 +228,4 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
     except ObjectDoesNotExist:
         errors['role'] = _("RoleDefinition {role} doesn't exist").format(role=role)
 
-    return errors
+    return errors  # type: ignore[return-value]

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -233,7 +233,7 @@ def process_groups(trigger_condition: dict, groups: list, map_id: int, tracking_
     groups = [f"{group}".casefold() for group in groups]
     trigger_condition = _lowercase_group_triggers(trigger_condition)
 
-    invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
+    invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())  # type: ignore[index]
     if invalid_conditions:
         logger.warning(f"[{tracking_id}] The conditions {', '.join(invalid_conditions)} for groups in mapping {map_id} are invalid and won't be processed")
 
@@ -276,6 +276,7 @@ def has_access_with_join(current_access: Optional[bool], new_access: bool, condi
 
     if condition == 'and':
         return current_access and new_access
+    return None
 
 
 def _lowercase_value(value: Any) -> Any:
@@ -346,7 +347,7 @@ def _validate_join_condition(join_condition, map_id: int, tracking_id: str) -> s
     Returns:
         Valid join condition ('or' or 'and')
     """
-    if join_condition not in TRIGGER_DEFINITION['attributes']['keys']['join_condition']['choices']:
+    if join_condition not in TRIGGER_DEFINITION['attributes']['keys']['join_condition']['choices']:  # type: ignore[index]
         logger.warning(f"[{tracking_id}] Trigger join_condition {join_condition} on authenticator map {map_id} is invalid and will be set to 'or'")
         return 'or'
     return join_condition
@@ -366,7 +367,7 @@ def _validate_attribute_conditions(attribute: str, condition: dict, map_id: int,
         True if conditions are valid and should be processed, False if should be skipped
     """
     # Warn if there are any invalid conditions, we are just going to ignore them
-    invalid_conditions = set(condition.keys()) - set(TRIGGER_DEFINITION['attributes']['keys']['*']['keys'].keys())
+    invalid_conditions = set(condition.keys()) - set(TRIGGER_DEFINITION['attributes']['keys']['*']['keys'].keys())  # type: ignore[index]
     if invalid_conditions:
         logger.warning(
             f"[{tracking_id}] The conditions {', '.join(invalid_conditions)} for attribute {attribute} "

--- a/ansible_base/jwt_consumer/common/util.py
+++ b/ansible_base/jwt_consumer/common/util.py
@@ -61,7 +61,7 @@ def validate_x_trusted_proxy_header(header_value: str, ignore_cache=False) -> bo
             logger.warning(f"Timestamp {timestamp} was too old by {header_age_ms}ms to be valid-alter trusted_header_timeout if needed")
             return False
     except ValueError:
-        logger.warning(f"Unable to convert timestamp (base64) {b64encode(timestamp.encode('UTF-8'))} into an integer")
+        logger.warning(f"Unable to convert timestamp (base64) {b64encode(timestamp.encode('UTF-8')).decode()} into an integer")
         return False
 
     try:
@@ -71,7 +71,7 @@ def validate_x_trusted_proxy_header(header_value: str, ignore_cache=False) -> bo
         return False
 
     try:
-        public_key.verify(
+        public_key.verify(  # type: ignore[call-arg]
             signature_bytes,
             bytes(f'{_SHARED_SECRET}-{timestamp}', 'utf-8'),
             padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),

--- a/ansible_base/lib/channels/middleware.py
+++ b/ansible_base/lib/channels/middleware.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('ansible_base.lib.channels.middleware')
 def _get_authenticated_user(scope: dict):
     request = HttpRequest()
     request.META = {_http_key(k.decode()): v.decode() for (k, v) in scope["headers"]}
-    auth_classes = [auth() for auth in api_settings.DEFAULT_AUTHENTICATION_CLASSES]
+    auth_classes = [auth() for auth in api_settings.DEFAULT_AUTHENTICATION_CLASSES]  # type: ignore[operator]
     try:
         return Request(request, authenticators=auth_classes).user
     except Exception:

--- a/ansible_base/lib/redis/client.py
+++ b/ansible_base/lib/redis/client.py
@@ -40,7 +40,7 @@ class DABRedisRespectACLFlushMixin:
     At some point in the future we may also want to override flushall as well
     """
 
-    def flushdb(self, asynchronous: Optional[bool] = None, **kwargs) -> ResponseT:
+    def flushdb(self, asynchronous: Optional[bool] = None, **kwargs) -> ResponseT:  # type: ignore[return]
         if asynchronous is not None:
             logger.warning("DABRedis clients implement an ACL friendly FLUSHDB which can not be async")
 
@@ -106,6 +106,11 @@ class RedisClient(DefaultClient):
 
 
 class RedisClientGetter:
+    url: str
+    connection_settings: dict
+    mode: str
+    redis_hosts: str | None
+
     def _redis_parse_url(self) -> None:
         if self.url == '':
             # If there is no URL we have nothing to do
@@ -190,7 +195,7 @@ class RedisClientGetter:
             raise ImproperlyConfigured(_('Unable to parse redis_hosts, see logs for more details'))
 
     def __init__(self, *args, **kwargs):
-        self.url = ''
+        self.url: str = ''
 
     def get_client(self, url: str = '', **kwargs) -> Union[DABRedis, DABRedisCluster]:
         # remove our settings which are invalid to the parent classes
@@ -265,7 +270,7 @@ def get_redis_status(url: str = '', timeout: int = _DEFAULT_STATUS_TIMEOUT_SEC, 
             response['status'] = determine_cluster_node_status(response['cluster_nodes'])
             # Now our status should be STATUS_GOOD or STATUS_DEGRADED
             # There is one more check we need to do and that is if the cluster_info did not return ok we are in a bad state
-            if response['cluster_info']['cluster_state'] != _REDIS_CLUSTER_OK_STATUS:
+            if response['cluster_info']['cluster_state'] != _REDIS_CLUSTER_OK_STATUS:  # type: ignore[index]
                 response['status'] = STATUS_FAILED
     except Exception as e:
         response['status'] = STATUS_FAILED

--- a/ansible_base/lib/routers/association_resource_router.py
+++ b/ansible_base/lib/routers/association_resource_router.py
@@ -271,7 +271,7 @@ class AssociationResourceRouter(routers.SimpleRouter):
         for method in exclude_list:
             setattr(AssociatedViewSetType, method, attribute_raiser)
 
-        class AssociatedViewSet(viewset, AssociationViewSetMethodsMixin, metaclass=AssociatedViewSetType):
+        class AssociatedViewSet(viewset, AssociationViewSetMethodsMixin, metaclass=AssociatedViewSetType):  # type: ignore[valid-type]
             """Adjusted version of given viewset for related endpoint with only list views"""
 
             pass

--- a/ansible_base/lib/utils/create_system_user.py
+++ b/ansible_base/lib/utils/create_system_user.py
@@ -15,7 +15,7 @@ These functions are in its own file because it is loaded during migrations so it
 """
 
 
-def create_system_user(user_model: Type[models.Model]) -> models.Model:
+def create_system_user(user_model: Type[models.Model]) -> Optional[models.Model]:
     # Note: We can't load models here so we can typecast to anything better than Model
     from ansible_base.lib.abstract_models.user import AbstractDABUser
 

--- a/ansible_base/lib/utils/db.py
+++ b/ansible_base/lib/utils/db.py
@@ -223,7 +223,7 @@ def combine_settings_dict(settings_dict1: dj_db_dict, settings_dict2: dj_db_dict
     settings_dict['OPTIONS'].update(extra_options)
     # Apply overrides from nested OPTIONS for the listener connection
     for k, v in settings_dict2.get('OPTIONS', {}).items():
-        settings_dict['OPTIONS'][k] = v
+        settings_dict['OPTIONS'][k] = v  # type: ignore[index]
 
     return settings_dict
 

--- a/ansible_base/oauth2_provider/utils.py
+++ b/ansible_base/oauth2_provider/utils.py
@@ -7,7 +7,7 @@ from ansible_base.authentication.models import Authenticator
 User = get_user_model()
 
 
-def is_external_account(user: User) -> Optional[Authenticator]:
+def is_external_account(user: "User") -> Optional[Authenticator]:  # type: ignore[valid-type]
     """
     Determines whether the user is associated with any external
     login source. If they are, return the source. Otherwise, None.

--- a/ansible_base/observability/instrument.py
+++ b/ansible_base/observability/instrument.py
@@ -21,7 +21,7 @@ from ansible_base.observability.propagation import outgoing_request_hook, reques
 
 
 def _setup_tracing(service_name: Optional[str] = None, span_exporter: Optional[SpanExporter] = None) -> Resource:
-    resource = Resource(attributes={SERVICE_NAME: service_name})
+    resource = Resource(attributes={SERVICE_NAME: service_name or "aap-generic"})
     provider = TracerProvider(resource=resource)
     trace.set_tracer_provider(provider)
 

--- a/ansible_base/observability/propagation.py
+++ b/ansible_base/observability/propagation.py
@@ -25,7 +25,7 @@ def headers_to_propagate(meta: dict[str, str]) -> dict[str, str]:
 
 def request_hook(_span: Span, request: HttpRequest) -> None:
     headers = headers_to_propagate(request.META)
-    request._otel_propagation_token = _active_propagation_headers.set(headers)  # type: ignore[attr-defined]
+    request._otel_propagation_token = _active_propagation_headers.set(headers)
 
 
 def response_hook(_span: Span, request: HttpRequest, _response: HttpResponse) -> None:

--- a/ansible_base/rbac/claims.py
+++ b/ansible_base/rbac/claims.py
@@ -238,7 +238,7 @@ def get_user_claims(user: Model) -> dict[str, Union[list[str], dict[str, Union[s
     global_roles = _get_user_global_roles(user)
 
     # Build final claims structure
-    return {'objects': object_arrays, 'object_roles': object_roles, 'global_roles': global_roles}
+    return {'objects': object_arrays, 'object_roles': object_roles, 'global_roles': global_roles}  # type: ignore[dict-item]
 
 
 # ---- for claims saving ----
@@ -428,9 +428,9 @@ def get_user_claims_hashable_form(claims: dict) -> dict[str, Union[list[str], di
                     ansible_ids.append(ansible_id)
 
         # Sort ansible_ids for deterministic ordering
-        hashable_claims['object_roles'][role_name] = sorted(ansible_ids)
+        hashable_claims['object_roles'][role_name] = sorted(ansible_ids)  # type: ignore[index]
 
-    return hashable_claims
+    return hashable_claims  # type: ignore[return-value]
 
 
 def get_claims_hash(hashable_claims: dict) -> str:

--- a/ansible_base/rbac/managed.py
+++ b/ansible_base/rbac/managed.py
@@ -33,7 +33,7 @@ class ManagedRoleConstructor:
         return self.permission_list
 
     def get_translated_name(self) -> str:
-        return _(self.name)
+        return _(self.name)  # type: ignore[return-value]
 
     def get_content_type(self, apps):
         model = self.get_model(apps)

--- a/ansible_base/rbac/models/content_type.py
+++ b/ansible_base/rbac/models/content_type.py
@@ -40,7 +40,7 @@ class DABContentTypeManager(django_models.Manager[django_models.Model]):
     def _get_from_cache(self, opts: Options, service: str) -> django_models.Model:
         """Return a cached ``DABContentType`` for ``opts`` and ``service``."""
         key = (service, opts.app_label, opts.model_name)
-        return self._cache[self.db][key]
+        return self._cache[self.db][key]  # type: ignore[index]
 
     def _get_opts(self, model: Union[Type[django_models.Model], django_models.Model], for_concrete_model: bool) -> Options:
         """Return the ``Options`` object for ``model``."""
@@ -109,9 +109,9 @@ class DABContentTypeManager(django_models.Manager[django_models.Model]):
                 ct = self._get_from_cache(opts, model_service)
             except KeyError:
                 needed_models[(model_service, opts.app_label)].add(opts.model_name)
-                needed_opts[(model_service, opts.app_label, opts.model_name)].append(model)
+                needed_opts[(model_service, opts.app_label, opts.model_name)].append(model)  # type: ignore[index]
             else:
-                results[model] = ct
+                results[model] = ct  # type: ignore[index]
 
         if needed_opts:
             condition = django_models.Q(

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -82,12 +82,12 @@ class RoleDefinitionManager(models.Manager):
 
     def give_creator_permissions(self, user, obj) -> Optional['RoleUserAssignment']:
         if not permission_registry.is_registered(obj):
-            return  # Exit before getting content type, which will not exist
+            return None  # Exit before getting content type, which will not exist
 
         # If the user is a superuser, no need to bother giving the creator permissions
         for super_flag in settings.ANSIBLE_BASE_BYPASS_SUPERUSER_FLAGS:
             if getattr(user, super_flag):
-                return
+                return None
 
         needed_actions = settings.ANSIBLE_BASE_CREATOR_DEFAULTS
 
@@ -122,6 +122,7 @@ class RoleDefinitionManager(models.Manager):
             # reverse sync the assignment
             maybe_reverse_sync_assignment(assignment)
             return assignment
+        return None
 
     def get_or_create(self, permissions=(), defaults=None, **kwargs):
         """Override get_or_create to support lookup by permissions list.

--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('ansible_base.rbac.permission_registry')
 
 class PermissionRegistry:
     def __init__(self):
-        self._registry: set[Model] = set()  # model registry
+        self._registry: set[type[Model]] = set()  # model registry
         self._name_to_model = dict()
         self._parent_fields = dict()
         self._managed_roles = dict()  # code-defined role definitions, managed=True
@@ -92,6 +92,7 @@ class PermissionRegistry:
         for managed_role in self._managed_roles.values():
             if managed_role.name == name:
                 return managed_role
+        return None
 
     def register_managed_role_constructor(self, shortname: str, managed_role: ManagedRoleConstructor) -> None:
         """Add the given managed role to the managed role registry"""

--- a/ansible_base/rbac/pipeline.py
+++ b/ansible_base/rbac/pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable, Sequence
-from typing import NamedTuple, Union
+from typing import NamedTuple, Union, cast
 
 from django.conf import settings
 from django.db import connection, models
@@ -46,9 +46,9 @@ def _resolve_content_object(obj: models.Model | RemoteObject) -> tuple[DABConten
     For local Django models: uses _meta (no extra query), empty parent_reference.
     """
     if isinstance(obj, RemoteObject):
-        return obj.content_type, str(obj.object_id), str(obj.parent_reference) if obj.parent_reference else ''
+        return cast(DABContentType, obj.content_type), str(obj.object_id), str(obj.parent_reference) if obj.parent_reference else ''
     return (
-        DABContentType.objects.get_for_model(obj),
+        cast(DABContentType, DABContentType.objects.get_for_model(obj)),
         str(obj._meta.pk.get_db_prep_value(obj.pk, connection)),
         '',
     )
@@ -175,7 +175,7 @@ def _create_assignments(
 ) -> list[AssignmentBase]:
     """Bulk-create user and team assignment objects, return all resulting assignments."""
     created_by = current_user_or_system_user()
-    all_assignments = []
+    all_assignments: list[AssignmentBase] = []
 
     user_assignments = []
     for ra in user_resolved:

--- a/ansible_base/rbac/validators.py
+++ b/ansible_base/rbac/validators.py
@@ -20,7 +20,7 @@ def system_roles_enabled():
 
 
 def prnt_model_name(model: Optional[Union[Type[Model], Type[RemoteObject]]]) -> str:
-    return model._meta.model_name if model else 'global role'
+    return model._meta.model_name if model else 'global role'  # type: ignore[return-value]
 
 
 def prnt_codenames(codename_set: set[str]) -> str:
@@ -67,7 +67,7 @@ def get_descendent_models_from_db(main_ct: Model):
 def permissions_allowed_for_role(cls) -> dict[Union[Type[Model], Type[RemoteObject]], list[str]]:
     "Permission codenames valid for a RoleDefinition of given class, organized by permission class"
     if cls is None:
-        return permissions_allowed_for_system_role()
+        return permissions_allowed_for_system_role()  # type: ignore[return-value]
 
     if not permission_registry.is_registered(cls):
         raise ValidationError(f'Django-ansible-base RBAC does not track permissions for model {cls._meta.model_name}')

--- a/ansible_base/resource_registry/resource_server.py
+++ b/ansible_base/resource_registry/resource_server.py
@@ -18,7 +18,12 @@ class ResourceServerConfig(TypedDict):
 def get_resource_server_config() -> ResourceServerConfig:
     defaults = {"JWT_ALGORITHM": "HS256", "VALIDATE_HTTPS": True}
     defaults.update(settings.RESOURCE_SERVER)
-    return defaults
+
+    for key in ("URL", "SECRET_KEY"):
+        if key not in defaults:
+            raise KeyError(f"RESOURCE_SERVER setting is missing required key: {key}")
+
+    return defaults  # type: ignore[return-value]
 
 
 def get_service_token(user_id=None, expiration=60, **kwargs):

--- a/ansible_base/resource_registry/service_client.py
+++ b/ansible_base/resource_registry/service_client.py
@@ -87,7 +87,7 @@ class BaseServiceClient:
         """
         if self._jwt is None or self._jwt_timeout is None or time.time() >= self._jwt_timeout:
             self.refresh_jwt()
-        return self._jwt
+        return self._jwt  # type: ignore[return-value]
 
     @property
     def requests_auth_kwargs(self) -> dict:

--- a/ansible_base/resource_registry/utils/resource_type_processor.py
+++ b/ansible_base/resource_registry/utils/resource_type_processor.py
@@ -66,4 +66,4 @@ class RoleDefinitionProcessor(ResourceTypeProcessor):
             if old_permissions != set(permissions):
                 self.instance.permissions.set(permissions)
                 changed = True
-        return (changed, self.instance)
+        return (changed, self.instance)  # type: ignore[return-value]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,6 @@ legacy_tox_ini = """
 """
 
 [tool.mypy]
-python_version = "3.11"
 plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
 ignore_missing_imports = true
 follow_imports = "silent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ legacy_tox_ini = """
         py312-in-files
     labels =
         test = py312-check, py312, py312-sqlite, py312-in-files
-        lint = flake8, black, isort
+        lint = flake8, black, isort, mypy
 
     [testenv]
     deps =
@@ -169,7 +169,38 @@ legacy_tox_ini = """
         isort==6.0.0
     docker =
     commands = isort {posargs:.}
+
+    [testenv:mypy]
+    deps =
+        -r{toxinidir}/requirements/requirements_all.txt
+        -r{toxinidir}/requirements/requirements_dev.txt
+    docker =
+    commands = mypy ansible_base {posargs}
 """
+
+[tool.mypy]
+python_version = "3.11"
+plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
+ignore_missing_imports = true
+follow_imports = "silent"
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+check_untyped_defs = false
+disallow_untyped_defs = false
+# Start permissive - tighten these as the codebase gets annotated
+disable_error_code = [
+    "attr-defined", "assignment", "union-attr", "var-annotated", "misc",
+    "arg-type",
+]
+exclude = ["test_app/", "migrations/", "\\.tox/", "build/", "\\.venv/", "venv/"]
+
+[[tool.mypy.overrides]]
+module = "ansible_base.lib.dynamic_config.dynamic_settings"
+disable_error_code = ["has-type", "used-before-def", "name-defined"]
+
+[tool.django-stubs]
+django_settings_module = "test_app.settings"
 
 [tool.coverage.run]
 omit = ["test_app/*", "manage.py"]

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -12,7 +12,11 @@ isort==6.0.0            # Linting tool, if changed update pyproject.toml as well
 jsonschema
 tox
 tox-docker
-typeguard
+mypy
+django-stubs[compatible-mypy]
+djangorestframework-stubs[compatible-mypy]
+types-requests
+types-tabulate
 openapi-spec-validator>=0.6.1  # Adapted to changing import locations in jsonschema
 pytest
 pytest-asyncio

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -5,19 +5,7 @@ Application current mode can be configured with TESTAPP_MODE environment variabl
 by default it will be development.
 """
 
-import sys
-
 from ansible_base.lib.dynamic_config import export, factory, load_envvars, load_standard_settings_files
-
-if "pytest" in sys.modules:
-    # https://github.com/agronholm/typeguard/issues/260
-    # Enable runtime type checking only for running tests
-    # must be done here because python hooks will not reliably call the
-    # typguard plugin setup before other plugins which setup Django, which loads settings.
-    # Lower in this settings file, the dynamic config imports ansible_base
-    from typeguard import install_import_hook
-
-    install_import_hook(packages=["ansible_base"])
 
 # Create a the standard DYNACONF instance which will come with DAB defaults
 # this loads the files passed to `settings_files` list

--- a/test_app/tests/authentication/authenticator_plugins/test_ldap.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_ldap.py
@@ -6,7 +6,6 @@ import ldap
 import pytest
 from django_auth_ldap import config
 from rest_framework.serializers import ValidationError
-from typeguard import suppress_type_checks
 
 from ansible_base.authentication.authenticator_plugins.ldap import (
     _MUST_BE_AN_ARRAY_MESSAGE,
@@ -372,7 +371,6 @@ def test_ldap_backend_authenticate_empty_username_password(
     assert response.status_code == 401
 
 
-@suppress_type_checks
 @pytest.mark.django_db
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")
@@ -404,7 +402,6 @@ def test_ldap_backend_authenticate_valid_user(
     assert response.data['results'][0]['name'] == ldap_authenticator.name
 
 
-@suppress_type_checks
 @pytest.mark.django_db
 @mock.patch("rest_framework.views.APIView.authentication_classes", [SessionAuthentication])
 @mock.patch("ansible_base.authentication.authenticator_plugins.ldap.LDAPBackend.authenticate")

--- a/test_app/tests/lib/utils/test_duration.py
+++ b/test_app/tests/lib/utils/test_duration.py
@@ -156,11 +156,8 @@ def test_convert_to_seconds_invalid_default_type(invalid_default_value, expected
     """
     Test that non-integer default values log a warning with stack trace and use 10 instead.
 
-    Note: Only booleans are tested here because the project uses typeguard for runtime
-    type checking, which prevents other invalid types (str, float, list, dict, None)
-    from even reaching the function. This is the expected behavior - typeguard provides
-    the first line of defense, and our isinstance check catches booleans (which are
-    technically ints in Python but should not be accepted as defaults).
+    Note: Only booleans are tested here because bool is a subclass of int in Python,
+    so it passes isinstance(x, int) checks but should not be accepted as defaults.
 
     The stack_info=True in the logger call provides developers with a full stack trace
     showing exactly where convert_to_seconds was called with an invalid default.

--- a/test_app/tests/lib/utils/test_hashing.py
+++ b/test_app/tests/lib/utils/test_hashing.py
@@ -1,7 +1,6 @@
 import uuid
 
 from rest_framework.serializers import CharField, IntegerField, Serializer, UUIDField
-from typeguard import suppress_type_checks
 
 from ansible_base.lib.utils.hashing import hash_serializer_data
 
@@ -14,19 +13,16 @@ class DataSerializer(Serializer):
     uuid = UUIDField()
 
 
-@suppress_type_checks
 def test_hash_serializer_data_idempotency():
     """Test hashing same data gives same output"""
     assert hash_serializer_data(DATA, DataSerializer) == hash_serializer_data(DATA, DataSerializer)
 
 
-@suppress_type_checks
 def test_hash_serializer_data_difference():
     """Test hashing different data changes the hash"""
     assert hash_serializer_data(DATA, DataSerializer) != hash_serializer_data({**DATA, **{"id": 4567}}, DataSerializer)
 
 
-@suppress_type_checks
 def test_hash_serializer_with_nested_field():
     """Test hashing can be performed on nested data"""
     NESTED_DATA = {"field": {"name": "foo", "id": 1234}}

--- a/test_app/tests/lib/utils/test_validation.py
+++ b/test_app/tests/lib/utils/test_validation.py
@@ -1,6 +1,5 @@
 import pytest
 from rest_framework.exceptions import ValidationError
-from typeguard import suppress_type_checks
 
 from ansible_base.lib.utils.validation import (
     _is_valid_domain_format,
@@ -18,7 +17,6 @@ from ansible_base.lib.utils.validation import (
 )
 
 
-@suppress_type_checks
 @pytest.mark.parametrize(
     "valid,url,schemes,allow_plain_hostname",
     [

--- a/test_app/tests/resource_registry/test_resource_server_settings.py
+++ b/test_app/tests/resource_registry/test_resource_server_settings.py
@@ -1,0 +1,30 @@
+import pytest
+from django.test import override_settings
+
+from ansible_base.resource_registry.resource_server import get_resource_server_config
+
+VALID_CONFIG = {"URL": "http://localhost", "SECRET_KEY": "my secret key"}
+
+
+def test_config_returns_defaults():
+    with override_settings(RESOURCE_SERVER=dict(VALID_CONFIG)):
+        config = get_resource_server_config()
+
+    assert config["URL"] == "http://localhost"
+    assert config["SECRET_KEY"] == "my secret key"
+    assert config["JWT_ALGORITHM"] == "HS256"
+    assert config["VALIDATE_HTTPS"] is True
+
+
+@pytest.mark.parametrize(
+    "config,missing",
+    (
+        ({}, "URL"),
+        ({"SECRET_KEY": "my secret key"}, "URL"),
+        ({"URL": "http://localhost"}, "SECRET_KEY"),
+    ),
+)
+def test_missing_required_key_raises(config, missing):
+    with override_settings(RESOURCE_SERVER=config):
+        with pytest.raises(KeyError, match=missing):
+            get_resource_server_config()


### PR DESCRIPTION
## Description
Obviously, mostly Claude here.

I added typeguard a long time ago. It was a creative idea, but the overall ecosystem has moved much further in the direction of static analysis and away from runtime checking.

To remain agile, we should be as consistent as possible, and typeguard was fighting against the current. It will be much easier to onboard people to DAB if we're on mypy, which this will do.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [x] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly static-typing and CI/tooling changes, but it touches several auth/RBAC/redis/jwt modules with signature/return-type tweaks and adds stricter `RESOURCE_SERVER` config validation that could surface as runtime errors if deployments are misconfigured.
> 
> **Overview**
> Switches the project from runtime `typeguard` checks to *static* `mypy` checking by adding a new `api-mypy` CI job, a `make check_mypy` target, a `tox -e mypy` env, and a baseline `[tool.mypy]` configuration (plus new stub/dev dependencies).
> 
> Updates various modules to satisfy mypy (explicit `None` returns, narrowed/adjusted annotations, and targeted `# type: ignore[...]` pragmas), removes test-time `typeguard` suppression/hooks, and includes a small behavior tweak: `get_resource_server_config()` now enforces required `RESOURCE_SERVER` keys (and JWT header timestamp logging now decodes base64 bytes to string).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f8f51504c609174f1e2090e341a0faeeb4ac8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added mypy-based static type checking to CI, Makefile, tox and project config.
  * Added a mypy test environment and included mypy in linting/checks.
  * Updated development dependencies to include mypy and typing stubs.
  * Removed runtime type-check suppression from tests so they run under static analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->