### PR TITLE
AAP-70751 Optimize RBAC evaluation rebuilding by passing obj details for look-ahead

### DIFF
--- a/ansible_base/rbac/caching.py
+++ b/ansible_base/rbac/caching.py
@@ -279,7 +279,7 @@ def _safe_bulk_create_evaluations(model, evaluations, ignore_conflicts):
                 logger.warning('Persistent IntegrityError in bulk_create for %s, will be corrected on next recompute', model.__name__)
 
 
-def compute_object_role_permissions(object_roles=None, types_prefetch=None):
+def compute_object_role_permissions(object_roles=None, types_prefetch=None, object_pk=None, object_ct_id=None):
     """
     Assumes the ObjectRole.provides_teams relationship is correct.
     Makes the RoleEvaluation table correct for all specified object_roles
@@ -293,7 +293,7 @@ def compute_object_role_permissions(object_roles=None, types_prefetch=None):
         object_roles = ObjectRole.objects.iterator()
 
     for object_role in object_roles:
-        role_to_delete, role_to_add = object_role.needed_cache_updates(types_prefetch=types_prefetch)
+        role_to_delete, role_to_add = object_role.needed_cache_updates(types_prefetch=types_prefetch, object_pk=object_pk, object_ct_id=object_ct_id)
 
         if role_to_delete:
             logger.debug(f'Removing {len(role_to_delete)} object-permissions from {object_role}')

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -729,20 +729,14 @@ class ObjectRole(ObjectRoleFields):
             # to the single target object.
             partial_filter = {'object_id': object_pk, 'content_type_id': object_ct_id}
             source = self.permission_partials_uuid if isinstance(object_pk, UUID) else self.permission_partials
-            for eval_id, codename, content_type_id, object_id in source.filter(**partial_filter).values_list(
-                'id', 'codename', 'content_type_id', 'object_id'
-            ):
+            for eval_id, codename, content_type_id, object_id in source.filter(**partial_filter).values_list('id', 'codename', 'content_type_id', 'object_id'):
                 existing_partials[(codename, content_type_id, object_id)] = eval_id
             self._log_partials_count(len(existing_partials), f'existing evaluation (object_pk={object_pk})', self.pk)
         else:
             # Full recompute: load all cached entries from both tables.
-            for eval_id, codename, content_type_id, object_id in self.permission_partials.values_list(
-                'id', 'codename', 'content_type_id', 'object_id'
-            ):
+            for eval_id, codename, content_type_id, object_id in self.permission_partials.values_list('id', 'codename', 'content_type_id', 'object_id'):
                 existing_partials[(codename, content_type_id, object_id)] = eval_id
-            for eval_id, codename, content_type_id, object_id in self.permission_partials_uuid.values_list(
-                'id', 'codename', 'content_type_id', 'object_id'
-            ):
+            for eval_id, codename, content_type_id, object_id in self.permission_partials_uuid.values_list('id', 'codename', 'content_type_id', 'object_id'):
                 existing_partials[(codename, content_type_id, object_id)] = eval_id
             self._log_partials_count(len(existing_partials), 'existing evaluation (full)', self.pk)
 

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -623,13 +623,17 @@ class ObjectRole(ObjectRoleFields):
 
         return (eval_ct, child_model, filter_path)
 
-    def expected_direct_permissions(self, types_prefetch=None) -> set[tuple[str, int, Union[int, UUID]]]:
+    def expected_direct_permissions(self, types_prefetch=None, object_pk=None, object_ct_id=None) -> set[tuple[str, int, Union[int, UUID]]]:
         """The expected permissions that holding this ObjectRole confers to the holder
 
         This is given in the form of tuples, which represent RoleEvaluation entries.
         Values are (permission codename, content type id, object primary key)
 
         In the case of remote objects, this list may not be comprehensive
+
+        When object_pk and object_ct_id identify a look-ahead object, child
+        content types that don't match are skipped entirely and matching id
+        lists are narrowed to the single pk, avoiding large querysets.
         """
         expected_evaluations = set()
         cached_id_lists = {}
@@ -643,20 +647,29 @@ class ObjectRole(ObjectRoleFields):
         else:
             # ObjectRole.object_id is stored as text, we convert it to the model pk native type
             object_id = role_model._meta.pk.to_python(self.object_id)
+        # When filtering to a look-ahead object, skip evaluations for the role's
+        # own content type (e.g. organization) if it doesn't match the target.
+        skip_role_ct = object_ct_id is not None and self.content_type_id != object_ct_id
+
         for permission in types_prefetch.permissions_for_object_role(self):
 
             # direct object permission
             if permission.content_type_id == self.content_type_id:
-                expected_evaluations.add((permission.codename, self.content_type_id, object_id))
+                if not skip_role_ct:
+                    expected_evaluations.add((permission.codename, self.content_type_id, object_id))
                 continue
 
             # Add evaluation for the parent object, usually only for add permission
-            if is_add_perm(permission.codename) or settings.ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS:
+            if not skip_role_ct and (is_add_perm(permission.codename) or settings.ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS):
                 expected_evaluations.add((permission.codename, self.content_type_id, object_id))
 
             # Add evaluations for child objects, where this role gives permission to child objects
             eval_ct, child_model, filter_path = self.get_child_filters(permission, role_content_type, types_prefetch)
             if not eval_ct:
+                continue
+
+            # Skip child types that don't match the look-ahead object
+            if object_ct_id is not None and eval_ct != object_ct_id:
                 continue
 
             # fetching child objects of an organization is very performance sensitive
@@ -679,21 +692,75 @@ class ObjectRole(ObjectRoleFields):
                 cached_id_lists[eval_ct] = list(id_list)
 
             for id in id_list:
+                if object_pk is not None and id != object_pk:
+                    continue
                 expected_evaluations.add((permission.codename, eval_ct, id))
         return expected_evaluations
 
-    def needed_cache_updates(self, types_prefetch=None):
-        existing_partials = {}
-        for eval_id, codename, content_type_id, object_id in self.permission_partials.values_list('id', 'codename', 'content_type_id', 'object_id'):
-            existing_partials[(codename, content_type_id, object_id)] = eval_id
-        for eval_id, codename, content_type_id, object_id in self.permission_partials_uuid.values_list('id', 'codename', 'content_type_id', 'object_id'):
-            existing_partials[(codename, content_type_id, object_id)] = eval_id
+    _PARTIALS_LOG_MSG = '%s: %d cached evaluation entries for object-role pk=%s'
 
-        expected_evaluations = self.expected_direct_permissions(types_prefetch)
+    @staticmethod
+    def _log_partials_count(count, label, role_pk):
+        msg = ObjectRole._PARTIALS_LOG_MSG
+        if count >= 500_000:
+            logger.warning(msg + ', expected during global recalculations', label, count, role_pk)
+        elif count >= 50_000:
+            logger.info(msg, label, count, role_pk)
+        else:
+            logger.debug(msg, label, count, role_pk)
+
+    def needed_cache_updates(self, types_prefetch=None, object_pk=None, object_ct_id=None):
+        """Return (to_delete, to_add) changes needed in the RoleEvaluation table
+        to make cached object-role permissions accurate for this role.
+
+        When object_pk and object_ct_id are provided, the scope is narrowed to
+        a single look-ahead object. In the RBAC inheritance system, signals
+        can start from a resource and crawl up the inheritance tree to
+        find ancestor roles (e.g. organization roles that grant permissions to
+        child inventories). The look-ahead object is that originating resource,
+        and filtering to it avoids loading the full set of cached evaluations
+        for roles that may span thousands of child objects.
+
+        Without object_pk/object_ct_id, a full recompute is performed for all
+        objects this role grants permissions to.
+        """
+        existing_partials = {}
+
+        # When object_pk and object_ct_id are given, we can filter the
+        # permission_partials queries to only the relevant object, avoiding
+        # loading tens of thousands of unrelated cached entries.
+        # Only query the table whose pk type matches object_pk — an int pk
+        # cannot exist in the UUID table and vice versa.
+        partial_filter = {}
+        query_int = True
+        query_uuid = True
+        if object_pk is not None and object_ct_id is not None:
+            partial_filter = {'object_id': object_pk, 'content_type_id': object_ct_id}
+            query_int = isinstance(object_pk, int)
+            query_uuid = isinstance(object_pk, UUID)
+
+        if query_int:
+            for eval_id, codename, content_type_id, object_id in self.permission_partials.filter(**partial_filter).values_list(
+                'id', 'codename', 'content_type_id', 'object_id'
+            ):
+                existing_partials[(codename, content_type_id, object_id)] = eval_id
+        self._log_partials_count(len(existing_partials), 'int evaluation', self.pk)
+
+        uuid_start = len(existing_partials)
+        if query_uuid:
+            for eval_id, codename, content_type_id, object_id in self.permission_partials_uuid.filter(**partial_filter).values_list(
+                'id', 'codename', 'content_type_id', 'object_id'
+            ):
+                existing_partials[(codename, content_type_id, object_id)] = eval_id
+        self._log_partials_count(len(existing_partials) - uuid_start, 'uuid evaluation', self.pk)
+
+        expected_evaluations = self.expected_direct_permissions(types_prefetch, object_pk=object_pk, object_ct_id=object_ct_id)
 
         for team in self.provides_teams.all():
             for team_role in team.has_roles.all():
-                expected_evaluations.update(team_role.expected_direct_permissions(types_prefetch))
+                expected_evaluations.update(team_role.expected_direct_permissions(types_prefetch, object_pk=object_pk, object_ct_id=object_ct_id))
+
+        self._log_partials_count(len(expected_evaluations), 'expected evaluation', self.pk)
 
         existing_set = set(existing_partials.keys())
 

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -697,11 +697,9 @@ class ObjectRole(ObjectRoleFields):
                 expected_evaluations.add((permission.codename, eval_ct, id))
         return expected_evaluations
 
-    _PARTIALS_LOG_MSG = '%s: %d cached evaluation entries for object-role pk=%s'
-
     @staticmethod
     def _log_partials_count(count, label, role_pk):
-        msg = ObjectRole._PARTIALS_LOG_MSG
+        msg = '%s: %d cached evaluation entries for object-role pk=%s'
         if count >= 500_000:
             logger.warning(msg + ', expected during global recalculations', label, count, role_pk)
         elif count >= 50_000:
@@ -726,33 +724,27 @@ class ObjectRole(ObjectRoleFields):
         """
         existing_partials = {}
 
-        # When object_pk and object_ct_id are given, we can filter the
-        # permission_partials queries to only the relevant object, avoiding
-        # loading tens of thousands of unrelated cached entries.
-        # Only query the table whose pk type matches object_pk — an int pk
-        # cannot exist in the UUID table and vice versa.
-        partial_filter = {}
-        query_int = True
-        query_uuid = True
         if object_pk is not None and object_ct_id is not None:
+            # Look-ahead: query only the table matching the pk type, filtered
+            # to the single target object.
             partial_filter = {'object_id': object_pk, 'content_type_id': object_ct_id}
-            query_int = isinstance(object_pk, int)
-            query_uuid = isinstance(object_pk, UUID)
-
-        if query_int:
-            for eval_id, codename, content_type_id, object_id in self.permission_partials.filter(**partial_filter).values_list(
+            source = self.permission_partials_uuid if isinstance(object_pk, UUID) else self.permission_partials
+            for eval_id, codename, content_type_id, object_id in source.filter(**partial_filter).values_list(
                 'id', 'codename', 'content_type_id', 'object_id'
             ):
                 existing_partials[(codename, content_type_id, object_id)] = eval_id
-        self._log_partials_count(len(existing_partials), 'int evaluation', self.pk)
-
-        uuid_start = len(existing_partials)
-        if query_uuid:
-            for eval_id, codename, content_type_id, object_id in self.permission_partials_uuid.filter(**partial_filter).values_list(
+            self._log_partials_count(len(existing_partials), f'existing evaluation (object_pk={object_pk})', self.pk)
+        else:
+            # Full recompute: load all cached entries from both tables.
+            for eval_id, codename, content_type_id, object_id in self.permission_partials.values_list(
                 'id', 'codename', 'content_type_id', 'object_id'
             ):
                 existing_partials[(codename, content_type_id, object_id)] = eval_id
-        self._log_partials_count(len(existing_partials) - uuid_start, 'uuid evaluation', self.pk)
+            for eval_id, codename, content_type_id, object_id in self.permission_partials_uuid.values_list(
+                'id', 'codename', 'content_type_id', 'object_id'
+            ):
+                existing_partials[(codename, content_type_id, object_id)] = eval_id
+            self._log_partials_count(len(existing_partials), 'existing evaluation (full)', self.pk)
 
         expected_evaluations = self.expected_direct_permissions(types_prefetch, object_pk=object_pk, object_ct_id=object_ct_id)
 

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -635,6 +635,8 @@ class ObjectRole(ObjectRoleFields):
         content types that don't match are skipped entirely and matching id
         lists are narrowed to the single pk, avoiding large querysets.
         """
+        if (object_pk is None) != (object_ct_id is None):
+            raise ValueError('object_pk and object_ct_id must both be provided or both be None')
         expected_evaluations = set()
         cached_id_lists = {}
         if not types_prefetch:
@@ -722,6 +724,8 @@ class ObjectRole(ObjectRoleFields):
         Without object_pk/object_ct_id, a full recompute is performed for all
         objects this role grants permissions to.
         """
+        if (object_pk is None) != (object_ct_id is None):
+            raise ValueError('object_pk and object_ct_id must both be provided or both be None')
         existing_partials = {}
 
         if object_pk is not None and object_ct_id is not None:

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -195,7 +195,7 @@ def get_parent_ids(instance) -> list[tuple[Model, Union[int, UUID]]]:
     return []
 
 
-def post_save_update_obj_permissions(instance):
+def post_save_update_obj_permissions(instance, object_pk=None, object_ct_id=None):
     "Utility method shared by multiple signals"
     # Account for organization roles (and other parent objects), new and old
     parent_gfks = get_parent_ids(instance)
@@ -227,7 +227,7 @@ def post_save_update_obj_permissions(instance):
         compute_team_member_roles(team_ids=[instance.id])
 
     if to_update:
-        compute_object_role_permissions(object_roles=to_update)
+        compute_object_role_permissions(object_roles=to_update, object_pk=object_pk, object_ct_id=object_ct_id)
 
 
 def rbac_pre_save_identify_changes(instance, *args, **kwargs):
@@ -259,7 +259,8 @@ def rbac_post_save_update_evaluations(instance, created, *args, **kwargs):
     # If child object is created and parent object has existing ObjectRoles
     # evaluations for the parent object roles need to be added
     if created:
-        post_save_update_obj_permissions(instance)
+        obj_ct_id = permission_registry.content_type_model.objects.get_for_model(instance).id
+        post_save_update_obj_permissions(instance, object_pk=instance.pk, object_ct_id=obj_ct_id)
         return
 
     # The parent object can not have changed if update_fields was given and did not list that field

--- a/test_app/tests/rbac/test_evaluation_filtering.py
+++ b/test_app/tests/rbac/test_evaluation_filtering.py
@@ -70,8 +70,9 @@ def test_filtered_evaluation_count_is_small(rando, organization, org_inv_rd):
     with patch.object(ObjectRole, '_log_partials_count', side_effect=lambda count, label, *a: logged.update({label: count})):
         org_role.needed_cache_updates(object_pk=new_inv.pk, object_ct_id=_inv_ct_id())
 
-    # The int evaluation count should be 0 since we deleted them
-    assert logged['int evaluation'] == 0
+    # The existing evaluation count should be 0 since we deleted them
+    existing_label = f'existing evaluation (object_pk={new_inv.pk})'
+    assert logged[existing_label] == 0
     # Expected evaluations should be scoped to just the one inventory's permissions
     # org_inv_rd grants change_inventory + view_inventory, so we expect a small number
     assert logged['expected evaluation'] < total_evals
@@ -130,6 +131,7 @@ def test_filtered_evaluations_fewer_than_unfiltered(rando, organization, org_inv
     with patch.object(ObjectRole, '_log_partials_count', side_effect=lambda count, label, *a: filtered.update({label: count})):
         org_role.needed_cache_updates(object_pk=target_inv.pk, object_ct_id=inv_ct_id)
 
-    # Filtered should load far fewer evaluation entries across all categories
-    assert filtered['int evaluation'] < unfiltered['int evaluation']
+    # Filtered should load far fewer existing evaluation entries
+    existing_filtered_label = f'existing evaluation (object_pk={target_inv.pk})'
+    assert filtered[existing_filtered_label] < unfiltered['existing evaluation (full)']
     assert filtered['expected evaluation'] < unfiltered['expected evaluation']

--- a/test_app/tests/rbac/test_evaluation_filtering.py
+++ b/test_app/tests/rbac/test_evaluation_filtering.py
@@ -135,3 +135,27 @@ def test_filtered_evaluations_fewer_than_unfiltered(rando, organization, org_inv
     existing_filtered_label = f'existing evaluation (object_pk={target_inv.pk})'
     assert filtered[existing_filtered_label] < unfiltered['existing evaluation (full)']
     assert filtered['expected evaluation'] < unfiltered['expected evaluation']
+
+
+@pytest.mark.django_db
+def test_needed_cache_updates_requires_both_pk_and_ct(rando, organization, org_inv_rd):
+    """Passing object_pk without object_ct_id (or vice versa) must raise ValueError."""
+    org_inv_rd.give_permission(rando, organization)
+    org_role = ObjectRole.objects.get(role_definition=org_inv_rd, object_id=organization.pk)
+
+    with pytest.raises(ValueError):
+        org_role.needed_cache_updates(object_pk=1)
+    with pytest.raises(ValueError):
+        org_role.needed_cache_updates(object_ct_id=1)
+
+
+@pytest.mark.django_db
+def test_expected_direct_permissions_requires_both_pk_and_ct(rando, organization, org_inv_rd):
+    """Passing object_pk without object_ct_id (or vice versa) must raise ValueError."""
+    org_inv_rd.give_permission(rando, organization)
+    org_role = ObjectRole.objects.get(role_definition=org_inv_rd, object_id=organization.pk)
+
+    with pytest.raises(ValueError):
+        org_role.expected_direct_permissions(object_pk=1)
+    with pytest.raises(ValueError):
+        org_role.expected_direct_permissions(object_ct_id=1)

--- a/test_app/tests/rbac/test_evaluation_filtering.py
+++ b/test_app/tests/rbac/test_evaluation_filtering.py
@@ -1,0 +1,135 @@
+# claude-opus-4-6
+"""Tests for the object_pk/object_ct_id filtering optimization in needed_cache_updates."""
+
+from unittest.mock import patch
+
+import pytest
+
+from ansible_base.rbac.models import ObjectRole, RoleEvaluation
+from ansible_base.rbac.permission_registry import permission_registry
+from test_app.models import Inventory
+
+
+def _inv_ct_id():
+    return permission_registry.content_type_model.objects.get_for_model(Inventory).id
+
+
+@pytest.mark.django_db
+def test_needed_cache_updates_filtered_returns_only_target_object(rando, organization, org_inv_rd):
+    """When object_pk and object_ct_id are given, needed_cache_updates
+    should only return evaluation entries for that specific object."""
+    Inventory.objects.create(name='inv1', organization=organization)
+    Inventory.objects.create(name='inv2', organization=organization)
+
+    org_inv_rd.give_permission(rando, organization)
+    org_role = ObjectRole.objects.get(
+        role_definition=org_inv_rd,
+        object_id=organization.pk,
+    )
+
+    # Full recompute should find nothing to change (already up to date)
+    to_delete, to_add = org_role.needed_cache_updates()
+    assert len(to_add) == 0
+    assert len(to_delete) == 0
+
+    # Create a new inventory - the signal handles it, but let's test the method directly
+    inv3 = Inventory.objects.create(name='inv3', organization=organization)
+
+    # Delete the evaluations for inv3 so needed_cache_updates has something to find
+    RoleEvaluation.objects.filter(role=org_role, object_id=inv3.pk).delete()
+
+    # Filtered call should only report adds for inv3
+    to_delete, to_add = org_role.needed_cache_updates(object_pk=inv3.pk, object_ct_id=_inv_ct_id())
+    assert len(to_delete) == 0
+    assert len(to_add) > 0
+    assert all(entry.object_id == inv3.pk for entry in to_add)
+
+
+@pytest.mark.django_db
+def test_filtered_evaluation_count_is_small(rando, organization, org_inv_rd):
+    """With many inventories, filtered needed_cache_updates should log a small
+    evaluation count, not the total for the whole org role."""
+    for i in range(200):
+        Inventory.objects.create(name=f'inv-{i}', organization=organization)
+
+    org_inv_rd.give_permission(rando, organization)
+    org_role = ObjectRole.objects.get(
+        role_definition=org_inv_rd,
+        object_id=organization.pk,
+    )
+
+    # Total evaluations for this role should be large (200 inventories * permissions + org perms)
+    total_evals = org_role.permission_partials.count()
+    assert total_evals > 200
+
+    # Create one more inventory and delete its evals to simulate needing an update
+    new_inv = Inventory.objects.create(name='inv-new', organization=organization)
+    RoleEvaluation.objects.filter(role=org_role, object_id=new_inv.pk).delete()
+
+    logged = {}
+    with patch.object(ObjectRole, '_log_partials_count', side_effect=lambda count, label, *a: logged.update({label: count})):
+        org_role.needed_cache_updates(object_pk=new_inv.pk, object_ct_id=_inv_ct_id())
+
+    # The int evaluation count should be 0 since we deleted them
+    assert logged['int evaluation'] == 0
+    # Expected evaluations should be scoped to just the one inventory's permissions
+    # org_inv_rd grants change_inventory + view_inventory, so we expect a small number
+    assert logged['expected evaluation'] < total_evals
+    assert logged['expected evaluation'] <= 10
+
+
+@pytest.mark.django_db
+def test_unfiltered_still_works(rando, organization, org_inv_rd):
+    """Calling needed_cache_updates without filtering should still work correctly."""
+    Inventory.objects.create(name='inv1', organization=organization)
+
+    org_inv_rd.give_permission(rando, organization)
+    org_role = ObjectRole.objects.get(
+        role_definition=org_inv_rd,
+        object_id=organization.pk,
+    )
+
+    to_delete, to_add = org_role.needed_cache_updates()
+    assert len(to_add) == 0
+    assert len(to_delete) == 0
+
+
+@pytest.mark.django_db
+def test_signal_passes_filter_on_create(rando, organization, org_inv_rd):
+    """Creating an inventory should trigger the optimized path and produce correct permissions."""
+    org_inv_rd.give_permission(rando, organization)
+
+    inv = Inventory.objects.create(name='signal-test-inv', organization=organization)
+
+    # Verify the signal-driven update created the right evaluations
+    assert rando.has_obj_perm(inv, 'change_inventory')
+    assert rando.has_obj_perm(inv, 'view_inventory')
+
+
+@pytest.mark.django_db
+def test_filtered_evaluations_fewer_than_unfiltered(rando, organization, org_inv_rd):
+    """Filtered needed_cache_updates should load fewer evaluation entries
+    than unfiltered when there are many inventories."""
+    for i in range(50):
+        Inventory.objects.create(name=f'inv-{i}', organization=organization)
+
+    org_inv_rd.give_permission(rando, organization)
+    org_role = ObjectRole.objects.get(
+        role_definition=org_inv_rd,
+        object_id=organization.pk,
+    )
+
+    inv_ct_id = _inv_ct_id()
+    target_inv = Inventory.objects.first()
+
+    unfiltered = {}
+    with patch.object(ObjectRole, '_log_partials_count', side_effect=lambda count, label, *a: unfiltered.update({label: count})):
+        org_role.needed_cache_updates()
+
+    filtered = {}
+    with patch.object(ObjectRole, '_log_partials_count', side_effect=lambda count, label, *a: filtered.update({label: count})):
+        org_role.needed_cache_updates(object_pk=target_inv.pk, object_ct_id=inv_ct_id)
+
+    # Filtered should load far fewer evaluation entries across all categories
+    assert filtered['int evaluation'] < unfiltered['int evaluation']
+    assert filtered['expected evaluation'] < unfiltered['expected evaluation']


### PR DESCRIPTION
## Description
Implementing my suggestions in:

https://github.com/ansible/django-ansible-base/pull/968

This differs from the other approach in that it is not creation-specific (although most edits won't trigger any of this), and filters based on the content type.

This also adds a log for the key performance issue we encountered, which is the quantity of evaluations we have to fetch for a given object role (and most often, organization admin). This is reduced by the look-forward optimization where the object id and type is passed in kwargs through the call chain.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RBAC cache recomputation and signal paths; while behavior should be equivalent, mistakes could leave `RoleEvaluation` entries stale or incomplete for inherited permissions.
> 
> **Overview**
> **RBAC evaluation recomputes can now be scoped to a single “look-ahead” object.** The recomputation pipeline (`post_save_update_obj_permissions` → `compute_object_role_permissions` → `ObjectRole.needed_cache_updates`/`expected_direct_permissions`) accepts `object_pk`/`object_ct_id` and uses them to filter existing cached partials and to skip/narrow expected child evaluations.
> 
> This adds observability for the performance hotspot by logging counts of loaded cached evaluations (int/UUID) and expected evaluations, and updates create-time signals to pass the new object identifiers so new child objects trigger the optimized path. New tests validate that filtered recomputes only produce changes for the target object, load fewer cached rows than unfiltered runs, and that the signal-driven create path still yields correct permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63daecd519b1ef94675ee04ddca4626a8319fc56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Scoped per-object permission recomputation so updates only load and evaluate data for the targeted object, reducing work and DB load.

* **Monitoring & Observability**
  * Added counts/logging of partial permission evaluations to surface scope and size of recomputations.

* **Tests**
  * Added tests validating filtered recomputation, reduced load on large datasets, and signal-driven optimized updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->