### PR TITLE
[AAP-74442] Fix CI failures and code issues from CVE-2026-6266 backport

### DIFF
--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Model
 from django.db.models.base import ModelBase  # post_migrate may call with phony objects
-from django.db.models.signals import post_delete, post_init, post_migrate, pre_save
+from django.db.models.signals import post_delete, post_init, post_migrate, post_save, pre_save
 from django.utils.functional import cached_property
 
 from ansible_base.rbac.managed import ManagedRoleConstructor, get_managed_role_constructors
@@ -151,6 +151,7 @@ class PermissionRegistry:
         if not getattr(self.user_model, 'EMAIL_ENFORCEMENT_VIA_SERIALIZER', False):
             post_init.connect(triggers.rbac_post_init_stash_email, sender=self.user_model, dispatch_uid='permission-registry-stash-email')
             pre_save.connect(triggers.rbac_pre_save_enforce_email_policy, sender=self.user_model, dispatch_uid='permission-registry-enforce-email')
+            post_save.connect(triggers.rbac_post_save_refresh_email_stash, sender=self.user_model, dispatch_uid='permission-registry-refresh-email')
 
         for cls in self._registry:
             triggers.connect_rbac_signals(cls)

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -14,6 +14,13 @@ from ansible_base.rbac.validators import validate_team_assignment_enabled
 
 logger = logging.getLogger('ansible_base.rbac.triggers')
 
+# Sentinel used to distinguish "we never stashed the email" from "the email was
+# stashed as None".  When a User instance is loaded via .only() without the
+# email field, post_init cannot record the original value.  Using a sentinel
+# instead of None lets pre_save detect this and fall back to a DB lookup rather
+# than silently skipping enforcement.
+_UNSET = object()
+
 
 """
 As the caching module will fill in cached data,
@@ -285,9 +292,15 @@ def rbac_post_delete_remove_object_roles(instance, *args, **kwargs):
 def rbac_post_init_stash_email(instance, **kwargs):
     """Capture the email at load time so pre_save can detect changes
     without an extra query, following the same pattern as
-    rbac_post_init_set_original_parent."""
+    rbac_post_init_set_original_parent.
+
+    When the email field is deferred (e.g. ``User.objects.only('id')``),
+    we intentionally leave the attribute at the ``_UNSET`` sentinel so
+    that pre_save knows it must perform a DB lookup before deciding."""
     if 'email' in instance.__dict__:
         instance._rbac_original_email = instance.email
+    else:
+        instance._rbac_original_email = _UNSET
 
 
 def rbac_pre_save_enforce_email_policy(instance, **kwargs):
@@ -301,15 +314,33 @@ def rbac_pre_save_enforce_email_policy(instance, **kwargs):
 
     from ansible_base.rbac.policies import can_change_user
 
+    # New objects never need enforcement.
     if instance.pk is None:
         return
 
-    original = getattr(instance, '_rbac_original_email', None)
-    if original is None or original == instance.email:
-        return
-
+    # If update_fields is given and email is not among them, the email
+    # column is not being persisted -- skip enforcement.
     update_fields = kwargs.get('update_fields')
     if update_fields and 'email' not in update_fields:
+        return
+
+    # If the email field itself is not loaded into __dict__ (deferred via
+    # .only() / .defer()), there is nothing to enforce -- the field is not
+    # being written.
+    if 'email' not in instance.__dict__:
+        return
+
+    original = getattr(instance, '_rbac_original_email', _UNSET)
+
+    # If the stash was never set (deferred load), do a DB lookup so we
+    # have the persisted value to compare against.
+    if original is _UNSET:
+        try:
+            original = type(instance).objects.values_list('email', flat=True).get(pk=instance.pk)
+        except type(instance).DoesNotExist:
+            return
+
+    if original == instance.email:
         return
 
     requesting_user = get_current_user()
@@ -321,6 +352,16 @@ def rbac_pre_save_enforce_email_policy(instance, **kwargs):
 
         instance.email = original
         raise ValidationError({'email': ["You do not have permission to change the email field."]})
+
+
+def rbac_post_save_refresh_email_stash(instance, **kwargs):
+    """Refresh ``_rbac_original_email`` after a successful save so the stash
+    always reflects the persisted value.  Without this, a second ``save()``
+    on the same Python instance would compare against the stale pre-load
+    value and could produce a false-positive ValidationError for non-admin
+    callers."""
+    if 'email' in instance.__dict__:
+        instance._rbac_original_email = instance.email
 
 
 def rbac_post_user_delete(instance, *args, **kwargs):

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -100,11 +100,12 @@ def test_self_edit_setting_requires_manage_org_auth():
 
 @pytest.mark.django_db
 @override_settings(MANAGE_ORGANIZATION_AUTH=False)
-def test_org_admin_cannot_change_email_when_manage_org_auth_disabled(org_admin_rd, organization):
+def test_org_admin_cannot_change_email_when_manage_org_auth_disabled(org_admin_rd, org_member_rd, organization):
     """Org admins cannot change their own or others' email when MANAGE_ORGANIZATION_AUTH is off."""
     org_admin = User.objects.create(username='org-admin')
     member = User.objects.create(username='member')
     org_admin_rd.give_permission(org_admin, organization)
+    org_member_rd.give_permission(member, organization)
     assert not can_change_user(org_admin, org_admin, can_self_edit=False)
     assert not can_change_user(org_admin, member, can_self_edit=False)
     assert not can_change_user(org_admin, org_admin)

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -306,10 +306,66 @@ class TestEmailPolicySignal:
     def test_email_enforcement_signals_registered_by_default(self):
         """Verify that email enforcement signals are registered when
         EMAIL_ENFORCEMENT_VIA_SERIALIZER is False (the default)."""
-        from django.db.models.signals import post_init, pre_save
+        from django.db.models.signals import post_init, post_save, pre_save
 
         assert not User.EMAIL_ENFORCEMENT_VIA_SERIALIZER
         pre_save_uids = {r[0][0] for r in pre_save.receivers}
         post_init_uids = {r[0][0] for r in post_init.receivers}
+        post_save_uids = {r[0][0] for r in post_save.receivers}
         assert 'permission-registry-enforce-email' in pre_save_uids
         assert 'permission-registry-stash-email' in post_init_uids
+        assert 'permission-registry-refresh-email' in post_save_uids
+
+    @pytest.mark.django_db
+    def test_post_save_refreshes_stash(self):
+        """After a successful save the stash must reflect the new email,
+        so a subsequent save on the same Python instance does not
+        false-positive."""
+        admin = User.objects.create(username='admin-su', is_superuser=True)
+        alice = User.objects.create(username='alice', email='alice@example.com')
+        with patch('crum.get_current_user', return_value=admin):
+            alice.email = 'alice-new@example.com'
+            alice.save()
+            # Stash should now be refreshed to the new value
+            assert alice._rbac_original_email == 'alice-new@example.com'
+            # A second save (no change) should not raise
+            alice.save()
+
+    @pytest.mark.django_db
+    def test_deferred_load_enforces_via_db_lookup(self):
+        """When a user is loaded via .only() without email, then the
+        email is assigned and saved, enforcement should still work by
+        falling back to a DB lookup."""
+        alice = User.objects.create(username='alice', email='alice@example.com')
+        deferred_alice = User.objects.only('id', 'username').get(pk=alice.pk)
+        with patch('crum.get_current_user', return_value=deferred_alice):
+            deferred_alice.email = 'hacked@evil.com'
+            with pytest.raises(ValidationError):
+                deferred_alice.save()
+        alice.refresh_from_db()
+        assert alice.email == 'alice@example.com'
+
+    @pytest.mark.django_db
+    def test_deferred_load_without_email_assignment_is_not_blocked(self):
+        """Saving a deferred-loaded user without touching email should
+        not trigger enforcement."""
+        alice = User.objects.create(username='alice', email='alice@example.com')
+        deferred_alice = User.objects.only('id', 'username', 'first_name').get(pk=alice.pk)
+        with patch('crum.get_current_user', return_value=deferred_alice):
+            deferred_alice.first_name = 'Alice'
+            deferred_alice.save(update_fields=['first_name'])
+        alice.refresh_from_db()
+        assert alice.first_name == 'Alice'
+        assert alice.email == 'alice@example.com'
+
+    @pytest.mark.django_db
+    def test_non_email_save_not_blocked(self):
+        """Saving a normally-loaded user without modifying email should
+        not be blocked even when a non-admin is the current user."""
+        alice = User.objects.create(username='alice', email='alice@example.com')
+        with patch('crum.get_current_user', return_value=alice):
+            alice.first_name = 'Alice'
+            alice.save()
+        alice.refresh_from_db()
+        assert alice.first_name == 'Alice'
+        assert alice.email == 'alice@example.com'


### PR DESCRIPTION
## Summary

Fixes CI failures and code correctness issues introduced by the CVE-2026-6266 email change enforcement backport (PR #994).

**Changes in `triggers.py`:**
- Add `_UNSET` sentinel value so deferred `.only()` loads trigger a DB lookup instead of silently skipping enforcement
- Add `rbac_post_save_refresh_email_stash` handler to prevent stale stash false-positives on subsequent saves
- Add early return when `email` is not in `instance.__dict__` to avoid blocking non-email save operations (fixes Hub CI test failures)

**Changes in `permission_registry.py`:**
- Connect the new `post_save` signal handler with dispatch UID `permission-registry-refresh-email`

**Changes in `test_policies.py`:**
- Fix `test_org_admin_cannot_change_email_when_manage_org_auth_disabled` by adding `org_member_rd` fixture and granting org membership to the member user

**Changes in `test_triggers.py`:**
- Add tests for post-save stash refresh, deferred load enforcement, deferred load without email assignment, and non-email save pass-through
- Verify `permission-registry-refresh-email` signal is registered

## Test plan
- [x] All 16 email policy signal tests pass locally
- [x] All 19 policy tests pass locally
- [ ] Hub CI tests pass (test_me_delete, test_me_update, test_superuser_can_not_be_deleted)
- [ ] SonarCloud quality gate passes
- [ ] Full CI green

Fixes: https://redhat.atlassian.net/browse/AAP-74442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email policy enforcement to correctly handle deferred database fields and multiple successive saves
  * Added post-save state refresh to prevent stale comparisons

* **Tests**
  * Expanded test coverage for post-save refresh behavior and deferred field scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->