### PR TITLE
AAP-65739 Update cryptography for CVE-2026-26007

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@
 # Only generic requirements for django-ansible-base (or the common feature) should be listed here.
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
-cryptography
+cryptography>=46.0.5  # Update for CVE-2026-26007
 Django>=4.2.26,<6.0    # Updating for CVE-2025-64459
 djangorestframework<3.16 # problem with OAuth2Application.organization null handling
 django-crum

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@
 # Only generic requirements for django-ansible-base (or the common feature) should be listed here.
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
-cryptography>=46.0.5  # Update for CVE-2026-26007
+cryptography
 Django>=4.2.26,<6.0    # Updating for CVE-2025-64459
 djangorestframework<3.16 # problem with OAuth2Application.organization null handling
 django-crum

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -15,7 +15,7 @@ channels==4.3.2
     # via -r requirements/requirements_channels.in
 charset-normalizer==3.4.4
     # via requests
-cryptography==46.0.5
+cryptography==46.0.5  # Components should use this or later for CVE-2026-26007
     # via
     #   -r requirements/requirements.in
     #   jwcrypto

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -15,7 +15,7 @@ channels==4.3.2
     # via -r requirements/requirements_channels.in
 charset-normalizer==3.4.4
     # via requests
-cryptography==46.0.3
+cryptography==46.0.5
     # via
     #   -r requirements/requirements.in
     #   jwcrypto


### PR DESCRIPTION
## Description
Updates cryptography >= 46.0.5 for CVE-2026-26007.

Follow-up to AAP-65408 — now that downstream components have applied the CVE fix, DAB can be updated.

Note: replaces https://github.com/ansible/django-ansible-base/pull/935

## Type of Change
- [x] Configuration change

## Testing Instructions
No functional changes — minor dependency version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cryptography package to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->