### PR TITLE
[AAP-59804] Extract shared resource type strings into constants

### DIFF
--- a/ansible_base/resource_registry/constants.py
+++ b/ansible_base/resource_registry/constants.py
@@ -1,0 +1,5 @@
+SHARED_USER_RESOURCE_TYPE = "shared.user"
+SHARED_ORGANIZATION_RESOURCE_TYPE = "shared.organization"
+SHARED_TEAM_RESOURCE_TYPE = "shared.team"
+SHARED_ROLE_DEFINITION_RESOURCE_TYPE = "shared.roledefinition"
+SHARED_AAP_FLAG_RESOURCE_TYPE = "shared.aapflag"

--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -5,6 +5,13 @@ from django.contrib.auth import authenticate
 from django.utils.translation import gettext_lazy as _
 
 from ansible_base.lib.utils.apps import is_rbac_installed
+from ansible_base.resource_registry.constants import (
+    SHARED_AAP_FLAG_RESOURCE_TYPE,
+    SHARED_ORGANIZATION_RESOURCE_TYPE,
+    SHARED_ROLE_DEFINITION_RESOURCE_TYPE,
+    SHARED_TEAM_RESOURCE_TYPE,
+    SHARED_USER_RESOURCE_TYPE,
+)
 from ansible_base.resource_registry.utils.resource_type_processor import ResourceTypeProcessor, RoleDefinitionProcessor
 
 ParentResource = namedtuple("ParentResource", ["model", "field_name"])
@@ -27,13 +34,13 @@ class ServiceAPIConfig:
     @classmethod
     def _get_default_resource_processors(cls):
         processors = {
-            "shared.team": ResourceTypeProcessor,
-            "shared.organization": ResourceTypeProcessor,
-            "shared.user": ResourceTypeProcessor,
-            "shared.aapflag": ResourceTypeProcessor,
+            SHARED_TEAM_RESOURCE_TYPE: ResourceTypeProcessor,
+            SHARED_ORGANIZATION_RESOURCE_TYPE: ResourceTypeProcessor,
+            SHARED_USER_RESOURCE_TYPE: ResourceTypeProcessor,
+            SHARED_AAP_FLAG_RESOURCE_TYPE: ResourceTypeProcessor,
         }
         if is_rbac_installed():
-            processors["shared.roledefinition"] = RoleDefinitionProcessor
+            processors[SHARED_ROLE_DEFINITION_RESOURCE_TYPE] = RoleDefinitionProcessor
         return processors
 
     custom_resource_processors = {}

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -19,6 +19,7 @@ from django.db.utils import Error, IntegrityError
 from requests import HTTPError
 
 from ansible_base.lib.utils.apps import is_rbac_installed
+from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.models.service_identifier import service_id
 from ansible_base.resource_registry.registry import get_registry
@@ -403,7 +404,7 @@ def get_orphan_resources(
     )
 
     # Exclude system user from deletion, consistent with manifest endpoint
-    if resource_type_name == "shared.user":
+    if resource_type_name == SHARED_USER_RESOURCE_TYPE:
         from ansible_base.lib.utils.models import get_system_user
 
         system_user = get_system_user()

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -15,6 +15,7 @@ from rest_framework.viewsets import GenericViewSet, mixins
 from ansible_base.lib.utils.response import CSVStreamResponse, get_relative_url
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 from ansible_base.lib.utils.views.permissions import try_add_oauth2_scope_permission
+from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
 from ansible_base.resource_registry.models import Resource, ResourceType, service_id
 from ansible_base.resource_registry.registry import get_registry
 from ansible_base.resource_registry.serializers import ResourceListSerializer, ResourceSerializer, ResourceTypeSerializer
@@ -149,7 +150,7 @@ class ResourceTypeViewSet(
 
         resources = Resource.objects.filter(content_type__resource_type=resource_type).filter(service_filter).prefetch_related("content_object")
 
-        if name == "shared.user" and (system_user := getattr(settings, "SYSTEM_USERNAME", None)):
+        if name == SHARED_USER_RESOURCE_TYPE and (system_user := getattr(settings, "SYSTEM_USERNAME", None)):
             resources = resources.exclude(name=system_user)
 
         if not resources:

--- a/test_app/resource_api.py
+++ b/test_app/resource_api.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from ansible_base.authentication.models import Authenticator
 from ansible_base.feature_flags.models import AAPFlag
 from ansible_base.rbac.models import RoleDefinition
+from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
 from ansible_base.resource_registry.registry import ResourceConfig, ServiceAPIConfig, SharedResource
 from ansible_base.resource_registry.shared_types import (
     FeatureFlagType,
@@ -27,7 +28,7 @@ class UserProcessor(ResourceTypeProcessor):
 
 
 class APIConfig(ServiceAPIConfig):
-    custom_resource_processors = {"shared.user": UserProcessor}
+    custom_resource_processors = {SHARED_USER_RESOURCE_TYPE: UserProcessor}
     service_type = "aap"
 
 

--- a/test_app/tests/resource_registry/test_rbac_conditional.py
+++ b/test_app/tests/resource_registry/test_rbac_conditional.py
@@ -7,6 +7,12 @@ import pytest
 from django.conf import settings
 from django.test import override_settings
 
+from ansible_base.resource_registry.constants import (
+    SHARED_ORGANIZATION_RESOURCE_TYPE,
+    SHARED_ROLE_DEFINITION_RESOURCE_TYPE,
+    SHARED_TEAM_RESOURCE_TYPE,
+    SHARED_USER_RESOURCE_TYPE,
+)
 from ansible_base.resource_registry.registry import ServiceAPIConfig
 from ansible_base.resource_registry.rest_client import ResourceAPIClient
 from ansible_base.resource_registry.shared_types import LenientPermissionSlugListField, RoleDefinitionType
@@ -57,12 +63,12 @@ class TestResourceRegistryWithoutRBAC:
         processors = ServiceAPIConfig._get_default_resource_processors()
 
         # Should not include shared.roledefinition when rbac is not installed
-        assert "shared.roledefinition" not in processors
+        assert SHARED_ROLE_DEFINITION_RESOURCE_TYPE not in processors
 
         # Should still include other processors
-        assert "shared.user" in processors
-        assert "shared.team" in processors
-        assert "shared.organization" in processors
+        assert SHARED_USER_RESOURCE_TYPE in processors
+        assert SHARED_TEAM_RESOURCE_TYPE in processors
+        assert SHARED_ORGANIZATION_RESOURCE_TYPE in processors
 
     @pytest.mark.django_db
     def test_resource_registry_basic_functionality_works(self):
@@ -129,12 +135,12 @@ class TestResourceRegistryWithRBAC:
         processors = ServiceAPIConfig._get_default_resource_processors()
 
         # Should include shared.roledefinition when rbac is installed
-        assert "shared.roledefinition" in processors
+        assert SHARED_ROLE_DEFINITION_RESOURCE_TYPE in processors
 
         # Should also include other processors
-        assert "shared.user" in processors
-        assert "shared.team" in processors
-        assert "shared.organization" in processors
+        assert SHARED_USER_RESOURCE_TYPE in processors
+        assert SHARED_TEAM_RESOURCE_TYPE in processors
+        assert SHARED_ORGANIZATION_RESOURCE_TYPE in processors
 
 
 class TestResourceRegistryConditionalImports:


### PR DESCRIPTION
## Summary

- Add `ansible_base/resource_registry/constants.py` with named constants for all shared resource type identifiers (`SHARED_USER_RESOURCE_TYPE`, `SHARED_ORGANIZATION_RESOURCE_TYPE`, `SHARED_TEAM_RESOURCE_TYPE`, `SHARED_ROLE_DEFINITION_RESOURCE_TYPE`, `SHARED_AAP_FLAG_RESOURCE_TYPE`)
- Update `registry.py`, `views.py`, `tasks/sync.py`, and test files to use these constants instead of string literals
- Enables downstream consumers (e.g., aap-gateway) to import from a single source of truth

## Motivation

SonarCloud flagged duplicated `"shared.*"` string literals across the codebase. Reviewer feedback on [ansible/jewel#32](https://github.com/ansible/jewel/pull/32) identified that these constants belong in DAB, not gateway, since they are a DAB resource registry concept.

## Testing

- [ ] Existing tests updated to use constants
- [ ] No behavioral changes — purely mechanical refactor

## JIRA

- Ticket: [AAP-59804](https://redhat.atlassian.net/browse/AAP-59804)

---
*Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>*

[AAP-59804]: https://redhat.atlassian.net/browse/AAP-59804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Created centralized constants for shared resource types: user, organization, team, role definition, and aapflag.
  * Updated resource registry modules to reference constants instead of hardcoded strings for improved consistency.

* **Tests**
  * Updated RBAC conditional tests to validate resource processor behavior with new resource type constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->