### PR TITLE
[AAP-55298] Fix OAuth2 scope mutation causing spurious activity stream entries

### DIFF
--- a/ansible_base/oauth2_provider/permissions.py
+++ b/ansible_base/oauth2_provider/permissions.py
@@ -20,11 +20,7 @@ class OAuth2ScopePermission(BasePermission):
         is_authenticated = IsAuthenticated().has_permission(request, view)
         is_oauth = False
         has_oauth_permission = False
-        if (
-            is_authenticated
-            and request.auth
-            and isinstance(request.auth, oauth2_models.AbstractAccessToken)
-        ):
+        if is_authenticated and request.auth and isinstance(request.auth, oauth2_models.AbstractAccessToken):
             is_oauth = True
             scopes = request.auth.scope.split()
             if "write" in scopes and "read" not in scopes:
@@ -35,9 +31,7 @@ class OAuth2ScopePermission(BasePermission):
                 request.auth.scope = original_scope + " read"  # write implies read
                 try:
                     token_permission = TokenHasReadWriteScope()
-                    has_oauth_permission = token_permission.has_permission(
-                        request, view
-                    )
+                    has_oauth_permission = token_permission.has_permission(request, view)
                 finally:
                     request.auth.scope = original_scope
             else:

--- a/ansible_base/oauth2_provider/permissions.py
+++ b/ansible_base/oauth2_provider/permissions.py
@@ -20,11 +20,27 @@ class OAuth2ScopePermission(BasePermission):
         is_authenticated = IsAuthenticated().has_permission(request, view)
         is_oauth = False
         has_oauth_permission = False
-        if is_authenticated and request.auth and isinstance(request.auth, oauth2_models.AbstractAccessToken):
+        if (
+            is_authenticated
+            and request.auth
+            and isinstance(request.auth, oauth2_models.AbstractAccessToken)
+        ):
             is_oauth = True
             scopes = request.auth.scope.split()
-            if 'write' in scopes and 'read' not in scopes:
-                request.auth.scope += ' read'  # write implies read
-            token_permission = TokenHasReadWriteScope()
-            has_oauth_permission = token_permission.has_permission(request, view)
+            if "write" in scopes and "read" not in scopes:
+                # Temporarily expand scope for permission check only.
+                # Use try/finally to guarantee the original scope is restored
+                # so the model instance is never left in a mutated state (AAP-55298).
+                original_scope = request.auth.scope
+                request.auth.scope = original_scope + " read"  # write implies read
+                try:
+                    token_permission = TokenHasReadWriteScope()
+                    has_oauth_permission = token_permission.has_permission(
+                        request, view
+                    )
+                finally:
+                    request.auth.scope = original_scope
+            else:
+                token_permission = TokenHasReadWriteScope()
+                has_oauth_permission = token_permission.has_permission(request, view)
         return is_authenticated and (not is_oauth or has_oauth_permission)

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -13,15 +13,11 @@ from ansible_base.oauth2_provider.models import OAuth2AccessToken
 def only_oauth_scope_permission(settings):
     from ansible_base.oauth2_provider.permissions import OAuth2ScopePermission
 
-    with mock.patch(
-        "rest_framework.views.APIView.permission_classes", [OAuth2ScopePermission]
-    ):
+    with mock.patch("rest_framework.views.APIView.permission_classes", [OAuth2ScopePermission]):
         yield
 
 
-def test_oauth2_bearer_get_user_correct(
-    unauthenticated_api_client, oauth2_admin_access_token
-):
+def test_oauth2_bearer_get_user_correct(unauthenticated_api_client, oauth2_admin_access_token):
     """
     Perform a GET with a bearer token and ensure the authed user is correct.
     """
@@ -34,12 +30,8 @@ def test_oauth2_bearer_get_user_correct(
     assert response.data["username"] == oauth2_admin_access_token[0].user.username
 
 
-@pytest.mark.parametrize(
-    "prefix", ["Bearer", "Token", "bearer", "token", "BEARER", "TOKEN"]
-)
-def test_oauth2_token_prefix_variants(
-    unauthenticated_api_client, oauth2_admin_access_token, animal, prefix
-):
+@pytest.mark.parametrize("prefix", ["Bearer", "Token", "bearer", "token", "BEARER", "TOKEN"])
+def test_oauth2_token_prefix_variants(unauthenticated_api_client, oauth2_admin_access_token, animal, prefix):
     """
     GET an animal with Bearer or Token prefix (AAP-68669).
     """
@@ -53,9 +45,7 @@ def test_oauth2_token_prefix_variants(
 
 
 @pytest.mark.parametrize("prefix", ["Junk", "Basic", "Digest"])
-def test_oauth2_token_invalid_prefix_rejected(
-    unauthenticated_api_client, oauth2_admin_access_token, animal, prefix
-):
+def test_oauth2_token_invalid_prefix_rejected(unauthenticated_api_client, oauth2_admin_access_token, animal, prefix):
     """
     Verify that valid tokens with unsupported prefixes are rejected (AAP-68669).
     """
@@ -74,9 +64,7 @@ def test_oauth2_token_invalid_prefix_rejected(
         ("bad", 401),
     ],
 )
-def test_oauth2_bearer_get(
-    unauthenticated_api_client, oauth2_admin_access_token, animal, token, expected
-):
+def test_oauth2_bearer_get(unauthenticated_api_client, oauth2_admin_access_token, animal, token, expected):
     """
     GET an animal with a bearer token.
     """
@@ -107,9 +95,7 @@ def test_oauth2_token_expiry(oauth2_admin_access_token):
         ("bad", 401),
     ],
 )
-def test_oauth2_bearer_post(
-    unauthenticated_api_client, oauth2_admin_access_token, admin_user, token, expected
-):
+def test_oauth2_bearer_post(unauthenticated_api_client, oauth2_admin_access_token, admin_user, token, expected):
     """
     POST an animal with a bearer token.
     """
@@ -196,9 +182,7 @@ def test_oauth2_bearer_put(
         assert response.data["name"] == "Fido"
 
 
-def test_oauth2_bearer_no_activitystream(
-    unauthenticated_api_client, oauth2_admin_access_token, animal
-):
+def test_oauth2_bearer_no_activitystream(unauthenticated_api_client, oauth2_admin_access_token, animal):
     """
     Ensure no activitystream entries for bearer token based auth
     """
@@ -213,9 +197,7 @@ def test_oauth2_bearer_no_activitystream(
     assert response.status_code == 200
     assert response.data["name"] == animal.name
 
-    updated_token = OAuth2AccessToken.objects.get(
-        token=oauth2_admin_access_token[0].token
-    )
+    updated_token = OAuth2AccessToken.objects.get(token=oauth2_admin_access_token[0].token)
     assert len(updated_token.activity_stream_entries) == existing_as_count
 
 
@@ -262,9 +244,7 @@ def test_oauth2_scope_permission(
     assert response.status_code == status, response.status_code
 
 
-def test_oauth2_scope_permission_not_oauth(
-    user, user_api_client, only_oauth_scope_permission
-):
+def test_oauth2_scope_permission_not_oauth(user, user_api_client, only_oauth_scope_permission):
     """
     Ensure that non-OAuth (but still authenticated) requests pass through.
     """
@@ -278,9 +258,7 @@ def test_oauth2_scope_permission_not_oauth(
     assert response.status_code == 201, response.status_code
 
 
-def test_oauth2_scope_permission_not_authenticated(
-    user, unauthenticated_api_client, only_oauth_scope_permission
-):
+def test_oauth2_scope_permission_not_authenticated(user, unauthenticated_api_client, only_oauth_scope_permission):
     """
     Ensure that non-authenticated are blocked.
     """
@@ -294,14 +272,10 @@ def test_oauth2_scope_permission_not_authenticated(
     assert response.status_code == 401, response.status_code
 
 
-def test_oauth2_unsupported_media_type(
-    user, user_api_client, only_oauth_scope_permission
-):
+def test_oauth2_unsupported_media_type(user, user_api_client, only_oauth_scope_permission):
     url = get_relative_url("animal-upload")
     data = b"TESTDATA"
-    response = user_api_client.post(
-        url, data=data, content_type="application/octet-stream"
-    )
+    response = user_api_client.post(url, data=data, content_type="application/octet-stream")
     assert response.status_code == 200, response.status_code
 
 
@@ -381,9 +355,7 @@ def test_oauth2_scope_not_mutated_after_permission_check(
 
     # The in-memory token scope must still be "write" -- not "write read"
     access_token_obj.refresh_from_db()
-    assert access_token_obj.scope == "write", (
-        f"Token scope was mutated to '{access_token_obj.scope}'; expected 'write'"
-    )
+    assert access_token_obj.scope == "write", f"Token scope was mutated to '{access_token_obj.scope}'; expected 'write'"
 
     # Also make a POST request (write operation) and verify scope is unchanged
     url = get_relative_url("animal-list")
@@ -396,9 +368,7 @@ def test_oauth2_scope_not_mutated_after_permission_check(
     assert response.status_code == 201
 
     access_token_obj.refresh_from_db()
-    assert access_token_obj.scope == "write", (
-        f"Token scope was mutated to '{access_token_obj.scope}' after POST; expected 'write'"
-    )
+    assert access_token_obj.scope == "write", f"Token scope was mutated to '{access_token_obj.scope}' after POST; expected 'write'"
 
 
 @pytest.mark.django_db
@@ -435,6 +405,4 @@ def test_oauth2_scope_no_activitystream_for_scope_field(
 
     # No new activity stream entries should have been created
     final_entry_count = Entry.objects.count()
-    assert final_entry_count == initial_entry_count, (
-        f"Expected no new activity stream entries, but {final_entry_count - initial_entry_count} were created"
-    )
+    assert final_entry_count == initial_entry_count, f"Expected no new activity stream entries, but {final_entry_count - initial_entry_count} were created"

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -13,70 +13,82 @@ from ansible_base.oauth2_provider.models import OAuth2AccessToken
 def only_oauth_scope_permission(settings):
     from ansible_base.oauth2_provider.permissions import OAuth2ScopePermission
 
-    with mock.patch('rest_framework.views.APIView.permission_classes', [OAuth2ScopePermission]):
+    with mock.patch(
+        "rest_framework.views.APIView.permission_classes", [OAuth2ScopePermission]
+    ):
         yield
 
 
-def test_oauth2_bearer_get_user_correct(unauthenticated_api_client, oauth2_admin_access_token):
+def test_oauth2_bearer_get_user_correct(
+    unauthenticated_api_client, oauth2_admin_access_token
+):
     """
     Perform a GET with a bearer token and ensure the authed user is correct.
     """
     url = get_relative_url("user-me")
     response = unauthenticated_api_client.get(
         url,
-        headers={'Authorization': f'Bearer {oauth2_admin_access_token[1]}'},
+        headers={"Authorization": f"Bearer {oauth2_admin_access_token[1]}"},
     )
     assert response.status_code == 200
-    assert response.data['username'] == oauth2_admin_access_token[0].user.username
+    assert response.data["username"] == oauth2_admin_access_token[0].user.username
 
 
-@pytest.mark.parametrize('prefix', ['Bearer', 'Token', 'bearer', 'token', 'BEARER', 'TOKEN'])
-def test_oauth2_token_prefix_variants(unauthenticated_api_client, oauth2_admin_access_token, animal, prefix):
+@pytest.mark.parametrize(
+    "prefix", ["Bearer", "Token", "bearer", "token", "BEARER", "TOKEN"]
+)
+def test_oauth2_token_prefix_variants(
+    unauthenticated_api_client, oauth2_admin_access_token, animal, prefix
+):
     """
     GET an animal with Bearer or Token prefix (AAP-68669).
     """
     url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
     response = unauthenticated_api_client.get(
         url,
-        headers={'Authorization': f'{prefix} {oauth2_admin_access_token[1]}'},
+        headers={"Authorization": f"{prefix} {oauth2_admin_access_token[1]}"},
     )
     assert response.status_code == 200
-    assert response.data['name'] == animal.name
+    assert response.data["name"] == animal.name
 
 
-@pytest.mark.parametrize('prefix', ['Junk', 'Basic', 'Digest'])
-def test_oauth2_token_invalid_prefix_rejected(unauthenticated_api_client, oauth2_admin_access_token, animal, prefix):
+@pytest.mark.parametrize("prefix", ["Junk", "Basic", "Digest"])
+def test_oauth2_token_invalid_prefix_rejected(
+    unauthenticated_api_client, oauth2_admin_access_token, animal, prefix
+):
     """
     Verify that valid tokens with unsupported prefixes are rejected (AAP-68669).
     """
     url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
     response = unauthenticated_api_client.get(
         url,
-        headers={'Authorization': f'{prefix} {oauth2_admin_access_token[1]}'},
+        headers={"Authorization": f"{prefix} {oauth2_admin_access_token[1]}"},
     )
     assert response.status_code == 401
 
 
 @pytest.mark.parametrize(
-    'token, expected',
+    "token, expected",
     [
-        ('fixture', 200),
-        ('bad', 401),
+        ("fixture", 200),
+        ("bad", 401),
     ],
 )
-def test_oauth2_bearer_get(unauthenticated_api_client, oauth2_admin_access_token, animal, token, expected):
+def test_oauth2_bearer_get(
+    unauthenticated_api_client, oauth2_admin_access_token, animal, token, expected
+):
     """
     GET an animal with a bearer token.
     """
     url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
-    token = oauth2_admin_access_token[1] if token == 'fixture' else generate_token()
+    token = oauth2_admin_access_token[1] if token == "fixture" else generate_token()
     response = unauthenticated_api_client.get(
         url,
-        headers={'Authorization': f'Bearer {token}'},
+        headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == expected
     if expected != 401:
-        assert response.data['name'] == animal.name
+        assert response.data["name"] == animal.name
 
 
 @pytest.mark.django_db
@@ -89,18 +101,20 @@ def test_oauth2_token_expiry(oauth2_admin_access_token):
 
 
 @pytest.mark.parametrize(
-    'token, expected',
+    "token, expected",
     [
-        ('fixture', 201),
-        ('bad', 401),
+        ("fixture", 201),
+        ("bad", 401),
     ],
 )
-def test_oauth2_bearer_post(unauthenticated_api_client, oauth2_admin_access_token, admin_user, token, expected):
+def test_oauth2_bearer_post(
+    unauthenticated_api_client, oauth2_admin_access_token, admin_user, token, expected
+):
     """
     POST an animal with a bearer token.
     """
     url = get_relative_url("animal-list")
-    token = oauth2_admin_access_token[1] if token == 'fixture' else generate_token()
+    token = oauth2_admin_access_token[1] if token == "fixture" else generate_token()
     data = {
         "name": "Fido",
         "owner": admin_user.pk,
@@ -108,52 +122,66 @@ def test_oauth2_bearer_post(unauthenticated_api_client, oauth2_admin_access_toke
     response = unauthenticated_api_client.post(
         url,
         data=data,
-        headers={'Authorization': f'Bearer {token}'},
+        headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == expected
     if expected != 401:
-        assert response.data['name'] == 'Fido'
+        assert response.data["name"] == "Fido"
 
 
 @pytest.mark.parametrize(
-    'token, expected',
+    "token, expected",
     [
-        ('fixture', 200),
-        ('bad', 401),
+        ("fixture", 200),
+        ("bad", 401),
     ],
 )
-def test_oauth2_bearer_patch(unauthenticated_api_client, oauth2_admin_access_token, animal, admin_user, token, expected):
+def test_oauth2_bearer_patch(
+    unauthenticated_api_client,
+    oauth2_admin_access_token,
+    animal,
+    admin_user,
+    token,
+    expected,
+):
     """
     PATCH an animal with a bearer token.
     """
     url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
-    token = oauth2_admin_access_token[1] if token == 'fixture' else generate_token()
+    token = oauth2_admin_access_token[1] if token == "fixture" else generate_token()
     data = {
         "name": "Fido",
     }
     response = unauthenticated_api_client.patch(
         url,
         data=data,
-        headers={'Authorization': f'Bearer {token}'},
+        headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == expected
     if expected != 401:
-        assert response.data['name'] == 'Fido'
+        assert response.data["name"] == "Fido"
 
 
 @pytest.mark.parametrize(
-    'token, expected',
+    "token, expected",
     [
-        ('fixture', 200),
-        ('bad', 401),
+        ("fixture", 200),
+        ("bad", 401),
     ],
 )
-def test_oauth2_bearer_put(unauthenticated_api_client, oauth2_admin_access_token, animal, admin_user, token, expected):
+def test_oauth2_bearer_put(
+    unauthenticated_api_client,
+    oauth2_admin_access_token,
+    animal,
+    admin_user,
+    token,
+    expected,
+):
     """
     PUT an animal with a bearer token.
     """
     url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
-    token = oauth2_admin_access_token[1] if token == 'fixture' else generate_token()
+    token = oauth2_admin_access_token[1] if token == "fixture" else generate_token()
     data = {
         "name": "Fido",
         "owner": admin_user.pk,
@@ -161,14 +189,16 @@ def test_oauth2_bearer_put(unauthenticated_api_client, oauth2_admin_access_token
     response = unauthenticated_api_client.put(
         url,
         data=data,
-        headers={'Authorization': f'Bearer {token}'},
+        headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == expected
     if expected != 401:
-        assert response.data['name'] == 'Fido'
+        assert response.data["name"] == "Fido"
 
 
-def test_oauth2_bearer_no_activitystream(unauthenticated_api_client, oauth2_admin_access_token, animal):
+def test_oauth2_bearer_no_activitystream(
+    unauthenticated_api_client, oauth2_admin_access_token, animal
+):
     """
     Ensure no activitystream entries for bearer token based auth
     """
@@ -178,31 +208,41 @@ def test_oauth2_bearer_no_activitystream(unauthenticated_api_client, oauth2_admi
 
     response = unauthenticated_api_client.get(
         url,
-        headers={'Authorization': f'Bearer {token}'},
+        headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
-    assert response.data['name'] == animal.name
+    assert response.data["name"] == animal.name
 
-    updated_token = OAuth2AccessToken.objects.get(token=oauth2_admin_access_token[0].token)
+    updated_token = OAuth2AccessToken.objects.get(
+        token=oauth2_admin_access_token[0].token
+    )
     assert len(updated_token.activity_stream_entries) == existing_as_count
 
 
 @pytest.mark.parametrize(
-    'scope, status',
+    "scope, status",
     [
-        ('write', 201),
-        ('read write', 201),
-        ('write read', 201),
-        ('read', 403),
-        ('openid', 403),
-        ('roles', 403),
-        ('openid roles', 403),
-        ('read openid roles', 403),
-        ('write openid roles', 201),
+        ("write", 201),
+        ("read write", 201),
+        ("write read", 201),
+        ("read", 403),
+        ("openid", 403),
+        ("roles", 403),
+        ("openid roles", 403),
+        ("read openid roles", 403),
+        ("write openid roles", 201),
     ],
 )
 @pytest.mark.django_db
-def test_oauth2_scope_permission(request, admin_user, oauth2_admin_access_token, unauthenticated_api_client, scope, status, only_oauth_scope_permission):
+def test_oauth2_scope_permission(
+    request,
+    admin_user,
+    oauth2_admin_access_token,
+    unauthenticated_api_client,
+    scope,
+    status,
+    only_oauth_scope_permission,
+):
     """
     Ensure that scopes are adhered to for PATs
     """
@@ -217,12 +257,14 @@ def test_oauth2_scope_permission(request, admin_user, oauth2_admin_access_token,
     response = unauthenticated_api_client.post(
         url,
         data=data,
-        headers={'Authorization': f'Bearer {oauth2_admin_access_token[1]}'},
+        headers={"Authorization": f"Bearer {oauth2_admin_access_token[1]}"},
     )
     assert response.status_code == status, response.status_code
 
 
-def test_oauth2_scope_permission_not_oauth(user, user_api_client, only_oauth_scope_permission):
+def test_oauth2_scope_permission_not_oauth(
+    user, user_api_client, only_oauth_scope_permission
+):
     """
     Ensure that non-OAuth (but still authenticated) requests pass through.
     """
@@ -236,7 +278,9 @@ def test_oauth2_scope_permission_not_oauth(user, user_api_client, only_oauth_sco
     assert response.status_code == 201, response.status_code
 
 
-def test_oauth2_scope_permission_not_authenticated(user, unauthenticated_api_client, only_oauth_scope_permission):
+def test_oauth2_scope_permission_not_authenticated(
+    user, unauthenticated_api_client, only_oauth_scope_permission
+):
     """
     Ensure that non-authenticated are blocked.
     """
@@ -250,14 +294,23 @@ def test_oauth2_scope_permission_not_authenticated(user, unauthenticated_api_cli
     assert response.status_code == 401, response.status_code
 
 
-def test_oauth2_unsupported_media_type(user, user_api_client, only_oauth_scope_permission):
+def test_oauth2_unsupported_media_type(
+    user, user_api_client, only_oauth_scope_permission
+):
     url = get_relative_url("animal-upload")
-    data = b'TESTDATA'
-    response = user_api_client.post(url, data=data, content_type='application/octet-stream')
+    data = b"TESTDATA"
+    response = user_api_client.post(
+        url, data=data, content_type="application/octet-stream"
+    )
     assert response.status_code == 200, response.status_code
 
 
-def test_oauth2_authentication_creates_activitystream_entry(unauthenticated_api_client, oauth2_admin_access_token, animal, django_capture_on_commit_callbacks):
+def test_oauth2_authentication_creates_activitystream_entry(
+    unauthenticated_api_client,
+    oauth2_admin_access_token,
+    animal,
+    django_capture_on_commit_callbacks,
+):
     """
     Ensure that authenticating with OAuth2 and making a GET request does NOT
     create spurious activity stream entries (regression test).
@@ -275,10 +328,10 @@ def test_oauth2_authentication_creates_activitystream_entry(unauthenticated_api_
         raw_token = oauth2_admin_access_token[1]
         response = unauthenticated_api_client.get(
             url,
-            headers={'Authorization': f'Bearer {raw_token}'},
+            headers={"Authorization": f"Bearer {raw_token}"},
         )
         assert response.status_code == 200
-        assert response.data['name'] == animal.name
+        assert response.data["name"] == animal.name
 
     # Verify OAuth2 was actually used by checking the token's last_used field was updated
     access_token_obj.refresh_from_db()
@@ -290,3 +343,98 @@ def test_oauth2_authentication_creates_activitystream_entry(unauthenticated_api_
     # No new activity stream entries should have been created by the GET request
     # (only the animal creation entry should exist, which was created before this test)
     assert final_entry_count == initial_entry_count
+
+
+@pytest.mark.django_db
+def test_oauth2_scope_not_mutated_after_permission_check(
+    unauthenticated_api_client,
+    oauth2_admin_access_token,
+    animal,
+    only_oauth_scope_permission,
+):
+    """
+    Regression test for AAP-55298: Ensure that OAuth2ScopePermission.has_permission()
+    does not permanently mutate the token's scope attribute.
+
+    Previously, a write-scoped token would have ' read' appended to its scope
+    during permission checking via ``request.auth.scope += ' read'``. This left
+    the in-memory model instance with scope='write read', which could be
+    persisted by any subsequent save() call, generating spurious activity stream
+    entries.
+    """
+    access_token_obj = oauth2_admin_access_token[0]
+    raw_token = oauth2_admin_access_token[1]
+
+    # Ensure the token starts with scope="write" (the model default)
+    access_token_obj.scope = "write"
+    access_token_obj.save(update_fields=["scope"])
+
+    # Make a GET request (read operation) using a write-scoped token.
+    # OAuth2ScopePermission should temporarily expand the scope for the
+    # permission check but restore it afterward.
+    url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
+    response = unauthenticated_api_client.get(
+        url,
+        headers={"Authorization": f"Bearer {raw_token}"},
+    )
+    assert response.status_code == 200
+
+    # The in-memory token scope must still be "write" -- not "write read"
+    access_token_obj.refresh_from_db()
+    assert access_token_obj.scope == "write", (
+        f"Token scope was mutated to '{access_token_obj.scope}'; expected 'write'"
+    )
+
+    # Also make a POST request (write operation) and verify scope is unchanged
+    url = get_relative_url("animal-list")
+    data = {"name": "ScopeTestAnimal", "owner": access_token_obj.user.pk}
+    response = unauthenticated_api_client.post(
+        url,
+        data=data,
+        headers={"Authorization": f"Bearer {raw_token}"},
+    )
+    assert response.status_code == 201
+
+    access_token_obj.refresh_from_db()
+    assert access_token_obj.scope == "write", (
+        f"Token scope was mutated to '{access_token_obj.scope}' after POST; expected 'write'"
+    )
+
+
+@pytest.mark.django_db
+def test_oauth2_scope_no_activitystream_for_scope_field(
+    unauthenticated_api_client,
+    oauth2_admin_access_token,
+    animal,
+    only_oauth_scope_permission,
+    django_capture_on_commit_callbacks,
+):
+    """
+    Regression test for AAP-55298: Ensure that authenticated requests with a
+    write-scoped OAuth2 token do not create activity stream entries recording
+    a scope change from 'write' to 'write read'.
+    """
+    access_token_obj = oauth2_admin_access_token[0]
+    raw_token = oauth2_admin_access_token[1]
+
+    # Set token scope to 'write'
+    access_token_obj.scope = "write"
+    access_token_obj.save(update_fields=["scope"])
+
+    # Record baseline activity stream count
+    initial_entry_count = Entry.objects.count()
+
+    # Make an authenticated request and flush on_commit callbacks
+    with django_capture_on_commit_callbacks(execute=True):
+        url = get_relative_url("animal-detail", kwargs={"pk": animal.pk})
+        response = unauthenticated_api_client.get(
+            url,
+            headers={"Authorization": f"Bearer {raw_token}"},
+        )
+        assert response.status_code == 200
+
+    # No new activity stream entries should have been created
+    final_entry_count = Entry.objects.count()
+    assert final_entry_count == initial_entry_count, (
+        f"Expected no new activity stream entries, but {final_entry_count - initial_entry_count} were created"
+    )


### PR DESCRIPTION
## Summary

OAuth2ScopePermission.has_permission() was mutating the token's `scope` attribute in-place by appending `' read'` to write-scoped tokens during permission checking. This left the model instance in a corrupted state (`scope="write read"` instead of `"write"`), which caused spurious activity stream entries when the token was subsequently saved by any code path that does not restrict `update_fields`.

This manifested as 192 seemingly identical activity stream entries for the `aap_operator_service_account`, each recording a scope change from `"write"` to `"write read"` on the same OAuth2 access token.

## Root Cause

In `ansible_base/oauth2_provider/permissions.py`, the line `request.auth.scope += ' read'` permanently mutated the `OAuth2AccessToken` model instance's `scope` field. The "write implies read" expansion was intended only for the `TokenHasReadWriteScope` permission check, but the original scope was never restored afterward. Any subsequent `.save()` on the token (without `update_fields` limiting the persisted fields) would persist the mutated scope to the database, and the activity stream would record the change.

## Changes

- **`ansible_base/oauth2_provider/permissions.py`**: Wrapped the scope expansion in a `try/finally` block that saves the original scope before mutation and restores it unconditionally after the permission check completes. The "write implies read" behavior is preserved for the permission check itself.
- **`test_app/tests/oauth2_provider/test_authentication.py`**: Added two regression tests:
  - `test_oauth2_scope_not_mutated_after_permission_check`: Verifies that the token's scope remains `"write"` after both GET and POST requests through the permission check.
  - `test_oauth2_scope_no_activitystream_for_scope_field`: Verifies that no activity stream entries are created for scope changes during authenticated requests with write-scoped tokens.

## Risk Assessment

- **Confidence:** Medium -- The scope mutation is clearly a bug and this fix addresses it. The full reproduction requires the operator's reconciliation loop, which is outside this codebase.
- **Risk:** Low -- The fix preserves the existing permission logic ("write implies read") while preventing model mutation. The `try/finally` pattern ensures the scope is always restored, even if the permission check raises an exception.
- **Scope:** 2 file(s) changed

## Testing

- [x] Unit tests pass (35/35 in test_authentication.py)
- [x] Regression tests added (2 new tests)
- [x] Lint checks pass (ruff check + ruff format)

## JIRA

- Ticket: [AAP-55298](https://redhat.atlassian.net/browse/AAP-55298)

---
*Assisted-by: claude-opus-4-6 | Review carefully before merging.*

[AAP-55298]: https://redhat.atlassian.net/browse/AAP-55298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth2 permission checks that were permanently modifying access token scopes in memory and the database.

* **Tests**
  * Added regression tests to verify token scopes remain unchanged during permission checks and that activity stream entries are not incorrectly created for scope changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->