### PR TITLE
[AAP-61226] Remove FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED feature flag

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -13,7 +13,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, models
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
-from flags.state import flag_enabled
 from rest_framework.serializers import DateTimeField
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap, AuthenticatorUser
@@ -216,10 +215,6 @@ def _add_rbac_role_mapping(has_permission, role_mapping, role, organization=None
             logger.warning(f"Role mapping is not possible, organization for team '{team}' is missing")
 
 
-def _is_case_insensitivity_enabled() -> bool:
-    return flag_enabled("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
-
-
 def _lowercase_group_triggers(trigger_condition: dict) -> dict:
     """
     Lowercase all group names provided to trigger
@@ -233,11 +228,10 @@ def _lowercase_group_triggers(trigger_condition: dict) -> dict:
 def process_groups(trigger_condition: dict, groups: list, map_id: int, tracking_id: str) -> TriggerResult:
     """
     Looks at a maps trigger for a group and users groups and determines if the trigger is defined for this user.
-    Group DNs are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS enabled.
+    Group DNs are always compared case-insensitively.
     """
-    if _is_case_insensitivity_enabled():
-        groups = [f"{group}".casefold() for group in groups]
-        trigger_condition = _lowercase_group_triggers(trigger_condition)
+    groups = [f"{group}".casefold() for group in groups]
+    trigger_condition = _lowercase_group_triggers(trigger_condition)
 
     invalid_conditions = set(trigger_condition.keys()) - set(TRIGGER_DEFINITION['groups']['keys'].keys())
     if invalid_conditions:
@@ -392,7 +386,7 @@ def _validate_attribute_conditions(attribute: str, condition: dict, map_id: int,
 
 def _prepare_case_insensitive_data(trigger_condition: dict, attributes: dict, map_id: int, tracking_id: str) -> tuple[dict, dict]:
     """
-    Prepare trigger conditions and attributes for case-insensitive comparison if enabled.
+    Normalize trigger conditions and attributes for case-insensitive comparison.
 
     Args:
         trigger_condition: Original trigger conditions
@@ -403,10 +397,9 @@ def _prepare_case_insensitive_data(trigger_condition: dict, attributes: dict, ma
     Returns:
         Tuple of (processed_trigger_condition, processed_attributes)
     """
-    if _is_case_insensitivity_enabled():
-        _prefixed_debug(map_id, tracking_id, f"[{tracking_id}] Case insensitivity enabled, converting attributes and values to lowercase")
-        attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
-        trigger_condition = _lowercase_attr_triggers(trigger_condition)
+    _prefixed_debug(map_id, tracking_id, f"[{tracking_id}] Converting attributes and values to lowercase for case-insensitive comparison")
+    attributes = {f"{k}".casefold(): v for k, v in attributes.items()}
+    trigger_condition = _lowercase_attr_triggers(trigger_condition)
 
     return trigger_condition, attributes
 
@@ -430,9 +423,8 @@ def _normalize_user_value(user_value):
 def process_user_attributes(trigger_condition: dict, attributes: dict, map_id: int, tracking_id: str) -> TriggerResult:
     """
     Looks at a maps trigger for an attribute and the users attributes and determines if the trigger is defined for this user.
-    Attribute names are compared case-insensitively when FEATURE_CASE_INSENSITIVE_AUTH_MAPS is enabled.
+    Attribute names are always compared case-insensitively.
     """
-    # Prepare data for case-insensitive comparison if needed
     trigger_condition, attributes = _prepare_case_insensitive_data(trigger_condition, attributes, map_id, tracking_id)
 
     # Extract and validate join condition
@@ -562,8 +554,7 @@ def _process_user_value(
     evaluate_fn = operators[operator]
 
     for a_user_value in user_value:
-        # Normalize user value for comparison
-        user_str = f"{a_user_value}".casefold() if _is_case_insensitivity_enabled() else f"{a_user_value}"
+        user_str = f"{a_user_value}".casefold()
 
         # Evaluate condition
         result = evaluate_fn(user_str, trigger_value)

--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -30,16 +30,6 @@
   toggle_type: install-time
   labels:
     - gateway
-- name: FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED
-  ui_name: Case Insensitive Authentication Maps
-  visibility: False
-  condition: boolean
-  value: 'True'
-  support_level: DEVELOPER_PREVIEW
-  description: Enable case-insensitive comparison for authentication mapping attributes and group names.
-  support_url: ''
-  labels:
-    - platform
 - name: FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED
   ui_name: OIDC Workload Identity
   visibility: False

--- a/ansible_base/feature_flags/migrations/0006_manual_20260515.py
+++ b/ansible_base/feature_flags/migrations/0006_manual_20260515.py
@@ -1,0 +1,17 @@
+###
+# Removal of FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED
+###
+
+# FileHash: b28c8c6621e3be1e7bc7d42c5cfb1433b3b94ead8ca49a0cd1940ba13ff8cee6
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dab_feature_flags', '0005_manual_20260417'),
+    ]
+
+    operations = [
+    ]

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -359,93 +359,78 @@ def test_create_claims_revoke(local_authenticator_map, process_function, trigger
 
 
 @pytest.mark.parametrize(
-    "trigger_condition, groups, case_insensitive, has_access",
+    "trigger_condition, groups, has_access",
     [
         # has_or
-        ({"has_or": ["foo"]}, ["foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["foo", "bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["baz"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["foo", "bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo", "bar"]}, ["bar", "baz"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"]}, ["baz", "foo", "qux"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_or": ["foo", "bar"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["bar"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
+        ({"has_or": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["baz", "foo", "qux"], claims.TriggerResult.ALLOW),
         # has_and
-        ({"has_and": ["foo"]}, ["foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo", "bar"]}, ["bar", "foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo", "bar"]}, ["foo"], False, claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["baz"], False, claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["foo", "baz"], False, claims.TriggerResult.SKIP),
-        ({"has_and": ["foo", "bar"]}, ["bar", "baz"], False, claims.TriggerResult.SKIP),
+        ({"has_and": ["foo"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo", "bar"]}, ["bar", "foo"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo", "bar"]}, ["foo"], claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["baz"], claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.SKIP),
+        ({"has_and": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.SKIP),
         # has_not
-        ({"has_not": ["foo"]}, ["foo"], False, claims.TriggerResult.SKIP),
-        ({"has_not": ["foo"]}, ["bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_not": ["foo", "bar"]}, ["foo"], False, claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["baz"], False, claims.TriggerResult.ALLOW),
-        ({"has_not": ["foo", "bar"]}, ["foo", "bar"], False, claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["foo", "baz"], False, claims.TriggerResult.SKIP),
-        ({"has_not": ["foo", "bar"]}, ["bar", "baz"], False, claims.TriggerResult.SKIP),
-        ({"has_not": ["foo"]}, ["baz", "foo", "qux"], False, claims.TriggerResult.SKIP),
+        ({"has_not": ["foo"]}, ["foo"], claims.TriggerResult.SKIP),
+        ({"has_not": ["foo"]}, ["bar"], claims.TriggerResult.ALLOW),
+        ({"has_not": ["foo", "bar"]}, ["foo"], claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["baz"], claims.TriggerResult.ALLOW),
+        ({"has_not": ["foo", "bar"]}, ["foo", "bar"], claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["foo", "baz"], claims.TriggerResult.SKIP),
+        ({"has_not": ["foo", "bar"]}, ["bar", "baz"], claims.TriggerResult.SKIP),
+        ({"has_not": ["foo"]}, ["baz", "foo", "qux"], claims.TriggerResult.SKIP),
         # has_or and has_and (only has_or has effect)
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
         # has_or and has_not (only has_or has effect)
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_not": ["bar"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
         # has_and and has_not (only has_and has effect)
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_and": ["foo"], "has_not": ["bar"]}, ["baz", "foo"], False, claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["foo"], "has_not": ["bar"]}, ["baz", "foo"], claims.TriggerResult.ALLOW),
         # has_or, has_and, and has_not (only has_or has effect)
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["bar"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["baz"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "bar"], False, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "baz"], False, claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["bar"], claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["baz"], claims.TriggerResult.SKIP),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"], "has_and": ["bar"], "has_not": ["baz"]}, ["foo", "baz"], claims.TriggerResult.ALLOW),
         # None of has_or, has_and, or has_not
-        ({}, ["foo"], False, claims.TriggerResult.SKIP),
-        ({"foo": "bar"}, ["foo"], False, claims.TriggerResult.SKIP),
-        # Case insensitivity (with and without flag enabled)
-        ({"has_or": ["FOO"]}, ["foo"], True, claims.TriggerResult.ALLOW),
-        ({"has_or": ["FOO"]}, ["foo"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["foo"]}, ["FOO"], True, claims.TriggerResult.ALLOW),
-        ({"has_or": ["foo"]}, ["FOO"], False, claims.TriggerResult.SKIP),
-        ({"has_or": ["bAR"]}, ["foo", "bar"], True, claims.TriggerResult.ALLOW),
-        ({"has_or": ["bAR"]}, ["foo", "bar"], False, claims.TriggerResult.SKIP),
-        ({"has_and": ["fOo", "bAr"]}, ["foo", "bar"], True, claims.TriggerResult.ALLOW),
-        ({"has_and": ["fOo", "bAr"]}, ["foo", "bar"], False, claims.TriggerResult.SKIP),
-        ({"has_not": ["FOO"]}, ["foo"], True, claims.TriggerResult.SKIP),
-        ({"has_and": ["fOo", "bAr"]}, ["foo", "BaZ"], True, claims.TriggerResult.SKIP),
+        ({}, ["foo"], claims.TriggerResult.SKIP),
+        ({"foo": "bar"}, ["foo"], claims.TriggerResult.SKIP),
+        # Case insensitivity (always enabled)
+        ({"has_or": ["FOO"]}, ["foo"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["foo"]}, ["FOO"], claims.TriggerResult.ALLOW),
+        ({"has_or": ["bAR"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_and": ["fOo", "bAr"]}, ["foo", "bar"], claims.TriggerResult.ALLOW),
+        ({"has_not": ["FOO"]}, ["foo"], claims.TriggerResult.SKIP),
+        ({"has_and": ["fOo", "bAr"]}, ["foo", "BaZ"], claims.TriggerResult.SKIP),
     ],
 )
 @pytest.mark.django_db
-def test_process_groups(trigger_condition, groups, case_insensitive, has_access):
+def test_process_groups(trigger_condition, groups, has_access):
     """
     Test the process_groups function.
     """
-    from flags.state import disable_flag, enable_flag
-
-    if case_insensitive:
-        enable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
-    else:
-        disable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
-
-    try:
-        res = claims.process_groups(trigger_condition, groups, map_id=1, tracking_id="xxx")
-        assert res is has_access
-    finally:
-        # Clean up: disable the flag after test
-        disable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
+    res = claims.process_groups(trigger_condition, groups, map_id=1, tracking_id="xxx")
+    assert res is has_access
 
 
 @pytest.mark.parametrize(
@@ -476,89 +461,77 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
 
 
 @pytest.mark.parametrize(
-    "trigger_condition, attributes, case_insensitive, expected",
+    "trigger_condition, attributes, expected",
     [
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": "foo@example.com"},
-            False,
             claims.TriggerResult.ALLOW,
             id="equals, positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": "foo@example.org"},
-            False,
             claims.TriggerResult.SKIP,
             id="equals, negative",
         ),
         pytest.param(
             {"email": {"matches": ".*@ex.*"}},
             {"email": "foo@example.com"},
-            False,
             claims.TriggerResult.ALLOW,
             id="matches, positive",
         ),
         pytest.param(
             {"email": {"matches": "^foo@.*"}},
             {"email": "foo@example.com"},
-            False,
             claims.TriggerResult.ALLOW,
             id="matches, start of line, positive",
         ),
         pytest.param(
             {"email": {"matches": "foo@.*"}},
             {"email": "bar@example.com"},
-            False,
             claims.TriggerResult.SKIP,
             id="matches, negative",
         ),
         pytest.param(
             {"email": {"matches": "^foo@.*"}},
             {"email": "bar@example.com"},
-            False,
             claims.TriggerResult.SKIP,
             id="matches, start of line, negative",
         ),
         pytest.param(
             {"email": {"contains": "@example.com"}},
             {"email": "foo@example.com"},
-            False,
             claims.TriggerResult.ALLOW,
             id="contains, positive",
         ),
         pytest.param(
             {"email": {"contains": "@example.com"}},
             {"email": "foo@example.org"},
-            False,
             claims.TriggerResult.SKIP,
             id="contains, negative",
         ),
         pytest.param(
             {"email": {"ends_with": "@example.com"}},
             {"email": "foo@example.com"},
-            False,
             claims.TriggerResult.ALLOW,
             id="ends_with, positive",
         ),
         pytest.param(
             {"email": {"ends_with": "@example.com"}},
             {"email": "foo@example.org"},
-            False,
             claims.TriggerResult.SKIP,
             id="ends_with, negative",
         ),
         pytest.param(
             {"email": {"in": ["foo@example.com", "bar@example.org"]}},
             {"email": "foo@example.com"},
-            False,
             claims.TriggerResult.ALLOW,
             id="in, positive",
         ),
         pytest.param(
             {"email": {"in": ["foo@example.com", "bar@example.org"]}},
             {"email": "baz@example.net"},
-            False,
             claims.TriggerResult.SKIP,
             id="in, negative",
         ),
@@ -571,7 +544,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "baz@example.net"},
-            False,
             claims.TriggerResult.SKIP,
             id="'and' join_condition, missing one attribute, negative",
         ),
@@ -584,7 +556,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "baz@example.net", "favorite_color": "red"},
-            False,
             claims.TriggerResult.SKIP,
             id="'and' join_condition, two false conditions, negative",
         ),
@@ -597,7 +568,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org", "favorite_color": "teal"},
-            False,
             claims.TriggerResult.SKIP,
             id="'and' join_condition, one false condition, negative",
         ),
@@ -610,7 +580,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "teal"},
-            False,
             claims.TriggerResult.ALLOW,
             id="'and' join_condition, positive",
         ),
@@ -623,7 +592,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "teal"},
-            False,
             claims.TriggerResult.ALLOW,
             id="'or' join_condition, both conditions true, positive",
         ),
@@ -636,7 +604,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "red"},
-            False,
             claims.TriggerResult.ALLOW,
             id="'or' join_condition, one condition true, positive",
         ),
@@ -648,7 +615,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.com", "favorite_color": "red"},
-            False,
             claims.TriggerResult.ALLOW,
             id="implicit 'or' join_condition, one condition true, positive",
         ),
@@ -660,7 +626,6 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org", "favorite_color": "red"},
-            False,
             claims.TriggerResult.SKIP,
             id="implicit 'or' join_condition, both conditions false, negative",
         ),
@@ -673,77 +638,66 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
                 },
             },
             {"email": "foo@example.org", "favorite_color": "red"},
-            False,
             claims.TriggerResult.SKIP,
             id="'or' join_condition, both conditions false, negative",
         ),
         pytest.param(
             {"email": {"invalid": "omg hey foo@example.com bye"}},
             {"email": "foo@example.org"},
-            False,
             claims.TriggerResult.SKIP,
             id="invalid predicate in trigger conditions returns None",
         ),
         pytest.param(
             {"email": {}},
             {"email": "foo@example.org"},
-            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attribute has empty dict, becomes 'exists', positive",
         ),
         pytest.param(
             {"email": {}},
             {"favorite_color": "teal"},
-            False,
             claims.TriggerResult.SKIP,
             id="trigger dict attribute has empty dict, becomes 'exists', negative",
         ),
         pytest.param(
             {"email": {}},
             {},
-            False,
             claims.TriggerResult.SKIP,
             id="trigger dict attribute has empty dict, becomes 'exists', empty attributes, negative",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}},
             {"favorite_color": "teal"},
-            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attributes have empty dicts, becomes 'exists', implicit 'or', positive",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}, "join_condition": "or"},
             {"favorite_color": "teal"},
-            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attributes have empty dicts, becomes 'exists', explicit 'or', positive",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}, "join_condition": "and"},
             {"favorite_color": "teal"},
-            False,
             claims.TriggerResult.SKIP,
             id="trigger dict attributes have empty dicts, becomes 'exists', explicit 'and', negative",
         ),
         pytest.param(
             {"email": {}, "favorite_color": {}, "join_condition": "and"},
             {"favorite_color": "teal", "email": "foo@example.com"},
-            False,
             claims.TriggerResult.ALLOW,
             id="trigger dict attributes have empty dicts, becomes 'exists', explicit 'and', positive",
         ),
         pytest.param(
             {"email": {"contains": "example"}},
             {"email": None},
-            False,
             claims.TriggerResult.SKIP,
             id="user attribute is None, no predicate checks, returns None",
         ),
         pytest.param(
             {"email": {}},
             {"email": None},
-            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is None, exists check still works, negative",
         ),
@@ -751,202 +705,154 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": ["bar@example.com", "baz@example.com"]},
-            False,
             claims.TriggerResult.SKIP,
             id="user attribute is list, no matches, negative",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}},
             {"email": ["bar@example.com", "foo@example.com"]},
-            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, one match, implicit 'or', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": ["bar@example.com", "foo@example.com"]},
-            False,
             claims.TriggerResult.SKIP,
             id="user attribute is list, one match, explicit 'and', negative",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": ["foo@example.com", "foo@example.com"]},
-            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, all matches, explicit 'and', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "or"},
             {"email": ["foo@example.com", "foo@example.com"]},
-            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, all matches, explicit 'or', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": []},
-            False,
             claims.TriggerResult.SKIP,
             id="user attribute is empty list, explicit 'and', returns None",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "or"},
             {"email": []},
-            False,
             claims.TriggerResult.SKIP,
             id="user attribute is empty list, explicit 'or', returns None",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "or"},
             {"email": ["foo@example.com", "bar@example.com"]},
-            False,
             claims.TriggerResult.ALLOW,
             id="user attribute is list, explicit 'or', second match is false, positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "invalid"},
             {"email": ["foo@example.com", "bar@example.com"]},
-            False,
             claims.TriggerResult.ALLOW,
             id="join condition is invalid, defaults to or",
         ),
         pytest.param(
             {"username": {"equals": "alice"}, "join_condition": "or"},
             {"username": "bob", "email": ""},
-            False,
             claims.TriggerResult.SKIP,
             id="user attribute is string, condition equals, join condition or, negative",
         ),
+        # Case insensitivity (always enabled)
         pytest.param(
             {"username": {"equals": "lowercase"}, "join_condition": "or"},
             {"username": "LOWERCASE"},
-            True,
             claims.TriggerResult.ALLOW,
-            id="username attribute value case mismatch",
-        ),
-        pytest.param(
-            {"username": {"equals": "lowercase"}, "join_condition": "or"},
-            {"username": "LOWERCASE"},
-            False,
-            claims.TriggerResult.SKIP,
             id="username attribute value case mismatch",
         ),
         pytest.param(
             {"uSeRnAmE": {"equals": "bbelcher"}, "join_condition": "or"},
             {"username": "bbelcher"},
-            True,
             claims.TriggerResult.ALLOW,
-            id="username attribute name/key case mismatch",
-        ),
-        pytest.param(
-            {"uSeRnAmE": {"equals": "bbelcher"}, "join_condition": "or"},
-            {"username": "bbelcher"},
-            False,
-            claims.TriggerResult.SKIP,
             id="username attribute name/key case mismatch",
         ),
         pytest.param(
             {"USERNAME": {"equals": "lowercase"}, "join_condition": "or"},
             {"username": "LOWERCASE"},
-            True,
             claims.TriggerResult.ALLOW,
             id="username attribute name/key and value case mismatch",
         ),
         pytest.param(
             {"username": {"contains": "USER"}, "join_condition": "or"},
             {"username": "myusername"},
-            True,
             claims.TriggerResult.ALLOW,
             id="username attribute value case mismatch contains",
         ),
         pytest.param(
             {"username": {"in": ["BOB", "JOE", "JOHN", "TAMAR"]}, "join_condition": "or"},
             {"username": "tamar"},
-            True,
             claims.TriggerResult.ALLOW,
             id="username attribute value case mismatch in",
         ),
         pytest.param(
             {"email": {"matches": ".*@REDHAT.COM"}, "join_condition": "or"},
             {"email": "fred@redhat.com"},
-            True,
             claims.TriggerResult.ALLOW,
             id="email attribute value case mismatch matches",
         ),
         pytest.param(
             {"email": {}},
             {"email": None},
-            True,
             claims.TriggerResult.ALLOW,
-            id="user attribute is None, exists check still works, case sensitive, negative",
+            id="user attribute is None, exists check still works",
         ),
         pytest.param(
             {"department": {"in": ["Engineering", "Sales", "Marketing"]}},
             {"department": "Engineering"},
-            False,
             claims.TriggerResult.ALLOW,
             id="in operator with list value, positive match",
         ),
         pytest.param(
             {"department": {"in": ["Engineering", "Sales", "Marketing"]}},
             {"department": "HR"},
-            False,
             claims.TriggerResult.SKIP,
             id="in operator with list value, negative match",
         ),
         pytest.param(
             {"department": {"in": ["Engineering", "Sales", "Marketing"]}},
             {"department": "engineering"},
-            True,
             claims.TriggerResult.ALLOW,
             id="in operator with list value, case insensitive match",
         ),
         pytest.param(
             {"department": {"in": "Engineering"}},
             {"department": "Engineering"},
-            False,
             claims.TriggerResult.SKIP,
             id="in operator with string value (invalid) should be ignored",
         ),
         pytest.param(
             {"cn": {"ends_with": "_admin"}, "employeeType": {"equals": "manager"}, "join_condition": "and"},
             {"cn": ["ldap_admin"]},
-            False,
             claims.TriggerResult.SKIP,
             id="missing attribute required by 'and' condition should result in skip",
         ),
         pytest.param(
             {"cn": {"ends_with": "_admin"}, "employeeType": {"equals": "manager"}, "join_condition": "or"},
             {"cn": ["ldap_admin"]},
-            False,
             claims.TriggerResult.ALLOW,
             id="missing attribute when using 'or' condition should result in allow",
         ),
         pytest.param(
             {"cn": {"ends_with": "_admin"}, "employeeType": {"equals": "manager"}, "join_condition": "and"},
             {"cn": ["ldap_org_admin"], "employeeType": ["manager"]},
-            False,
             claims.TriggerResult.ALLOW,
             id="all attribute required by 'and' condition should result in allow",
         ),
     ],
 )
 @pytest.mark.django_db
-def test_process_user_attributes(trigger_condition, attributes, expected, case_insensitive):
-    from flags.state import disable_flag, enable_flag
-
-    if case_insensitive:
-        enable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
-    else:
-        disable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
-
-    try:
-        res = claims.process_user_attributes(trigger_condition, attributes, map_id=1, tracking_id="xxx")
-        assert res is expected
-    finally:
-        # Clean up: disable the flag after test
-        disable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
+def test_process_user_attributes(trigger_condition, attributes, expected):
+    res = claims.process_user_attributes(trigger_condition, attributes, map_id=1, tracking_id="xxx")
+    assert res is expected
 
 
 def test_update_user_claims_extra_data(user, local_authenticator_map):
@@ -2214,42 +2120,22 @@ class TestClaimsHelperFunctions:
         if expected_log_contains:
             assert expected_log_contains in caplog.text
 
-    @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "case_insensitive_enabled, trigger_condition, attributes, expected_trigger, expected_attrs",
+        "trigger_condition, attributes, expected_trigger, expected_attrs",
         [
             (
-                False,
                 {"USERNAME": {"equals": "TestUser"}},
                 {"USERNAME": "TestUser"},
-                {"USERNAME": {"equals": "TestUser"}},  # No change when disabled
-                {"USERNAME": "TestUser"},  # No change when disabled
-            ),
-            (
-                True,
-                {"USERNAME": {"equals": "TestUser"}},
-                {"USERNAME": "TestUser"},
-                {"username": {"equals": "testuser"}},  # Lowercased when enabled
+                {"username": {"equals": "testuser"}},
                 {"username": "TestUser"},  # Keys lowercased, values unchanged
             ),
         ],
     )
-    def test_prepare_case_insensitive_data(self, case_insensitive_enabled, trigger_condition, attributes, expected_trigger, expected_attrs):
-        """Test _prepare_case_insensitive_data with case insensitivity enabled/disabled"""
-        from flags.state import disable_flag, enable_flag
-
-        if case_insensitive_enabled:
-            enable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
-        else:
-            disable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
-
-        try:
-            result_trigger, result_attrs = claims._prepare_case_insensitive_data(trigger_condition, attributes, 1, "test-id")
-            assert result_trigger == expected_trigger
-            assert result_attrs == expected_attrs
-        finally:
-            # Clean up: disable the flag after test
-            disable_flag("FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED")
+    def test_prepare_case_insensitive_data(self, trigger_condition, attributes, expected_trigger, expected_attrs):
+        """Test _prepare_case_insensitive_data always normalizes case"""
+        result_trigger, result_attrs = claims._prepare_case_insensitive_data(trigger_condition, attributes, 1, "test-id")
+        assert result_trigger == expected_trigger
+        assert result_attrs == expected_attrs
 
     @pytest.mark.parametrize(
         "user_value, expected",


### PR DESCRIPTION
## Summary

Removes the `FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED` feature flag and makes case-insensitive authentication map comparison the permanent, always-on behavior.

**Why:** With the Runtime Feature Flag UI shipping in 2.7 (and backported to 2.6), customers would see this Developer Preview flag that is on by default. Developer Preview is unsupported, and this behavior is now considered permanent. Removing the flag avoids customer confusion and aligns with the direction to minimize DP flags in shipped product.

## Changes

- **feature_flags.yaml**: Remove the `FEATURE_CASE_INSENSITIVE_AUTH_MAPS_ENABLED` flag definition
- **claims.py**: Remove `_is_case_insensitivity_enabled()` helper and the `from flags.state import flag_enabled` import. `process_groups()` and `_prepare_case_insensitive_data()` now always perform case-insensitive normalization unconditionally.
- **test_claims.py**: Remove all `enable_flag`/`disable_flag` toggling and the `case_insensitive` parameter from `test_process_groups`, `test_process_user_attributes`, and `test_prepare_case_insensitive_data`. Drop test cases that specifically tested the flag-off (case-sensitive) path.

## Test plan

- [x] DAB unit tests for `test_claims.py` pass
- [ ] Companion gateway PR updates tests that referenced this flag

## Jira

AAP-61226

[AAP-61226]: https://redhat.atlassian.net/browse/AAP-61226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Case-insensitive authentication mapping is now permanently enabled. This previously optional behavior is now standard, ensuring consistent authentication handling across all scenarios without requiring configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->