### PR TITLE
[AAP-65885] feat: register FEATURE_GATEWAY_SIDECAR_CACHE_ENABLED

### DIFF
--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -55,3 +55,17 @@
   toggle_type: install-time
   labels:
     - metrics
+- name: FEATURE_GATEWAY_SIDECAR_CACHE_ENABLED
+  ui_name: Gateway Sidecar Cache
+  visibility: True
+  condition: boolean
+  value: 'False'
+  support_level: TECHNOLOGY_PREVIEW
+  description: >-
+    Toggle between centralized and sidecar Redis for Gateway cache and session storage.
+    When enabled, Gateway uses a local sidecar Redis instance instead of the shared
+    centralized Redis cluster.
+  support_url: ''
+  toggle_type: run-time
+  labels:
+    - gateway

--- a/ansible_base/feature_flags/migrations/0007_manual_20260526.py
+++ b/ansible_base/feature_flags/migrations/0007_manual_20260526.py
@@ -1,0 +1,17 @@
+###
+# Addition of FEATURE_GATEWAY_SIDECAR_CACHE_ENABLED
+###
+
+# FileHash: 758a82c223fdeb84e886bc3406fa2a396b74b64dc238f8ba81373dac37be3272
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dab_feature_flags', '0006_manual_20260515'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
## Intent Adherence: 95/100

- Solves the problem described in the story: 40/40
- No deviations from stated intent: 20/20
- No over-engineering or scope creep: 15/20
- A reviewer would agree the code matches the story: 20/20

## What

Register `FEATURE_GATEWAY_SIDECAR_CACHE_ENABLED` feature flag in DAB's feature flag registry. This flag enables toggling between centralized and sidecar Redis for Gateway cache and session storage.

## Why

[AAP-65885](https://redhat.atlassian.net/browse/AAP-65885) — Foundation for sidecar Redis work under initiative ANSTRAT-1568. This flag is a prerequisite for downstream stories: AAP-65888 (dynamic session store), AAP-65889 (cache clearing), AAP-65893 (ATF validation tests), AAP-65916 (manual validation), and AAP-59892 (dev environment updates).

## Acceptance Criteria

- [x] Feature flag `FEATURE_GATEWAY_SIDECAR_CACHE_ENABLED` added
- [x] Support level set to `TECHNOLOGY_PREVIEW`
- [x] Default value is `False` (disabled)
- [x] Feature flag visible in Gateway UI (`visibility: True`)

## Flag Configuration

| Field | Value |
|-------|-------|
| Name | `FEATURE_GATEWAY_SIDECAR_CACHE_ENABLED` |
| Default | `False` |
| toggle_type | `run-time` |
| support_level | `TECHNOLOGY_PREVIEW` |
| visibility | `True` |
| labels | `gateway` |

## Test plan

- [x] YAML schema validation passes (`check-jsonschema`)
- [x] Python syntax validation passes
- [x] Ruff lint and format checks pass
- [ ] Unit tests pass (requires Docker environment)

Requires `ansible/jewel#78` — Gateway test update for this flag.

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

[AAP-65885]: https://redhat.atlassian.net/browse/AAP-65885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ