### PR TITLE
[AAP-65882] Migrate AWX Redis cache driver to DAB

### DIFF
--- a/ansible_base/lib/cache/redis_cache.py
+++ b/ansible_base/lib/cache/redis_cache.py
@@ -59,7 +59,7 @@ class DABRedisCache(RedisCache):
     def delete(self, key, version=None):
         return super().delete(key, version)
 
-    @optionally_ignore_exceptions
+    @optionally_ignore_exceptions(return_value={})
     def get_many(self, keys, version=None):
         return super().get_many(keys, version)
 

--- a/ansible_base/lib/cache/redis_cache.py
+++ b/ansible_base/lib/cache/redis_cache.py
@@ -1,0 +1,83 @@
+import functools
+import socket
+
+from django.conf import settings
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+from django.core.cache.backends.redis import RedisCache
+from redis.exceptions import ConnectionError, ResponseError, TimeoutError
+
+IGNORED_EXCEPTIONS = (TimeoutError, ResponseError, ConnectionError, socket.timeout)
+
+CONNECTION_INTERRUPTED_SENTINEL = object()
+
+
+def optionally_ignore_exceptions(func=None, return_value=None):
+    if func is None:
+        return functools.partial(optionally_ignore_exceptions, return_value=return_value)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except IGNORED_EXCEPTIONS as e:
+            if getattr(settings, 'DJANGO_REDIS_IGNORE_EXCEPTIONS', True):
+                return return_value
+            raise e.__cause__ or e
+
+    return wrapper
+
+
+class DABRedisCache(RedisCache):
+    """
+    Wraps Django's RedisCache to optionally ignore exceptions when the cache is unavailable.
+    """
+
+    @optionally_ignore_exceptions
+    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        return super().add(key, value, timeout, version)
+
+    @optionally_ignore_exceptions(return_value=CONNECTION_INTERRUPTED_SENTINEL)
+    def _get(self, key, default=None, version=None):
+        return super().get(key, default, version)
+
+    def get(self, key, default=None, version=None):
+        value = self._get(key, default, version)
+        if value is CONNECTION_INTERRUPTED_SENTINEL:
+            return default
+        return value
+
+    @optionally_ignore_exceptions
+    def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        return super().set(key, value, timeout, version)
+
+    @optionally_ignore_exceptions
+    def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
+        return super().touch(key, timeout, version)
+
+    @optionally_ignore_exceptions
+    def delete(self, key, version=None):
+        return super().delete(key, version)
+
+    @optionally_ignore_exceptions
+    def get_many(self, keys, version=None):
+        return super().get_many(keys, version)
+
+    @optionally_ignore_exceptions
+    def has_key(self, key, version=None):
+        return super().has_key(key, version)
+
+    @optionally_ignore_exceptions
+    def incr(self, key, delta=1, version=None):
+        return super().incr(key, delta, version)
+
+    @optionally_ignore_exceptions
+    def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
+        return super().set_many(data, timeout, version)
+
+    @optionally_ignore_exceptions
+    def delete_many(self, keys, version=None):
+        return super().delete_many(keys, version)
+
+    @optionally_ignore_exceptions
+    def clear(self):
+        return super().clear()

--- a/ansible_base/lib/cache/redis_cache.py
+++ b/ansible_base/lib/cache/redis_cache.py
@@ -6,6 +6,7 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.core.cache.backends.redis import RedisCache
 from redis.exceptions import ConnectionError, ResponseError, TimeoutError
 
+# socket.timeout is redundant (alias for TimeoutError since Python 3.3) but kept for parity with the AWX original.
 IGNORED_EXCEPTIONS = (TimeoutError, ResponseError, ConnectionError, socket.timeout)
 
 CONNECTION_INTERRUPTED_SENTINEL = object()

--- a/test_app/tests/lib/cache/test_redis_cache.py
+++ b/test_app/tests/lib/cache/test_redis_cache.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from django.core.cache.backends.redis import RedisCache
 from django.test import override_settings
-from redis.exceptions import ConnectionError
+from redis.exceptions import ConnectionError, ResponseError, TimeoutError
 
 from ansible_base.lib.cache.redis_cache import CONNECTION_INTERRUPTED_SENTINEL, DABRedisCache, optionally_ignore_exceptions
 
@@ -13,21 +13,23 @@ def test_dab_redis_cache_inherits_redis_cache():
 
 
 @override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
-def test_ignores_exceptions_when_enabled():
+@pytest.mark.parametrize("exc_class", [ConnectionError, TimeoutError, ResponseError])
+def test_ignores_exceptions_when_enabled(exc_class):
     @optionally_ignore_exceptions
     def failing():
-        raise ConnectionError("redis down")
+        raise exc_class("redis down")
 
     assert failing() is None
 
 
 @override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=False)
-def test_raises_exceptions_when_disabled():
+@pytest.mark.parametrize("exc_class", [ConnectionError, TimeoutError, ResponseError])
+def test_raises_exceptions_when_disabled(exc_class):
     @optionally_ignore_exceptions
     def failing():
-        raise ConnectionError("redis down")
+        raise exc_class("redis down")
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(exc_class):
         failing()
 
 
@@ -54,6 +56,7 @@ def test_custom_return_value():
 
 
 def _make_cache():
+    # Skip __init__ to avoid requiring a live Redis connection for unit tests.
     return DABRedisCache.__new__(DABRedisCache)
 
 

--- a/test_app/tests/lib/cache/test_redis_cache.py
+++ b/test_app/tests/lib/cache/test_redis_cache.py
@@ -1,0 +1,130 @@
+from unittest import mock
+
+import pytest
+from django.core.cache.backends.redis import RedisCache
+from django.test import override_settings
+from redis.exceptions import ConnectionError
+
+from ansible_base.lib.cache.redis_cache import CONNECTION_INTERRUPTED_SENTINEL, DABRedisCache, optionally_ignore_exceptions
+
+
+def test_dab_redis_cache_inherits_redis_cache():
+    assert issubclass(DABRedisCache, RedisCache)
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
+def test_ignores_exceptions_when_enabled():
+    @optionally_ignore_exceptions
+    def failing():
+        raise ConnectionError("redis down")
+
+    assert failing() is None
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=False)
+def test_raises_exceptions_when_disabled():
+    @optionally_ignore_exceptions
+    def failing():
+        raise ConnectionError("redis down")
+
+    with pytest.raises(ConnectionError):
+        failing()
+
+
+def test_defaults_to_ignore_when_setting_absent(settings):
+    if hasattr(settings, 'DJANGO_REDIS_IGNORE_EXCEPTIONS'):
+        delattr(settings, 'DJANGO_REDIS_IGNORE_EXCEPTIONS')
+
+    @optionally_ignore_exceptions
+    def failing():
+        raise ConnectionError("redis down")
+
+    assert failing() is None
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
+def test_custom_return_value():
+    sentinel = object()
+
+    @optionally_ignore_exceptions(return_value=sentinel)
+    def failing():
+        raise ConnectionError("redis down")
+
+    assert failing() is sentinel
+
+
+def _make_cache():
+    return DABRedisCache.__new__(DABRedisCache)
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
+def test_get_returns_default_on_connection_error():
+    cache = _make_cache()
+    my_default = object()
+    with mock.patch.object(RedisCache, 'get', side_effect=ConnectionError("redis down")):
+        result = cache.get("some_key", default=my_default)
+    assert result is my_default
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
+def test_get_returns_none_when_no_default():
+    cache = _make_cache()
+    with mock.patch.object(RedisCache, 'get', side_effect=ConnectionError("redis down")):
+        result = cache.get("some_key")
+    assert result is None
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
+def test_get_does_not_return_sentinel():
+    cache = _make_cache()
+    with mock.patch.object(RedisCache, 'get', side_effect=ConnectionError("redis down")):
+        result = cache.get("some_key", default="fallback")
+    assert result is not CONNECTION_INTERRUPTED_SENTINEL
+    assert result == "fallback"
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
+@pytest.mark.parametrize(
+    "method_name, args",
+    [
+        ("add", ("key", "value")),
+        ("set", ("key", "value")),
+        ("touch", ("key",)),
+        ("delete", ("key",)),
+        ("get_many", (["key1", "key2"],)),
+        ("has_key", ("key",)),
+        ("incr", ("key",)),
+        ("set_many", ({"key": "value"},)),
+        ("delete_many", (["key1", "key2"],)),
+        ("clear", ()),
+    ],
+)
+def test_method_handles_connection_error(method_name, args):
+    cache = _make_cache()
+    with mock.patch.object(RedisCache, method_name, side_effect=ConnectionError("redis down")):
+        result = getattr(cache, method_name)(*args)
+    assert result is None
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=False)
+@pytest.mark.parametrize(
+    "method_name, args",
+    [
+        ("add", ("key", "value")),
+        ("get", ("key",)),
+        ("set", ("key", "value")),
+        ("touch", ("key",)),
+        ("delete", ("key",)),
+        ("get_many", (["key1", "key2"],)),
+        ("has_key", ("key",)),
+        ("incr", ("key",)),
+        ("set_many", ({"key": "value"},)),
+        ("delete_many", (["key1", "key2"],)),
+        ("clear", ()),
+    ],
+)
+def test_method_raises_when_disabled(method_name, args):
+    cache = _make_cache()
+    with mock.patch.object(RedisCache, method_name, side_effect=ConnectionError("redis down")):
+        with pytest.raises(ConnectionError):
+            getattr(cache, method_name)(*args)

--- a/test_app/tests/lib/cache/test_redis_cache.py
+++ b/test_app/tests/lib/cache/test_redis_cache.py
@@ -94,7 +94,6 @@ def test_get_does_not_return_sentinel():
         ("set", ("key", "value")),
         ("touch", ("key",)),
         ("delete", ("key",)),
-        ("get_many", (["key1", "key2"],)),
         ("has_key", ("key",)),
         ("incr", ("key",)),
         ("set_many", ({"key": "value"},)),
@@ -107,6 +106,14 @@ def test_method_handles_connection_error(method_name, args):
     with mock.patch.object(RedisCache, method_name, side_effect=ConnectionError("redis down")):
         result = getattr(cache, method_name)(*args)
     assert result is None
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True)
+def test_get_many_returns_empty_dict_on_connection_error():
+    cache = _make_cache()
+    with mock.patch.object(RedisCache, 'get_many', side_effect=ConnectionError("redis down")):
+        result = cache.get_many(["key1", "key2"])
+    assert result == {}
 
 
 @override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=False)


### PR DESCRIPTION
## Description

- **What is being changed?**
  Adds `DABRedisCache` to `ansible_base/lib/cache/redis_cache.py`, migrated from AWX's `AWXRedisCache` (`awx/main/cache.py`). The class wraps Django's built-in `RedisCache` and optionally ignores Redis exceptions (`ConnectionError`, `TimeoutError`, `ResponseError`, `socket.timeout`) when `DJANGO_REDIS_IGNORE_EXCEPTIONS` is `True`. Also adds an `__init__.py` to the `cache/` package for consistency with all other `ansible_base/lib/` subdirectories, and 33 unit tests.

- **Why is this change needed?**
  The AWX Redis driver needs to be shared across AAP services. Gateway's sidecar Redis initiative ([ANSTRAT-1568](https://issues.redhat.com/browse/ANSTRAT-1568)) requires the same fault-tolerant cache backend. Centralizing it in DAB avoids code duplication and enables reuse.

- **How does this change address the issue?**
  Copies the driver to DAB with a DAB-appropriate name (`DABRedisCache`), adds one robustness improvement (`getattr(settings, 'DJANGO_REDIS_IGNORE_EXCEPTIONS', True)` instead of direct attribute access, so consumers that don't define the setting default to fault-tolerant mode instead of raising `AttributeError`), and provides comprehensive test coverage.

Related Jira: [AAP-65882](https://issues.redhat.com/browse/AAP-65882)
Parent Epic: [AAP-73182](https://issues.redhat.com/browse/AAP-73182) — Phase 1: Gateway Foundation & Dev Environment

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

A working DAB development environment with the `redis` Python package installed.

### Steps to Test

1. Run the new cache tests:
   ```
   DJANGO_SETTINGS_MODULE=test_app.settings pytest test_app/tests/lib/cache/test_redis_cache.py -v
   ```
2. Run all cache tests (including existing `test_fallback_cache.py`) to verify no regressions:
   ```
   DJANGO_SETTINGS_MODULE=test_app.settings pytest test_app/tests/lib/cache/ -v
   ```
3. Verify the import path resolves correctly:
   ```python
   from ansible_base.lib.cache.redis_cache import DABRedisCache
   ```

### Expected Results

- 33 new tests pass for `test_redis_cache.py`
- All 13 existing `test_fallback_cache.py` tests continue to pass (46 total)
- `DABRedisCache` is importable and is a subclass of `django.core.cache.backends.redis.RedisCache`

## Additional Context

### Required Actions

- [ ] Requires documentation updates
- [x] Requires downstream repository changes
  - AWX must update `CACHES` backend in `awx/settings/defaults.py` to use `ansible_base.lib.cache.redis_cache.DABRedisCache` and delete `awx/main/cache.py`. See companion PR: ansible/awx#XXXX
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams

Assisted-by: Claude Code / Opus 4.6 (Anthropic)


[ANSTRAT-1568]: https://redhat.atlassian.net/browse/ANSTRAT-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAP-65882]: https://redhat.atlassian.net/browse/AAP-65882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Redis cache backend option that can suppress Redis/connection errors and return fallback values (e.g., None or empty results) instead of raising exceptions; behavior is configurable via settings.

* **Tests**
  * Added tests covering inheritance, suppressed vs. re-raised exception behavior, default configuration, fallback return values, and all affected cache operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->