### PR TITLE
[AAP-73775] Add Hub to DAB consumers

### DIFF
--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -7,6 +7,108 @@ on:
       - "stable-*"
   pull_request:
 jobs:
+  awx:
+    name: AWX
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Pull AWX devel image
+        run: docker pull ghcr.io/ansible/awx_devel:devel
+
+      # Generate a docker image that includes current DAB
+      - name: Create image for AWX devel that includes our DAB
+        run: |
+          mkdir awx-dockerfile
+          cat <<EOF > awx-dockerfile/Dockerfile
+          FROM ghcr.io/ansible/awx_devel:devel
+          COPY . /opt/dab/
+          RUN pip install -e /opt/dab/
+          RUN pip install jq
+          EOF
+          docker build -t awx-with-dab:latest -f awx-dockerfile/Dockerfile .
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ansible/awx
+          path: awx
+
+      - name: Run AWX tests in the generated image
+        run: |
+          cd awx
+          DEVEL_IMAGE_NAME=awx-with-dab:latest AWX_DOCKER_CMD=/start_tests.sh make docker-runner
+
+  eda-server:
+    name: eda-server
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+    env:
+      EDA_SECRET_KEY: 'test'
+      EDA_DB_PASSWORD: 'secret'
+    services:
+      postgres:
+        image: 'quay.io/sclorg/postgresql-15-c9s:latest'
+        env:
+          POSTGRESQL_USER: eda
+          POSTGRESQL_PASSWORD: secret
+          POSTGRESQL_ADMIN_PASSWORD: secret
+          POSTGRESQL_DATABASE: eda
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - '5432:5432'
+      redis:
+        image: 'quay.io/fedora/redis-6:latest'
+        ports:
+          - '6379:6379'
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ansible/eda-server
+          path: eda-server
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run eda-server tests
+        run: |
+          DAB_PATH="$PWD"
+          mv eda-server /tmp
+          cd /tmp/eda-server
+          pipx install poetry
+          poetry install -E all --only main,test
+          poetry run pip install -e "$DAB_PATH"
+          poetry run pip show django-ansible-base
+          poetry run pytest
+
   hub:
     name: hub
     runs-on: ubuntu-latest
@@ -38,12 +140,4 @@ jobs:
       - name: Run Hub unit tests
         working-directory: hub
         run: |
-          pwd
-          echo "--ls -la--"
-          ls -la
-          echo "--ls -la ../--"
-          ls -la ../
-          echo "--tox--"
           tox -e py312
-          .tox/py312/bin/pip show galaxy-ng
-          .tox/py312/bin/pip show django-ansible-base

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -128,7 +128,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install tox
-        run: pip install --only-binary :all: tox==4.53.0
+        run: pip install tox
 
       - name: Run Hub unit tests
         working-directory: hub

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -117,18 +117,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          show-progress: false
-          path: django-ansible-base 
-
-      - name: install system dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y libsasl2-dev libldap2-dev libssl-dev gettext
-
-      - uses: actions/checkout@v4
-        with:
           repository: ansible/galaxy_ng
           path: hub
+          ref: custom-dab-install
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev gettext
 
       - uses: actions/setup-python@v5
         with:
@@ -139,5 +133,7 @@ jobs:
 
       - name: Run Hub unit tests
         working-directory: hub
-        run: |
-          tox -e py312
+        env:
+          DJANGO_ANSIBLE_BASE_BRANCH: ${{ github.sha }}
+        run: tox -e py312
+

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -128,7 +128,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install tox
-        run: pip install tox
+        run: pip install --only-binary ':all:' tox==4.53.0
 
       - name: Run Hub unit tests
         working-directory: hub

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -128,7 +128,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install tox
-        run: pip install tox
+        run: pip install --only-binary :all: tox==4.53.0
 
       - name: Run Hub unit tests
         working-directory: hub

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -18,6 +18,11 @@ jobs:
           show-progress: false
           path: django-ansible-base 
 
+      - name: install system dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libsasl2-dev libldap2-dev libssl-dev gettext
+
       - uses: actions/checkout@v4
         with:
           repository: ansible/galaxy_ng

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -7,104 +7,34 @@ on:
       - "stable-*"
   pull_request:
 jobs:
-  awx:
-    name: AWX
+  hub:
+    name: hub
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
           show-progress: false
+          path: django-ansible-base 
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ansible/galaxy_ng
+          path: hub
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Pull AWX devel image
-        run: docker pull ghcr.io/ansible/awx_devel:devel
+      - name: Install tox
+        run: pip install tox
 
-      # Generate a docker image that includes current DAB
-      - name: Create image for AWX devel that includes our DAB
+      - name: Run Hub unit tests
+        working-directory: hub
         run: |
-          mkdir awx-dockerfile
-          cat <<EOF > awx-dockerfile/Dockerfile
-          FROM ghcr.io/ansible/awx_devel:devel
-          COPY . /opt/dab/
-          RUN pip install -e /opt/dab/
-          RUN pip install jq
-          EOF
-          docker build -t awx-with-dab:latest -f awx-dockerfile/Dockerfile .
+          pwd
+          ls -la
 
-      - uses: actions/checkout@v4
-        with:
-          repository: ansible/awx
-          path: awx
+          tox -e py312
 
-      - name: Run AWX tests in the generated image
-        run: |
-          cd awx
-          DEVEL_IMAGE_NAME=awx-with-dab:latest AWX_DOCKER_CMD=/start_tests.sh make docker-runner
-
-  eda-server:
-    name: eda-server
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    strategy:
-      fail-fast: false
-    env:
-      EDA_SECRET_KEY: 'test'
-      EDA_DB_PASSWORD: 'secret'
-    services:
-      postgres:
-        image: 'quay.io/sclorg/postgresql-15-c9s:latest'
-        env:
-          POSTGRESQL_USER: eda
-          POSTGRESQL_PASSWORD: secret
-          POSTGRESQL_ADMIN_PASSWORD: secret
-          POSTGRESQL_DATABASE: eda
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - '5432:5432'
-      redis:
-        image: 'quay.io/fedora/redis-6:latest'
-        ports:
-          - '6379:6379'
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          show-progress: false
-
-      - uses: actions/checkout@v4
-        with:
-          repository: ansible/eda-server
-          path: eda-server
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Run eda-server tests
-        run: |
-          DAB_PATH="$PWD"
-          mv eda-server /tmp
-          cd /tmp/eda-server
-          pipx install poetry
-          poetry install -E all --only main,test
-          poetry run pip install -e "$DAB_PATH"
-          poetry run pip show django-ansible-base
-          poetry run pytest

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -128,7 +128,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install tox
-        run: pip install --only-binary ':all:' tox==4.53.0
+        run: pip install --only-binary ':all:' tox
 
       - name: Run Hub unit tests
         working-directory: hub

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -119,7 +119,6 @@ jobs:
         with:
           repository: ansible/galaxy_ng
           path: hub
-          ref: custom-dab-install
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev gettext

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -128,7 +128,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install tox
-        run: pip install --only-binary ':all:' tox
+        run: pip install --only-binary ':all:' tox==4.53.0
 
       - name: Run Hub unit tests
         working-directory: hub

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -39,7 +39,11 @@ jobs:
         working-directory: hub
         run: |
           pwd
+          echo "--ls -la--"
           ls -la
-
+          echo "--ls -la ../--"
+          ls -la ../
+          echo "--tox--"
           tox -e py312
-
+          .tox/py312/bin/pip show galaxy-ng
+          .tox/py312/bin/pip show django-ansible-base

--- a/ansible_base/__init__.py
+++ b/ansible_base/__init__.py
@@ -1,1 +1,0 @@
-print(">>> DAB CI TEST - USING LATEST DAB FROM PR <<<")

--- a/ansible_base/__init__.py
+++ b/ansible_base/__init__.py
@@ -1,0 +1,1 @@
+print(">>> DAB CI TEST - USING LATEST DAB FROM PR <<<")


### PR DESCRIPTION
## Description
Issue: https://redhat.atlassian.net/browse/AAP-73775
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
DAB consumers are missing Hub. This adds Hub to the list and runs unit test with current DAB.
How it works
1. Checks out `galaxy_ng` into `hub/` directory
2. Runs `tox -e py312` from the `hub/` directory with `DJANGO_ANSIBLE_BASE_BRANCH: ${{ github.sha }}` - latest commit on the branch
3. galaxy_ng's `setup.py` reads the `DJANGO_ANSIBLE_BASE_BRANCH` env var to determine which DAB commit to
  install:
  ```
  django_ansible_base_branch = os.getenv(
      'DJANGO_ANSIBLE_BASE_BRANCH', '<pinned-commit>'
  )
  ```
4. By passing the current PR's commit SHA, `pip install -e .` (galaxy_ng) fetches and installs this PR's
  version of DAB directly instead of the default pinned commit
5. Hub's unit tests (galaxy_ng.tests.unit) then run against this DAB version, catching any breaking
  changes before they're merged
  
```
  $GITHUB_WORKSPACE/
  └── hub/                    ← galaxy_ng
      └── tox.ini             ← pip install -e . uses DJANGO_ANSIBLE_BASE_BRANCH=${{ github.sha }}
```

Requires https://github.com/ansible-automation-platform/galaxy_ng/pull/474 (done)



## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI job to run the Hub unit test suite using Python 3.12, ensuring tests execute against the current commit to improve reliability and catch regressions earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->