### PR TITLE
fix: improve rbac computation performance when new object is created

### DIFF
--- a/ansible_base/rbac/caching.py
+++ b/ansible_base/rbac/caching.py
@@ -239,7 +239,7 @@ def _safe_bulk_create_evaluations(model, evaluations, ignore_conflicts):
                 logger.warning('Persistent IntegrityError in bulk_create for %s, will be corrected on next recompute', model.__name__)
 
 
-def compute_object_role_permissions(object_roles=None, types_prefetch=None):
+def compute_object_role_permissions(object_roles=None, types_prefetch=None, is_create=False, new_object_pk=None):
     """
     Assumes the ObjectRole.provides_teams relationship is correct.
     Makes the RoleEvaluation table correct for all specified object_roles
@@ -253,7 +253,7 @@ def compute_object_role_permissions(object_roles=None, types_prefetch=None):
         object_roles = ObjectRole.objects.iterator()
 
     for object_role in object_roles:
-        role_to_delete, role_to_add = object_role.needed_cache_updates(types_prefetch=types_prefetch)
+        role_to_delete, role_to_add = object_role.needed_cache_updates(types_prefetch=types_prefetch, is_create=is_create, new_object_pk=new_object_pk)
 
         if role_to_delete:
             logger.debug(f'Removing {len(role_to_delete)} object-permissions from {object_role}')

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -682,18 +682,30 @@ class ObjectRole(ObjectRoleFields):
                 expected_evaluations.add((permission.codename, eval_ct, id))
         return expected_evaluations
 
-    def needed_cache_updates(self, types_prefetch=None):
+    def needed_cache_updates(self, types_prefetch=None, is_create=False, new_object_pk=None):
         existing_partials = {}
-        for permission_partial in self.permission_partials.all():
-            existing_partials[permission_partial.obj_perm_id()] = permission_partial
-        for permission_partial in self.permission_partials_uuid.all():
-            existing_partials[permission_partial.obj_perm_id()] = permission_partial
+
+        # if we're creating a new object we don't expect any permission partials to exist
+        # and can skip this block
+        if not is_create:
+            for permission_partial in self.permission_partials.all():
+                existing_partials[permission_partial.obj_perm_id()] = permission_partial
+            for permission_partial in self.permission_partials_uuid.all():
+                existing_partials[permission_partial.obj_perm_id()] = permission_partial
 
         expected_evaluations = self.expected_direct_permissions(types_prefetch)
 
         for team in self.provides_teams.all():
             for team_role in team.has_roles.all():
                 expected_evaluations.update(team_role.expected_direct_permissions(types_prefetch))
+
+        # if we're creating a new object, filter out all expected evaluations that are unrelated
+        # to the new object. Otherwise we'd end up with a large diff because existing_partials is empty
+        if is_create and new_object_pk is not None:
+            expected_evaluations = {
+                (c, ct_id, pk) for c, ct_id, pk in expected_evaluations
+                if pk == new_object_pk
+            }
 
         existing_set = set(existing_partials.keys())
 

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -156,7 +156,7 @@ def get_parent_ids(instance) -> list[tuple[Model, Union[int, UUID]]]:
     return []
 
 
-def post_save_update_obj_permissions(instance):
+def post_save_update_obj_permissions(instance, is_create=False, new_object_pk=None):
     "Utility method shared by multiple signals"
     # Account for organization roles (and other parent objects), new and old
     parent_gfks = get_parent_ids(instance)
@@ -188,7 +188,7 @@ def post_save_update_obj_permissions(instance):
         compute_team_member_roles()
 
     if to_update:
-        compute_object_role_permissions(object_roles=to_update)
+        compute_object_role_permissions(object_roles=to_update, is_create=is_create, new_object_pk=new_object_pk)
 
 
 def rbac_pre_save_identify_changes(instance, *args, **kwargs):
@@ -220,7 +220,7 @@ def rbac_post_save_update_evaluations(instance, created, *args, **kwargs):
     # If child object is created and parent object has existing ObjectRoles
     # evaluations for the parent object roles need to be added
     if created:
-        post_save_update_obj_permissions(instance)
+        post_save_update_obj_permissions(instance, is_create=True, new_object_pk=instance.pk)
         return
 
     # The parent object can not have changed if update_fields was given and did not list that field


### PR DESCRIPTION
## Description

Updates `needed_cache_updates` to not process existing permission partials when a new object is created.

**Problem description**: `needed_cache_updates` computes a diff of permission partials by comparing expected to existing evaluations. If a large number of existing evaluations exist (because e.g. a large number of inventories exist),this can take a long time.

**Fix description**: when a new object (e.g. an inventory) is created, we know that no evaluations exist yet. Hence, there is no reason to fetch all existing evaluations (for a role). We also know that the number of expected evaluations is exactly one, so we can remove all unrelated evaluations from the list.

**Fix result**: For a newly created object we always end up with only one new evaluation to be inserted and we're not iterating over thousands of unrelated evaluations.

**Performance impact**:

In an environment with 10.000 inventories, creating a new smart inventory took:

```
$ time curl -sk -u admin:<password> -X POST https://localhost:8043/api/v2/inventories/ -H "Content-Type: application/json" -d '{"name": "aap69544-smart-test2", "organization": 12, "kind": "smart", "host_filter": "name__icontains=localhost"}'
{"id":110038,"type":"inventory","url":"/api/v2/inventories/110038/","related":{"named_url":"/api/v2/inventories/aap69544-smart-test2++aap69544-test-org/","created_by":"/api/v2/users/1/","modified_by":"/api/v2/users/1/","hosts":"/api/v2/inventories/110038/hosts/","variable_data":"/api/v2/inventories/110038/variable_data/","script":"/api/v2/inventories/110038/script/","activity_stream":"/api/v2/inventories/110038/activity_stream/","job_templates":"/api/v2/inventories/110038/job_templates/","ad_hoc_commands":"/api/v2/inventories/110038/ad_hoc_commands/","access_list":"/api/v2/inventories/110038/access_list/","object_roles":"/api/v2/inventories/110038/object_roles/","instance_groups":"/api/v2/inventories/110038/instance_groups/","copy":"/api/v2/inventories/110038/copy/","labels":"/api/v2/inventories/110038/labels/","organization":"/api/v2/organizations/12/"},"summary_fields":{"organization":{"id":12,"name":"aap69544-test-org","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can manage all aspects of the inventory","name":"Admin","id":358},"update_role":{"description":"May update the inventory","name":"Update","id":359},"adhoc_role":{"description":"May run ad hoc commands on the inventory","name":"Ad Hoc","id":360},"use_role":{"description":"Can use the inventory in a job template","name":"Use","id":361},"read_role":{"description":"May view settings for the inventory","name":"Read","id":362}},"user_capabilities":{"edit":true,"delete":true,"copy":true,"adhoc":true},"labels":{"count":0,"results":[]}},"created":"2026-04-02T14:37:29.540026Z","modified":"2026-04-02T14:37:29.540045Z","name":"aap69544-smart-test2","description":"","organization":12,"kind":"smart","host_filter":"name__icontains=localhost","variables":"","has_active_failures":false,"total_hosts":0,"hosts_with_active_failures":0,"total_groups":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"pending_deletion":false,"prevent_instance_group_fallback":false,"opa_query_path":""}
real    1m5,411s
user    0m0,013s
sys     0m0,016s

```

With this patch, it improves to:

```
$ time curl -sk -u admin:<password> -X POST https://localhost:8043/api/v2/inventories/ -H "Content-Type: application/json" -d '{"name": "aap69544-smart-test2", "organization": 12, "kind": "smart", "host_filter": "name__icontains=localhost"}'
{"id":110053,"type":"inventory","url":"/api/v2/inventories/110053/","related":{"named_url":"/api/v2/inventories/aap69544-smart-test2++aap69544-test-org/","created_by":"/api/v2/users/1/","modified_by":"/api/v2/users/1/","hosts":"/api/v2/inventories/110053/hosts/","variable_data":"/api/v2/inventories/110053/variable_data/","script":"/api/v2/inventories/110053/script/","activity_stream":"/api/v2/inventories/110053/activity_stream/","job_templates":"/api/v2/inventories/110053/job_templates/","ad_hoc_commands":"/api/v2/inventories/110053/ad_hoc_commands/","access_list":"/api/v2/inventories/110053/access_list/","object_roles":"/api/v2/inventories/110053/object_roles/","instance_groups":"/api/v2/inventories/110053/instance_groups/","copy":"/api/v2/inventories/110053/copy/","labels":"/api/v2/inventories/110053/labels/","organization":"/api/v2/organizations/12/"},"summary_fields":{"organization":{"id":12,"name":"aap69544-test-org","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can manage all aspects of the inventory","name":"Admin","id":433},"update_role":{"description":"May update the inventory","name":"Update","id":434},"adhoc_role":{"description":"May run ad hoc commands on the inventory","name":"Ad Hoc","id":435},"use_role":{"description":"Can use the inventory in a job template","name":"Use","id":436},"read_role":{"description":"May view settings for the inventory","name":"Read","id":437}},"user_capabilities":{"edit":true,"delete":true,"copy":true,"adhoc":true},"labels":{"count":0,"results":[]}},"created":"2026-04-02T22:33:24.948722Z","modified":"2026-04-02T22:33:24.948730Z","name":"aap69544-smart-test2","description":"","organization":12,"kind":"smart","host_filter":"name__icontains=localhost","variables":"","has_active_failures":false,"total_hosts":0,"hosts_with_active_failures":0,"total_groups":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"pending_deletion":false,"prevent_instance_group_fallback":false,"opa_query_path":""}
real    0m4,080s
user    0m0,010s
sys     0m0,016s

```

**Note**: I might mix up the terminology here (evaluations / permission partials).

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Create around 10k inventories linked to the same organization
2. Create a smart inventory in the same organization
3. Without this change, it will be very slow. With this change it should only take a few seconds.

### Expected Results

Dramatically improved performance for object creation.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized role-based access control permission evaluation for newly created objects, reducing redundant calculations and improving system responsiveness when managing hierarchical role structures and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->