### PR TITLE
[AAP-72703] Update FEATURE_DASHBOARD_COLLECTION_ENABLED flag toggle type

### DIFF
--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -62,6 +62,6 @@
     When enabled, Controller job data is collected and stored locally in the platform
     database to power the dashboard_reports API and automation-reports UI.
   support_url: ''
-  toggle_type: run-time
+  toggle_type: install-time
   labels:
     - metrics

--- a/ansible_base/feature_flags/migrations/0005_manual_20260417.py
+++ b/ansible_base/feature_flags/migrations/0005_manual_20260417.py
@@ -2,7 +2,7 @@
 # Addition of FEATURE_DASHBOARD_COLLECTION_ENABLED
 ###
 
-# FileHash: 2f5c26fd5d1e8a3e93ee14f76b3dd7fcebff316ab07fc27b6d3e8f22c2740e01
+# FileHash: 11f68664f09302bb83628f80405c111a9e58bf07527bd2d63adfc972226711c0
 
 from django.db import migrations
 


### PR DESCRIPTION
Changed the toggle type of the `FEATURE_DASHBOARD_COLLECTION_ENABLED` feature flag from `run-time` to `install-time` in `feature_flags.yaml`. Updated the file hash in the migration script `0005_manual_20260417.py` to reflect this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config metadata change plus hash update; no logic changes beyond restricting when the flag can be toggled.
> 
> **Overview**
> Updates the `FEATURE_DASHBOARD_COLLECTION_ENABLED` feature flag definition to be **install-time** (was `run-time`), changing when it can be toggled.
> 
> Refreshes the tracked `FileHash` in `0005_manual_20260417.py` to match the updated `feature_flags.yaml` content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9c8f07f3954601213b30689fcc3add440d27ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated how the dashboard collection feature is configured. The feature is now set during installation rather than being adjustable afterward, simplifying deployment configuration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->