### PR TITLE
[AAP-45394 AAP-45047] Fix: allow maps can now recover access after an earlier deny

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -120,9 +120,8 @@ def create_claims(authenticator: Authenticator, username: str, attrs: dict, grou
         rule_responses.append({mpk: has_permission, 'enabled': auth_map.enabled})
 
         understood_map = False
-        if auth_map.map_type == 'allow' and not has_permission:
-            # If any rule does not allow we don't want to return this to true
-            access_allowed = False
+        if auth_map.map_type == 'allow':
+            access_allowed = has_permission
             understood_map = True
         elif auth_map.map_type == 'is_superuser':
             is_superuser = has_permission

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -2740,23 +2740,21 @@ def test_create_claims_deny_all_then_allow_override(
     access remained denied.
     """
     # order=1: deny-all rule (trigger 'never' -> has_permission=False)
-    local_authenticator_map.map_type = "allow"
-    local_authenticator_map.triggers = {"never": {}}
+    local_authenticator_map.map_type = 'allow'
+    local_authenticator_map.triggers = {'never': {}}
     local_authenticator_map.order = 1
     local_authenticator_map.save()
 
     # order=2: allow-always rule (trigger 'always' -> has_permission=True)
-    local_authenticator_map_1.map_type = "allow"
-    local_authenticator_map_1.triggers = {"always": {}}
+    local_authenticator_map_1.map_type = 'allow'
+    local_authenticator_map_1.triggers = {'always': {}}
     local_authenticator_map_1.order = 2
     local_authenticator_map_1.save()
 
     authenticator = local_authenticator_map.authenticator
-    res = claims.create_claims(authenticator, "username", {}, [])
+    res = claims.create_claims(authenticator, 'username', {}, [])
 
-    assert res["access_allowed"] is True, (
-        "An allow-always map at order=2 must override a deny-all map at order=1 (AAP-45394)"
-    )
+    assert res['access_allowed'] is True, 'An allow-always map at order=2 must override a deny-all map at order=1 (AAP-45394)'
 
 
 def test_create_claims_deny_all_not_overridden_without_match(
@@ -2768,24 +2766,22 @@ def test_create_claims_deny_all_not_overridden_without_match(
     allow map's trigger, access must remain denied.
     """
     # order=1: deny-all
-    local_authenticator_map.map_type = "allow"
-    local_authenticator_map.triggers = {"never": {}}
+    local_authenticator_map.map_type = 'allow'
+    local_authenticator_map.triggers = {'never': {}}
     local_authenticator_map.order = 1
     local_authenticator_map.save()
 
-    # order=2: allow only for members of group "special-group"; user has no groups
-    local_authenticator_map_1.map_type = "allow"
-    local_authenticator_map_1.triggers = {"groups": {"has_or": ["special-group"]}}
+    # order=2: allow only for members of group 'special-group'; user has no groups
+    local_authenticator_map_1.map_type = 'allow'
+    local_authenticator_map_1.triggers = {'groups': {'has_or': ['special-group']}}
     local_authenticator_map_1.order = 2
     local_authenticator_map_1.save()
 
     authenticator = local_authenticator_map.authenticator
-    # Pass an empty groups list — the user is NOT in "special-group"
-    res = claims.create_claims(authenticator, "username", {}, [])
+    # Pass an empty groups list -- the user is NOT in 'special-group'
+    res = claims.create_claims(authenticator, 'username', {}, [])
 
-    assert res["access_allowed"] is False, (
-        "User not matching the second allow map must remain denied (AAP-45394)"
-    )
+    assert res['access_allowed'] is False, 'User not matching the second allow map must remain denied (AAP-45394)'
 
 
 def test_create_claims_deny_all_overridden_with_group_match(
@@ -2797,21 +2793,19 @@ def test_create_claims_deny_all_overridden_with_group_match(
     map's trigger, the deny from the first map must be overridden.
     """
     # order=1: deny-all
-    local_authenticator_map.map_type = "allow"
-    local_authenticator_map.triggers = {"never": {}}
+    local_authenticator_map.map_type = 'allow'
+    local_authenticator_map.triggers = {'never': {}}
     local_authenticator_map.order = 1
     local_authenticator_map.save()
 
-    # order=2: allow for members of "special-group"
-    local_authenticator_map_1.map_type = "allow"
-    local_authenticator_map_1.triggers = {"groups": {"has_or": ["special-group"]}}
+    # order=2: allow for members of 'special-group'
+    local_authenticator_map_1.map_type = 'allow'
+    local_authenticator_map_1.triggers = {'groups': {'has_or': ['special-group']}}
     local_authenticator_map_1.order = 2
     local_authenticator_map_1.save()
 
     authenticator = local_authenticator_map.authenticator
-    # Pass "special-group" in the groups list — the user IS in the group
-    res = claims.create_claims(authenticator, "username", {}, ["special-group"])
+    # Pass 'special-group' in the groups list -- the user IS in the group
+    res = claims.create_claims(authenticator, 'username', {}, ['special-group'])
 
-    assert res["access_allowed"] is True, (
-        "User matching the second allow map must have access granted despite earlier deny (AAP-45394)"
-    )
+    assert res['access_allowed'] is True, 'User matching the second allow map must have access granted despite earlier deny (AAP-45394)'

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -73,6 +73,18 @@ from test_app.tests.authentication.conftest import ORG_ADMIN_ROLE_NAME, ORG_MEMB
         ),
         pytest.param(
             {"always": {}},
+            "allow",
+            "",
+            {},
+            [],
+            True,
+            None,
+            {"team_membership": {}, "organization_membership": {}, 'rbac_roles': {'system': {'roles': {}}, 'organizations': {}}},
+            [{1: True, 'enabled': True}],
+            id="map_type 'allow' with trigger 'always' sets 'access_allowed' to True (AAP-45394)",
+        ),
+        pytest.param(
+            {"always": {}},
             "team",
             TEAM_MEMBER_ROLE_NAME,
             {},
@@ -2710,3 +2722,96 @@ class TestRefactoredCacheExisting:
         if "Test Role" in cache_instance.cache:
             for content_type_id in expected_skipped_content_types:
                 assert content_type_id not in cache_instance.cache["Test Role"]
+
+
+# --- AAP-45394 regression tests ---
+
+
+def test_create_claims_deny_all_then_allow_override(
+    local_authenticator_map,
+    local_authenticator_map_1,
+):
+    """
+    Regression test for AAP-45394: a deny-all allow map at order=1 must be
+    recoverable by an allow-always allow map at order=2.
+
+    Before the fix the 'allow' branch only triggered when has_permission=False,
+    so the affirmative branch (has_permission=True) was silently dropped and
+    access remained denied.
+    """
+    # order=1: deny-all rule (trigger 'never' -> has_permission=False)
+    local_authenticator_map.map_type = "allow"
+    local_authenticator_map.triggers = {"never": {}}
+    local_authenticator_map.order = 1
+    local_authenticator_map.save()
+
+    # order=2: allow-always rule (trigger 'always' -> has_permission=True)
+    local_authenticator_map_1.map_type = "allow"
+    local_authenticator_map_1.triggers = {"always": {}}
+    local_authenticator_map_1.order = 2
+    local_authenticator_map_1.save()
+
+    authenticator = local_authenticator_map.authenticator
+    res = claims.create_claims(authenticator, "username", {}, [])
+
+    assert res["access_allowed"] is True, (
+        "An allow-always map at order=2 must override a deny-all map at order=1 (AAP-45394)"
+    )
+
+
+def test_create_claims_deny_all_not_overridden_without_match(
+    local_authenticator_map,
+    local_authenticator_map_1,
+):
+    """
+    Regression test for AAP-45394: when the user does NOT match the second
+    allow map's trigger, access must remain denied.
+    """
+    # order=1: deny-all
+    local_authenticator_map.map_type = "allow"
+    local_authenticator_map.triggers = {"never": {}}
+    local_authenticator_map.order = 1
+    local_authenticator_map.save()
+
+    # order=2: allow only for members of group "special-group"; user has no groups
+    local_authenticator_map_1.map_type = "allow"
+    local_authenticator_map_1.triggers = {"groups": {"has_or": ["special-group"]}}
+    local_authenticator_map_1.order = 2
+    local_authenticator_map_1.save()
+
+    authenticator = local_authenticator_map.authenticator
+    # Pass an empty groups list — the user is NOT in "special-group"
+    res = claims.create_claims(authenticator, "username", {}, [])
+
+    assert res["access_allowed"] is False, (
+        "User not matching the second allow map must remain denied (AAP-45394)"
+    )
+
+
+def test_create_claims_deny_all_overridden_with_group_match(
+    local_authenticator_map,
+    local_authenticator_map_1,
+):
+    """
+    Regression test for AAP-45394: when the user DOES match the second allow
+    map's trigger, the deny from the first map must be overridden.
+    """
+    # order=1: deny-all
+    local_authenticator_map.map_type = "allow"
+    local_authenticator_map.triggers = {"never": {}}
+    local_authenticator_map.order = 1
+    local_authenticator_map.save()
+
+    # order=2: allow for members of "special-group"
+    local_authenticator_map_1.map_type = "allow"
+    local_authenticator_map_1.triggers = {"groups": {"has_or": ["special-group"]}}
+    local_authenticator_map_1.order = 2
+    local_authenticator_map_1.save()
+
+    authenticator = local_authenticator_map.authenticator
+    # Pass "special-group" in the groups list — the user IS in the group
+    res = claims.create_claims(authenticator, "username", {}, ["special-group"])
+
+    assert res["access_allowed"] is True, (
+        "User matching the second allow map must have access granted despite earlier deny (AAP-45394)"
+    )

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -2809,3 +2809,85 @@ def test_create_claims_deny_all_overridden_with_group_match(
     res = claims.create_claims(authenticator, 'username', {}, ['special-group'])
 
     assert res['access_allowed'] is True, 'User matching the second allow map must have access granted despite earlier deny (AAP-45394)'
+
+
+def test_create_claims_allow_then_deny_preserves_deny(
+    local_authenticator_map,
+    local_authenticator_map_1,
+):
+    """
+    Verify the reverse ordering: allow-always at order=1, deny-all at order=2.
+    The later deny must override the earlier allow (last writer wins).
+    """
+    local_authenticator_map.map_type = 'allow'
+    local_authenticator_map.triggers = {'always': {}}
+    local_authenticator_map.order = 1
+    local_authenticator_map.save()
+
+    local_authenticator_map_1.map_type = 'allow'
+    local_authenticator_map_1.triggers = {'never': {}}
+    local_authenticator_map_1.order = 2
+    local_authenticator_map_1.save()
+
+    authenticator = local_authenticator_map.authenticator
+    res = claims.create_claims(authenticator, 'username', {}, [])
+
+    assert res['access_allowed'] is False, 'A deny-all map at order=2 must override an allow-always map at order=1'
+
+
+def test_create_claims_revoke_deny_overridden_by_later_allow(
+    local_authenticator_map,
+    local_authenticator_map_1,
+):
+    """
+    A revoke=True allow map whose trigger does not match converts SKIP to DENY.
+    A subsequent allow-always map must override that denial (last writer wins).
+    """
+    # order=1: allow for group 'admins' with revoke=True
+    # user NOT in admins -> SKIP -> revoke converts to DENY -> access_allowed=False
+    local_authenticator_map.map_type = 'allow'
+    local_authenticator_map.triggers = {'groups': {'has_or': ['admins']}}
+    local_authenticator_map.revoke = True
+    local_authenticator_map.order = 1
+    local_authenticator_map.save()
+
+    # order=2: allow-always -> access_allowed=True
+    local_authenticator_map_1.map_type = 'allow'
+    local_authenticator_map_1.triggers = {'always': {}}
+    local_authenticator_map_1.order = 2
+    local_authenticator_map_1.save()
+
+    authenticator = local_authenticator_map.authenticator
+    res = claims.create_claims(authenticator, 'username', {}, [])
+
+    assert res['access_allowed'] is True, 'An allow-always map must override a revoke-deny from an earlier map'
+
+
+def test_create_claims_three_maps_last_writer_wins(
+    local_authenticator_map,
+    local_authenticator_map_1,
+    local_authenticator_map_2,
+):
+    """
+    Three allow maps: allow(1) -> deny(2) -> allow(3).
+    The last evaluated map must win.
+    """
+    local_authenticator_map.map_type = 'allow'
+    local_authenticator_map.triggers = {'always': {}}
+    local_authenticator_map.order = 1
+    local_authenticator_map.save()
+
+    local_authenticator_map_1.map_type = 'allow'
+    local_authenticator_map_1.triggers = {'never': {}}
+    local_authenticator_map_1.order = 2
+    local_authenticator_map_1.save()
+
+    local_authenticator_map_2.map_type = 'allow'
+    local_authenticator_map_2.triggers = {'always': {}}
+    local_authenticator_map_2.order = 3
+    local_authenticator_map_2.save()
+
+    authenticator = local_authenticator_map.authenticator
+    res = claims.create_claims(authenticator, 'username', {}, [])
+
+    assert res['access_allowed'] is True, 'The last allow map (order=3, always) must win over the deny at order=2'

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -2727,6 +2727,26 @@ class TestRefactoredCacheExisting:
 # --- AAP-45394 regression tests ---
 
 
+@mock.patch("ansible_base.authentication.utils.claims.logger")
+def test_create_claims_allow_grant_no_error_logged(
+    logger,
+    local_authenticator_map,
+    shut_up_logging,
+):
+    """
+    Regression test for AAP-45047: map_type 'allow' with a firing trigger
+    must NOT log an error or fall through to the catch-all else branch.
+    """
+    local_authenticator_map.triggers = {"always": {}}
+    local_authenticator_map.map_type = "allow"
+    local_authenticator_map.save()
+
+    authenticator = local_authenticator_map.authenticator
+    claims.create_claims(authenticator, "username", {}, [])
+
+    logger.error.assert_not_called()
+
+
 def test_create_claims_deny_all_then_allow_override(
     local_authenticator_map,
     local_authenticator_map_1,


### PR DESCRIPTION
## Summary

Authenticator maps of `map_type=allow` could not recover `access_allowed` once it had been set to `False` by an earlier deny-all rule. The `create_claims()` function in `ansible_base/authentication/utils/claims.py` guarded the `allow` branch with `and not has_permission`, which silently dropped the case where a later allow-map fires affirmatively (`has_permission=True`). As a result, once `access_allowed=False` was set by the first map, no subsequent allow map — regardless of order — could ever restore access.

## Root Cause

At line 123 of `ansible_base/authentication/utils/claims.py`, the condition:

```python
if auth_map.map_type == 'allow' and not has_permission:
    access_allowed = False
    understood_map = True
```

only executed when `has_permission=False`. When a later allow-map evaluated to `ALLOW` (`has_permission=True`), the condition was `False`, control fell through to the `if not understood_map` catch-all, and the error `"Map type allow of rule ... does not know how to be processed"` was logged. The `access_allowed` variable was never reset to `True`.

## Changes

- **`ansible_base/authentication/utils/claims.py`** — Remove the `and not has_permission` guard and replace `access_allowed = False` with `access_allowed = has_permission`. This makes `access_allowed` always track the most recently evaluated allow-map result, letting later (higher-order) rules override earlier ones as the ordering mechanism is designed to support.
- **`test_app/tests/authentication/utils/test_claims.py`** — Add one parametrized case (`allow` + `always` trigger) to the existing `test_create_claims_single_map_acl` suite, and three new standalone regression tests:
  - `test_create_claims_deny_all_then_allow_override` — deny at order=1, allow-always at order=2 → access granted
  - `test_create_claims_deny_all_not_overridden_without_match` — deny at order=1, allow-group at order=2, user NOT in group → access denied
  - `test_create_claims_deny_all_overridden_with_group_match` — deny at order=1, allow-group at order=2, user IS in group → access granted

## Risk Assessment

- **Confidence:** HIGH (95%)
- **Risk:** Low — the change only affects `map_type == 'allow'` maps. The deny path (`has_permission=False`) produces the same result as before (`access_allowed = False`). The only behavior change is that the grant path (`has_permission=True`) now sets `access_allowed = True` instead of being silently dropped.
- **Scope:** 2 files changed

## Testing

- [ ] Unit tests pass
- [ ] Regression tests added (4 new test cases covering the fixed code path)
- [ ] Lint checks pass

## JIRA

- Ticket: [AAP-45394](https://redhat.atlassian.net/browse/AAP-45394)

## See Also

See also: https://github.com/ansible/django-ansible-base/pull/959 — an open PR with an identical fix (also covering AAP-45047 and AAP-45394). Reviewers may choose to close this PR in favor of #959 or merge whichever is reviewed first.

---
*Debuggernaut autonomous fix -- review carefully before merging.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication rule evaluation updated so later allow rules can override earlier denials, ensuring rule ordering is respected.

* **Tests**
  * Added regression tests covering rule override scenarios: deny-then-allow, non-matching allow, group-based matches, allow-then-deny precedence, revoke-deny overridden, and multi-rule "last writer wins" behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->