### PR TITLE
[AAP-72703] - Add FEATURE_DASHBOARD_COLLECTION_ENABLED flag and migration

### DIFF
--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -59,8 +59,8 @@
   support_level: TECHNOLOGY_PREVIEW
   description: >-
     Enable data collection for the automation-reports dashboard integration.
-    When enabled, AWX job data is collected and stored to power the
-    dashboard_reports API and automation-reports UI.
+    When enabled, Controller job data is collected and stored locally in the platform
+    database to power the dashboard_reports API and automation-reports UI.
   support_url: ''
   toggle_type: run-time
   labels:

--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -51,3 +51,17 @@
   toggle_type: install-time
   labels:
     - platform
+- name: FEATURE_DASHBOARD_COLLECTION_ENABLED
+  ui_name: Dashboard Reports Collection
+  visibility: True
+  condition: boolean
+  value: 'False'
+  support_level: TECHNOLOGY_PREVIEW
+  description: >-
+    Enable data collection for the automation-reports dashboard integration.
+    When enabled, AWX job data is collected and stored to power the
+    dashboard_reports API and automation-reports UI.
+  support_url: ''
+  toggle_type: run-time
+  labels:
+    - metrics

--- a/ansible_base/feature_flags/definitions/schema.json
+++ b/ansible_base/feature_flags/definitions/schema.json
@@ -57,7 +57,7 @@
         "type": "array",
         "items": {
           "type": "string",
-          "enum": ["controller", "eda", "gateway", "platform"]
+          "enum": ["controller", "eda", "gateway", "metrics", "platform"]
         },
         "minItems": 1,
         "uniqueItems": true

--- a/ansible_base/feature_flags/migrations/0005_manual_20260417.py
+++ b/ansible_base/feature_flags/migrations/0005_manual_20260417.py
@@ -1,0 +1,17 @@
+###
+# Addition of FEATURE_DASHBOARD_COLLECTION_ENABLED
+###
+
+# FileHash: 3b05aadcaf50652c8bd5311656dcbce325cc6510606e5ba84fd8494d386fbad5
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dab_feature_flags', '0004_remove_dispatcherd_feature_flag'),
+    ]
+
+    operations = [
+    ]

--- a/ansible_base/feature_flags/migrations/0005_manual_20260417.py
+++ b/ansible_base/feature_flags/migrations/0005_manual_20260417.py
@@ -2,7 +2,7 @@
 # Addition of FEATURE_DASHBOARD_COLLECTION_ENABLED
 ###
 
-# FileHash: 3b05aadcaf50652c8bd5311656dcbce325cc6510606e5ba84fd8494d386fbad5
+# FileHash: 2f5c26fd5d1e8a3e93ee14f76b3dd7fcebff316ab07fc27b6d3e8f22c2740e01
 
 from django.db import migrations
 


### PR DESCRIPTION
## Description

Adds the `FEATURE_DASHBOARD_COLLECTION_ENABLED` feature flag to django-ansible-base to enable runtime control of data collection for the automation-reports dashboard integration.

### What is being changed?
- Added `FEATURE_DASHBOARD_COLLECTION_ENABLED` to `ansible_base/feature_flags/definitions/feature_flags.yaml` with `toggle_type: run-time`, defaulting to `False`, at `TECHNOLOGY_PREVIEW` support level
- Added migration `0005_manual_20260417.py` to register the flag in the database
- Extended the feature flag JSON schema to allow the `metrics` label category

### Why is this change needed?
Without this flag defined in DAB, there was no supported mechanism to enable or disable dashboard data collection at runtime via the platform Feature Flags API or UI. Services depending on this flag (e.g. metrics-service, automation-reports) would silently fall back to disabled with no operator control.

### How does this change address the issue?
The flag is now registered in the platform feature flag registry, visible in the UI (`visibility: True`), and toggleable at runtime without a service restart.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- A running AAP instance with this DAB version installed

### Steps to Test
1. Run `manage.py migrate` to apply migration `0005_manual_20260417`
2. Navigate to the Feature Flags API or UI
3. Confirm `FEATURE_DASHBOARD_COLLECTION_ENABLED` appears with `visibility: True` and default value `False`
4. Toggle the flag to `True` and confirm it takes effect without a service restart

### Expected Results
- Flag appears in the Feature Flags API with correct metadata
- Toggling the flag at runtime controls dashboard data collection in dependent services

## Additional Context

### Required Actions
- [x] Requires downstream repository changes
  - `metrics-service`: runtime feature flag check gates the `daily_anonymize` and `send_to_segment_daily` tasks on `ANONYMIZED_DATA_COLLECTION`; dashboard collection tasks will use `FEATURE_DASHBOARD_COLLECTION_ENABLED`
  - `automation-reports`: dashboard data collection gated on this flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new feature-flag definition plus a schema enum update, with no changes to runtime logic beyond enabling configuration.
> 
> **Overview**
> Introduces the new **runtime** feature flag `FEATURE_DASHBOARD_COLLECTION_ENABLED` (default `False`, visible in UI, *TECHNOLOGY_PREVIEW*) to gate dashboard/automation-reports data collection.
> 
> Updates the feature flag JSON schema to allow the new `metrics` label, and adds a no-op `dab_feature_flags` migration file to track the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11670785576330c7ca127b806ae68b85c8c70930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional data collection feature for AWX job metrics to power dashboard reports and automation-reports UI capabilities (disabled by default)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->