### PR TITLE
[AAP-71514] Address deletion with partially completed requests in resource_sync 

### DIFF
--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -182,39 +182,64 @@ class RemoteAssignmentResult:
     is_complete: bool = False
 
 
-def _paginate_assignments(list_fn, actor_id_key: str, assignment_type: str, assignments: set[AssignmentTuple]) -> bool:
-    """Paginate a single assignment type endpoint, adding results to *assignments*.
+class RemoteAssignmentFetcher:
+    """Fetches role assignments from a remote resource server with pagination.
 
-    Returns True if all pages were fetched successfully, False on any error.
+    Collects user and team assignments into a single set.  If any page
+    request fails the fetcher stops early and marks the result as
+    incomplete so the caller can skip deletions safely.
     """
-    page = 1
-    try:
-        while True:
-            resp = list_fn(filters={'page': page})
-            if resp.status_code != 200:
-                logger.warning(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {resp.status_code}")
-                return False
 
-            data = resp.json()
-            for assignment in data.get('results', []):
-                ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
-                assignments.add(
-                    AssignmentTuple(
-                        actor_ansible_id=assignment[actor_id_key],
-                        ansible_id_or_pk=ansible_id_or_pk,
-                        role_definition_name=assignment['role_definition'],
-                        assignment_type=assignment_type,
+    def __init__(self, api_client: ResourceAPIClient):
+        self.api_client = api_client
+        self.assignments: set[AssignmentTuple] = set()
+
+    def fetch(self) -> RemoteAssignmentResult:
+        """Paginate user then team assignments and return the result.
+
+        If user pagination fails, team pagination is skipped entirely
+        because the result will be incomplete regardless.
+        """
+        users_ok = self._paginate(self.api_client.list_user_assignments, 'user_ansible_id', 'user')
+        if not users_ok:
+            return RemoteAssignmentResult(assignments=self.assignments, is_complete=False)
+
+        teams_ok = self._paginate(self.api_client.list_team_assignments, 'team_ansible_id', 'team')
+        return RemoteAssignmentResult(assignments=self.assignments, is_complete=teams_ok)
+
+    def _paginate(self, list_fn, actor_id_key: str, assignment_type: str) -> bool:
+        """Paginate a single assignment endpoint, adding results to ``self.assignments``.
+
+        Returns True if all pages were fetched successfully, False on any error.
+        """
+        page = 1
+        try:
+            while True:
+                resp = list_fn(filters={'page': page})
+                if resp.status_code != 200:
+                    logger.warning(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {resp.status_code}")
+                    return False
+
+                data = resp.json()
+                for assignment in data.get('results', []):
+                    ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
+                    self.assignments.add(
+                        AssignmentTuple(
+                            actor_ansible_id=assignment[actor_id_key],
+                            ansible_id_or_pk=ansible_id_or_pk,
+                            role_definition_name=assignment['role_definition'],
+                            assignment_type=assignment_type,
+                        )
                     )
-                )
 
-            if not data.get('next'):
-                return True
+                if not data.get('next'):
+                    return True
 
-            page += 1
-            logger.debug(f"Fetching next page {page} of {assignment_type} assignments")
-    except Exception as e:
-        logger.exception(f"Failed to fetch remote {assignment_type} assignments: {e}")
-        return False
+                page += 1
+                logger.debug(f"Fetching next page {page} of {assignment_type} assignments")
+        except Exception as e:
+            logger.exception(f"Failed to fetch remote {assignment_type} assignments: {e}")
+            return False
 
 
 def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentResult:
@@ -224,12 +249,7 @@ def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentRes
     complete fetch from a partial one (e.g. due to HTTP errors or
     timeouts mid-pagination).
     """
-    assignments: set[AssignmentTuple] = set()
-
-    users_ok = _paginate_assignments(api_client.list_user_assignments, 'user_ansible_id', 'user', assignments)
-    teams_ok = _paginate_assignments(api_client.list_team_assignments, 'team_ansible_id', 'team', assignments)
-
-    return RemoteAssignmentResult(assignments=assignments, is_complete=users_ok and teams_ok)
+    return RemoteAssignmentFetcher(api_client).fetch()
 
 
 def get_local_assignments() -> set[AssignmentTuple]:

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -237,8 +237,8 @@ class RemoteAssignmentFetcher:
 
                 page += 1
                 logger.debug(f"Fetching next page {page} of {assignment_type} assignments")
-        except Exception as e:
-            logger.exception(f"Failed to fetch remote {assignment_type} assignments: {e}")
+        except Exception:
+            logger.exception(f"Failed to fetch remote {assignment_type} assignments")
             return False
 
 

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -182,6 +182,41 @@ class RemoteAssignmentResult:
     is_complete: bool = False
 
 
+def _paginate_assignments(list_fn, actor_id_key: str, assignment_type: str, assignments: set[AssignmentTuple]) -> bool:
+    """Paginate a single assignment type endpoint, adding results to *assignments*.
+
+    Returns True if all pages were fetched successfully, False on any error.
+    """
+    page = 1
+    try:
+        while True:
+            resp = list_fn(filters={'page': page})
+            if resp.status_code != 200:
+                logger.warning(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {resp.status_code}")
+                return False
+
+            data = resp.json()
+            for assignment in data.get('results', []):
+                ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
+                assignments.add(
+                    AssignmentTuple(
+                        actor_ansible_id=assignment[actor_id_key],
+                        ansible_id_or_pk=ansible_id_or_pk,
+                        role_definition_name=assignment['role_definition'],
+                        assignment_type=assignment_type,
+                    )
+                )
+
+            if not data.get('next'):
+                return True
+
+            page += 1
+            logger.debug(f"Fetching next page {page} of {assignment_type} assignments")
+    except Exception as e:
+        logger.exception(f"Failed to fetch remote {assignment_type} assignments: {e}")
+        return False
+
+
 def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentResult:
     """Fetch remote assignments from the resource server and convert to tuples.
 
@@ -190,81 +225,11 @@ def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentRes
     timeouts mid-pagination).
     """
     assignments: set[AssignmentTuple] = set()
-    # Default to incomplete — only promote to True after both
-    # pagination loops finish without error.  This way any unexpected
-    # early return or unanticipated exception is treated as partial,
-    # preventing destructive deletions from an incomplete set.
-    is_complete = False
 
-    # Fetch user assignments with pagination
-    try:
-        page = 1
-        while True:
-            filters = {'page': page}
-            user_resp = api_client.list_user_assignments(filters=filters)
-            if user_resp.status_code == 200:
-                user_data = user_resp.json()
-                for assignment in user_data.get('results', []):
-                    # Handle both object_id and object_ansible_id
-                    ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
-                    assignments.add(
-                        AssignmentTuple(
-                            actor_ansible_id=assignment['user_ansible_id'],
-                            ansible_id_or_pk=ansible_id_or_pk,
-                            role_definition_name=assignment['role_definition'],
-                            assignment_type='user',
-                        )
-                    )
+    users_ok = _paginate_assignments(api_client.list_user_assignments, 'user_ansible_id', 'user', assignments)
+    teams_ok = _paginate_assignments(api_client.list_team_assignments, 'team_ansible_id', 'team', assignments)
 
-                # Check if there's a next page
-                if not user_data.get('next'):
-                    break
-
-                page += 1
-                logger.debug(f"Fetching next page {page} of user assignments")
-            else:
-                logger.warning(f"Failed to fetch user assignments page {page}: HTTP {user_resp.status_code}")
-                return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
-    except Exception as e:
-        logger.exception(f"Failed to fetch remote user assignments: {e}")
-        return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
-
-    # Fetch team assignments with pagination
-    try:
-        page = 1
-        while True:
-            filters = {'page': page}
-            team_resp = api_client.list_team_assignments(filters=filters)
-            if team_resp.status_code == 200:
-                team_data = team_resp.json()
-                for assignment in team_data.get('results', []):
-                    # Handle both object_id and object_ansible_id
-                    ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
-                    assignments.add(
-                        AssignmentTuple(
-                            actor_ansible_id=assignment['team_ansible_id'],
-                            ansible_id_or_pk=ansible_id_or_pk,
-                            role_definition_name=assignment['role_definition'],
-                            assignment_type='team',
-                        )
-                    )
-
-                # Check if there's a next page
-                if not team_data.get('next'):
-                    break
-
-                page += 1
-                logger.debug(f"Fetching next page {page} of team assignments")
-            else:
-                logger.warning(f"Failed to fetch team assignments page {page}: HTTP {team_resp.status_code}")
-                return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
-    except Exception as e:
-        logger.exception(f"Failed to fetch remote team assignments: {e}")
-        return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
-
-    # Both loops completed without error — the set is complete.
-    is_complete = True
-    return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
+    return RemoteAssignmentResult(assignments=assignments, is_complete=users_ok and teams_ok)
 
 
 def get_local_assignments() -> set[AssignmentTuple]:
@@ -743,6 +708,21 @@ class SyncExecutor:
             self.write()
             self._process_manifest_list(manifest_list)
 
+    def _apply_assignment_changes(self, assignment_set, action_fn, label):
+        """Apply *action_fn* to each assignment in *assignment_set* and return (success_count, error_count)."""
+        success_count = 0
+        error_count = 0
+        for assignment_tuple in assignment_set:
+            if action_fn(assignment_tuple):
+                success_count += 1
+                self.write(
+                    f"{label} assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
+                    f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                )
+            else:
+                error_count += 1
+        return success_count, error_count
+
     def _sync_assignments(self):
         """Synchronize role assignments between local and remote systems."""
         if not self.sync_assignments:
@@ -755,53 +735,27 @@ class SyncExecutor:
         self.write(">>> Syncing role assignments")
 
         try:
-            # Get remote and local assignments
             remote_result = get_remote_assignments(self.api_client)
             local_assignments = get_local_assignments()
 
-            # Calculate differences
-            to_create = remote_result.assignments - local_assignments
-
-            deleted_count = 0
-            created_count = 0
-            error_count = 0
-
-            # Delete local assignments that don't exist remotely —
-            # but ONLY when the remote fetch was complete.  A partial
-            # fetch (HTTP error / timeout mid-pagination) would make
-            # ``to_delete`` contain assignments that simply weren't
-            # fetched, leading to destructive removal of valid data.
+            # Deletions are only safe when the remote fetch was complete.
+            # A partial fetch would cause us to delete assignments that
+            # simply weren't fetched.
             if remote_result.is_complete:
                 to_delete = local_assignments - remote_result.assignments
-                for assignment_tuple in to_delete:
-                    if delete_local_assignment(assignment_tuple):
-                        deleted_count += 1
-                        self.write(
-                            f"DELETED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                            f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
-                        )
-                    else:
-                        error_count += 1
+                deleted_count, delete_errors = self._apply_assignment_changes(to_delete, delete_local_assignment, "DELETED")
             else:
                 self.write("Skipping assignment deletions — remote fetch was incomplete. Will retry on next sync cycle.")
                 logger.warning("Skipping assignment deletions: remote fetch was incomplete. Deletions deferred to next complete sync.")
+                deleted_count, delete_errors = 0, 0
 
-            # Create local assignments that exist remotely but not locally.
-            # Safe even on a partial fetch — at worst we create assignments
-            # that already exist (no-op) or create a subset of what's needed.
-            for assignment_tuple in to_create:
-                if create_local_assignment(assignment_tuple):
-                    created_count += 1
-                    self.write(
-                        f"CREATED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                        f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
-                    )
-                else:
-                    error_count += 1
+            # Creations are safe even on a partial fetch.
+            to_create = remote_result.assignments - local_assignments
+            created_count, create_errors = self._apply_assignment_changes(to_create, create_local_assignment, "CREATED")
 
+            error_count = delete_errors + create_errors
             self.write(f"Assignment sync completed: Created {created_count} | Deleted {deleted_count} | Errors {error_count}")
 
-            # Store results for reporting
             self.results["assignments_created"] = [created_count]
             self.results["assignments_deleted"] = [deleted_count]
             self.results["assignment_errors"] = [error_count]

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -226,7 +226,7 @@ def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentRes
                 logger.warning(f"Failed to fetch user assignments page {page}: HTTP {user_resp.status_code}")
                 return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
     except Exception as e:
-        logger.warning(f"Failed to fetch remote user assignments: {e}")
+        logger.exception(f"Failed to fetch remote user assignments: {e}")
         return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
 
     # Fetch team assignments with pagination
@@ -259,7 +259,7 @@ def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentRes
                 logger.warning(f"Failed to fetch team assignments page {page}: HTTP {team_resp.status_code}")
                 return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
     except Exception as e:
-        logger.warning(f"Failed to fetch remote team assignments: {e}")
+        logger.exception(f"Failed to fetch remote team assignments: {e}")
         return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
 
     # Both loops completed without error — the set is complete.

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -169,9 +169,32 @@ def get_content_object(role_definition, assignment_tuple: AssignmentTuple) -> An
     return content_object
 
 
-def get_remote_assignments(api_client: ResourceAPIClient) -> set[AssignmentTuple]:
-    """Fetch remote assignments from the resource server and convert to tuples."""
-    assignments = set()
+@dataclass
+class RemoteAssignmentResult:
+    """Result of fetching remote assignments, including completeness status.
+
+    When ``is_complete`` is False the caller must not use the partial
+    ``assignments`` set for deletion decisions — doing so would remove
+    local assignments that simply weren't fetched.
+    """
+
+    assignments: set[AssignmentTuple] = field(default_factory=set)
+    is_complete: bool = False
+
+
+def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentResult:
+    """Fetch remote assignments from the resource server and convert to tuples.
+
+    Returns a ``RemoteAssignmentResult`` so the caller can distinguish a
+    complete fetch from a partial one (e.g. due to HTTP errors or
+    timeouts mid-pagination).
+    """
+    assignments: set[AssignmentTuple] = set()
+    # Default to incomplete — only promote to True after both
+    # pagination loops finish without error.  This way any unexpected
+    # early return or unanticipated exception is treated as partial,
+    # preventing destructive deletions from an incomplete set.
+    is_complete = False
 
     # Fetch user assignments with pagination
     try:
@@ -201,9 +224,10 @@ def get_remote_assignments(api_client: ResourceAPIClient) -> set[AssignmentTuple
                 logger.debug(f"Fetching next page {page} of user assignments")
             else:
                 logger.warning(f"Failed to fetch user assignments page {page}: HTTP {user_resp.status_code}")
-                break
+                return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
     except Exception as e:
         logger.warning(f"Failed to fetch remote user assignments: {e}")
+        return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
 
     # Fetch team assignments with pagination
     try:
@@ -233,11 +257,14 @@ def get_remote_assignments(api_client: ResourceAPIClient) -> set[AssignmentTuple
                 logger.debug(f"Fetching next page {page} of team assignments")
             else:
                 logger.warning(f"Failed to fetch team assignments page {page}: HTTP {team_resp.status_code}")
-                break
+                return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
     except Exception as e:
         logger.warning(f"Failed to fetch remote team assignments: {e}")
+        return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
 
-    return assignments
+    # Both loops completed without error — the set is complete.
+    is_complete = True
+    return RemoteAssignmentResult(assignments=assignments, is_complete=is_complete)
 
 
 def get_local_assignments() -> set[AssignmentTuple]:
@@ -729,29 +756,48 @@ class SyncExecutor:
 
         try:
             # Get remote and local assignments
-            remote_assignments = get_remote_assignments(self.api_client)
+            remote_result = get_remote_assignments(self.api_client)
             local_assignments = get_local_assignments()
 
             # Calculate differences
-            to_delete = local_assignments - remote_assignments
-            to_create = remote_assignments - local_assignments
+            to_create = remote_result.assignments - local_assignments
 
             deleted_count = 0
             created_count = 0
             error_count = 0
 
-            # Delete local assignments that don't exist remotely
-            for assignment_tuple in to_delete:
-                if delete_local_assignment(assignment_tuple):
-                    deleted_count += 1
-                    self.write(
-                        f"DELETED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
-                    )
-                else:
-                    error_count += 1
+            # Delete local assignments that don't exist remotely —
+            # but ONLY when the remote fetch was complete.  A partial
+            # fetch (HTTP error / timeout mid-pagination) would make
+            # ``to_delete`` contain assignments that simply weren't
+            # fetched, leading to destructive removal of valid data.
+            if remote_result.is_complete:
+                to_delete = local_assignments - remote_result.assignments
+                for assignment_tuple in to_delete:
+                    if delete_local_assignment(assignment_tuple):
+                        deleted_count += 1
+                        self.write(
+                            f"DELETED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
+                            " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                        )
+                    else:
+                        error_count += 1
+            else:
+                skipped = len(local_assignments - remote_result.assignments)
+                self.write(
+                    f"Skipping deletion of {skipped} assignment(s) — remote fetch was incomplete. "
+                    "Will retry on next sync cycle."
+                )
+                logger.warning(
+                    "Skipping assignment deletions: remote fetch was incomplete "
+                    "(%d local, %d remote fetched). Deletions deferred to next complete sync.",
+                    len(local_assignments),
+                    len(remote_result.assignments),
+                )
 
-            # Create local assignments that exist remotely but not locally
+            # Create local assignments that exist remotely but not locally.
+            # Safe even on a partial fetch — at worst we create assignments
+            # that already exist (no-op) or create a subset of what's needed.
             for assignment_tuple in to_create:
                 if create_local_assignment(assignment_tuple):
                     created_count += 1

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -778,22 +778,13 @@ class SyncExecutor:
                         deleted_count += 1
                         self.write(
                             f"DELETED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                            " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                            f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                         )
                     else:
                         error_count += 1
             else:
-                skipped = len(local_assignments - remote_result.assignments)
-                self.write(
-                    f"Skipping deletion of {skipped} assignment(s) — remote fetch was incomplete. "
-                    "Will retry on next sync cycle."
-                )
-                logger.warning(
-                    "Skipping assignment deletions: remote fetch was incomplete "
-                    "(%d local, %d remote fetched). Deletions deferred to next complete sync.",
-                    len(local_assignments),
-                    len(remote_result.assignments),
-                )
+                self.write("Skipping assignment deletions — remote fetch was incomplete. Will retry on next sync cycle.")
+                logger.warning("Skipping assignment deletions: remote fetch was incomplete. Deletions deferred to next complete sync.")
 
             # Create local assignments that exist remotely but not locally.
             # Safe even on a partial fetch — at worst we create assignments
@@ -803,7 +794,7 @@ class SyncExecutor:
                     created_count += 1
                     self.write(
                         f"CREATED assignment {assignment_tuple.assignment_type} {assignment_tuple.actor_ansible_id}"
-                        " -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
+                        f" -> {assignment_tuple.role_definition_name} on {assignment_tuple.ansible_id_or_pk or 'global'}"
                     )
                 else:
                     error_count += 1

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -360,16 +360,19 @@ def test_role_assignment_resource_sync(mock_delete, mock_create, static_api_clie
         assert executor.results["assignment_errors"] == [0]
 
     # Mock a local assignment with no matching remote assignment to test deletion
-    with mock.patch(
-        "ansible_base.resource_registry.tasks.sync.get_remote_assignments",
-        return_value=RemoteAssignmentResult(assignments=set(), is_complete=True),
-    ), mock.patch(
-        "ansible_base.resource_registry.tasks.sync.get_local_assignments",
-        return_value={
-            AssignmentTuple(
-                actor_ansible_id='97447387-8596-404f-b0d0-6429b04c8d22', ansible_id_or_pk='1', role_definition_name='Team Member', assignment_type='user'
-            ),
-        },
+    with (
+        mock.patch(
+            "ansible_base.resource_registry.tasks.sync.get_remote_assignments",
+            return_value=RemoteAssignmentResult(assignments=set(), is_complete=True),
+        ),
+        mock.patch(
+            "ansible_base.resource_registry.tasks.sync.get_local_assignments",
+            return_value={
+                AssignmentTuple(
+                    actor_ansible_id='97447387-8596-404f-b0d0-6429b04c8d22', ansible_id_or_pk='1', role_definition_name='Team Member', assignment_type='user'
+                ),
+            },
+        ),
     ):
         executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
         executor._sync_assignments()
@@ -404,15 +407,18 @@ def test_role_assignment_sync_skips_deletions_on_incomplete_fetch(mock_delete, m
         assignment_type='user',
     )
 
-    with mock.patch(
-        "ansible_base.resource_registry.tasks.sync.get_remote_assignments",
-        return_value=RemoteAssignmentResult(
-            assignments={remote_only},
-            is_complete=False,
+    with (
+        mock.patch(
+            "ansible_base.resource_registry.tasks.sync.get_remote_assignments",
+            return_value=RemoteAssignmentResult(
+                assignments={remote_only},
+                is_complete=False,
+            ),
         ),
-    ), mock.patch(
-        "ansible_base.resource_registry.tasks.sync.get_local_assignments",
-        return_value={local_only},
+        mock.patch(
+            "ansible_base.resource_registry.tasks.sync.get_local_assignments",
+            return_value={local_only},
+        ),
     ):
         executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
         executor._sync_assignments()
@@ -426,7 +432,7 @@ def test_role_assignment_sync_skips_deletions_on_incomplete_fetch(mock_delete, m
         assert executor.results["assignments_created"] == [1]
 
         # Verify the skip message was logged
-        assert any('Skipping deletion' in line for line in stdout.lines)
+        assert any('Skipping assignment deletions' in line for line in stdout.lines)
 
 
 def _mock_response(status_code=200, body=None):
@@ -437,32 +443,36 @@ def _mock_response(status_code=200, body=None):
 
 
 @pytest.mark.parametrize("failure_mode", ["http_error", "exception"])
-def test_get_remote_assignments_incomplete_on_failure(static_api_client, failure_mode):
+def test_get_remote_assignments_incomplete_on_failure(failure_mode):
     """is_complete must be False on HTTP error or exception mid-pagination."""
-    page1 = _mock_response(body={
-        "results": [{"user_ansible_id": "u1", "object_ansible_id": "o1", "role_definition": "Team Member"}],
-        "next": "http://example.com/page2",
-    })
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    page1 = _mock_response(
+        body={
+            "results": [{"user_ansible_id": "u1", "object_ansible_id": "o1", "role_definition": "Team Member"}],
+            "next": "http://example.com/page2",
+        }
+    )
 
     if failure_mode == "http_error":
-        side_effect = [page1, _mock_response(status_code=500)]
+        api_client.list_user_assignments.side_effect = [page1, _mock_response(status_code=500)]
     else:
-        side_effect = [page1, ConnectionError("reset")]
+        api_client.list_user_assignments.side_effect = [page1, ConnectionError("reset")]
 
-    with mock.patch.object(static_api_client, "list_user_assignments", side_effect=side_effect):
-        result = get_remote_assignments(static_api_client)
+    result = get_remote_assignments(api_client)
 
     assert result.is_complete is False
     # Page 1 assignments are still captured
     assert AssignmentTuple(actor_ansible_id="u1", ansible_id_or_pk="o1", role_definition_name="Team Member", assignment_type="user") in result.assignments
 
 
-def test_get_remote_assignments_complete_on_success(static_api_client):
+def test_get_remote_assignments_complete_on_success():
     """is_complete must be True only when both pagination loops finish cleanly."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
     ok = _mock_response()
-    with mock.patch.object(static_api_client, "list_user_assignments", return_value=ok), \
-         mock.patch.object(static_api_client, "list_team_assignments", return_value=ok):
-        result = get_remote_assignments(static_api_client)
+    api_client.list_user_assignments.return_value = ok
+    api_client.list_team_assignments.return_value = ok
+
+    result = get_remote_assignments(api_client)
 
     assert result.is_complete is True
     assert len(result.assignments) == 0

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -13,10 +13,12 @@ from ansible_base.resource_registry.models.service_identifier import service_id
 from ansible_base.resource_registry.tasks.sync import (
     AssignmentTuple,
     ManifestItem,
+    RemoteAssignmentResult,
     ResourceSyncHTTPError,
     SyncExecutor,
     _attempt_create_resource,
     _attempt_update_resource,
+    get_remote_assignments,
 )
 
 
@@ -340,11 +342,14 @@ def test_role_assignment_resource_sync(mock_delete, mock_create, static_api_clie
     # Mock a remote assignment that does not exist locally to test creation
     with mock.patch(
         "ansible_base.resource_registry.tasks.sync.get_remote_assignments",
-        return_value={
-            AssignmentTuple(
-                actor_ansible_id='97447387-8596-404f-b0d0-6429b04c8d22', ansible_id_or_pk='1', role_definition_name='Team Member', assignment_type='user'
-            ),
-        },
+        return_value=RemoteAssignmentResult(
+            assignments={
+                AssignmentTuple(
+                    actor_ansible_id='97447387-8596-404f-b0d0-6429b04c8d22', ansible_id_or_pk='1', role_definition_name='Team Member', assignment_type='user'
+                ),
+            },
+            is_complete=True,
+        ),
     ):
         executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
         executor._sync_assignments()
@@ -356,6 +361,9 @@ def test_role_assignment_resource_sync(mock_delete, mock_create, static_api_clie
 
     # Mock a local assignment with no matching remote assignment to test deletion
     with mock.patch(
+        "ansible_base.resource_registry.tasks.sync.get_remote_assignments",
+        return_value=RemoteAssignmentResult(assignments=set(), is_complete=True),
+    ), mock.patch(
         "ansible_base.resource_registry.tasks.sync.get_local_assignments",
         return_value={
             AssignmentTuple(
@@ -370,3 +378,91 @@ def test_role_assignment_resource_sync(mock_delete, mock_create, static_api_clie
         assert executor.results["assignments_created"] == [0]
         assert executor.results["assignments_deleted"] == [1]
         assert executor.results["assignment_errors"] == [0]
+
+
+@mock.patch('ansible_base.resource_registry.tasks.sync.create_local_assignment')
+@mock.patch('ansible_base.resource_registry.tasks.sync.delete_local_assignment')
+@pytest.mark.django_db
+def test_role_assignment_sync_skips_deletions_on_incomplete_fetch(mock_delete, mock_create, static_api_client, stdout):
+    """When the remote fetch is incomplete (e.g. HTTP error mid-pagination),
+    deletions must be skipped to avoid removing valid local assignments
+    that simply weren't fetched.  Creations from the partial set are still
+    safe and should proceed."""
+    mock_delete.return_value = True
+    mock_create.return_value = True
+
+    local_only = AssignmentTuple(
+        actor_ansible_id='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        ansible_id_or_pk='1',
+        role_definition_name='Team Admin',
+        assignment_type='user',
+    )
+    remote_only = AssignmentTuple(
+        actor_ansible_id='bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        ansible_id_or_pk='2',
+        role_definition_name='Team Member',
+        assignment_type='user',
+    )
+
+    with mock.patch(
+        "ansible_base.resource_registry.tasks.sync.get_remote_assignments",
+        return_value=RemoteAssignmentResult(
+            assignments={remote_only},
+            is_complete=False,
+        ),
+    ), mock.patch(
+        "ansible_base.resource_registry.tasks.sync.get_local_assignments",
+        return_value={local_only},
+    ):
+        executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
+        executor._sync_assignments()
+
+        # Deletions must NOT happen — the remote set is partial
+        mock_delete.assert_not_called()
+        assert executor.results["assignments_deleted"] == [0]
+
+        # Creations from the partial set are safe and should proceed
+        mock_create.assert_called_once_with(remote_only)
+        assert executor.results["assignments_created"] == [1]
+
+        # Verify the skip message was logged
+        assert any('Skipping deletion' in line for line in stdout.lines)
+
+
+def _mock_response(status_code=200, body=None):
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.json.return_value = body or {"results": [], "next": None}
+    return resp
+
+
+@pytest.mark.parametrize("failure_mode", ["http_error", "exception"])
+def test_get_remote_assignments_incomplete_on_failure(static_api_client, failure_mode):
+    """is_complete must be False on HTTP error or exception mid-pagination."""
+    page1 = _mock_response(body={
+        "results": [{"user_ansible_id": "u1", "object_ansible_id": "o1", "role_definition": "Team Member"}],
+        "next": "http://example.com/page2",
+    })
+
+    if failure_mode == "http_error":
+        side_effect = [page1, _mock_response(status_code=500)]
+    else:
+        side_effect = [page1, ConnectionError("reset")]
+
+    with mock.patch.object(static_api_client, "list_user_assignments", side_effect=side_effect):
+        result = get_remote_assignments(static_api_client)
+
+    assert result.is_complete is False
+    # Page 1 assignments are still captured
+    assert AssignmentTuple(actor_ansible_id="u1", ansible_id_or_pk="o1", role_definition_name="Team Member", assignment_type="user") in result.assignments
+
+
+def test_get_remote_assignments_complete_on_success(static_api_client):
+    """is_complete must be True only when both pagination loops finish cleanly."""
+    ok = _mock_response()
+    with mock.patch.object(static_api_client, "list_user_assignments", return_value=ok), \
+         mock.patch.object(static_api_client, "list_team_assignments", return_value=ok):
+        result = get_remote_assignments(static_api_client)
+
+    assert result.is_complete is True
+    assert len(result.assignments) == 0

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -461,8 +461,14 @@ def test_get_remote_assignments_incomplete_on_failure(failure_mode):
     result = get_remote_assignments(api_client)
 
     assert result.is_complete is False
-    # Page 1 assignments are still captured
-    assert AssignmentTuple(actor_ansible_id="u1", ansible_id_or_pk="o1", role_definition_name="Team Member", assignment_type="user") in result.assignments
+    # Compare fields directly — AssignmentTuple.__eq__ uses isinstance,
+    # which can fail across pytest-xdist worker forks.
+    assert len(result.assignments) == 1
+    assignment = next(iter(result.assignments))
+    assert assignment.actor_ansible_id == "u1"
+    assert assignment.ansible_id_or_pk == "o1"
+    assert assignment.role_definition_name == "Team Member"
+    assert assignment.assignment_type == "user"
 
 
 def test_get_remote_assignments_complete_on_success():

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -470,6 +470,9 @@ def test_get_remote_assignments_incomplete_on_failure(failure_mode):
     assert assignment.role_definition_name == "Team Member"
     assert assignment.assignment_type == "user"
 
+    # Team pagination must be skipped when user pagination fails
+    api_client.list_team_assignments.assert_not_called()
+
 
 def test_get_remote_assignments_complete_on_success():
     """is_complete must be True only when both pagination loops finish cleanly."""


### PR DESCRIPTION
## Description

Fixes an issue where deletions were performed on get_remote_assignments when the requests were paginated and errored out during pagination.

We saw an error where, with a large number of role_user_assignments, Controller was deleting these assignments during the background sync job. This appears to be because the background sync errored part-way through the request, so only some of the pages had data, and the rest were cut off (for instance, we fetched the first 40 pages, but the remainder weren't included in the response, so were deleted as they were missing from the set).

This commit attempts to resolve that issue. 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
* Have a large number of role_user_assignments, forcing the background sync job to paginate over them.

### Steps to Test
1. Wait for the background sync to begin (should run every 15 minutes).
2. Bring the Gateway node down, so that the request fails part-way through.
3. Confirm that no role_user_assignments were deleted, even on the failed sync.

### Expected Results
We may create on an error, but we shouldn't delete role_user_assignments (or other resource syncs) if there's an error during the requests.

## Additional Context


### Required Actions


### Screenshots/Logs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Assignment sync now preserves partial remote results and defers deletions when remote fetches are incomplete or fail; creations from available remote data are still applied and a warning plus “Skipping assignment deletions” is logged to prevent accidental removals.

* **Tests**
  * Added tests covering pagination success, pagination failures/exceptions, incomplete fetch behavior, deferred-deletion handling, and creation-from-partial-data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->