### PR TITLE
[AAP-74899] Add Codecov integration for coverage tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,15 @@ jobs:
           name: coverage-${{ matrix.tests.env }}
           path: coverage.xml
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16  # v6.0.1
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: ${{ matrix.tests.env }}
+          fail_ci_if_error: false
+
       - name: Upload jUnit XML test results
         if: matrix.tests.junit-xml-upload && github.event_name == 'push' && github.repository == 'ansible/django-ansible-base' && github.ref_name == 'devel'
         continue-on-error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,51 @@
+# Codecov configuration for django-ansible-base
+# Exclusions aligned with sonar-project.properties to prevent coverage divergence
+
+coverage:
+  # Files and directories to exclude from coverage calculations
+  ignore:
+    # Test files and directories
+    - "**/tests/**"
+    - "test_app/**"
+
+    # Django-specific files
+    - "**/migrations/**"
+    - "**/settings*.py"
+    - "**/defaults.py"
+    - "**/grpc_defaults.py"
+    - "**/manage.py"
+    - "**/wsgi.py"
+    - "**/asgi.py"
+    - "**/__main__.py"
+
+    # Build and environment directories
+    - "**/.tox/**"
+    - "**/venv/**"
+    - "**/.venv/**"
+    - "**/env/**"
+    - "**/__pycache__/**"
+    - "**/build/**"
+    - "**/dist/**"
+    - "**/*.egg-info/**"
+
+    # Project-specific exclusions
+    - "aap-dev/**"
+    - "tools/**"
+
+  # Flag management for different test environments
+  status:
+    project:
+      default:
+        # Allow coverage to drop slightly on PRs
+        threshold: 0.5%
+    patch:
+      default:
+        # New code should maintain coverage
+        target: auto
+        threshold: 0.5%
+
+# Comment configuration for PR feedback
+comment:
+  layout: "diff,flags,files,footer"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

This PR adds Codecov integration to track code coverage metrics as part of the CoverPort initiative (AAP-74899). The CoverPort initiative is a leadership-driven effort to make Quality an organization-wide priority by tracking leading indicators like code coverage and PR cycle time.

## Changes

- **CI Workflow**: Added `codecov-action@v4` step to upload coverage.xml after test runs
- **Codecov Configuration**: Created `codecov.yml` with exclusions aligned to `sonar-project.properties` to prevent coverage divergence
- **Coverage Baseline**: Established baseline (94.41% coverage) from devel branch commit 5c17ff1

## Related

- **JIRA**: [AAP-74899](https://redhat.atlassian.net/browse/AAP-74899)
- **Initiative**: CoverPort/DevLake Quality Metrics
- **Example**: galaxy_ng onboarding ([AAP-74453](https://redhat.atlassian.net/browse/AAP-74453))

[AAP-74899]: https://redhat.atlassian.net/browse/AAP-74899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Codecov service for automated coverage reporting in CI pipeline
  * Configured coverage analysis with exclusion rules for tests and build artifacts, including PR-based status tracking and thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[AAP-74453]: https://redhat.atlassian.net/browse/AAP-74453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ