### PR TITLE
AAP-65871 Fix openapi spec for ATF

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -91,7 +91,7 @@ class BaseAssignmentSerializer(CommonModelSerializer):
             qs = self.get_actor_queryset(request.user)
         else:
             qs = self.Meta.model._meta.get_field(self.actor_field).model.objects.all()
-        self.fields[self.actor_field] = serializers.PrimaryKeyRelatedField(queryset=qs, required=False)
+        self.fields[self.actor_field] = serializers.PrimaryKeyRelatedField(queryset=qs, required=False, allow_null=True)
 
     def raise_id_fields_error(self, field1, field2):
         msg = _('Provide exactly one of %(actor_field)s or %(actor_field)s_ansible_id') % {'actor_field': self.actor_field}
@@ -121,9 +121,9 @@ class BaseAssignmentSerializer(CommonModelSerializer):
         """Validate that exactly one of actor or actor_ansible_id is provided"""
         actor_aid_field = f'{self.actor_field}_ansible_id'
 
-        # Check what was actually provided in the request
-        has_actor_in_request = self.actor_field in self.initial_data
-        has_actor_aid_in_request = actor_aid_field in self.initial_data
+        # Check what was actually provided in the request (null counts as not provided)
+        has_actor_in_request = self.initial_data.get(self.actor_field) is not None
+        has_actor_aid_in_request = self.initial_data.get(actor_aid_field) is not None
 
         # If both actor and actor_ansible_id are present or both not present than we error out
         if has_actor_in_request == has_actor_aid_in_request:

--- a/test_app/tests/rbac/api/test_ansible_id_assignments.py
+++ b/test_app/tests/rbac/api/test_ansible_id_assignments.py
@@ -64,6 +64,17 @@ def test_assignment_id_validation(admin_api_client, inv_rd, team, inventory, ran
 
 
 @pytest.mark.django_db
+def test_user_assignment_ansible_id_with_null_actor(admin_api_client, inv_rd, rando, inventory):
+    """Sending user=null with a valid user_ansible_id should succeed thanks to allow_null=True."""
+    resource = Resource.objects.get(object_id=rando.pk, content_type=ContentType.objects.get_for_model(rando).pk)
+    url = get_relative_url('roleuserassignment-list')
+    data = dict(role_definition=inv_rd.id, content_type='aap.inventory', user=None, user_ansible_id=str(resource.ansible_id), object_id=inventory.id)
+    response = admin_api_client.post(url, data=data, format="json")
+    assert response.status_code == 201, response.data
+    assert rando.has_obj_perm(inventory, 'change')
+
+
+@pytest.mark.django_db
 def test_object_ansible_id_user(admin_api_client, org_inv_rd, rando, inventory, organization):
     resource = Resource.objects.get(object_id=organization.pk, content_type=ContentType.objects.get_for_model(organization).pk)
     url = get_relative_url('roleuserassignment-list')


### PR DESCRIPTION
## Description

Just fixing the mutual exclusiveness of user and ansible id in roleuserassignments by request from ATF.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. View gw openapi spec and verify roleuserassignments api for user/user_ansible_id show up properly
2. 
3. 

### Expected Results
Fixed openapi spec.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved role assignment validation to correctly handle explicit null values in actor fields. The API now properly accepts role assignment requests with null actor values when alternate identifiers are provided, enhancing flexibility and ensuring consistent request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->