### PR TITLE
AAP-70750 Apply optimization of skipping RoleEvaluation object materialization

### DIFF
--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -684,10 +684,10 @@ class ObjectRole(ObjectRoleFields):
 
     def needed_cache_updates(self, types_prefetch=None):
         existing_partials = {}
-        for permission_partial in self.permission_partials.all():
-            existing_partials[permission_partial.obj_perm_id()] = permission_partial
-        for permission_partial in self.permission_partials_uuid.all():
-            existing_partials[permission_partial.obj_perm_id()] = permission_partial
+        for eval_id, codename, content_type_id, object_id in self.permission_partials.values_list('id', 'codename', 'content_type_id', 'object_id'):
+            existing_partials[(codename, content_type_id, object_id)] = eval_id
+        for eval_id, codename, content_type_id, object_id in self.permission_partials_uuid.values_list('id', 'codename', 'content_type_id', 'object_id'):
+            existing_partials[(codename, content_type_id, object_id)] = eval_id
 
         expected_evaluations = self.expected_direct_permissions(types_prefetch)
 
@@ -698,8 +698,8 @@ class ObjectRole(ObjectRoleFields):
         existing_set = set(existing_partials.keys())
 
         to_delete = set()
-        for identifier in existing_set - expected_evaluations:
-            to_delete.add((existing_partials[identifier].id, type(identifier[-1])))
+        for codename, content_type_id, object_id in existing_set - expected_evaluations:
+            to_delete.add((existing_partials[(codename, content_type_id, object_id)], type(object_id)))
 
         to_add = []
         for codename, ct_id, obj_pk in expected_evaluations - existing_set:

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -755,10 +755,6 @@ class RoleEvaluationFields(models.Model):
     # this can be relaxed as we have comparative performance testing to confirm doing so does not affect permissions
     content_type_id = models.PositiveIntegerField(null=False, help_text=_("The related content type id."))
 
-    def obj_perm_id(self):
-        "Used for in-memory hashing of the type of object permission this represents"
-        return (self.codename, self.content_type_id, self.object_id)
-
     @classmethod
     def accessible_ids(cls, model_cls, actor, codename: str, content_types: Optional[Iterable[int]] = None, cast_field=None) -> QuerySet:
         """


### PR DESCRIPTION
## Description
Referencing https://github.com/ansible/awx/pull/16386 for the concrete data. A snippet showing the main issue here:

```
1) .all() full model instances:      0.5784s  (60135 rows)
2) .iterator() full model instances:  0.4700s  (60135 rows)
3) values_list (3 fields, as set):    0.0353s  (60135 rows)
4) values_list (4 fields, as dict):   0.0472s  (60135 rows)
5) .values() dict rows:               0.0745s  (60135 rows)
6) Raw SQL cursor:                    0.0434s  (60135 rows)
```

So, specifically in the loop `for permission_partial in self.permission_partials.all()` we had 60k records being returned and there was a 12x multiplier for materializing the actual Django objects.

This performance-sensitive part of the code has no actual need or semantic value in materializing the objects. So this 12x factor is essentially completely free. We abandon the objects very quickly after hitting this loop.

It also seems that this is the **primary** factor driving the performance complaint. Using this patch would also be the safest for backport. This is as opposed to the structural refactor in:

https://github.com/ansible/django-ansible-base/pull/970

Now, for a high-level comparison of results:
 - all optimizations in-place, `peter_alan_opt`: Created inventory perf-inventory-10016 in 0.0864s
 - branch `AAP-69544` from https://github.com/ansible/django-ansible-base/pull/968: Created inventory perf-inventory-10017 in 0.0954s
 - just values_list optimization, `evals_values_list`: Created inventory perf-inventory-10018 in 0.1759s
 - `devel`: Created inventory perf-inventory-10019 in 0.7687s

This is for adding 1 more inventory while 10k are already in the system in the same organization and there is 1 organization admin.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the logic that computes RoleEvaluation cache adds/deletes, which is performance-sensitive and affects permission correctness if tuple keys or type handling diverge. Functional intent is unchanged but mistakes could lead to stale or missing cached permissions.
> 
> **Overview**
> Optimizes `ObjectRole.needed_cache_updates()` by switching from iterating `RoleEvaluation` model instances to using `values_list()` tuples, avoiding expensive Django object materialization when reconciling large permission caches.
> 
> Removes the now-unneeded `RoleEvaluationFields.obj_perm_id()` helper and adjusts deletion bookkeeping to store evaluation IDs directly while preserving object-id type handling for integer vs UUID evaluations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 262014995b5a7974a711714d7e0a553b40558ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance and reliability of role cache update operations, reducing overhead and speeding up permission reconciliation. This lowers transient inconsistencies and system load during bulk role/permission updates, resulting in smoother permission changes with no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->