### PR TITLE
AAP-65871 fix resource_data for openapi spec

### DIFF
--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -30,7 +30,7 @@ class ResourceListSerializer(serializers.ModelSerializer):
     has_serializer = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     resource_type = serializers.CharField(required=False)
-    resource_data = ResourceDataField(source="*", write_only=True)
+    resource_data = ResourceDataField(source="*", write_only=True, required=False, default={})
 
     class Meta:
         model = Resource
@@ -85,7 +85,7 @@ class ResourceListSerializer(serializers.ModelSerializer):
 
             return Resource.create_resource(
                 resource_type,
-                validated_data["resource_data"],
+                validated_data.get("resource_data", {}),
                 ansible_id=validated_data.get("ansible_id"),
                 service_id=validated_data.get("service_id"),
                 is_partially_migrated=validated_data.get("is_partially_migrated", False),


### PR DESCRIPTION
## Description

Yet another small fix for openapi spec.  Fixes the ATF client and a failing test in platform-services-test-suite.

Root cause: The generated gateway client's ResourceList.from_dict() does d.pop("resource_data") without a default value. The resource_data field is marked writeOnly: true in the OpenAPI spec, meaning it's not included in list API responses — so d.pop("resource_data") raises KeyError.

In DAB, resource_data is write_only=True — DRF won't include it in responses. But drf-spectacular still marks it as required because it's in fields without a default. The fix is to add required=False to the field, since it's only needed for write operations (create/update handle it being absent via .get()).


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites

### Steps to Test
1. Already verified to fix ATF, inconsequential to DAB
2. 
3. 

### Expected Results
Openapi spec more accurate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource data field is now optional in API requests, preventing errors when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->