### PR TITLE
[AAP-73651] Fix cross-service RBAC sync for non-existent remote objects

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Optional
 
 import jwt
+from crum import impersonate
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import IntegrityError
@@ -19,8 +20,6 @@ from ansible_base.lib.utils.auth import get_user_by_ansible_id
 from ansible_base.lib.utils.translations import translatableConditionally as _
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.rest_client import get_resource_server_client
-from crum import impersonate
-
 from ansible_base.resource_registry.signals.handlers import no_reverse_sync
 
 logger = logging.getLogger("ansible_base.jwt_consumer.common.auth")

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -19,6 +19,8 @@ from ansible_base.lib.utils.auth import get_user_by_ansible_id
 from ansible_base.lib.utils.translations import translatableConditionally as _
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.rest_client import get_resource_server_client
+from crum import impersonate
+
 from ansible_base.resource_registry.signals.handlers import no_reverse_sync
 
 logger = logging.getLogger("ansible_base.jwt_consumer.common.auth")
@@ -177,7 +179,7 @@ class JWTCommonAuth:
                 setattr(self.user, attribute, new_value)
                 user_needs_save = True
         if user_needs_save:
-            with no_reverse_sync():
+            with no_reverse_sync(), impersonate(None):
                 logger.info(f"Saving user {self.user.username}")
                 self.user.save()
 

--- a/ansible_base/rbac/service_api/serializers.py
+++ b/ansible_base/rbac/service_api/serializers.py
@@ -1,6 +1,7 @@
 import logging
 
 from crum import impersonate
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
@@ -137,7 +138,7 @@ class BaseAssignmentSerializer(serializers.ModelSerializer):
                 else:
                     try:
                         obj = model.objects.get(pk=object_id)
-                    except (model.DoesNotExist, ValueError, TypeError):
+                    except (model.DoesNotExist, ValueError, TypeError, DjangoValidationError):
                         logger.info("Object pk=%s not found locally for %s, using RemoteObject fallback", object_id, model.__name__)
                         obj = RemoteObject(content_type=rd.content_type, object_id=object_id)
 

--- a/ansible_base/rbac/service_api/serializers.py
+++ b/ansible_base/rbac/service_api/serializers.py
@@ -133,7 +133,7 @@ class BaseAssignmentSerializer(serializers.ModelSerializer):
                 else:
                     try:
                         obj = model.objects.get(pk=object_id)
-                    except model.DoesNotExist:
+                    except (model.DoesNotExist, ValueError, TypeError):
                         obj = RemoteObject(content_type=rd.content_type, object_id=object_id)
 
             # Validators not ran, because this should be an internal action

--- a/ansible_base/rbac/service_api/serializers.py
+++ b/ansible_base/rbac/service_api/serializers.py
@@ -1,3 +1,5 @@
+import logging
+
 from crum import impersonate
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
@@ -7,6 +9,8 @@ from ..api.fields import ActorAnsibleIdField
 from ..models import DABContentType, DABPermission, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ..policies import check_content_obj_permission
 from ..remote import RemoteObject
+
+logger = logging.getLogger('ansible_base.rbac.service_api.serializers')
 
 
 class ObjectAnsibleIdField(serializers.Field):
@@ -134,6 +138,7 @@ class BaseAssignmentSerializer(serializers.ModelSerializer):
                     try:
                         obj = model.objects.get(pk=object_id)
                     except (model.DoesNotExist, ValueError, TypeError):
+                        logger.info("Object pk=%s not found locally for %s, using RemoteObject fallback", object_id, model.__name__)
                         obj = RemoteObject(content_type=rd.content_type, object_id=object_id)
 
             # Validators not ran, because this should be an internal action

--- a/ansible_base/rbac/service_api/serializers.py
+++ b/ansible_base/rbac/service_api/serializers.py
@@ -133,8 +133,8 @@ class BaseAssignmentSerializer(serializers.ModelSerializer):
                 else:
                     try:
                         obj = model.objects.get(pk=object_id)
-                    except model.DoesNotExist as exc:
-                        raise serializers.ValidationError({'object_id': str(exc)})
+                    except model.DoesNotExist:
+                        obj = RemoteObject(content_type=rd.content_type, object_id=object_id)
 
             # Validators not ran, because this should be an internal action
 

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -142,6 +142,43 @@ class TestJWTCommonAuth:
                 assert user.save.called
 
     @pytest.mark.django_db
+    def test_map_user_fields_email_change_bypasses_rbac_policy(self, django_user_model):
+        """JWT auth field sync must update email even when the RBAC email
+        policy signal would block it for a regular requesting user.
+
+        The pre_save signal rbac_pre_save_enforce_email_policy blocks email
+        changes from non-privileged CRUM users.  map_user_fields() runs during
+        JWT authentication (a trusted system operation), so it must bypass
+        the signal by clearing the CRUM user via impersonate(None).
+        """
+        from crum import impersonate
+
+        regular_user = django_user_model.objects.create_user(
+            username='regular', password='password',
+        )
+        target_user = django_user_model.objects.create_user(
+            username='jwt-synced', password='password', email='old@example.com',
+        )
+
+        common_auth = JWTCommonAuth()
+        common_auth.user = target_user
+        common_auth.token = {
+            'user_data': {
+                'username': 'jwt-synced',
+                'first_name': '',
+                'last_name': '',
+                'email': 'new@example.com',
+                'is_superuser': False,
+            }
+        }
+
+        with impersonate(regular_user):
+            common_auth.map_user_fields()
+
+        target_user.refresh_from_db()
+        assert target_user.email == 'new@example.com'
+
+    @pytest.mark.django_db
     @pytest.mark.parametrize(
         "remove,is_user_data_entry",
         [

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import pytest
 from django.test.utils import override_settings
 from jwt.exceptions import DecodeError
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, ValidationError
 
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication, JWTCommonAuth, RbacAwareJWTAuthentication, default_mapped_user_fields
 from ansible_base.jwt_consumer.common.cert import JWTCert, JWTCertException
@@ -175,6 +175,16 @@ class TestJWTCommonAuth:
             }
         }
 
+        # Precondition: prove the signal blocks a direct save under this user
+        with impersonate(regular_user):
+            target_user.email = 'new@example.com'
+            with pytest.raises(ValidationError, match="permission to change the email"):
+                target_user.save()
+
+        target_user.refresh_from_db()
+        assert target_user.email == 'old@example.com', "precondition: direct save should have been blocked"
+
+        # The actual test: map_user_fields bypasses the signal via impersonate(None)
         with impersonate(regular_user):
             common_auth.map_user_fields()
 

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -154,10 +154,13 @@ class TestJWTCommonAuth:
         from crum import impersonate
 
         regular_user = django_user_model.objects.create_user(
-            username='regular', password='password',
+            username='regular',
+            password='password',
         )
         target_user = django_user_model.objects.create_user(
-            username='jwt-synced', password='password', email='old@example.com',
+            username='jwt-synced',
+            password='password',
+            email='old@example.com',
         )
 
         common_auth = JWTCommonAuth()

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -678,6 +678,7 @@ class TestValidationErrors:
 
         response = admin_api_client.post(url, data=data)
         assert response.status_code == 201, response.data
+        assert str(response.data["object_id"]) == "99999"
 
     def test_object_role_without_object_specified_error(self, admin_api_client, rando, inv_rd):
         """Test that object role without object_id raises validation error"""

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -665,20 +665,19 @@ class TestValidationErrors:
         assert response.status_code == 400, response.data
         assert "Can not provide either 'object_id' or 'object_ansible_id' for system role" in str(response.data)
 
-    def test_object_role_without_valid_object_error(self, admin_api_client, rando, inv_rd):
-        """Test that object role without valid object raises validation error"""
+    def test_object_role_with_nonexistent_object_creates_remote_assignment(self, admin_api_client, rando, inv_rd):
+        """Synced assignments for non-existent local objects fall back to
+        RemoteObject so that cross-service sync is not blocked by object
+        ordering (the object may not have been synced yet)."""
         url = get_relative_url('serviceuserassignment-assign')
         data = {
             "role_definition": inv_rd.name,
             "user_ansible_id": str(rando.resource.ansible_id),
-            "object_id": "99999",  # Non-existent inventory ID
+            "object_id": "99999",
         }
 
         response = admin_api_client.post(url, data=data)
-        assert response.status_code == 400, response.data
-        # Check if the error is about object not existing
-        error_msg = str(response.data)
-        assert "does not exist" in error_msg.lower()
+        assert response.status_code == 201, response.data
 
     def test_object_role_without_object_specified_error(self, admin_api_client, rando, inv_rd):
         """Test that object role without object_id raises validation error"""


### PR DESCRIPTION
## Summary

- **Service API serializer**: When a synced assignment references an `object_id` that does not exist locally, fall back to `RemoteObject` instead of raising `ValidationError`. This unblocks cross-service RBAC sync when object sync ordering differs from assignment sync ordering.
- **JWT auth `map_user_fields()`**: Wrap `user.save()` with `crum.impersonate(None)` so the RBAC email policy pre_save signal treats JWT field sync as a system operation, preventing 400 errors on downstream services.

## Root Cause

The ATF test `test_org_admin_cross_org_team_role_visibility_on_remote_objects` creates a `role_team_assignment` with a synthetic `object_id="999999"`. Gateway creates the local assignment (as a `RemoteObject`) but then syncs to Controller, where the service API serializer rejects it:

```
{"object_id":"JobTemplate matching query does not exist."}
```

The service API is an internal endpoint for cross-service sync — it should accept assignments even when the referenced object doesn't exist locally, since the object may live on a different service or may not have been synced yet.

## Test plan

- [x] Existing test `test_object_role_without_valid_object_error` updated to verify RemoteObject fallback (201 instead of 400)
- [x] New test `test_map_user_fields_email_change_bypasses_rbac_policy` verifies JWT email sync bypasses RBAC policy
- [x] All 38 service API tests pass
- [x] All 84 JWT auth tests pass (1 pre-existing SQLite-only failure excluded)
- [x] All 12 email policy signal tests pass

Fixes: https://redhat.atlassian.net/browse/AAP-73651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User email and field updates now persist correctly even when pre-save enforcement policies would previously block them
  * Role assignments now proceed and synchronize remotely when the referenced local object is missing

* **Tests**
  * Added test covering user field updates bypassing enforcement for JWT-driven changes
  * Updated remote role-assignment tests to reflect acceptance and creation of remote assignments for nonexistent local objects

* **Chores**
  * Added informational logging when falling back to a remote lookup for missing local objects
<!-- end of auto-generated comment: release notes by coderabbit.ai -->