### PR TITLE
[AAP-72504] Add configurable page_size and jwt_expiration for resource sync

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -268,6 +268,10 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
         'RESOURCE_SERVICE_PATH': "/api/gateway/v1/service-index/",
         # Disable legacy SSO by default
         'ENABLE_SERVICE_BACKED_SSO': False,
+        # Page size for assignment pagination during resource sync (capped server-side by MAX_PAGE_SIZE)
+        'RESOURCE_SYNC_PAGE_SIZE': 50,
+        # JWT service token lifetime in seconds for resource sync API calls
+        'RESOURCE_SYNC_JWT_EXPIRATION': 60,
     }
     if 'ansible_base.resource_registry' in installed_apps:
         for key, value in resource_registry_defaults.items():

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -268,9 +268,11 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
         'RESOURCE_SERVICE_PATH': "/api/gateway/v1/service-index/",
         # Disable legacy SSO by default
         'ENABLE_SERVICE_BACKED_SSO': False,
-        # Interval (in seconds) between periodic resource sync runs
+        # Interval (in seconds) between periodic resource sync runs.
+        # Not consumed by DAB directly; read by downstream schedulers
         'RESOURCE_SYNC_INTERVAL_SECONDS': 900,
-        # Page size for assignment pagination during resource sync (capped server-side by MAX_PAGE_SIZE)
+        # Page size for assignment pagination during resource sync (capped server-side by MAX_PAGE_SIZE).
+        # Defaults must match DEFAULT_SYNC_PAGE_SIZE / DEFAULT_SYNC_JWT_EXPIRATION in tasks/sync.py.
         'RESOURCE_SYNC_PAGE_SIZE': 50,
         # JWT service token lifetime in seconds for resource sync API calls
         'RESOURCE_SYNC_JWT_EXPIRATION': 60,

--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -268,6 +268,8 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
         'RESOURCE_SERVICE_PATH': "/api/gateway/v1/service-index/",
         # Disable legacy SSO by default
         'ENABLE_SERVICE_BACKED_SSO': False,
+        # Interval (in seconds) between periodic resource sync runs
+        'RESOURCE_SYNC_INTERVAL_SECONDS': 900,
         # Page size for assignment pagination during resource sync (capped server-side by MAX_PAGE_SIZE)
         'RESOURCE_SYNC_PAGE_SIZE': 50,
         # JWT service token lifetime in seconds for resource sync API calls

--- a/ansible_base/resource_registry/management/commands/resource_sync.py
+++ b/ansible_base/resource_registry/management/commands/resource_sync.py
@@ -62,10 +62,20 @@ class Command(BaseCommand):  # pragma: no cover
             required=False,
         )
         parser.add_argument("--asyncio", action="store_true", default=False, help="Enable asyncio executor")
+        parser.add_argument(
+            "--page-size",
+            type=int,
+            default=None,
+            dest="page_size",
+            help="Page size for pagination when fetching assignments (default: from settings, capped server-side by MAX_PAGE_SIZE)",
+            required=False,
+        )
 
     def handle(self, *args, **options):
         """Handle RESOURCE_PROVIDER sync"""
-        arguments = ["resource_type_names", "retries", "retrysleep", "asyncio"]
+        if options.get("page_size") is not None and options["page_size"] < 1:
+            raise CommandError("--page-size must be at least 1")
+        arguments = ["resource_type_names", "retries", "retrysleep", "asyncio", "page_size"]
         options = {k: v for k, v in options.items() if k in arguments}
         try:
             executor = SyncExecutor(**options, stdout=self.stdout)

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -26,6 +26,10 @@ from ansible_base.resource_registry.rest_client import ResourceAPIClient, get_re
 
 logger = logging.getLogger('ansible_base.resources_api.tasks.sync')
 
+# Must match defaults in lib/dynamic_config/settings_logic.py resource_registry_defaults
+DEFAULT_SYNC_PAGE_SIZE = 50
+DEFAULT_SYNC_JWT_EXPIRATION = 60
+
 
 class ManifestNotFound(HTTPError):
     """Raise when server returns 404 for a manifest"""
@@ -109,7 +113,7 @@ def create_api_client() -> ResourceAPIClient:
     if not service_path:
         raise ValueError("RESOURCE_SERVICE_PATH is not set.")
     params["service_path"] = service_path
-    params["jwt_expiration"] = getattr(settings, "RESOURCE_SYNC_JWT_EXPIRATION", 60)
+    params["jwt_expiration"] = getattr(settings, "RESOURCE_SYNC_JWT_EXPIRATION", DEFAULT_SYNC_JWT_EXPIRATION)
 
     client = get_resource_server_client(**params)
     return client
@@ -194,7 +198,7 @@ class RemoteAssignmentFetcher:
     def __init__(self, api_client: ResourceAPIClient, page_size: int | None = None):
         self.api_client = api_client
         self.assignments: set[AssignmentTuple] = set()
-        self.page_size = page_size if page_size is not None else getattr(settings, 'RESOURCE_SYNC_PAGE_SIZE', 50)
+        self.page_size = page_size if page_size is not None else getattr(settings, 'RESOURCE_SYNC_PAGE_SIZE', DEFAULT_SYNC_PAGE_SIZE)
 
     def fetch(self) -> RemoteAssignmentResult:
         """Paginate user then team assignments and return the result.

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -109,6 +109,7 @@ def create_api_client() -> ResourceAPIClient:
     if not service_path:
         raise ValueError("RESOURCE_SERVICE_PATH is not set.")
     params["service_path"] = service_path
+    params["jwt_expiration"] = getattr(settings, "RESOURCE_SYNC_JWT_EXPIRATION", 60)
 
     client = get_resource_server_client(**params)
     return client
@@ -190,9 +191,10 @@ class RemoteAssignmentFetcher:
     incomplete so the caller can skip deletions safely.
     """
 
-    def __init__(self, api_client: ResourceAPIClient):
+    def __init__(self, api_client: ResourceAPIClient, page_size: int | None = None):
         self.api_client = api_client
         self.assignments: set[AssignmentTuple] = set()
+        self.page_size = page_size if page_size is not None else getattr(settings, 'RESOURCE_SYNC_PAGE_SIZE', 50)
 
     def fetch(self) -> RemoteAssignmentResult:
         """Paginate user then team assignments and return the result.
@@ -219,7 +221,7 @@ class RemoteAssignmentFetcher:
         page = 1
         try:
             while True:
-                resp = list_fn(filters={'page': page})
+                resp = list_fn(filters={'page': page, 'page_size': self.page_size})
                 if resp.status_code != 200:
                     logger.warning(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {resp.status_code}")
                     return False
@@ -250,14 +252,14 @@ class RemoteAssignmentFetcher:
             return False
 
 
-def get_remote_assignments(api_client: ResourceAPIClient) -> RemoteAssignmentResult:
+def get_remote_assignments(api_client: ResourceAPIClient, page_size: int | None = None) -> RemoteAssignmentResult:
     """Fetch remote assignments from the resource server and convert to tuples.
 
     Returns a ``RemoteAssignmentResult`` so the caller can distinguish a
     complete fetch from a partial one (e.g. due to HTTP errors or
     timeouts mid-pagination).
     """
-    return RemoteAssignmentFetcher(api_client).fetch()
+    return RemoteAssignmentFetcher(api_client, page_size=page_size).fetch()
 
 
 def get_local_assignments() -> set[AssignmentTuple]:
@@ -617,6 +619,7 @@ class SyncExecutor:
     asyncio: bool = False
     results: dict = field(default_factory=lambda: defaultdict(list))
     sync_assignments: bool = True
+    page_size: int | None = None
 
     def write(self, text: str = ""):
         """Write to assigned IO or simply ignores the text."""
@@ -763,7 +766,7 @@ class SyncExecutor:
         self.write(">>> Syncing role assignments")
 
         try:
-            remote_result = get_remote_assignments(self.api_client)
+            remote_result = get_remote_assignments(self.api_client, page_size=self.page_size)
             local_assignments = get_local_assignments()
 
             # Deletions are only safe when the remote fetch was complete.

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -12,6 +12,8 @@ from ansible_base.rbac.models import RoleDefinition
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.models.service_identifier import service_id
 from ansible_base.resource_registry.tasks.sync import (
+    DEFAULT_SYNC_JWT_EXPIRATION,
+    DEFAULT_SYNC_PAGE_SIZE,
     AssignmentTuple,
     ManifestItem,
     RemoteAssignmentFetcher,
@@ -601,3 +603,40 @@ def test_create_api_client_reads_jwt_expiration(mock_get_client):
         create_api_client()
 
     assert mock_get_client.call_args.kwargs["jwt_expiration"] == 120
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_default_page_size():
+    """When no setting is configured, page_size should fall back to DEFAULT_SYNC_PAGE_SIZE."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    fetcher = RemoteAssignmentFetcher(api_client)
+    assert fetcher.page_size == DEFAULT_SYNC_PAGE_SIZE
+
+
+@mock.patch("ansible_base.resource_registry.tasks.sync.get_resource_server_client")
+def test_create_api_client_default_jwt_expiration(mock_get_client):
+    """When no setting is configured, jwt_expiration should fall back to DEFAULT_SYNC_JWT_EXPIRATION."""
+    mock_get_client.return_value = mock.Mock()
+
+    with override_settings(RESOURCE_SERVICE_PATH="/api/gateway/v1/service-index/"):
+        create_api_client()
+
+    assert mock_get_client.call_args.kwargs["jwt_expiration"] == DEFAULT_SYNC_JWT_EXPIRATION
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_sends_page_size_on_all_pages():
+    """page_size should be included in filters on every page, not just the first."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+
+    page1 = _mock_response(body={"results": [], "next": "http://example.com/page2"})
+    page2 = _mock_response(body={"results": [], "next": None})
+    api_client.list_user_assignments.side_effect = [page1, page2]
+    api_client.list_team_assignments.return_value = _mock_response()
+
+    RemoteAssignmentFetcher(api_client, page_size=100).fetch()
+
+    user_calls = api_client.list_user_assignments.call_args_list
+    assert len(user_calls) == 2
+    assert user_calls[0] == mock.call(filters={'page': 1, 'page_size': 100})
+    assert user_calls[1] == mock.call(filters={'page': 2, 'page_size': 100})

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 from django.db.utils import Error
+from django.test import override_settings
 
 from ansible_base.lib.testing.util import StaticResourceAPIClient
 from ansible_base.lib.utils.response import get_relative_url
@@ -13,11 +14,13 @@ from ansible_base.resource_registry.models.service_identifier import service_id
 from ansible_base.resource_registry.tasks.sync import (
     AssignmentTuple,
     ManifestItem,
+    RemoteAssignmentFetcher,
     RemoteAssignmentResult,
     ResourceSyncHTTPError,
     SyncExecutor,
     _attempt_create_resource,
     _attempt_update_resource,
+    create_api_client,
     get_remote_assignments,
 )
 
@@ -543,3 +546,58 @@ def test_get_remote_assignments_filters_unknown_roles(static_api_client):
     assert len(result.assignments) == 1
     assignment = next(iter(result.assignments))
     assert assignment.role_definition_name == local_role.name
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_passes_page_size():
+    """page_size should be included in the pagination filters."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    ok = _mock_response()
+    api_client.list_user_assignments.return_value = ok
+    api_client.list_team_assignments.return_value = ok
+
+    RemoteAssignmentFetcher(api_client, page_size=100).fetch()
+
+    api_client.list_user_assignments.assert_called_with(filters={'page': 1, 'page_size': 100})
+    api_client.list_team_assignments.assert_called_with(filters={'page': 1, 'page_size': 100})
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_reads_page_size_from_settings():
+    """When page_size is not provided, it should be read from settings."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    ok = _mock_response()
+    api_client.list_user_assignments.return_value = ok
+    api_client.list_team_assignments.return_value = ok
+
+    with override_settings(RESOURCE_SYNC_PAGE_SIZE=200):
+        fetcher = RemoteAssignmentFetcher(api_client)
+        assert fetcher.page_size == 200
+        fetcher.fetch()
+
+    api_client.list_user_assignments.assert_called_with(filters={'page': 1, 'page_size': 200})
+
+
+@mock.patch('ansible_base.resource_registry.tasks.sync.get_remote_assignments')
+@mock.patch('ansible_base.resource_registry.tasks.sync.get_local_assignments', return_value=set())
+@pytest.mark.django_db
+def test_sync_executor_passes_page_size(mock_local, mock_remote, static_api_client, stdout):
+    """SyncExecutor should forward page_size to get_remote_assignments."""
+    mock_remote.return_value = RemoteAssignmentResult(assignments=set(), is_complete=True)
+    executor = SyncExecutor(api_client=static_api_client, stdout=stdout, page_size=75)
+    executor._sync_assignments()
+    mock_remote.assert_called_once_with(static_api_client, page_size=75)
+
+
+@mock.patch("ansible_base.resource_registry.tasks.sync.get_resource_server_client")
+def test_create_api_client_reads_jwt_expiration(mock_get_client):
+    """create_api_client should read RESOURCE_SYNC_JWT_EXPIRATION from settings."""
+    mock_get_client.return_value = mock.Mock()
+
+    with override_settings(
+        RESOURCE_SERVICE_PATH="/api/gateway/v1/service-index/",
+        RESOURCE_SYNC_JWT_EXPIRATION=120,
+    ):
+        create_api_client()
+
+    assert mock_get_client.call_args.kwargs["jwt_expiration"] == 120


### PR DESCRIPTION
## Description

Allow operators to tune RESOURCE_SYNC_PAGE_SIZE and RESOURCE_SYNC_JWT_EXPIRATION via Django settings. These are read automatically by SyncExecutor and create_api_client(), so consuming services (tower, hub, EDA) pick up new values without code changes.

This change is occurring due to multiple customers having pagination issues, and also the performance impact of having a hardcoded page_size value of 50 when thousands of roles exist.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource sync command accepts an optional --page-size (must be >=1) to control pagination.
  * Added configurable resource-sync settings: RESOURCE_SYNC_INTERVAL_SECONDS, RESOURCE_SYNC_PAGE_SIZE (default 50), and RESOURCE_SYNC_JWT_EXPIRATION (default 60s).

* **Tests**
  * Added tests covering pagination behavior and settings-driven configuration for resource sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->