### PR TITLE
[AAP-68669] Allows OAuth tokens to start with "Token"

### DIFF
--- a/ansible_base/oauth2_provider/authentication.py
+++ b/ansible_base/oauth2_provider/authentication.py
@@ -25,7 +25,9 @@ class OAuthLibCore(_OAuthLibCore):
         # DOT flows (verify_request, create_userinfo_response, etc.).
         bearer_token = request.META.get('HTTP_AUTHORIZATION', '')
         did_hash = False
-        if bearer_token.lower().startswith('bearer '):
+        # (AAP-68669) Accommodate the ansible-galaxy CLI, which sends OAuth tokens
+        # prefixed with `Token ` instead of `Bearer ` (deviates from RFC 6750).
+        if bearer_token.lower().startswith(("bearer ", "token ")):
             token_component = bearer_token.split(' ', 1)[1]
             hashed = hash_string(token_component, hasher=hashlib.sha256, algo="sha256")
             request.META['HTTP_AUTHORIZATION'] = f"Bearer {hashed}"

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -30,6 +30,33 @@ def test_oauth2_bearer_get_user_correct(unauthenticated_api_client, oauth2_admin
     assert response.data['username'] == oauth2_admin_access_token[0].user.username
 
 
+@pytest.mark.parametrize('prefix', ['Bearer', 'Token', 'bearer', 'token', 'BEARER', 'TOKEN'])
+def test_oauth2_token_prefix_variants(unauthenticated_api_client, oauth2_admin_access_token, animal, prefix):
+    """
+    GET an animal with Bearer or Token prefix (AAP-68669).
+    """
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
+    response = unauthenticated_api_client.get(
+        url,
+        headers={'Authorization': f'{prefix} {oauth2_admin_access_token[1]}'},
+    )
+    assert response.status_code == 200
+    assert response.data['name'] == animal.name
+
+
+@pytest.mark.parametrize('prefix', ['Junk', 'Basic', 'Digest'])
+def test_oauth2_token_invalid_prefix_rejected(unauthenticated_api_client, oauth2_admin_access_token, animal, prefix):
+    """
+    Verify that valid tokens with unsupported prefixes are rejected (AAP-68669).
+    """
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
+    response = unauthenticated_api_client.get(
+        url,
+        headers={'Authorization': f'{prefix} {oauth2_admin_access_token[1]}'},
+    )
+    assert response.status_code == 401
+
+
 @pytest.mark.parametrize(
     'token, expected',
     [


### PR DESCRIPTION
This addresses a bug with the ansible-galaxy CLI, where OAuth tokens begin with `Token ` instead of `Bearer `. It was noticed that the CLI tool wasn't functioning once using only JWT tokens were enforced.

## Description
- What is being changed?
Allows OAuth Bearer tokens to be sent with either `Bearer` or `Token`.

- Why is this change needed?
With the change to mandate all communication through Gateway, and sending JWTs to backend components, this is broken as we don't accept the `Authorization: Token $TOKEN` header that ansible-galaxy generates.

- How does this change address the issue?
Updates our authentication to accept tokens that begin with `Token` to be accepted, provided they remain valid OAuth tokens.


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

Spin up an aap-dev instance, and attempt to upload or download a collection using the ansible-galaxy CLI by specifying the `--server http://localhost:44927/api/galaxy/ --token <TOKEN>` options

### Steps to Test
1. Create a collection and upload it to the AAP instance.
2. Create an API Token for a user with write privileges.
3. Attempt to download the collection using the token:
``` 
$ ansible-galaxy collection download demo.test --server "${SERVER}" --token "${TOKEN}"
Process download dependency map
ERROR! Error when getting the collection info for demo.test from cmd_arg (http://localhost:44927/api/galaxy/) (HTTP Code: 403, Message: Authentication credentials were not provided. Code: not_authenticated)
```

### Expected Results
The download should succeed, as this is a valid OAuth token.

## Additional Context
I acknowledge this supports OAuth access outside of the [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750); however, there was acknowledgement in slack by engineering management to include these changes to support the initiative for all components going performing authentication through Gateway .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth2 authentication now accepts both "Bearer" and "Token" schemes (case-insensitive); tokens are hashed when processed and original authorization headers are preserved for compatibility and security.

* **Tests**
  * Added tests validating both valid and invalid authorization prefixes to ensure consistent authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->