### PR TITLE
AAP-77154: Disable warnings-as-errors for downstream consumer tests

### DIFF
--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           cd awx
           DEVEL_IMAGE_NAME=awx-with-dab:latest AWX_DOCKER_CMD=/start_tests.sh make docker-runner
+        env:
+          PYTEST_ADDOPTS: --disable-warnings
 
   eda-server:
     name: eda-server
@@ -108,6 +110,8 @@ jobs:
           poetry run pip install -e "$DAB_PATH"
           poetry run pip show django-ansible-base
           poetry run pytest
+        env:
+          PYTEST_ADDOPTS: --disable-warnings
 
   hub:
     name: hub


### PR DESCRIPTION
## Summary

Fixes failing downstream compatibility tests in AWX and eda-server by disabling warnings-as-errors during the dab-consumers CI job.

AWX and EDA pytest configs treat all warnings as errors, which causes compatibility tests to fail when DAB introduces deprecation warnings. This change adds `PYTEST_ADDOPTS=--disable-warnings` to override this behavior for the DAB consumer tests, allowing the CI to pass while maintaining strict warning handling in the respective projects.

## Changes

- AWX test step: Add env var to disable warnings-as-errors
- eda-server test step: Add env var to disable warnings-as-errors

## Related Issue

AAP-77154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to suppress pytest warning output for automated test steps, reducing noise in test logs and making test failures and summaries easier to read during runs. This change only affects test output verbosity and does not alter test logic or results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->