### PR TITLE
[AAP-68463] fix: recurring error with RoleDefinition sync

### DIFF
--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -200,6 +200,10 @@ class RemoteAssignmentFetcher:
         If user pagination fails, team pagination is skipped entirely
         because the result will be incomplete regardless.
         """
+        from ansible_base.rbac.models.role import RoleDefinition
+
+        self.local_role_names: set[str] = set(RoleDefinition.objects.values_list('name', flat=True))
+
         users_ok = self._paginate(self.api_client.list_user_assignments, 'user_ansible_id', 'user')
         if not users_ok:
             return RemoteAssignmentResult(assignments=self.assignments, is_complete=False)
@@ -222,12 +226,16 @@ class RemoteAssignmentFetcher:
 
                 data = resp.json()
                 for assignment in data.get('results', []):
+                    role_name = assignment['role_definition']
+                    if role_name not in self.local_role_names:
+                        logger.debug(f"Skipping remote {assignment_type} assignment with unknown local role: {role_name}")
+                        continue
                     ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
                     self.assignments.add(
                         AssignmentTuple(
                             actor_ansible_id=assignment[actor_id_key],
                             ansible_id_or_pk=ansible_id_or_pk,
-                            role_definition_name=assignment['role_definition'],
+                            role_definition_name=role_name,
                             assignment_type=assignment_type,
                         )
                     )

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -442,9 +442,11 @@ def _mock_response(status_code=200, body=None):
     return resp
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize("failure_mode", ["http_error", "exception"])
 def test_get_remote_assignments_incomplete_on_failure(failure_mode):
     """is_complete must be False on HTTP error or exception mid-pagination."""
+    RoleDefinition.objects.managed.team_member  # ensure the role exists for filtering
     api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
     page1 = _mock_response(
         body={
@@ -474,6 +476,7 @@ def test_get_remote_assignments_incomplete_on_failure(failure_mode):
     api_client.list_team_assignments.assert_not_called()
 
 
+@pytest.mark.django_db
 def test_get_remote_assignments_complete_on_success():
     """is_complete must be True only when both pagination loops finish cleanly."""
     api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
@@ -485,3 +488,58 @@ def test_get_remote_assignments_complete_on_success():
 
     assert result.is_complete is True
     assert len(result.assignments) == 0
+
+
+@pytest.mark.django_db
+def test_get_remote_assignments_filters_unknown_roles(static_api_client):
+    """Assignments for roles that do not exist locally should be filtered out.
+
+    The resource server returns assignments across all services. Roles from
+    other services (e.g. Controller's 'Credential Admin') do not exist in the
+    local database and must be skipped to avoid DoesNotExist errors.
+    """
+    local_role = RoleDefinition.objects.managed.sys_auditor
+
+    user_results = {
+        'results': [
+            # Assignment for a role that exists locally — should be included
+            {
+                'user_ansible_id': 'aaaaaaaa-1111-2222-3333-444444444444',
+                'object_ansible_id': '1',
+                'role_definition': local_role.name,
+            },
+            # Assignment for a role from another service — should be filtered out
+            {
+                'user_ansible_id': 'bbbbbbbb-1111-2222-3333-444444444444',
+                'object_ansible_id': '1',
+                'role_definition': 'Credential Admin',
+            },
+        ],
+        'next': None,
+    }
+    team_results = {
+        'results': [
+            # Assignment for a role from another service — should be filtered out
+            {
+                'team_ansible_id': 'cccccccc-1111-2222-3333-444444444444',
+                'object_ansible_id': '1',
+                'role_definition': 'Some Other Service Role',
+            },
+        ],
+        'next': None,
+    }
+
+    user_response = mock.Mock(status_code=200)
+    user_response.json.return_value = user_results
+    team_response = mock.Mock(status_code=200)
+    team_response.json.return_value = team_results
+
+    static_api_client.list_user_assignments = mock.Mock(return_value=user_response)
+    static_api_client.list_team_assignments = mock.Mock(return_value=team_response)
+
+    result = get_remote_assignments(static_api_client)
+
+    assert result.is_complete is True
+    assert len(result.assignments) == 1
+    assignment = next(iter(result.assignments))
+    assert assignment.role_definition_name == local_role.name


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Add local role name filter to get_remote_assignments() to resolve a bug where AAP components were reporting sync errors caused by Gateway returning assignments for all services, not just the ones specific to that component, which produces the below error in the logs when the periodic sync is performed.
```
pulp [7b6124db8e5b43638c1aa5276c3318ba]: ansible_base.resources_api.tasks.sync:ERROR: Failed to create assignment AssignmentTuple(actor_ansible_id='1d5643cf-e316-4405-8957-5c7ffd05b354', ansible_id_or_pk='1', role_definition_name='Credential Admin', assignment_type='user'): RoleDefinition matching query does not exist.
```

- Why is this change needed?
To address the bug reported in https://redhat.atlassian.net/browse/AAP-68463

- How does this change address the issue?
Introduces local role name filtering in `get_remote_assignments()` to prevent cross-service assignments from entering the sync diff for each service, which eliminates the sync errors.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Run a new devel deployment and execute resource sync
2. Review one of the component log (EDA/Hub)

### Expected Results
- The "RoleDefinition matching query does not exist" should no longer be reported in component logs. 
- If debug logging is enabled, a "Skipping remote user assignment with unknown local role" message will be present indicate an unknown role was skipped for that components.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync now excludes remote assignments that reference roles not present locally; these are skipped and recorded, improving data integrity and preventing sync errors.

* **Tests**
  * Added database-backed tests to verify unknown-role assignments are filtered, that only valid assignments remain, and that sync reports completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->