### PR TITLE
AAP-65883: Add shared cache invalidation utility

### DIFF
--- a/ansible_base/lib/cache/tasks.py
+++ b/ansible_base/lib/cache/tasks.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
 import logging
+from collections.abc import Callable, Iterable
 
 from django.core.cache import cache
 
 logger = logging.getLogger('ansible_base.lib.cache.tasks')
 
 
-def clear_cache(cache_keys, dependent_keys_resolver=None, post_invalidation_hook=None):
+def clear_cache(
+    cache_keys: list[str],
+    dependent_keys_resolver: Callable[[str], Iterable[str]] | None = None,
+    post_invalidation_hook: Callable[[set[str]], None] | None = None,
+) -> None:
     """Clear the specified keys from the Django cache backend.
 
     This is a plain utility function, not a dispatcherd task. Each consuming
@@ -19,7 +26,8 @@ def clear_cache(cache_keys, dependent_keys_resolver=None, post_invalidation_hook
         post_invalidation_hook: Optional callable (set[key] -> None) invoked
             after cache deletion with the full set of invalidated keys.
     """
-    logger.info("clear_cache called for keys %s", cache_keys)
+    logger.info("clear_cache called for %d key(s)", len(cache_keys))
+    logger.debug("clear_cache key payload: %s", cache_keys)
 
     all_keys = list(cache_keys)
     if dependent_keys_resolver:
@@ -32,7 +40,7 @@ def clear_cache(cache_keys, dependent_keys_resolver=None, post_invalidation_hook
                 logger.exception("dependent_keys_resolver failed for key %r", all_keys[i])
 
     unique_keys = set(all_keys)
-    logger.debug('cache delete_many(%r)', unique_keys)
+    logger.debug("Invalidating %d cache key(s) via delete_many: %r", len(unique_keys), unique_keys)
     cache.delete_many(unique_keys)
 
     if post_invalidation_hook:

--- a/ansible_base/lib/cache/tasks.py
+++ b/ansible_base/lib/cache/tasks.py
@@ -25,12 +25,18 @@ def clear_cache(cache_keys, dependent_keys_resolver=None, post_invalidation_hook
     if dependent_keys_resolver:
         orig_len = len(all_keys)
         for i in range(orig_len):
-            for dep_key in dependent_keys_resolver(all_keys[i]):
-                all_keys.append(dep_key)
+            try:
+                for dep_key in dependent_keys_resolver(all_keys[i]):
+                    all_keys.append(dep_key)
+            except Exception:
+                logger.exception("dependent_keys_resolver failed for key %r", all_keys[i])
 
     unique_keys = set(all_keys)
     logger.debug('cache delete_many(%r)', unique_keys)
     cache.delete_many(unique_keys)
 
     if post_invalidation_hook:
-        post_invalidation_hook(unique_keys)
+        try:
+            post_invalidation_hook(unique_keys)
+        except Exception:
+            logger.exception("post_invalidation_hook failed after invalidating keys %r", unique_keys)

--- a/ansible_base/lib/cache/tasks.py
+++ b/ansible_base/lib/cache/tasks.py
@@ -1,0 +1,36 @@
+import logging
+
+from django.core.cache import cache
+
+logger = logging.getLogger('ansible_base.lib.cache.tasks')
+
+
+def clear_cache(cache_keys, dependent_keys_resolver=None, post_invalidation_hook=None):
+    """Clear the specified keys from the Django cache backend.
+
+    This is a plain utility function, not a dispatcherd task. Each consuming
+    service wraps it with its own @task(queue='...') decorator to broadcast
+    cache invalidation across cluster nodes.
+
+    Args:
+        cache_keys: List of cache key strings to invalidate.
+        dependent_keys_resolver: Optional callable (key -> iterable[key]) that
+            returns additional keys to invalidate for a given key.
+        post_invalidation_hook: Optional callable (set[key] -> None) invoked
+            after cache deletion with the full set of invalidated keys.
+    """
+    logger.info("clear_cache called for keys %s", cache_keys)
+
+    all_keys = list(cache_keys)
+    if dependent_keys_resolver:
+        orig_len = len(all_keys)
+        for i in range(orig_len):
+            for dep_key in dependent_keys_resolver(all_keys[i]):
+                all_keys.append(dep_key)
+
+    unique_keys = set(all_keys)
+    logger.debug('cache delete_many(%r)', unique_keys)
+    cache.delete_many(unique_keys)
+
+    if post_invalidation_hook:
+        post_invalidation_hook(unique_keys)

--- a/docs/lib/cache_invalidation.md
+++ b/docs/lib/cache_invalidation.md
@@ -1,0 +1,91 @@
+## Cache Invalidation
+
+Django-ansible-base provides a shared cache invalidation utility that AAP
+services use to clear cache keys across cluster nodes. Each service wraps
+the utility with its own dispatcherd `@task` decorator to broadcast
+invalidation over the appropriate queue.
+
+### Core Utility
+
+```python
+from ansible_base.lib.cache.tasks import clear_cache
+
+clear_cache(
+    cache_keys,
+    dependent_keys_resolver=None,
+    post_invalidation_hook=None,
+)
+```
+
+**Parameters:**
+
+- `cache_keys` — list of cache key strings to invalidate
+- `dependent_keys_resolver` — optional callable `(key) -> iterable[key]` that
+  returns additional keys to invalidate for a given key (e.g., settings that
+  depend on the changed setting)
+- `post_invalidation_hook` — optional callable `(set[key]) -> None` invoked
+  after cache deletion with the full set of invalidated keys
+
+The function resolves dependent keys, deduplicates, calls
+`cache.delete_many()`, and then invokes the post-invalidation hook.
+
+### Usage Pattern
+
+Each service creates a thin wrapper that decorates `clear_cache` as a
+dispatcherd broadcast task:
+
+```python
+from dispatcherd.publish import task
+from ansible_base.lib.cache.tasks import clear_cache
+
+@task(queue='my_service_broadcast', timeout=600)
+def clear_my_cache(cache_keys):
+    clear_cache(cache_keys)
+```
+
+To trigger invalidation after a database change (e.g., from a view or signal
+handler), use Django's `connection.on_commit` to ensure the task fires only
+after the transaction commits:
+
+```python
+from django.db import connection
+
+def perform_update(self, serializer):
+    # ... save changes ...
+    if changed_keys:
+        connection.on_commit(
+            lambda: clear_my_cache.delay(changed_keys)
+        )
+```
+
+### Dependent Key Resolution
+
+When a setting change should cascade to other settings, pass a resolver:
+
+```python
+@task(queue='my_service_broadcast', timeout=600)
+def clear_setting_cache(setting_keys):
+    def resolve(key):
+        return settings_registry.get_dependent_settings(key)
+
+    clear_cache(setting_keys, dependent_keys_resolver=resolve)
+```
+
+The resolver is called for each key in the original list. Returned keys are
+added to the invalidation set and deduplicated before deletion.
+
+### Post-Invalidation Hooks
+
+To perform side effects after cache invalidation (e.g., reconfiguring a
+logging handler), pass a hook:
+
+```python
+def _post_invalidation(invalidated_keys):
+    if 'LOG_LEVEL' in invalidated_keys:
+        reconfigure_logging()
+
+clear_cache(keys, post_invalidation_hook=_post_invalidation)
+```
+
+The hook receives the full set of invalidated keys (including resolved
+dependents).

--- a/test_app/tests/lib/cache/test_cache_tasks.py
+++ b/test_app/tests/lib/cache/test_cache_tasks.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible_base.lib.cache.tasks import clear_cache
+
+
+@pytest.fixture
+def populated_cache(settings):
+    settings.CACHES = {'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache', 'LOCATION': 'test-cache-tasks'}}
+    from django.core.cache import cache
+
+    cache.clear()
+    cache.set('key_a', 'value_a')
+    cache.set('key_b', 'value_b')
+    cache.set('key_c', 'value_c')
+    cache.set('key_d', 'value_d')
+    yield cache
+    cache.clear()
+
+
+def test_clear_cache_deletes_specified_keys(populated_cache):
+    clear_cache(['key_a', 'key_b'])
+
+    assert populated_cache.get('key_a') is None
+    assert populated_cache.get('key_b') is None
+    assert populated_cache.get('key_c') == 'value_c'
+    assert populated_cache.get('key_d') == 'value_d'
+
+
+def test_clear_cache_with_dependent_keys_resolver(populated_cache):
+    def resolver(key):
+        if key == 'key_a':
+            return ['key_b', 'key_c']
+        return []
+
+    clear_cache(['key_a'], dependent_keys_resolver=resolver)
+
+    assert populated_cache.get('key_a') is None
+    assert populated_cache.get('key_b') is None
+    assert populated_cache.get('key_c') is None
+    assert populated_cache.get('key_d') == 'value_d'
+
+
+def test_clear_cache_with_post_invalidation_hook(populated_cache):
+    hook = MagicMock()
+
+    clear_cache(['key_a', 'key_b'], post_invalidation_hook=hook)
+
+    hook.assert_called_once()
+    assert hook.call_args[0][0] == {'key_a', 'key_b'}
+
+
+def test_clear_cache_hook_receives_expanded_keys(populated_cache):
+    def resolver(key):
+        if key == 'key_a':
+            return ['key_b']
+        return []
+
+    hook = MagicMock()
+
+    clear_cache(['key_a'], dependent_keys_resolver=resolver, post_invalidation_hook=hook)
+
+    hook.assert_called_once()
+    assert hook.call_args[0][0] == {'key_a', 'key_b'}
+
+
+def test_clear_cache_empty_key_list(populated_cache):
+    clear_cache([])
+
+    assert populated_cache.get('key_a') == 'value_a'
+    assert populated_cache.get('key_b') == 'value_b'
+
+
+def test_clear_cache_deduplicates_keys(populated_cache):
+    def resolver(key):
+        return ['key_b']
+
+    with patch('ansible_base.lib.cache.tasks.cache') as mock_cache:
+        clear_cache(['key_a', 'key_b'], dependent_keys_resolver=resolver)
+
+        mock_cache.delete_many.assert_called_once()
+        deleted_keys = mock_cache.delete_many.call_args[0][0]
+        assert deleted_keys == {'key_a', 'key_b'}
+
+
+def test_clear_cache_no_hook_no_resolver(populated_cache):
+    clear_cache(['key_a'])
+
+    assert populated_cache.get('key_a') is None
+    assert populated_cache.get('key_b') == 'value_b'

--- a/test_app/tests/lib/cache/test_cache_tasks.py
+++ b/test_app/tests/lib/cache/test_cache_tasks.py
@@ -89,3 +89,27 @@ def test_clear_cache_no_hook_no_resolver(populated_cache):
 
     assert populated_cache.get('key_a') is None
     assert populated_cache.get('key_b') == 'value_b'
+
+
+def test_clear_cache_resolver_failure_still_invalidates_original_keys(populated_cache):
+    def bad_resolver(key):
+        if key == 'key_b':
+            raise ValueError("bad key")
+        return ['key_c']
+
+    clear_cache(['key_a', 'key_b'], dependent_keys_resolver=bad_resolver)
+
+    assert populated_cache.get('key_a') is None
+    assert populated_cache.get('key_b') is None
+    assert populated_cache.get('key_c') is None
+    assert populated_cache.get('key_d') == 'value_d'
+
+
+def test_clear_cache_hook_failure_does_not_undo_deletion(populated_cache):
+    def exploding_hook(keys):
+        raise RuntimeError("hook failed")
+
+    clear_cache(['key_a', 'key_b'], post_invalidation_hook=exploding_hook)
+
+    assert populated_cache.get('key_a') is None
+    assert populated_cache.get('key_b') is None

--- a/test_app/tests/rbac/models/test_content_type.py
+++ b/test_app/tests/rbac/models/test_content_type.py
@@ -19,6 +19,8 @@ def test_migration_shadows_real_contenttype():
 
 @pytest.mark.django_db
 def test_auto_create_content_type():
+    DABContentType.objects.get_for_model(Inventory)
+    DABContentType.objects.get_for_model(Organization)
     DABContentType.objects.all().delete()
     inv_ct = DABContentType.objects.get_for_model(Inventory)
     assert inv_ct.model == 'inventory'
@@ -30,6 +32,8 @@ def test_auto_create_content_type():
 
 @pytest.mark.django_db
 def test_auto_create_content_type_multiples():
+    DABContentType.objects.get_for_model(Inventory)
+    DABContentType.objects.get_for_model(Organization)
     DABContentType.objects.all().delete()
     data = DABContentType.objects.get_for_models(Inventory, Organization)
     inv_ct = data[Inventory]


### PR DESCRIPTION
## Summary

- Add `clear_cache()` utility in `ansible_base.lib.cache.tasks` for reusable cache key invalidation across AAP services
- Supports dependent key resolution and post-invalidation hooks so services can customize behavior
- Each service wraps it with its own dispatcherd `@task` decorator to broadcast invalidation over its queue
- 7 unit tests with 100% coverage on `tasks.py`
- Documentation in `docs/lib/cache_invalidation.md`

## Related PRs

- AWX: bhavenst/awx AAP-65883/awx-use-dab-cache-invalidation (refactors `clear_setting_cache` to delegate to this utility)
- Gateway: bhavenst/jewel AAP-65883/gateway-cache-invalidation-task (adds `clear_gateway_cache` task)

## Test plan

- [x] `pytest test_app/tests/lib/cache/test_cache_tasks.py` — 7 tests pass
- [x] Coverage: 100% on `ansible_base/lib/cache/tasks.py`
- [ ] CI passes

Jira: https://redhat.atlassian.net/browse/AAP-65883

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cluster-capable cache invalidation utility with optional dependent-key expansion, deduplication, bulk deletion, and an optional post-invalidation callback.

* **Behavior**
  * Resolver or hook errors are caught and logged without aborting deletion; original keys are still invalidated and deletions remain applied.

* **Documentation**
  * Added usage guidance and integration examples for the cache invalidation utility.

* **Tests**
  * Added comprehensive tests for cache invalidation and updated content-type tests to ensure runtime creation before assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->