### PR TITLE
[AAP-74442] Fix email enforcement edge cases from CVE-2026-6266 backport

### DIFF
--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -119,6 +119,7 @@ class PermissionRegistry:
         return ret
 
     def call_when_apps_ready(self, apps, app_config) -> None:
+        """Wire up RBAC signals once all Django apps are ready."""
         from ansible_base.rbac import triggers
         from ansible_base.rbac.evaluations import bound_has_obj_perm, bound_singleton_permissions, connect_rbac_methods
         from ansible_base.rbac.management import create_dab_permissions

--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Model
 from django.db.models.base import ModelBase  # post_migrate may call with phony objects
-from django.db.models.signals import post_delete, post_init, post_migrate, pre_save
+from django.db.models.signals import post_delete, post_init, post_migrate, post_save, pre_save
 from django.utils.functional import cached_property
 
 from ansible_base.rbac.managed import ManagedRoleConstructor, get_managed_role_constructors
@@ -151,6 +151,7 @@ class PermissionRegistry:
         if not getattr(self.user_model, 'EMAIL_ENFORCEMENT_VIA_SERIALIZER', False):
             post_init.connect(triggers.rbac_post_init_stash_email, sender=self.user_model, dispatch_uid='permission-registry-stash-email')
             pre_save.connect(triggers.rbac_pre_save_enforce_email_policy, sender=self.user_model, dispatch_uid='permission-registry-enforce-email')
+            post_save.connect(triggers.rbac_post_save_refresh_email_stash, sender=self.user_model, dispatch_uid='permission-registry-refresh-email-stash')
 
         for cls in self._registry:
             triggers.connect_rbac_signals(cls)

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -307,9 +307,13 @@ def rbac_pre_save_enforce_email_policy(instance, **kwargs):
     if instance.pk is None:
         return
 
+    # None when post_init signal was not connected (management commands, migrations, manual construction)
     original = getattr(instance, '_rbac_original_email', None)
     if original is _SENTINEL:
-        original = type(instance).objects.values_list('email', flat=True).get(pk=instance.pk)
+        try:
+            original = type(instance).objects.values_list('email', flat=True).get(pk=instance.pk)
+        except type(instance).DoesNotExist:
+            return
     if original is None or original == instance.email:
         return
 

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -92,6 +92,7 @@ def update_after_assignment(update_teams, to_update):
 
 
 def permissions_changed(instance, action, model, pk_set, reverse, **kwargs):
+    """Recompute object role permissions when a RoleDefinition's permissions m2m changes."""
     if action.startswith('pre_'):
         return
     to_recompute = set(ObjectRole.objects.filter(role_definition=instance).prefetch_related('teams__member_roles'))

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -69,8 +69,7 @@ def needed_updates_on_assignment(role_definition, actor, object_role, created=Fa
     deleted = False
     if (not giving) and (not (object_role.users.exists() or object_role.teams.exists())):
         # time to delete the object role because it is unused
-        if object_role in to_update:
-            to_update.remove(object_role)
+        to_update.discard(object_role)
         deleted = True
 
     # giving or revoking team permissions may not change the parentage
@@ -109,8 +108,7 @@ def permissions_changed(instance, action, model, pk_set, reverse, **kwargs):
         # All team member roles that give this permission through this role need to be updated
         for role in to_recompute.copy():
             for team in role.teams.all():
-                for team_role in team.member_roles.all():
-                    to_recompute.add(team_role)
+                to_recompute.update(team.member_roles.all())
     elif action == 'post_clear':
         # unfortunately this does not give us a list of permissions to work with
         # this is slow, not ideal, but will at least be correct

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -14,6 +14,8 @@ from ansible_base.rbac.validators import validate_team_assignment_enabled
 
 logger = logging.getLogger('ansible_base.rbac.triggers')
 
+_SENTINEL = object()
+
 
 """
 As the caching module will fill in cached data,
@@ -288,6 +290,8 @@ def rbac_post_init_stash_email(instance, **kwargs):
     rbac_post_init_set_original_parent."""
     if 'email' in instance.__dict__:
         instance._rbac_original_email = instance.email
+    else:
+        instance._rbac_original_email = _SENTINEL
 
 
 def rbac_pre_save_enforce_email_policy(instance, **kwargs):
@@ -305,6 +309,8 @@ def rbac_pre_save_enforce_email_policy(instance, **kwargs):
         return
 
     original = getattr(instance, '_rbac_original_email', None)
+    if original is _SENTINEL:
+        original = type(instance).objects.values_list('email', flat=True).get(pk=instance.pk)
     if original is None or original == instance.email:
         return
 
@@ -321,6 +327,16 @@ def rbac_pre_save_enforce_email_policy(instance, **kwargs):
 
         instance.email = original
         raise ValidationError({'email': ["You do not have permission to change the email field."]})
+
+
+def rbac_post_save_refresh_email_stash(instance, **kwargs):
+    """Refresh the email stash after a successful save so subsequent
+    saves on the same instance do not false-positive."""
+    update_fields = kwargs.get('update_fields')
+    if update_fields is not None and 'email' not in update_fields:
+        return
+    if 'email' in instance.__dict__:
+        instance._rbac_original_email = instance.email
 
 
 def rbac_post_user_delete(instance, *args, **kwargs):

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -100,11 +100,12 @@ def test_self_edit_setting_requires_manage_org_auth():
 
 @pytest.mark.django_db
 @override_settings(MANAGE_ORGANIZATION_AUTH=False)
-def test_org_admin_cannot_change_email_when_manage_org_auth_disabled(org_admin_rd, organization):
+def test_org_admin_cannot_change_email_when_manage_org_auth_disabled(org_admin_rd, org_member_rd, organization):
     """Org admins cannot change their own or others' email when MANAGE_ORGANIZATION_AUTH is off."""
     org_admin = User.objects.create(username='org-admin')
     member = User.objects.create(username='member')
     org_admin_rd.give_permission(org_admin, organization)
+    org_member_rd.give_permission(member, organization)
     assert not can_change_user(org_admin, org_admin, can_self_edit=False)
     assert not can_change_user(org_admin, member, can_self_edit=False)
     assert not can_change_user(org_admin, org_admin)
@@ -143,6 +144,48 @@ def test_superuser_can_still_change_user_when_manage_org_auth_disabled(admin_use
     alice = User.objects.create(username='alice')
     assert can_change_user(admin_user, alice)
     assert can_change_user(admin_user, admin_user)
+
+
+@pytest.mark.django_db
+def test_update_fields_bypass_vector(org_admin_rd, org_member_rd, organization):
+    """Partial save(update_fields=['first_name']) followed by full save must not skip enforcement."""
+    from crum import impersonate
+
+    admin = User.objects.create(username='admin-user')
+    org_admin_rd.give_permission(admin, organization)
+
+    target = User.objects.create(username='target-user', email='original@example.com')
+    org_member_rd.give_permission(target, organization)
+
+    with impersonate(admin):
+        target.first_name = 'Updated'
+        target.save(update_fields=['first_name'])
+
+        target.email = 'changed@example.com'
+        target.save()
+
+    target.refresh_from_db()
+    assert target.email == 'changed@example.com'
+    assert target.first_name == 'Updated'
+
+
+@pytest.mark.django_db
+def test_deferred_only_load_enforces_email_policy(org_member_rd, organization):
+    """User loaded via .only('id') must still enforce email policy."""
+    from crum import impersonate
+    from rest_framework.exceptions import ValidationError
+
+    member = User.objects.create(username='deferred-member', email='original@example.com')
+    org_member_rd.give_permission(member, organization)
+
+    deferred = User.objects.only('id', 'username').get(pk=member.pk)
+    with impersonate(deferred):
+        deferred.email = 'hacked@example.com'
+        with pytest.raises(ValidationError):
+            deferred.save()
+
+    member.refresh_from_db()
+    assert member.email == 'original@example.com'
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -147,25 +147,26 @@ def test_superuser_can_still_change_user_when_manage_org_auth_disabled(admin_use
 
 
 @pytest.mark.django_db
-def test_update_fields_bypass_vector(org_admin_rd, org_member_rd, organization):
-    """Partial save(update_fields=['first_name']) followed by full save must not skip enforcement."""
+def test_update_fields_bypass_vector(org_member_rd, organization):
+    """Partial save(update_fields=['first_name']) followed by full save must still enforce email policy."""
     from crum import impersonate
+    from rest_framework.exceptions import ValidationError
 
-    admin = User.objects.create(username='admin-user')
-    org_admin_rd.give_permission(admin, organization)
+    unprivileged = User.objects.create(username='unprivileged-user')
 
     target = User.objects.create(username='target-user', email='original@example.com')
     org_member_rd.give_permission(target, organization)
 
-    with impersonate(admin):
+    with impersonate(unprivileged):
         target.first_name = 'Updated'
         target.save(update_fields=['first_name'])
 
-        target.email = 'changed@example.com'
-        target.save()
+        target.email = 'hacked@example.com'
+        with pytest.raises(ValidationError):
+            target.save()
 
     target.refresh_from_db()
-    assert target.email == 'changed@example.com'
+    assert target.email == 'original@example.com'
     assert target.first_name == 'Updated'
 
 


### PR DESCRIPTION
## Summary

Hardens the email change enforcement logic added in PR #994 (CVE-2026-6266 backport) by fixing three edge cases in `triggers.py` and a test gap in `test_policies.py`:

- **Stale stash after save**: Added `post_save` signal handler (`rbac_post_save_refresh_email_stash`) to refresh `_rbac_original_email` after a successful save. Includes `update_fields` guard to prevent a partial save from updating the stash to a dirty in-memory value.
- **Deferred `.only()` bypass**: Replaced `None` default with a sentinel value so that deferred field loads trigger a DB lookup instead of silently skipping enforcement.
- **Test gap**: Fixed `test_org_admin_cannot_change_email_when_manage_org_auth_disabled` — the member user was never granted org membership, making the org-admin → member assertions false negatives.
- **Regression tests**: Added `test_update_fields_bypass_vector` and `test_deferred_only_load_enforces_email_policy`.

## Test plan

- [ ] DAB test suite passes (py311, py312, all variants)
- [ ] New regression tests cover the update_fields bypass and deferred load vectors
- [ ] SonarCloud quality gate passes
- [ ] Existing email enforcement tests continue to pass

Fixes: https://redhat.atlassian.net/browse/AAP-74442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened email-change policy so partially loaded or incrementally saved user records cannot bypass enforcement; original-email caches are refreshed after saves to avoid false positives.
  * Improved RBAC cache invalidation and recomputation to more reliably handle role and permission updates.
* **Tests**
  * Expanded coverage for email-policy edge cases, deferred/partial loads, and save-path bypass scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->