### PR TITLE
[AAP-71149] Bump jwcrypto>=1.5.7 for CVE-2026-39373

### DIFF
--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -66,8 +66,10 @@ jsonschema==4.25.1
     # via drf-spectacular
 jsonschema-specifications==2025.9.1
     # via jsonschema
-jwcrypto==1.5.6
-    # via django-oauth-toolkit
+jwcrypto==1.5.7
+    # via
+    #   -r requirements/requirements_oauth2_provider.in
+    #   django-oauth-toolkit
 ldap-filter==1.0.1
     # via -r requirements/requirements_authentication.in
 lxml==5.3.0

--- a/requirements/requirements_oauth2_provider.in
+++ b/requirements/requirements_oauth2_provider.in
@@ -1,1 +1,2 @@
 django-oauth-toolkit<2.4.0
+jwcrypto>=1.5.7  # CVE-2026-39373: Memory exhaustion via crafted compressed JWE tokens


### PR DESCRIPTION
Description

Updates jwcrypto >= 1.5.7 floor pin to requirements_oauth2_provider.in to address CVE-2026-39373

Type of Change

    Configuration change

Testing Instructions

No functional changes — minor dependency version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `jwcrypto` dependency to version 1.5.7 for enhanced security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->