### PR TITLE
[AAP-69161] Fix TOCTOU race in RBAC caching causing FK violations under concurrency

### DIFF
--- a/ansible_base/rbac/caching.py
+++ b/ansible_base/rbac/caching.py
@@ -4,6 +4,8 @@ from typing import Optional
 from uuid import UUID
 
 from django.conf import settings
+from django.db import transaction
+from django.db.utils import IntegrityError
 
 from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleEvaluation, RoleEvaluationUUID
 from ansible_base.rbac.permission_registry import permission_registry
@@ -121,6 +123,56 @@ def get_parent_teams_of_teams(org_team_mapping: dict) -> dict[int, list[int]]:
     return team_team_parents
 
 
+def _is_stale_objectrole_fk(exc):
+    """Return True if *exc* is specifically an FK violation from a stale ObjectRole reference.
+
+    PostgreSQL (psycopg2/psycopg3): checks SQLSTATE 23503 (foreign_key_violation)
+    and that the referenced table is ``dab_rbac_objectrole``.  Other
+    IntegrityError sub-types (unique-constraint, check-constraint, etc.) or FK
+    violations referencing a different table return False so they propagate
+    normally.
+
+    Other backends (SQLite): returns False.  The TOCTOU race requires truly
+    concurrent committed transactions, which SQLite's global write lock
+    prevents, so FK errors there indicate a real bug.
+    """
+    cause = exc.__cause__
+    if cause is None:
+        return False
+    # psycopg3 exposes .sqlstate, psycopg2 exposes .pgcode
+    sqlstate = getattr(cause, 'sqlstate', None) or getattr(cause, 'pgcode', None)
+    if sqlstate != '23503':
+        return False
+    return 'dab_rbac_objectrole' in str(cause)
+
+
+def _safe_m2m_add(team, to_add):
+    """Add ObjectRole IDs to team.member_roles, handling concurrent deletions.
+
+    A TOCTOU race exists: ObjectRole IDs collected during the read phase of
+    compute_team_member_roles() may be deleted by a concurrent transaction
+    (e.g. org deletion cascading through rbac_post_delete_remove_object_roles)
+    before this write.  The savepoint allows us to catch the FK violation
+    without aborting the outer transaction, then retry with only IDs that
+    still exist.
+    """
+    try:
+        with transaction.atomic():
+            team.member_roles.add(*to_add)
+    except IntegrityError as exc:
+        if not _is_stale_objectrole_fk(exc):
+            raise
+        to_add = set(ObjectRole.objects.filter(id__in=to_add).values_list('id', flat=True))
+        if to_add:
+            try:
+                with transaction.atomic():
+                    team.member_roles.add(*to_add)
+            except IntegrityError as exc:
+                if not _is_stale_objectrole_fk(exc):
+                    raise
+                logger.warning('Persistent IntegrityError adding member_roles for team %s, will be corrected on next recompute', team.id)
+
+
 def compute_team_member_roles():
     """
     Fills in the ObjectRole.provides_teams relationship for all teams.
@@ -154,9 +206,37 @@ def compute_team_member_roles():
         to_add = expected_ids - existing_ids
         to_remove = existing_ids - expected_ids
         if to_add:
-            team.member_roles.add(*to_add)
+            _safe_m2m_add(team, to_add)
         if to_remove:
             team.member_roles.remove(*to_remove)
+
+
+def _safe_bulk_create_evaluations(model, evaluations, ignore_conflicts):
+    """bulk_create RoleEvaluation rows, handling concurrent ObjectRole deletions.
+
+    ignore_conflicts (ON CONFLICT DO NOTHING) only suppresses unique-constraint
+    violations.  A concurrent ObjectRole deletion causes an FK violation on
+    the role_id column which is a different IntegrityError.  We use a savepoint
+    so the outer transaction stays healthy, then retry without the stale rows.
+    """
+    if not evaluations:
+        return
+    try:
+        with transaction.atomic():
+            model.objects.bulk_create(evaluations, ignore_conflicts=ignore_conflicts)
+    except IntegrityError as exc:
+        if not _is_stale_objectrole_fk(exc):
+            raise
+        existing_role_ids = set(ObjectRole.objects.filter(id__in={e.role_id for e in evaluations}).values_list('id', flat=True))
+        evaluations = [e for e in evaluations if e.role_id in existing_role_ids]
+        if evaluations:
+            try:
+                with transaction.atomic():
+                    model.objects.bulk_create(evaluations, ignore_conflicts=ignore_conflicts)
+            except IntegrityError as exc:
+                if not _is_stale_objectrole_fk(exc):
+                    raise
+                logger.warning('Persistent IntegrityError in bulk_create for %s, will be corrected on next recompute', model.__name__)
 
 
 def compute_object_role_permissions(object_roles=None, types_prefetch=None):
@@ -194,10 +274,8 @@ def compute_object_role_permissions(object_roles=None, types_prefetch=None):
                 to_add_uuid.append(evaluation)
             else:
                 raise RuntimeError(f'Could not find a place in cache for {evaluation}')
-        if to_add_int:
-            RoleEvaluation.objects.bulk_create(to_add_int, ignore_conflicts=settings.ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS)
-        if to_add_uuid:
-            RoleEvaluationUUID.objects.bulk_create(to_add_uuid, ignore_conflicts=settings.ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS)
+        _safe_bulk_create_evaluations(RoleEvaluation, to_add_int, settings.ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS)
+        _safe_bulk_create_evaluations(RoleEvaluationUUID, to_add_uuid, settings.ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS)
 
     if to_delete:
         logger.info(f'Deleting {len(to_delete)} object-permission records')

--- a/test_app/tests/rbac/test_caching.py
+++ b/test_app/tests/rbac/test_caching.py
@@ -1,0 +1,343 @@
+"""Tests for ansible_base.rbac.caching — specifically the TOCTOU race-condition
+guards: _is_stale_objectrole_fk, _safe_m2m_add, and _safe_bulk_create_evaluations.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.db.utils import IntegrityError
+
+from ansible_base.rbac.caching import (
+    _is_stale_objectrole_fk,
+    _safe_bulk_create_evaluations,
+    _safe_m2m_add,
+)
+from ansible_base.rbac.models import RoleEvaluation
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock psycopg-style exceptions
+# ---------------------------------------------------------------------------
+
+
+def _make_integrity_error(sqlstate=None, message='some error', use_pgcode=False):
+    """Build a Django IntegrityError wrapping a fake DB-level cause."""
+    cause = Exception(message)
+    if use_pgcode:
+        cause.pgcode = sqlstate
+    else:
+        cause.sqlstate = sqlstate
+    exc = IntegrityError(message)
+    exc.__cause__ = cause
+    return exc
+
+
+def _make_objectrole_fk_error(use_pgcode=False):
+    """Build an IntegrityError that mimics a Postgres FK violation on dab_rbac_objectrole."""
+    return _make_integrity_error(
+        sqlstate='23503',
+        message=(
+            'insert or update on table "dab_rbac_objectrole_provides_teams" violates '
+            'foreign key constraint "dab_rbac_objectrole_p_objectrole_id_abc123_fk_dab_rbac_o"\n'
+            'DETAIL:  Key (objectrole_id)=(999) is not present in table "dab_rbac_objectrole".'
+        ),
+        use_pgcode=use_pgcode,
+    )
+
+
+@contextmanager
+def _noop_atomic(*args, **kwargs):
+    """Stand-in for transaction.atomic() that skips real savepoint SQL."""
+    yield
+
+
+# ---------------------------------------------------------------------------
+# _is_stale_objectrole_fk
+# ---------------------------------------------------------------------------
+
+
+class TestIsStaleObjectroleFk:
+    def test_returns_true_for_objectrole_fk_violation_psycopg3(self):
+        exc = _make_objectrole_fk_error(use_pgcode=False)
+        assert _is_stale_objectrole_fk(exc) is True
+
+    def test_returns_true_for_objectrole_fk_violation_psycopg2(self):
+        exc = _make_objectrole_fk_error(use_pgcode=True)
+        assert _is_stale_objectrole_fk(exc) is True
+
+    def test_returns_false_when_no_cause(self):
+        exc = IntegrityError('bare error')
+        assert _is_stale_objectrole_fk(exc) is False
+
+    def test_returns_false_for_unique_constraint_violation(self):
+        exc = _make_integrity_error(
+            sqlstate='23505',
+            message='duplicate key value violates unique constraint "dab_rbac_objectrole_one_object_role"',
+        )
+        assert _is_stale_objectrole_fk(exc) is False
+
+    def test_returns_false_for_fk_violation_on_different_table(self):
+        exc = _make_integrity_error(
+            sqlstate='23503',
+            message='Key (team_id)=(42) is not present in table "main_team".',
+        )
+        assert _is_stale_objectrole_fk(exc) is False
+
+    def test_returns_false_for_check_constraint(self):
+        exc = _make_integrity_error(
+            sqlstate='23514',
+            message='new row violates check constraint "positive_id"',
+        )
+        assert _is_stale_objectrole_fk(exc) is False
+
+    def test_returns_false_for_sqlite_fk_error(self):
+        """SQLite FK errors have no sqlstate/pgcode — should not be suppressed."""
+        cause = Exception('FOREIGN KEY constraint failed')
+        exc = IntegrityError('FOREIGN KEY constraint failed')
+        exc.__cause__ = cause
+        assert _is_stale_objectrole_fk(exc) is False
+
+    def test_returns_false_when_sqlstate_is_none(self):
+        cause = Exception('some random db error')
+        exc = IntegrityError('some random db error')
+        exc.__cause__ = cause
+        assert _is_stale_objectrole_fk(exc) is False
+
+    def test_returns_true_for_role_evaluation_fk_violation(self):
+        """The role_id FK on dab_rbac_roleevaluation also references dab_rbac_objectrole."""
+        exc = _make_integrity_error(
+            sqlstate='23503',
+            message=(
+                'insert or update on table "dab_rbac_roleevaluation" violates '
+                'foreign key constraint "dab_rbac_roleevaluat_role_id_abc_fk_dab_rbac_o"\n'
+                'DETAIL:  Key (role_id)=(42) is not present in table "dab_rbac_objectrole".'
+            ),
+        )
+        assert _is_stale_objectrole_fk(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# _safe_m2m_add
+#
+# team.member_roles is a Django M2M descriptor that returns a fresh manager
+# each access, so we cannot patch it on a real Team instance.  Instead these
+# tests use a MagicMock team whose .member_roles.add is fully controllable,
+# and mock transaction.atomic to skip real savepoint SQL (the mock-raised
+# IntegrityError never touches the DB).
+# ---------------------------------------------------------------------------
+
+
+class TestSafeM2mAdd:
+    @pytest.mark.django_db
+    def test_happy_path_adds_ids(self, team, member_rd, rando):
+        """When no race occurs, compute_team_member_roles (which calls
+        _safe_m2m_add internally) works end-to-end with real DB objects."""
+        from ansible_base.rbac.caching import compute_team_member_roles
+
+        member_rd.give_permission(rando, team)
+        compute_team_member_roles()
+        assert team.member_roles.exists()
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    def test_retries_on_stale_fk(self, mock_or_qs):
+        """First add() hits a stale-FK IntegrityError, retry succeeds with filtered IDs."""
+        mock_or_qs.filter.return_value.values_list.return_value = [1]
+        team = MagicMock()
+        call_count = 0
+
+        def flaky_add(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _make_objectrole_fk_error()
+
+        team.member_roles.add.side_effect = flaky_add
+        _safe_m2m_add(team, {1, 9999})
+        assert call_count == 2
+        mock_or_qs.filter.assert_called_once()
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    @patch('ansible_base.rbac.caching.logger')
+    def test_logs_warning_on_persistent_fk_error(self, mock_logger, mock_or_qs):
+        """Both attempts fail with stale-FK error — logs warning, does not raise."""
+        mock_or_qs.filter.return_value.values_list.return_value = [1]
+        team = MagicMock()
+        team.member_roles.add.side_effect = _make_objectrole_fk_error()
+
+        _safe_m2m_add(team, {1})
+        mock_logger.warning.assert_called_once()
+        assert 'Persistent IntegrityError' in mock_logger.warning.call_args[0][0]
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    def test_reraises_non_fk_integrity_error(self):
+        """A unique-constraint IntegrityError is re-raised, not swallowed."""
+        team = MagicMock()
+        team.member_roles.add.side_effect = _make_integrity_error(sqlstate='23505', message='duplicate key')
+        with pytest.raises(IntegrityError, match='duplicate key'):
+            _safe_m2m_add(team, {1})
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    def test_retry_reraises_non_fk_integrity_error(self, mock_or_qs):
+        """First call hits stale FK (retries), second call hits a different error — re-raised."""
+        mock_or_qs.filter.return_value.values_list.return_value = [1]
+        team = MagicMock()
+        stale_exc = _make_objectrole_fk_error()
+        unique_exc = _make_integrity_error(sqlstate='23505', message='duplicate key')
+        call_count = 0
+
+        def switching_add(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise stale_exc
+            raise unique_exc
+
+        team.member_roles.add.side_effect = switching_add
+        with pytest.raises(IntegrityError, match='duplicate key'):
+            _safe_m2m_add(team, {1})
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    def test_skips_retry_when_no_valid_ids_remain(self, mock_or_qs):
+        """After filtering, no IDs remain — second add() is never called."""
+        mock_or_qs.filter.return_value.values_list.return_value = []
+        team = MagicMock()
+        exc = _make_objectrole_fk_error()
+        team.member_roles.add.side_effect = exc
+
+        _safe_m2m_add(team, {9999})
+        team.member_roles.add.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _safe_bulk_create_evaluations
+# ---------------------------------------------------------------------------
+
+
+class TestSafeBulkCreateEvaluations:
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    def test_noop_on_empty_list(self):
+        """Empty evaluations list returns immediately without DB calls."""
+        with patch.object(RoleEvaluation.objects, 'bulk_create') as mock_bc:
+            _safe_bulk_create_evaluations(RoleEvaluation, [], False)
+            mock_bc.assert_not_called()
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    def test_happy_path_calls_bulk_create(self):
+        """When no error, bulk_create is called once."""
+        evals = [MagicMock(role_id=1, object_id=1)]
+        with patch.object(RoleEvaluation.objects, 'bulk_create') as mock_bc:
+            _safe_bulk_create_evaluations(RoleEvaluation, evals, True)
+            mock_bc.assert_called_once_with(evals, ignore_conflicts=True)
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    def test_retries_on_stale_fk(self, mock_or_qs):
+        """First bulk_create hits stale FK, retry succeeds after filtering."""
+        mock_or_qs.filter.return_value.values_list.return_value = [1]
+        eval1 = MagicMock(role_id=1, object_id=10)
+        eval2 = MagicMock(role_id=2, object_id=20)
+        exc = _make_objectrole_fk_error()
+        call_count = 0
+
+        def flaky_bulk_create(objs, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise exc
+
+        with patch.object(RoleEvaluation.objects, 'bulk_create', side_effect=flaky_bulk_create):
+            _safe_bulk_create_evaluations(RoleEvaluation, [eval1, eval2], True)
+
+        assert call_count == 2
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    @patch('ansible_base.rbac.caching.logger')
+    def test_logs_warning_on_persistent_fk_error(self, mock_logger, mock_or_qs):
+        """Both attempts fail with stale-FK — logs warning, does not raise."""
+        mock_or_qs.filter.return_value.values_list.return_value = [1]
+        eval1 = MagicMock(role_id=1, object_id=10)
+        exc = _make_objectrole_fk_error()
+
+        with patch.object(RoleEvaluation.objects, 'bulk_create', side_effect=exc):
+            _safe_bulk_create_evaluations(RoleEvaluation, [eval1], False)
+            mock_logger.warning.assert_called_once()
+            assert 'Persistent IntegrityError' in mock_logger.warning.call_args[0][0]
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    def test_reraises_non_fk_integrity_error(self):
+        """A unique-constraint IntegrityError propagates."""
+        eval1 = MagicMock(role_id=1, object_id=10)
+        exc = _make_integrity_error(sqlstate='23505', message='duplicate key')
+
+        with patch.object(RoleEvaluation.objects, 'bulk_create', side_effect=exc):
+            with pytest.raises(IntegrityError, match='duplicate key'):
+                _safe_bulk_create_evaluations(RoleEvaluation, [eval1], False)
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    def test_retry_reraises_non_fk_integrity_error(self, mock_or_qs):
+        """First call hits stale FK, retry hits different error — re-raised."""
+        mock_or_qs.filter.return_value.values_list.return_value = [1]
+        eval1 = MagicMock(role_id=1, object_id=10)
+        stale_exc = _make_objectrole_fk_error()
+        unique_exc = _make_integrity_error(sqlstate='23505', message='duplicate key')
+        call_count = 0
+
+        def switching_bulk_create(objs, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise stale_exc
+            raise unique_exc
+
+        with patch.object(RoleEvaluation.objects, 'bulk_create', side_effect=switching_bulk_create):
+            with pytest.raises(IntegrityError, match='duplicate key'):
+                _safe_bulk_create_evaluations(RoleEvaluation, [eval1], False)
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    def test_filters_out_stale_role_ids(self, mock_or_qs):
+        """After first failure, only evaluations with still-valid role_ids are retried."""
+        mock_or_qs.filter.return_value.values_list.return_value = [1]
+        eval_good = MagicMock(role_id=1, object_id=10)
+        eval_stale = MagicMock(role_id=999, object_id=20)
+        exc = _make_objectrole_fk_error()
+
+        retried_evals = []
+        call_count = 0
+
+        def flaky_then_capture(objs, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise exc
+            retried_evals.extend(objs)
+
+        with patch.object(RoleEvaluation.objects, 'bulk_create', side_effect=flaky_then_capture):
+            _safe_bulk_create_evaluations(RoleEvaluation, [eval_good, eval_stale], True)
+
+        assert retried_evals == [eval_good]
+
+    @patch('ansible_base.rbac.caching.transaction.atomic', _noop_atomic)
+    @patch('ansible_base.rbac.caching.ObjectRole.objects')
+    def test_skips_retry_when_no_valid_ids_remain(self, mock_or_qs):
+        """After filtering, no evaluations remain — second bulk_create is never called."""
+        mock_or_qs.filter.return_value.values_list.return_value = []
+        eval1 = MagicMock(role_id=999, object_id=10)
+        exc = _make_objectrole_fk_error()
+        call_count = 0
+
+        def counting_bulk_create(objs, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise exc
+
+        with patch.object(RoleEvaluation.objects, 'bulk_create', side_effect=counting_bulk_create):
+            _safe_bulk_create_evaluations(RoleEvaluation, [eval1], False)
+
+        assert call_count == 1


### PR DESCRIPTION
## Description

- **What:** Fix a TOCTOU (Time-of-Check-Time-of-Use) race condition in `compute_team_member_roles()` and `compute_object_role_permissions()` in `ansible_base/rbac/caching.py`.
- **Why:** Under concurrent API operations (e.g. parallel test workers or simultaneous role assignment + org deletion), `compute_team_member_roles()` collects ObjectRole IDs in a read phase, then later writes them to the `dab_rbac_objectrole_provides_teams` M2M table. A concurrent committed transaction (e.g. org deletion cascading through `rbac_post_delete_remove_object_roles`) can delete those ObjectRoles between the two phases, causing PostgreSQL to reject the M2M insert with: `insert or update on table "dab_rbac_objectrole_provides_teams" violates foreign key constraint — Key (objectrole_id)=(NNN) is not present in table "dab_rbac_objectrole"`.
- **How:** Wrap the `team.member_roles.add()` and `RoleEvaluation.bulk_create()` calls in database savepoints (`transaction.atomic()`). If an `IntegrityError` from a stale FK reference is caught, re-filter to only ObjectRole IDs that still exist and retry. The savepoint ensures the outer transaction is not aborted. If the retry also fails (extremely unlikely), a warning is logged and the state self-corrects on the next recompute.

The same class of bug also exists in `compute_object_role_permissions()` — the `bulk_create` for `RoleEvaluation` rows references ObjectRoles via the `role_id` FK, and `ignore_conflicts=True` only suppresses unique-constraint violations, not FK violations. This PR fixes both locations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- PostgreSQL database (not SQLite — FK enforcement differs)
- Multiple concurrent database connections (e.g. `pytest -n auto`)

### Steps to Test
1. Run the DAB RBAC test suite: `ANSIBLE_BASE_TEST_DIRS="" tox -e py312 -- test_app/tests/rbac/ -v`
2. To reproduce the original race: run AAP platform-services-test-suite with `pytest -n auto` (12+ parallel workers). The race manifests when one worker creates a `role_user_assignment` (triggering `compute_team_member_roles`) while another worker's test cleanup deletes an organization (triggering cascade ObjectRole deletion).

### Expected Results
- All RBAC tests pass
- No `IntegrityError` FK violations on `dab_rbac_objectrole_provides_teams` under concurrent operations
- If a race does occur, it is caught gracefully with a log warning and self-corrects on the next recompute

## Additional Context

### Root Cause Analysis
The `transaction.atomic()` wrapper in the serializer's `create()` method does not prevent this race because the competing DELETE is in a **different database connection's already-committed transaction**. The fix uses savepoints (nested `transaction.atomic()`) to create a safe rollback boundary around the specific write operations, combined with a re-validation + retry pattern.

### Why not SELECT FOR UPDATE?
`SELECT FOR UPDATE` on the ObjectRole rows would be heavyweight and could introduce deadlocks in this global recompute function, which iterates all teams. The catch-and-retry approach is simpler, has minimal performance impact in the common (non-racy) case, and the system self-heals because deletion triggers also call `compute_team_member_roles()`.

---
**Note:** This PR was developed with assistance from Claude AI assistant.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of team role adds and bulk evaluation writes against race conditions when referenced roles are deleted concurrently: operations now detect stale references, retry once after filtering out removed roles, and log persistent failures without changing public APIs.
* **Tests**
  * Added comprehensive tests for error classification, retry/filter behavior, non-retryable error propagation, and logging of persistent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->