### PR TITLE
[AAP-68023] Use direct JOINs instead of nested IN subqueries in RBAC evaluation

### DIFF
--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -757,16 +757,16 @@ class RoleEvaluationFields(models.Model):
 
     @staticmethod
     def _actor_role_filter(actor):
-        """Return filter kwargs using a direct JOIN instead of a nested IN subquery.
+        """Return filter kwargs that skip the objectrole table entirely.
 
-        Replaces ``role__in=actor.has_roles.all()`` with ``role__users=actor``
-        or ``role__teams=actor``.  The former generates a nested IN subquery that
-        PostgreSQL must materialise; the latter produces an INNER JOIN that allows
-        index-nested-loop evaluation.
+        Uses ``role_id__in`` with a subquery on the assignment table, which
+        avoids JOINing through ``dab_rbac_objectrole``.  Both
+        ``roleevaluation.role_id`` and ``assignment.object_role_id`` reference
+        the same objectrole PK, so the intermediate table is unnecessary.
         """
         if actor._meta.model_name == permission_registry.user_model._meta.model_name:
-            return {'role__users': actor}
-        return {'role__teams': actor}
+            return {'role_id__in': RoleUserAssignment.objects.filter(user_id=actor.id).values('object_role_id')}
+        return {'role_id__in': RoleTeamAssignment.objects.filter(team_id=actor.id).values('object_role_id')}
 
     @classmethod
     def accessible_ids(cls, model_cls, actor, codename: str, content_types: Optional[Iterable[int]] = None, cast_field=None) -> QuerySet:

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -396,7 +396,7 @@ class ObjectRoleFields(models.Model):
     @classmethod
     def _visible_items(cls, eval_cls, user, qs=None):
         permission_qs = eval_cls.objects.filter(
-            role__in=user.has_roles.all(),
+            **eval_cls._actor_role_filter(user),
             content_type_id=models.OuterRef('content_type_id'),
         )
         # NOTE: type casting is necessary in postgres but not sqlite3
@@ -755,6 +755,19 @@ class RoleEvaluationFields(models.Model):
     # this can be relaxed as we have comparative performance testing to confirm doing so does not affect permissions
     content_type_id = models.PositiveIntegerField(null=False, help_text=_("The related content type id."))
 
+    @staticmethod
+    def _actor_role_filter(actor):
+        """Return filter kwargs using a direct JOIN instead of a nested IN subquery.
+
+        Replaces ``role__in=actor.has_roles.all()`` with ``role__users=actor``
+        or ``role__teams=actor``.  The former generates a nested IN subquery that
+        PostgreSQL must materialise; the latter produces an INNER JOIN that allows
+        index-nested-loop evaluation.
+        """
+        if actor._meta.model_name == permission_registry.user_model._meta.model_name:
+            return {'role__users': actor}
+        return {'role__teams': actor}
+
     @classmethod
     def accessible_ids(cls, model_cls, actor, codename: str, content_types: Optional[Iterable[int]] = None, cast_field=None) -> QuerySet:
         """
@@ -768,7 +781,7 @@ class RoleEvaluationFields(models.Model):
         """
         # We only have a content_types exception for multiple content types for polymorphic models
         # for normal models you should not need it, but AWX unified_ models need it to get by
-        filter_kwargs = {'role__in': actor.has_roles.all(), 'codename': codename}
+        filter_kwargs = {**cls._actor_role_filter(actor), 'codename': codename}
         if content_types:
             filter_kwargs['content_type_id__in'] = content_types
         else:
@@ -791,7 +804,7 @@ class RoleEvaluationFields(models.Model):
         Returns permissions that a user has to obj from object-roles,
         does not consider permissions from user flags or system-wide roles
         """
-        return cls.objects.filter(role__in=user.has_roles.all(), content_type_id=DABContentType.objects.get_for_model(obj).id, object_id=obj.id).values_list(
+        return cls.objects.filter(**cls._actor_role_filter(user), content_type_id=DABContentType.objects.get_for_model(obj).id, object_id=obj.id).values_list(
             'codename', flat=True
         )
 
@@ -802,7 +815,7 @@ class RoleEvaluationFields(models.Model):
         method on permission classes, but it is named differently to avoid unintentionally conflicting
         """
         return cls.objects.filter(
-            role__in=user.has_roles.all(), content_type_id=DABContentType.objects.get_for_model(obj).id, object_id=obj.pk, codename=codename
+            **cls._actor_role_filter(user), content_type_id=DABContentType.objects.get_for_model(obj).id, object_id=obj.pk, codename=codename
         ).exists()
 
 


### PR DESCRIPTION
Replace `role__in=actor.has_roles.all()` with `role__users=actor` or `role__teams=actor` in RoleEvaluation methods.  The former generates a nested IN subquery that PostgreSQL must materialise; the latter produces a direct INNER JOIN that allows index-nested-loop evaluation, improving host_list_rbac performance at scale.

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
This was tested locally using AAP-Dev, see full results in the Jira.
### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RBAC permission-evaluation query paths; while intended as a performance optimization, incorrect filtering could change which objects/permissions are considered accessible for users/teams.
> 
> **Overview**
> Improves RBAC evaluation query performance by replacing repeated `role__in=actor.has_roles.all()` filters with a shared `_actor_role_filter()` helper that filters `RoleEvaluation` rows via `RoleUserAssignment`/`RoleTeamAssignment` subqueries on `object_role_id`.
> 
> This change is applied across `visible_items`, `accessible_ids`, `get_permissions`, and `has_obj_perm`, aiming to avoid extra joins/nested subqueries when determining accessible objects and object-level permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745fa9dee4d6198a175d9ef7b7d2cfabb03eeb6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved permission filtering and role lookup internals for faster permission checks and quicker list filtering across the app while preserving existing visible behavior and access outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->