### PR TITLE
AAP-65871: Fix openapi spec for oauth2 algorithms

### DIFF
--- a/ansible_base/oauth2_provider/serializers/application.py
+++ b/ansible_base/oauth2_provider/serializers/application.py
@@ -24,6 +24,7 @@ class OAuth2ApplicationSerializer(NamedCommonModelSerializer):
             'redirect_uris': {'label': _('Redirect URIs')},
             'app_url': {'label': _('Application URL')},
             'skip_authorization': {'label': _('Skip Authorization')},
+            'algorithm': {'allow_blank': False},
         }
 
     def _get_client_secret(self, obj):

--- a/ansible_base/oauth2_provider/serializers/application.py
+++ b/ansible_base/oauth2_provider/serializers/application.py
@@ -24,7 +24,7 @@ class OAuth2ApplicationSerializer(NamedCommonModelSerializer):
             'redirect_uris': {'label': _('Redirect URIs')},
             'app_url': {'label': _('Application URL')},
             'skip_authorization': {'label': _('Skip Authorization')},
-            'algorithm': {'allow_blank': False},
+            'algorithm': {'allow_blank': False, 'label': _('Algorithm')},
         }
 
     def _get_client_secret(self, obj):


### PR DESCRIPTION
Removes double blank value for algorithm
  - blank already defined in ALGORITHM_TYPES

## Description

Just a small update to fix up OAuth2Application openapi schema (double blank value in enum list).  Should have no other effect.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Generate gateway openapi spec.
2. See that oauth2application algorithm enum list does not contain double blank values
3. 

### Expected Results
openapi spec is correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The algorithm field for OAuth2 applications is now required and cannot be left blank, ensuring proper configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->