### PR TITLE
[AAP-71476] Improve SonarCloud metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish dists to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # was release/v1
 
   post-release-repo-update:
     name: Make a GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
           ansible-playbook
           tools/ansible/release.yml
           -i localhost
-          -e github_token=${{ secrets.GITHUB_TOKEN }}
+          -e github_token="$GITHUB_TOKEN"
           -t build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
@@ -113,5 +115,7 @@ jobs:
           ansible-playbook
           tools/ansible/release.yml
           -i localhost
-          -e github_token=${{ secrets.GITHUB_TOKEN }}
+          -e github_token="$GITHUB_TOKEN"
           -t github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish dists to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # was release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)
 
   post-release-repo-update:
     name: Make a GitHub Release

--- a/ansible_base/lib/testing/fixtures.py
+++ b/ansible_base/lib/testing/fixtures.py
@@ -3,7 +3,7 @@ import os
 import uuid
 from collections import namedtuple
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -265,8 +265,8 @@ def rsa_keypair_with_signed_cert(rsa_keypair_factory):
         .issuer_name(issuer)
         .public_key(root_public_key)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName(u"mycompany.com")]),
             critical=False,
@@ -279,8 +279,8 @@ def rsa_keypair_with_signed_cert(rsa_keypair_factory):
         .issuer_name(issuer)
         .public_key(public_key)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName(u"qa.mycompany.com")]),
             critical=False,
@@ -320,8 +320,8 @@ def rsa_keypair_with_cert(rsa_keypair_factory):
         .issuer_name(issuer)
         .public_key(public_key)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName(u"mycompany.com")]),
             critical=False,

--- a/test_app/static/test_templatetags_util_inline_file.css
+++ b/test_app/static/test_templatetags_util_inline_file.css
@@ -1,2 +1,2 @@
-* { color: red;  font-family: 'Comic Sans MS', 'Comic Sans'; }
+* { color: red;  font-family: 'Comic Sans MS', 'Comic Sans', cursive; }
 div > p.foo { color: blue; }

--- a/test_app/templates/index.html
+++ b/test_app/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,7 +18,7 @@
                 <ul class="navbar-nav ms-auto">
 
                     <li id='user-item' class="nav-item">
-                        <a class="nav-link" href="#"></a>
+                        <a class="nav-link" href="#" aria-label="User"></a>
                     </li>
 
                     <li id='login-button' class="nav-item">
@@ -58,7 +58,7 @@
                 document.getElementById('user-item').innerHTML = `<a class="nav-link" href="#">${username}</a>`;
                 document.getElementById('login-button').innerHTML = '<a class="nav-link" href="/login/logout/">Logout</a>';
             } else {
-                document.getElementById('user-item').innerHTML = `<a class="nav-link" href="#"></a>`;
+                document.getElementById('user-item').innerHTML = `<a class="nav-link" href="#" aria-label="User"></a>`;
                 document.getElementById('login-button').innerHTML = '<a class="nav-link" href="/login/login/">Login</a>';
             }
         }


### PR DESCRIPTION
## Summary

- Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in certificate test fixtures
- Add generic font family fallback in test CSS file
- Add `lang` attribute and `aria-label` to test app HTML template
- Pass secrets via `env:` block instead of command-line argument in release workflow
- Pin `pypa/gh-action-pypi-publish` to full commit SHA for supply chain security
- Mark 6 false-positive `__all__` issues as false positives in SonarCloud (dynamically created by `@copy_fixture` decorator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added page language declaration for better browser language handling.
  * Improved user navigation labeling for screen reader accessibility.
  * Adjusted default font fallback to include an additional option for more consistent rendering.

* **Chores**
  * Updated release automation to use safer token handling and pinned publishing action for stability.
  * Improved test infrastructure by making certificate timestamps timezone-aware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->