### PR TITLE
AAP-72039 Introduce partial-recomputation of team permissions

### DIFF
--- a/ansible_base/rbac/caching.py
+++ b/ansible_base/rbac/caching.py
@@ -49,6 +49,27 @@ def all_team_parents(team_id: int, team_team_parents: dict, seen: Optional[set] 
     return parent_team_ids
 
 
+def all_team_children(team_id: int, team_team_children: dict, seen: Optional[set] = None) -> set[int]:
+    """
+    Returns child teams, and child teams of child teams, until we have them all.
+    Mirror of all_team_parents but traversing the reverse direction.
+
+    team_id: id of the team we want to get the direct and indirect children of
+    team_team_children: mapping of team id to ids of its children (reverse of team_team_parents)
+    seen: mutable set to prevent infinite recursion in the event of loops
+    """
+    child_team_ids = set()
+    if seen is None:
+        seen = set()
+    for child_id in team_team_children.get(team_id, []):
+        if child_id in seen:
+            continue
+        child_team_ids.add(child_id)
+        seen.add(child_id)
+        child_team_ids.update(all_team_children(child_id, team_team_children, seen=seen))
+    return child_team_ids
+
+
 def get_org_team_mapping() -> dict[int, list[int]]:
     """
     Returns the teams in all organization as a dictionary.
@@ -173,11 +194,16 @@ def _safe_m2m_add(team, to_add):
                 logger.warning('Persistent IntegrityError adding member_roles for team %s, will be corrected on next recompute', team.id)
 
 
-def compute_team_member_roles():
+def compute_team_member_roles(team_ids=None):
     """
-    Fills in the ObjectRole.provides_teams relationship for all teams.
-    This relationship is a list of teams that the role grants membership for
-    This method is always ran globally.
+    Fills in the ObjectRole.provides_teams relationship for teams.
+    This relationship is a list of teams that the role grants membership for.
+
+    Args:
+        team_ids: Optional iterable of team IDs to scope the write phase.
+            When provided, only those teams (plus their descendants in the
+            team-of-team graph) have their member_roles updated.
+            When None, all teams are updated (global recompute).
     """
     # Manually prefetch the team to org memberships
     org_team_mapping = get_org_team_mapping()
@@ -198,8 +224,22 @@ def compute_team_member_roles():
             all_member_roles[team_id].update(set(direct_member_roles.get(parent_team_id, [])))
 
     # Great! we should be done building all_member_roles which tells what roles gives team membership for all teams
-    # now at this point we save that data
-    for team in permission_registry.team_model.objects.prefetch_related('member_roles'):
+    # now at this point we save that data, optionally scoped to specific teams
+    if team_ids is not None:
+        team_ids = set(team_ids)
+        # Expand to include descendants in the team-of-team graph
+        team_team_children = defaultdict(set)
+        for child, parents in team_team_parents.items():
+            for parent in parents:
+                team_team_children[parent].add(child)
+        expanded = set(team_ids)
+        for tid in team_ids:
+            expanded.update(all_team_children(tid, team_team_children))
+        teams_qs = permission_registry.team_model.objects.filter(id__in=expanded)
+    else:
+        teams_qs = permission_registry.team_model.objects.all()
+
+    for team in teams_qs.prefetch_related('member_roles'):
         # NOTE: the .set method will not use the prefetched data, thus the messy implementation here
         existing_ids = set(r.id for r in team.member_roles.all())
         expected_ids = set(all_member_roles.get(team.id, []))

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -312,7 +312,7 @@ class RoleDefinition(CommonModel):
 
         from ansible_base.rbac.triggers import needed_updates_on_assignment, update_after_assignment
 
-        update_teams, to_update = needed_updates_on_assignment(self, actor, object_role, created=created, giving=True)
+        recompute_team_ids, to_update = needed_updates_on_assignment(self, actor, object_role, created=created, giving=True)
 
         assignment = None
         if actor._meta.model_name == 'user':
@@ -331,7 +331,7 @@ class RoleDefinition(CommonModel):
                 to_update.remove(object_role)
             object_role.delete()
 
-        update_after_assignment(update_teams, to_update)
+        update_after_assignment(recompute_team_ids, to_update)
 
         return assignment
 

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -37,12 +37,33 @@ def team_ancestor_roles(team):
     return set(ObjectRole.objects.filter(permission_partials__in=RoleEvaluation.objects.filter(**permission_kwargs)))
 
 
+def _team_ids_from_role_target(object_role: 'ObjectRole') -> set[int]:
+    """Derive which teams a member_team ObjectRole targets from its content type.
+
+    Used only when the provides_teams relationship is not yet computed —
+    i.e. for newly created ObjectRoles or when member_team permission was
+    just added to a RoleDefinition. For existing roles where provides_teams
+    is already populated, query provides_teams directly instead.
+    """
+    if object_role.content_type_id == permission_registry.team_ct_id:
+        return {int(object_role.object_id)}
+    if object_role.content_type_id == permission_registry.org_ct_id:
+        parent_fd = permission_registry.get_parent_fd_name(permission_registry.team_model)
+        if parent_fd:
+            return set(
+                permission_registry.team_model.objects.filter(
+                    **{f'{parent_fd}_id': int(object_role.object_id)}
+                ).values_list('id', flat=True)
+            )
+    return set()
+
+
 def needed_updates_on_assignment(role_definition, actor, object_role, created=False, giving=True):
     """
     If a user or a team is granted a role or has a role revoked,
     then this returns instructions for what needs to be updated
     returns tuple
-        (bool: should update team owners, set: object roles to update)
+        (set or None: team IDs needing provides_teams recomputation, set: object roles to update)
     """
     # we maintain a list of object roles that we need to update evaluations for
     to_update = set()
@@ -78,15 +99,23 @@ def needed_updates_on_assignment(role_definition, actor, object_role, created=Fa
         to_update.update(object_role.descendent_roles())
 
     # actions which can change the team parentage structure
-    recompute_teams = bool(has_team_perm and (created or deleted or changes_team_owners))
+    recompute_team_ids = None
+    if has_team_perm and (created or deleted or changes_team_owners):
+        if created:
+            # provides_teams not yet computed for new ObjectRoles
+            recompute_team_ids = _team_ids_from_role_target(object_role)
+        else:
+            # For existing roles, provides_teams already captures which
+            # teams this role grants membership to
+            recompute_team_ids = set(object_role.provides_teams.values_list('id', flat=True))
 
-    return (recompute_teams, to_update)
+    return (recompute_team_ids, to_update)
 
 
-def update_after_assignment(update_teams, to_update):
+def update_after_assignment(recompute_team_ids, to_update):
     "Call this with the output of needed_updates_on_assignment"
-    if update_teams:
-        compute_team_member_roles()
+    if recompute_team_ids is not None:
+        compute_team_member_roles(team_ids=recompute_team_ids)
 
     compute_object_role_permissions(object_roles=to_update)
 
@@ -105,15 +134,28 @@ def permissions_changed(instance, action, model, pk_set, reverse, **kwargs):
         if permission_registry.permission_qs.filter(codename=permission_registry.team_permission, pk__in=pk_set).exists():
             for object_role in to_recompute.copy():
                 to_recompute.update(object_role.descendent_roles())
-            compute_team_member_roles()
+            team_ids = set()
+            for object_role in to_recompute:
+                # provides_teams covers removal (member_team was present, teams are populated)
+                team_ids.update(object_role.provides_teams.values_list('id', flat=True))
+                if action == 'post_add':
+                    # provides_teams is empty when member_team was just added,
+                    # so derive affected teams from the role's content type
+                    team_ids.update(_team_ids_from_role_target(object_role))
+            compute_team_member_roles(team_ids=team_ids)
         # All team member roles that give this permission through this role need to be updated
         for role in to_recompute.copy():
             for team in role.teams.all():
                 to_recompute.update(team.member_roles.all())
     elif action == 'post_clear':
         # unfortunately this does not give us a list of permissions to work with
-        # this is slow, not ideal, but will at least be correct
-        compute_team_member_roles()
+        # provides_teams captures teams if member_team was among the cleared permissions;
+        # content-type derivation covers the case where it wasn't yet computed
+        team_ids = set()
+        for object_role in to_recompute:
+            team_ids.update(object_role.provides_teams.values_list('id', flat=True))
+            team_ids.update(_team_ids_from_role_target(object_role))
+        compute_team_member_roles(team_ids=team_ids)
         to_recompute = None  # all
     compute_object_role_permissions(object_roles=to_recompute)
 
@@ -186,7 +228,7 @@ def post_save_update_obj_permissions(instance):
     # If the actual object changed (created or modified) was a team, any org role
     # that has member_team needs to be updated, and any parent teams that have that role
     if instance._meta.model_name == permission_registry.team_model._meta.model_name:
-        compute_team_member_roles()
+        compute_team_member_roles(team_ids=[instance.id])
 
     if to_update:
         compute_object_role_permissions(object_roles=to_update)
@@ -238,6 +280,16 @@ def rbac_post_save_update_evaluations(instance, created, *args, **kwargs):
 
 def team_pre_delete(instance, *args, **kwargs):
     instance.__rbac_stashed_member_roles = list(instance.member_roles.all())
+    # Stash IDs of teams that have this team as a parent in the team-of-team graph.
+    # After this team is deleted, those teams need their member_roles recomputed.
+    # provides_teams tells us which teams these roles grant membership to.
+    stashed_team_ids = set()
+    for object_role in ObjectRole.objects.filter(
+        teams=instance, role_definition__permissions__codename=permission_registry.team_permission
+    ):
+        stashed_team_ids.update(object_role.provides_teams.values_list('id', flat=True))
+    stashed_team_ids.discard(instance.id)  # the deleted team itself won't need recomputation
+    instance.__rbac_stashed_recompute_team_ids = stashed_team_ids
 
 
 def rbac_post_delete_remove_object_roles(instance, *args, **kwargs):
@@ -250,7 +302,7 @@ def rbac_post_delete_remove_object_roles(instance, *args, **kwargs):
         indirectly_affected_roles.update(team_ancestor_roles(instance))
         for team_role in instance.__rbac_stashed_member_roles:
             indirectly_affected_roles.update(team_role.descendent_roles())
-        compute_team_member_roles()
+        compute_team_member_roles(team_ids=instance.__rbac_stashed_recompute_team_ids)
         compute_object_role_permissions(object_roles=indirectly_affected_roles)
 
         # Similar to user deletion, clean up any orphaned object roles

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -50,11 +50,7 @@ def _team_ids_from_role_target(object_role: 'ObjectRole') -> set[int]:
     if object_role.content_type_id == permission_registry.org_ct_id:
         parent_fd = permission_registry.get_parent_fd_name(permission_registry.team_model)
         if parent_fd:
-            return set(
-                permission_registry.team_model.objects.filter(
-                    **{f'{parent_fd}_id': int(object_role.object_id)}
-                ).values_list('id', flat=True)
-            )
+            return set(permission_registry.team_model.objects.filter(**{f'{parent_fd}_id': int(object_role.object_id)}).values_list('id', flat=True))
     return set()
 
 
@@ -284,9 +280,7 @@ def team_pre_delete(instance, *args, **kwargs):
     # After this team is deleted, those teams need their member_roles recomputed.
     # provides_teams tells us which teams these roles grant membership to.
     stashed_team_ids = set()
-    for object_role in ObjectRole.objects.filter(
-        teams=instance, role_definition__permissions__codename=permission_registry.team_permission
-    ):
+    for object_role in ObjectRole.objects.filter(teams=instance, role_definition__permissions__codename=permission_registry.team_permission):
         stashed_team_ids.update(object_role.provides_teams.values_list('id', flat=True))
     stashed_team_ids.discard(instance.id)  # the deleted team itself won't need recomputation
     instance.__rbac_stashed_recompute_team_ids = stashed_team_ids

--- a/test_app/tests/rbac/models/test_role_definition.py
+++ b/test_app/tests/rbac/models/test_role_definition.py
@@ -111,6 +111,35 @@ def test_change_role_definition_member_permission(organization, inventory, org_t
 
 
 @pytest.mark.django_db
+def test_clear_role_definition_member_permission(organization, inventory, org_team_member_rd, member_rd, inv_rd):
+    """Clearing all permissions from a RoleDefinition that includes member_team
+    correctly breaks team membership (exercises the post_clear branch in permissions_changed)."""
+    team_user = permission_registry.user_model.objects.create(username='team-user')
+    org_team_user = permission_registry.user_model.objects.create(username='org-team-user')
+    team = permission_registry.team_model.objects.create(name='ateam', organization=organization)
+    org_team = permission_registry.team_model.objects.create(name='org-team', organization=organization)
+    in_org_team = permission_registry.team_model.objects.create(name='child-team', organization=organization)
+
+    inv_rd.give_permission(team, inventory)
+    member_rd.give_permission(team_user, team)
+
+    org_team_member_rd.give_permission(org_team, organization)
+    member_rd.give_permission(org_team_user, org_team)
+    inv_rd.give_permission(in_org_team, inventory)
+
+    assert [u.has_obj_perm(inventory, 'change') for u in (team_user, org_team_user)] == [True, True]
+
+    # Clear all permissions — triggers post_clear instead of post_remove
+    member_rd.permissions.clear()
+    assert [u.has_obj_perm(inventory, 'change') for u in (team_user, org_team_user)] == [False, False]
+
+    # Restoring the permission brings membership back
+    member_perm = permission_registry.permission_qs.get(codename='member_team')
+    member_rd.permissions.add(member_perm)
+    assert [u.has_obj_perm(inventory, 'change') for u in (team_user, org_team_user)] == [True, True]
+
+
+@pytest.mark.django_db
 def test_get_or_create_reuses_existing_role_by_name():
     """
     Test that get_or_create reuses an existing RoleDefinition when called

--- a/test_app/tests/rbac/test_scoped_team_recompute.py
+++ b/test_app/tests/rbac/test_scoped_team_recompute.py
@@ -7,8 +7,9 @@ and team creation previously caused FK violations because the global
 recompute touched ObjectRoles from unrelated orgs.
 """
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from ansible_base.rbac.caching import (
     all_team_children,

--- a/test_app/tests/rbac/test_scoped_team_recompute.py
+++ b/test_app/tests/rbac/test_scoped_team_recompute.py
@@ -1,0 +1,405 @@
+"""Tests for scoped compute_team_member_roles — verifying that the team_ids
+parameter correctly limits which teams are updated and that the team-of-team
+graph expansion works correctly.
+
+These tests exercise the race-condition fix where concurrent org deletion
+and team creation previously caused FK violations because the global
+recompute touched ObjectRoles from unrelated orgs.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from ansible_base.rbac.caching import (
+    all_team_children,
+    compute_team_member_roles,
+)
+from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleEvaluation
+from ansible_base.rbac.permission_registry import permission_registry
+from test_app.models import Inventory, Organization
+
+
+@pytest.mark.django_db
+class TestScopedComputeTeamMemberRoles:
+    """Test that compute_team_member_roles(team_ids=...) only writes to the specified teams."""
+
+    def test_scoped_to_new_team_does_not_touch_other_org(self, rando, member_rd, org_team_member_rd):
+        """Creating a team in org A should not touch org B's provides_teams.
+
+        This is the core race-condition scenario: org B is being deleted
+        concurrently, so touching its ObjectRoles causes FK violations.
+        """
+        org_a = Organization.objects.create(name='org-a')
+        org_b = Organization.objects.create(name='org-b')
+
+        team_b = permission_registry.team_model.objects.create(name='team-b', organization=org_b)
+        member_rd.give_permission(rando, team_b)
+
+        # Sanity: team_b has member_roles
+        assert team_b.member_roles.exists()
+        original_member_role_ids = set(team_b.member_roles.values_list('id', flat=True))
+
+        # Now create team in org_a and do a scoped recompute for just this team
+        team_a = permission_registry.team_model.objects.create(name='team-a', organization=org_a)
+
+        # Wipe team_b's member_roles to prove a scoped recompute doesn't touch it
+        team_b.member_roles.clear()
+        compute_team_member_roles(team_ids=[team_a.id])
+
+        # team_b should still have empty member_roles (was not touched by the scoped recompute)
+        assert not team_b.member_roles.exists()
+
+        # A global recompute would restore it
+        compute_team_member_roles()
+        assert set(team_b.member_roles.values_list('id', flat=True)) == original_member_role_ids
+
+    def test_scoped_recompute_updates_specified_team(self, rando, member_rd, org_team_member_rd):
+        """A scoped recompute correctly updates the specified team's member_roles."""
+        org = Organization.objects.create(name='test-org')
+        team = permission_registry.team_model.objects.create(name='test-team', organization=org)
+
+        # Give org-level member_team role — this should make the ObjectRole provide membership to the team
+        assignment = org_team_member_rd.give_permission(rando, org)
+
+        # Clear and re-derive using scoped compute
+        team.member_roles.clear()
+        assert not team.member_roles.exists()
+
+        compute_team_member_roles(team_ids=[team.id])
+        assert team.member_roles.exists()
+        assert assignment.object_role in team.member_roles.all()
+
+    def test_team_creation_signal_scopes_correctly(self, rando, org_team_member_rd, inv_rd):
+        """End-to-end: creating a team after an org-level member_team role exists
+        correctly populates provides_teams for just the new team.
+        """
+        org = Organization.objects.create(name='org')
+        inv = Inventory.objects.create(name='inv', organization=org)
+
+        assignment = org_team_member_rd.give_permission(rando, org)
+
+        # Create team — the post_save signal calls compute_team_member_roles(team_ids=[team.id])
+        team = permission_registry.team_model.objects.create(name='new-team', organization=org)
+        assert set(assignment.object_role.provides_teams.all()) == {team}
+
+        # User should get access to inv through team membership
+        inv_rd.give_permission(team, inv)
+        assert rando.has_obj_perm(inv, 'change')
+
+
+@pytest.mark.django_db
+class TestTeamOfTeamExpansion:
+    """Test that the team_ids expansion correctly includes child teams in the team-of-team graph."""
+
+    def test_all_team_children_simple(self):
+        """all_team_children finds direct children."""
+        children_map = {1: {2, 3}, 2: {4}}
+        assert all_team_children(1, children_map) == {2, 3, 4}
+        assert all_team_children(2, children_map) == {4}
+        assert all_team_children(3, children_map) == set()
+
+    def test_all_team_children_with_cycle(self):
+        """all_team_children handles cycles without infinite recursion."""
+        children_map = {1: {2}, 2: {3}, 3: {1}}
+        result = all_team_children(1, children_map)
+        assert result == {2, 3, 1}
+
+    def test_scoped_recompute_expands_to_children(self, rando, organization, member_rd, inv_rd):
+        """When team T1 is specified in team_ids and T1 is parent of T2,
+        T2 is automatically included in the recompute.
+        """
+        team1 = permission_registry.team_model.objects.create(name='team-1', organization=organization)
+        team2 = permission_registry.team_model.objects.create(name='team-2', organization=organization)
+        inv = Inventory.objects.create(name='inv', organization=organization)
+
+        # Make team1 a parent of team2 (member of team1 → member of team2)
+        member_rd.give_permission(team1, team2)
+        # Give team2 inventory permission
+        inv_rd.give_permission(team2, inv)
+
+        # Give user membership to team1
+        assignment = member_rd.give_permission(rando, team1)
+
+        # Verify the provides_teams chain works
+        assert team2 in assignment.object_role.provides_teams.all()
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Clear member_roles for both teams and do a scoped recompute with just team1
+        team1.member_roles.clear()
+        team2.member_roles.clear()
+
+        # Scoped to team1 — should expand to include team2 (child)
+        compute_team_member_roles(team_ids=[team1.id])
+
+        # Both teams should be restored
+        assert team1.member_roles.exists()
+        assert team2.member_roles.exists()
+
+    def test_five_nested_teams_scoped(self, rando, organization, member_rd, inv_rd):
+        """Scoped recompute on the top team expands through the full chain."""
+        inv = Inventory.objects.create(name='inv', organization=organization)
+        teams = [permission_registry.team_model.objects.create(name=f'team-{i}', organization=organization) for i in range(5)]
+
+        # Create chain: team-0 <- team-1 <- team-2 <- team-3 <- team-4
+        for parent_team, child_team in zip(teams[:-1], teams[1:]):
+            member_rd.give_permission(parent_team, child_team)
+        inv_rd.give_permission(teams[-1], inv)
+        member_rd.give_permission(rando, teams[0])
+
+        # Sanity: full chain works
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Clear all member_roles and do a scoped recompute on team-0 only
+        for t in teams:
+            t.member_roles.clear()
+
+        compute_team_member_roles(team_ids=[teams[0].id])
+
+        # All teams should be restored via expansion
+        for t in teams:
+            assert t.member_roles.exists(), f'{t.name} should have member_roles after expansion'
+
+        # Permissions should still work
+        assert rando.has_obj_perm(inv, 'change')
+
+
+@pytest.mark.django_db
+class TestTeamDeletionScoping:
+    """Test that team deletion correctly identifies and scopes the recompute to affected teams."""
+
+    def test_delete_team_middle_of_chain(self, rando, organization, member_rd, inv_rd):
+        """Deleting a team in the middle of a chain correctly updates downstream teams."""
+        inv = Inventory.objects.create(name='inv', organization=organization)
+        team1 = permission_registry.team_model.objects.create(name='team-1', organization=organization)
+        team2 = permission_registry.team_model.objects.create(name='team-2', organization=organization)
+        team3 = permission_registry.team_model.objects.create(name='team-3', organization=organization)
+
+        # Chain: team1 -> team2 -> team3
+        member_rd.give_permission(team1, team2)
+        member_rd.give_permission(team2, team3)
+        inv_rd.give_permission(team3, inv)
+        member_rd.give_permission(rando, team1)
+
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Delete middle team — should break the chain
+        team2.delete()
+        assert not rando.has_obj_perm(inv, 'change')
+
+    def test_delete_parent_team_does_not_touch_unrelated_org(self, rando, member_rd, inv_rd):
+        """Deleting a team should only recompute teams that were children of the deleted team,
+        not teams in unrelated orgs.
+        """
+        org_a = Organization.objects.create(name='org-a')
+        org_b = Organization.objects.create(name='org-b')
+
+        team_a1 = permission_registry.team_model.objects.create(name='team-a1', organization=org_a)
+        team_a2 = permission_registry.team_model.objects.create(name='team-a2', organization=org_a)
+        team_b = permission_registry.team_model.objects.create(name='team-b', organization=org_b)
+
+        # team_a1 is parent of team_a2
+        member_rd.give_permission(team_a1, team_a2)
+        member_rd.give_permission(rando, team_b)
+
+        # Sanity
+        assert team_b.member_roles.exists()
+
+        # Track calls to see scoping
+        original_compute = compute_team_member_roles.__wrapped__ if hasattr(compute_team_member_roles, '__wrapped__') else compute_team_member_roles
+        captured_team_ids = []
+
+        def tracking_compute(team_ids=None):
+            captured_team_ids.append(team_ids)
+            return original_compute(team_ids=team_ids)
+
+        with patch('ansible_base.rbac.triggers.compute_team_member_roles', tracking_compute):
+            team_a1.delete()
+
+        # The recompute should have been scoped (not global)
+        assert len(captured_team_ids) > 0
+        for tid_set in captured_team_ids:
+            if tid_set is not None:
+                assert team_b.id not in tid_set, "team_b should not be in the recompute scope"
+
+    def test_delete_team_in_org_with_many_teams(self, rando, organization, member_rd, inv_rd):
+        """Deleting a team that is a parent of another correctly updates the child."""
+        team_parent = permission_registry.team_model.objects.create(name='parent', organization=organization)
+        team_child = permission_registry.team_model.objects.create(name='child', organization=organization)
+        inv = Inventory.objects.create(name='inv', organization=organization)
+
+        # parent is parent of child
+        member_rd.give_permission(team_parent, team_child)
+        inv_rd.give_permission(team_child, inv)
+        member_rd.give_permission(rando, team_parent)
+
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Delete parent — child should lose the transitive member_roles
+        team_parent.delete()
+        assert not rando.has_obj_perm(inv, 'change')
+
+
+@pytest.mark.django_db
+class TestRoleAssignmentScoping:
+    """Test that role assignments correctly scope the provides_teams recompute."""
+
+    def test_give_member_team_scopes_to_target_team(self, rando, member_rd, inv_rd):
+        """Giving a member_team role on a team scopes the recompute to that team."""
+        org_a = Organization.objects.create(name='org-a')
+        org_b = Organization.objects.create(name='org-b')
+
+        team_a = permission_registry.team_model.objects.create(name='team-a', organization=org_a)
+        team_b = permission_registry.team_model.objects.create(name='team-b', organization=org_b)
+        inv = Inventory.objects.create(name='inv', organization=org_a)
+
+        inv_rd.give_permission(team_a, inv)
+        inv_rd.give_permission(team_b, Inventory.objects.create(name='inv-b', organization=org_b))
+
+        # Track recompute calls
+        original_compute = compute_team_member_roles.__wrapped__ if hasattr(compute_team_member_roles, '__wrapped__') else compute_team_member_roles
+        captured_team_ids = []
+
+        def tracking_compute(team_ids=None):
+            captured_team_ids.append(team_ids)
+            return original_compute(team_ids=team_ids)
+
+        with patch('ansible_base.rbac.triggers.compute_team_member_roles', tracking_compute):
+            member_rd.give_permission(rando, team_a)
+
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Verify scoping happened — the recompute should have included team_a but not team_b
+        recompute_calls_with_ids = [ids for ids in captured_team_ids if ids is not None]
+        assert len(recompute_calls_with_ids) > 0
+        for ids in recompute_calls_with_ids:
+            assert team_a.id in ids
+            assert team_b.id not in ids
+
+    def test_org_level_member_team_scopes_to_org_teams(self, rando, org_team_member_rd, inv_rd):
+        """Giving an org-level member_team role scopes to all teams in that org."""
+        org_a = Organization.objects.create(name='org-a')
+        org_b = Organization.objects.create(name='org-b')
+
+        team_a1 = permission_registry.team_model.objects.create(name='team-a1', organization=org_a)
+        team_a2 = permission_registry.team_model.objects.create(name='team-a2', organization=org_a)
+        team_b = permission_registry.team_model.objects.create(name='team-b', organization=org_b)
+
+        inv = Inventory.objects.create(name='inv', organization=org_a)
+        inv_rd.give_permission(team_a1, inv)
+
+        original_compute = compute_team_member_roles.__wrapped__ if hasattr(compute_team_member_roles, '__wrapped__') else compute_team_member_roles
+        captured_team_ids = []
+
+        def tracking_compute(team_ids=None):
+            captured_team_ids.append(team_ids)
+            return original_compute(team_ids=team_ids)
+
+        with patch('ansible_base.rbac.triggers.compute_team_member_roles', tracking_compute):
+            org_team_member_rd.give_permission(rando, org_a)
+
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Should include both org_a teams but not org_b's team
+        recompute_calls_with_ids = [ids for ids in captured_team_ids if ids is not None]
+        assert len(recompute_calls_with_ids) > 0
+        for ids in recompute_calls_with_ids:
+            assert team_a1.id in ids
+            assert team_a2.id in ids
+            assert team_b.id not in ids
+
+    def test_revoke_member_team_scoped(self, rando, member_rd, inv_rd):
+        """Revoking a member_team role correctly scopes the recompute."""
+        org = Organization.objects.create(name='org')
+        team = permission_registry.team_model.objects.create(name='team', organization=org)
+        inv = Inventory.objects.create(name='inv', organization=org)
+
+        inv_rd.give_permission(team, inv)
+        member_rd.give_permission(rando, team)
+        assert rando.has_obj_perm(inv, 'change')
+
+        member_rd.remove_permission(rando, team)
+        assert not rando.has_obj_perm(inv, 'change')
+
+    def test_team_to_team_assignment_scoped(self, rando, member_rd, inv_rd):
+        """Assigning a member_team role to a team actor scopes correctly."""
+        org = Organization.objects.create(name='org')
+        parent = permission_registry.team_model.objects.create(name='parent', organization=org)
+        child = permission_registry.team_model.objects.create(name='child', organization=org)
+        inv = Inventory.objects.create(name='inv', organization=org)
+
+        inv_rd.give_permission(child, inv)
+        member_rd.give_permission(rando, parent)
+        assert not rando.has_obj_perm(inv, 'change')
+
+        # Assign parent as team member of child — user should now get access
+        member_rd.give_permission(parent, child)
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Revoke — access should be removed
+        member_rd.remove_permission(parent, child)
+        assert not rando.has_obj_perm(inv, 'change')
+
+
+@pytest.mark.django_db
+class TestTeamOrganizationChange:
+    """Test that moving a team between organizations correctly scopes the recompute."""
+
+    def test_move_team_to_different_org(self, rando, org_team_member_rd, inv_rd):
+        """Moving a team between orgs correctly updates provides_teams.
+
+        Uses org_team_member_rd (team membership only, no direct inventory perms)
+        so that access is purely through team membership.
+        """
+        org_a = Organization.objects.create(name='org-a')
+        org_b = Organization.objects.create(name='org-b')
+
+        team = permission_registry.team_model.objects.create(name='test-team', organization=org_a)
+        inv = Inventory.objects.create(name='inv', organization=org_a)
+
+        org_team_member_rd.give_permission(rando, org_a)
+        inv_rd.give_permission(team, inv)
+        assert rando.has_obj_perm(inv, 'change')
+
+        # Move team to org_b — rando's org_a membership no longer covers this team
+        team.organization = org_b
+        team.save(update_fields=['organization'])
+
+        assert not rando.has_obj_perm(inv, 'change')
+
+        # User with org_b team membership should gain access
+        user_b = permission_registry.user_model.objects.create(username='user_b')
+        org_team_member_rd.give_permission(user_b, org_b)
+        assert user_b.has_obj_perm(inv, 'change')
+
+
+@pytest.mark.django_db
+class TestGlobalRecomputeStillWorks:
+    """Verify that compute_team_member_roles(team_ids=None) still does a full global recompute."""
+
+    def test_global_recompute_fixes_all_teams(self, rando, member_rd, org_team_member_rd):
+        """A global recompute (no team_ids) restores all teams."""
+        org_a = Organization.objects.create(name='org-a')
+        org_b = Organization.objects.create(name='org-b')
+
+        team_a = permission_registry.team_model.objects.create(name='team-a', organization=org_a)
+        team_b = permission_registry.team_model.objects.create(name='team-b', organization=org_b)
+
+        member_rd.give_permission(rando, team_a)
+        member_rd.give_permission(rando, team_b)
+
+        assert team_a.member_roles.exists()
+        assert team_b.member_roles.exists()
+
+        # Clear both and do global recompute
+        team_a.member_roles.clear()
+        team_b.member_roles.clear()
+
+        compute_team_member_roles()
+
+        assert team_a.member_roles.exists()
+        assert team_b.member_roles.exists()
+
+    def test_empty_team_ids_is_noop(self):
+        """Passing an empty team_ids set should not error and should be a no-op."""
+        compute_team_member_roles(team_ids=set())
+        compute_team_member_roles(team_ids=[])

--- a/test_app/tests/rbac/test_scoped_team_recompute.py
+++ b/test_app/tests/rbac/test_scoped_team_recompute.py
@@ -14,7 +14,6 @@ from ansible_base.rbac.caching import (
     all_team_children,
     compute_team_member_roles,
 )
-from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleEvaluation
 from ansible_base.rbac.permission_registry import permission_registry
 from test_app.models import Inventory, Organization
 


### PR DESCRIPTION
## Description
This is created in response to a particularly server error observed from tests.

```
"14/Apr/2026:22:29:23 +0000" client=3.88.60.90 x_forwarded_for=3.88.60.90 realip=- method=DELETE request="DELETE /api/controller/v2/service-index/resources/0d2714bf-466b-4840-991d-576da783ec61/ HTTP/1.1" request_length=1986 status=204 bytes_sent=627 body_bytes_sent=0 referer=- user_agent="python-requests/2.32.3" upstream_addr=127.0.0.1:8050 upstream_status=204 request_time=0.174 upstream_response_time=0.174 upstream_connect_time=0.000 upstream_header_time=0.174 request_id="7372abe8-6950-4b7d-8966-b8a2428d8e24" trusted_proxy=trusted-proxy dab_jwt=dab-jwt
[pid: 265|app: -|req: -/-] 3.88.60.90 (-) {54 vars in 2393 bytes} [Tue Apr 14 22:29:22 2026] DELETE /api/controller/v2/service-index/resources/0d2714bf-466b-4840-991d-576da783ec61/ => generated 0 bytes in 174 msecs (HTTP/1.1 204) 11 headers in 413 bytes (1 switches on core 0) x-request-id: 7372abe8-6950-4b7d-8966-b8a2428d8e24
2026-04-14 22:29:23,107 ERROR    [cf3b32387b0d44fe9d183483accd5d53] django.request Internal Server Error: /api/controller/v2/teams/
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 303, in _commit
    return self.connection.commit()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 274, in commit
    self.wait(self._commit_gen())
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 453, in wait
    return waiting.wait(gen, self.pgconn.socket, interval=interval)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/waiting.py", line 354, in wait_poll
    s = gen.send(ready)
        ^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 581, in _commit_gen
    yield from self._exec_command(b"COMMIT")
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 479, in _exec_command
    raise e.error_from_result(result, encoding=self.pgconn._encoding)
psycopg.errors.ForeignKeyViolation: insert or update on table "dab_rbac_objectrole_provides_teams" violates foreign key constraint "dab_rbac_objectrole__objectrole_id_406b577e_fk_dab_rbac_"
DETAIL:  Key (objectrole_id)=(1772) is not present in table "dab_rbac_objectrole".
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/contextlib.py", line 80, in inner
    with self._recreate_cm():
         ^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/transaction.py", line 263, in __exit__
    connection.commit()
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 327, in commit
    self._commit()
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 302, in _commit
    with debug_transaction(self, "COMMIT"), self.wrap_database_errors:
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 303, in _commit
    return self.connection.commit()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 274, in commit
    self.wait(self._commit_gen())
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 453, in wait
    return waiting.wait(gen, self.pgconn.socket, interval=interval)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/waiting.py", line 354, in wait_poll
    s = gen.send(ready)
        ^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 581, in _commit_gen
    yield from self._exec_command(b"COMMIT")
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 479, in _exec_command
    raise e.error_from_result(result, encoding=self.pgconn._encoding)
django.db.utils.IntegrityError: insert or update on table "dab_rbac_objectrole_provides_teams" violates foreign key constraint "dab_rbac_objectrole__objectrole_id_406b577e_fk_dab_rbac_"
DETAIL:  Key (objectrole_id)=(1772) is not present in table "dab_rbac_objectrole".
2026-04-14 22:29:23,107 ERROR    [cf3b32387b0d44fe9d183483accd5d53] django.request Internal Server Error: /api/controller/v2/teams/
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 303, in _commit
    return self.connection.commit()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 274, in commit
    self.wait(self._commit_gen())
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 453, in wait
    return waiting.wait(gen, self.pgconn.socket, interval=interval)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/waiting.py", line 354, in wait_poll
    s = gen.send(ready)
        ^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 581, in _commit_gen
    yield from self._exec_command(b"COMMIT")
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 479, in _exec_command
    raise e.error_from_result(result, encoding=self.pgconn._encoding)
psycopg.errors.ForeignKeyViolation: insert or update on table "dab_rbac_objectrole_provides_teams" violates foreign key constraint "dab_rbac_objectrole__objectrole_id_406b577e_fk_dab_rbac_"
DETAIL:  Key (objectrole_id)=(1772) is not present in table "dab_rbac_objectrole".
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/contextlib.py", line 80, in inner
    with self._recreate_cm():
         ^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/transaction.py", line 263, in __exit__
    connection.commit()
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 327, in commit
    self._commit()
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 302, in _commit
    with debug_transaction(self, "COMMIT"), self.wrap_database_errors:
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 303, in _commit
    return self.connection.commit()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 274, in commit
    self.wait(self._commit_gen())
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 453, in wait
    return waiting.wait(gen, self.pgconn.socket, interval=interval)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/waiting.py", line 354, in wait_poll
    s = gen.send(ready)
        ^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 581, in _commit_gen
    yield from self._exec_command(b"COMMIT")
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py", line 479, in _exec_command
    raise e.error_from_result(result, encoding=self.pgconn._encoding)
django.db.utils.IntegrityError: insert or update on table "dab_rbac_objectrole_provides_teams" violates foreign key constraint "dab_rbac_objectrole__objectrole_id_406b577e_fk_dab_rbac_"
DETAIL:  Key (objectrole_id)=(1772) is not present in table "dab_rbac_objectrole".

```

This happened due to requests dealing with 2 unrelated objects, which becomes a problem because of the global nature of the method here, `compute_team_member_roles`

This tries to introduce a reduced form of that method so that it can better isolate things and go faster.

This is heavily overlapping with
 - https://github.com/ansible/django-ansible-base/pull/970
 - https://github.com/ansible/django-ansible-base/pull/979

Because I think that 970 isn't hitting the _worst_ inefficiency of the system. This should probably be a higher priority item. And I think 979 doesn't really approach this with clarity of mind. I think this will probably solve the issues that one is wanting to solve.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Team role recalculation is now scoped to affected teams and their descendant teams, reducing unnecessary global recomputations.

* **Behavior Changes**
  * Role/permission updates, team moves, and deletions trigger targeted recomputations only for relevant teams and organizations.

* **Bug Fixes**
  * Fix handling of role permission changes that affect team-derived permissions so revokes and restores are correctly reflected.

* **Tests**
  * Added comprehensive tests validating scoped recomputes, deletion/move scenarios, permission-clear paths, and global/empty-input behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->