### PR TITLE
[AAP-65921] Add auto-sync cache invalidation to DABRedisCache

### DIFF
--- a/ansible_base/lib/cache/redis_cache.py
+++ b/ansible_base/lib/cache/redis_cache.py
@@ -15,14 +15,17 @@ IGNORED_EXCEPTIONS = (TimeoutError, ResponseError, ConnectionError, socket.timeo
 
 CONNECTION_INTERRUPTED_SENTINEL = object()
 
-# Thread-local guard to prevent infinite broadcast loops.
-# When the receiving side calls clear_cache() -> cache.delete_many() -> DABRedisCache.delete_many(),
-# this guard ensures the delete_many does not trigger another broadcast.
+# Defense-in-depth re-entrancy guard for future broadcast expansion.
+# Today, storm prevention relies on bulk ops (delete_many, set_many, clear) not broadcasting.
+# If a future change (AAP-77769) extends broadcasting to those methods, this guard prevents
+# infinite loops within the same thread. It does NOT protect against cross-process storms
+# (dispatcherd tasks run in separate processes) — that requires a different mechanism.
 _broadcast_guard = threading.local()
 
 # Log the missing-dispatcherd warning only once to avoid flooding logs under load.
 _dispatcherd_warning_logged = False
 _cluster_host_id_warning_logged = False
+_cluster_host_id_logged = False
 
 
 def optionally_ignore_exceptions(func=None, return_value=None):
@@ -76,8 +79,12 @@ class DABRedisCache(RedisCache):
         can skip self-invalidation — without this guard, a cache.set() would be
         immediately followed by a delete on the originating node, making the cache
         useless for high-cost operations like JWT creation (60ms-4000ms per P3).
+
+        The _broadcast_guard around apply_async is defense-in-depth for future changes
+        (AAP-77769). Today, cross-process storm prevention relies on bulk ops not
+        broadcasting — see the comment on _broadcast_guard above.
         """
-        global _dispatcherd_warning_logged, _cluster_host_id_warning_logged
+        global _dispatcherd_warning_logged, _cluster_host_id_warning_logged, _cluster_host_id_logged
 
         if not self._should_broadcast():
             return
@@ -94,6 +101,9 @@ class DABRedisCache(RedisCache):
         if not origin and not _cluster_host_id_warning_logged:
             logger.warning("ANSIBLE_BASE_REDIS_AUTO_INVALIDATE is True but CLUSTER_HOST_ID is not set; self-invalidation guard will be ineffective")
             _cluster_host_id_warning_logged = True
+        elif origin and not _cluster_host_id_logged:
+            logger.info("DABRedisCache auto-sync broadcasting as node %r", origin)
+            _cluster_host_id_logged = True
 
         _broadcast_guard.active = True
         try:
@@ -153,11 +163,11 @@ class DABRedisCache(RedisCache):
     def incr(self, key, delta=1, version=None):
         return super().incr(key, delta, version)
 
-    # Bulk write operations (set_many, delete_many, clear) intentionally do NOT broadcast.
-    # The AC for AAP-65921 scopes auto-sync to individual key operations (add, set, delete).
-    # All Gateway cache data types (JWT tokens, settings) use individual keys, not bulk ops.
-    # Cache clearing (clear) is handled by a separate story (AAP-65889) via startup and
-    # feature-flag-toggle events, not through the auto-sync driver.
+    # Bulk write operations (set_many, delete_many, clear) and other mutations (touch, incr)
+    # intentionally do NOT broadcast. AAP-65921 scopes auto-sync to add, set, delete.
+    # Extending to all mutations requires decoupling storm prevention first — the receiving
+    # side calls clear_cache() -> cache.delete_many(), and if delete_many also broadcasts
+    # it creates a cross-process infinite loop. See AAP-77769 for follow-up.
 
     @optionally_ignore_exceptions
     def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):

--- a/ansible_base/lib/cache/redis_cache.py
+++ b/ansible_base/lib/cache/redis_cache.py
@@ -1,15 +1,28 @@
 import functools
+import logging
 import socket
+import threading
 
 from django.conf import settings
 from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.core.cache.backends.redis import RedisCache
 from redis.exceptions import ConnectionError, ResponseError, TimeoutError
 
+logger = logging.getLogger('ansible_base.lib.cache.redis_cache')
+
 # socket.timeout is redundant (alias for TimeoutError since Python 3.3) but kept for parity with the AWX original.
 IGNORED_EXCEPTIONS = (TimeoutError, ResponseError, ConnectionError, socket.timeout)
 
 CONNECTION_INTERRUPTED_SENTINEL = object()
+
+# Thread-local guard to prevent infinite broadcast loops.
+# When the receiving side calls clear_cache() -> cache.delete_many() -> DABRedisCache.delete_many(),
+# this guard ensures the delete_many does not trigger another broadcast.
+_broadcast_guard = threading.local()
+
+# Log the missing-dispatcherd warning only once to avoid flooding logs under load.
+_dispatcherd_warning_logged = False
+_cluster_host_id_warning_logged = False
 
 
 def optionally_ignore_exceptions(func=None, return_value=None):
@@ -31,11 +44,76 @@ def optionally_ignore_exceptions(func=None, return_value=None):
 class DABRedisCache(RedisCache):
     """
     Wraps Django's RedisCache to optionally ignore exceptions when the cache is unavailable.
+
+    When ANSIBLE_BASE_REDIS_AUTO_INVALIDATE is True, cache write operations (add, set, delete)
+    automatically broadcast invalidation to other cluster nodes via dispatcherd. This enables
+    sidecar Redis instances to stay in sync without application code needing to call dispatcherd
+    explicitly. Requires dispatcherd to be installed and running in the consuming service.
+
+    Settings:
+        ANSIBLE_BASE_REDIS_AUTO_INVALIDATE (bool, default False):
+            Master switch for automatic cache invalidation broadcasting.
+        ANSIBLE_BASE_CACHE_BROADCAST_QUEUE (str, default 'broadcast'):
+            The dispatcherd queue name used for fan-out to all nodes.
+            Gateway uses 'gateway_broadcast'; AWX uses 'tower_broadcast_all'.
+        CLUSTER_HOST_ID (str):
+            Unique identifier for this node. Used by the self-invalidation guard
+            to skip broadcasts received by the originating node.
     """
+
+    def _should_broadcast(self):
+        """Check whether this cache operation should trigger a broadcast.
+
+        Returns False when auto-invalidation is disabled or when we are already
+        inside a broadcast handler (re-entrancy guard).
+        """
+        return getattr(settings, 'ANSIBLE_BASE_REDIS_AUTO_INVALIDATE', False) and not getattr(_broadcast_guard, 'active', False)
+
+    def _broadcast_invalidation(self, keys):
+        """Publish a cache invalidation message to all cluster nodes via dispatcherd.
+
+        Includes this node's CLUSTER_HOST_ID as origin_node so the receiving side
+        can skip self-invalidation — without this guard, a cache.set() would be
+        immediately followed by a delete on the originating node, making the cache
+        useless for high-cost operations like JWT creation (60ms-4000ms per P3).
+        """
+        global _dispatcherd_warning_logged, _cluster_host_id_warning_logged
+
+        if not self._should_broadcast():
+            return
+
+        from ansible_base.lib.cache.tasks import HAS_DISPATCHERD, broadcast_cache_invalidation
+
+        if not HAS_DISPATCHERD or broadcast_cache_invalidation is None:
+            if not _dispatcherd_warning_logged:
+                logger.warning("ANSIBLE_BASE_REDIS_AUTO_INVALIDATE is True but dispatcherd is not installed")
+                _dispatcherd_warning_logged = True
+            return
+
+        origin = getattr(settings, 'CLUSTER_HOST_ID', '')
+        if not origin and not _cluster_host_id_warning_logged:
+            logger.warning("ANSIBLE_BASE_REDIS_AUTO_INVALIDATE is True but CLUSTER_HOST_ID is not set; self-invalidation guard will be ineffective")
+            _cluster_host_id_warning_logged = True
+
+        _broadcast_guard.active = True
+        try:
+            broadcast_cache_invalidation.apply_async(
+                args=[list(keys)],
+                kwargs={'origin_node': origin},
+            )
+        except Exception:
+            logger.exception("Failed to broadcast cache invalidation for keys %r", keys)
+        finally:
+            _broadcast_guard.active = False
 
     @optionally_ignore_exceptions
     def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
-        return super().add(key, value, timeout, version)
+        result = super().add(key, value, timeout, version)
+        # Only broadcast when the key was actually added (result is True).
+        # When the key already exists, add() returns False and no write occurred.
+        if result:
+            self._broadcast_invalidation([key])
+        return result
 
     @optionally_ignore_exceptions(return_value=CONNECTION_INTERRUPTED_SENTINEL)
     def _get(self, key, default=None, version=None):
@@ -49,7 +127,9 @@ class DABRedisCache(RedisCache):
 
     @optionally_ignore_exceptions
     def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
-        return super().set(key, value, timeout, version)
+        result = super().set(key, value, timeout, version)
+        self._broadcast_invalidation([key])
+        return result
 
     @optionally_ignore_exceptions
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
@@ -57,7 +137,9 @@ class DABRedisCache(RedisCache):
 
     @optionally_ignore_exceptions
     def delete(self, key, version=None):
-        return super().delete(key, version)
+        result = super().delete(key, version)
+        self._broadcast_invalidation([key])
+        return result
 
     @optionally_ignore_exceptions(return_value={})
     def get_many(self, keys, version=None):
@@ -70,6 +152,12 @@ class DABRedisCache(RedisCache):
     @optionally_ignore_exceptions
     def incr(self, key, delta=1, version=None):
         return super().incr(key, delta, version)
+
+    # Bulk write operations (set_many, delete_many, clear) intentionally do NOT broadcast.
+    # The AC for AAP-65921 scopes auto-sync to individual key operations (add, set, delete).
+    # All Gateway cache data types (JWT tokens, settings) use individual keys, not bulk ops.
+    # Cache clearing (clear) is handled by a separate story (AAP-65889) via startup and
+    # feature-flag-toggle events, not through the auto-sync driver.
 
     @optionally_ignore_exceptions
     def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):

--- a/ansible_base/lib/cache/tasks.py
+++ b/ansible_base/lib/cache/tasks.py
@@ -82,6 +82,11 @@ try:
         broadcast reaches ALL nodes (including the originator). Without this
         guard, the originator would immediately delete the value it just set,
         making the cache useless for expensive operations like JWT creation.
+
+        Note: this calls bare clear_cache() without dependent_keys_resolver or
+        post_invalidation_hook. Services that need those (e.g., Gateway's
+        clear_gateway_cache) should be able to register their own wrapper.
+        See AAP-77769 for follow-up on service wrapper delegation.
         """
         from django.conf import settings
 

--- a/ansible_base/lib/cache/tasks.py
+++ b/ansible_base/lib/cache/tasks.py
@@ -48,3 +48,51 @@ def clear_cache(
             post_invalidation_hook(unique_keys)
         except Exception:
             logger.exception("post_invalidation_hook failed after invalidating keys %r", unique_keys)
+
+
+# --- Auto-sync broadcast task (dispatcherd) ---
+#
+# This @task-decorated function is the RECEIVING side of the auto-sync pattern.
+# When DABRedisCache broadcasts a cache invalidation via dispatcherd, this task
+# runs on each cluster node and deletes the specified keys from local cache.
+#
+# dispatcherd is optional — it is not a DAB dependency. If the package is not
+# installed, the task is unavailable and DABRedisCache logs a warning.
+
+try:
+    from dispatcherd.publish import task
+
+    def _get_broadcast_queue():
+        """Return the dispatcherd broadcast queue name from Django settings.
+
+        Read at call time (not import time) so each consuming service can
+        configure its own queue: Gateway uses 'gateway_broadcast',
+        AWX uses 'tower_broadcast_all'.
+        """
+        from django.conf import settings
+
+        return getattr(settings, 'ANSIBLE_BASE_CACHE_BROADCAST_QUEUE', 'broadcast')
+
+    @task(queue=_get_broadcast_queue)
+    def broadcast_cache_invalidation(cache_keys, origin_node=None):
+        """Delete cache keys on this node, skipping if we are the originator.
+
+        The origin_node parameter implements the self-invalidation guard:
+        when a node writes to its local sidecar Redis and broadcasts, the
+        broadcast reaches ALL nodes (including the originator). Without this
+        guard, the originator would immediately delete the value it just set,
+        making the cache useless for expensive operations like JWT creation.
+        """
+        from django.conf import settings
+
+        local_node = getattr(settings, 'CLUSTER_HOST_ID', '')
+        if origin_node and origin_node == local_node:
+            logger.debug("Skipping self-invalidation for node %s", origin_node)
+            return
+        clear_cache(cache_keys)
+
+    HAS_DISPATCHERD = True
+
+except ImportError:
+    HAS_DISPATCHERD = False
+    broadcast_cache_invalidation = None

--- a/docs/lib/cache_invalidation.md
+++ b/docs/lib/cache_invalidation.md
@@ -89,3 +89,78 @@ clear_cache(keys, post_invalidation_hook=_post_invalidation)
 
 The hook receives the full set of invalidated keys (including resolved
 dependents).
+
+---
+
+## Auto-Sync Cache Driver
+
+DAB provides `DABRedisCache`, a cache backend that automatically broadcasts
+cache invalidation to other cluster nodes via dispatcherd when cache write
+operations occur. This implements the "G3" pattern from the platform caching
+strategy — dispatcherd sync is transparent to application code.
+
+### How It Works
+
+When `ANSIBLE_BASE_REDIS_AUTO_INVALIDATE` is `True`, the `add`, `set`, and
+`delete` methods on `DABRedisCache` automatically publish a dispatcherd task
+after the local cache write succeeds. On each receiving node, the task calls
+`clear_cache()` to delete the specified keys from that node's local sidecar
+Redis.
+
+### Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ANSIBLE_BASE_REDIS_AUTO_INVALIDATE` | bool | `False` | Enable automatic cache invalidation broadcasting on write operations |
+| `ANSIBLE_BASE_CACHE_BROADCAST_QUEUE` | str | `'broadcast'` | Dispatcherd queue name for fan-out to all nodes |
+| `CLUSTER_HOST_ID` | str | — | Unique node identifier; used by the self-invalidation guard |
+
+### Consumer Setup
+
+To enable auto-sync in a consuming service:
+
+1. **Use `DABRedisCache` as the CACHES backend:**
+
+```python
+CACHES = {
+    "default": {
+        "BACKEND": "ansible_base.lib.cache.redis_cache.DABRedisCache",
+        "LOCATION": "unix:///var/run/redis/redis.sock",
+    },
+}
+```
+
+2. **Set the auto-invalidation settings:**
+
+```python
+ANSIBLE_BASE_REDIS_AUTO_INVALIDATE = True
+ANSIBLE_BASE_CACHE_BROADCAST_QUEUE = 'my_service_broadcast'
+```
+
+3. **Ensure dispatcherd is running** with a matching broadcast channel in
+   its configuration. For example, Gateway uses `gateway_broadcast`.
+
+4. **`dispatcherd` must be installed** as a dependency of the consuming
+   service. It is not a DAB dependency — if the package is absent,
+   `DABRedisCache` logs a warning and operates without broadcasting.
+
+### Self-Invalidation Guard
+
+When a node writes to its local sidecar Redis and broadcasts invalidation,
+the broadcast reaches ALL nodes — including the originator. Without
+protection, the originator would immediately delete the value it just set.
+
+This is particularly harmful for expensive cache entries like JWT tokens
+(60ms–4000ms to create). To prevent this, each broadcast includes the
+originating node's `CLUSTER_HOST_ID`. The receiving task skips cache
+clearing when the origin matches the local node.
+
+### Re-Entrancy Protection
+
+The receiving side calls `clear_cache()` → `cache.delete_many()` →
+`DABRedisCache.delete_many()`. Without protection, `delete_many` could
+trigger another broadcast, creating an infinite loop.
+
+A thread-local guard (`_broadcast_guard`) prevents this: when a broadcast
+handler is already running, subsequent write operations on the same thread
+skip the broadcast step.

--- a/docs/lib/cache_invalidation.md
+++ b/docs/lib/cache_invalidation.md
@@ -107,13 +107,19 @@ after the local cache write succeeds. On each receiving node, the task calls
 `clear_cache()` to delete the specified keys from that node's local sidecar
 Redis.
 
+**Note:** Bulk operations (`set_many`, `delete_many`, `clear`) do not trigger
+broadcasts. Use individual `set`/`delete` calls when cross-node invalidation
+is required. The raw cache key name is broadcast without a `version` parameter;
+all nodes must share the same `KEY_PREFIX` and `VERSION` in their CACHES
+configuration for invalidation to target the correct key.
+
 ### Settings
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `ANSIBLE_BASE_REDIS_AUTO_INVALIDATE` | bool | `False` | Enable automatic cache invalidation broadcasting on write operations |
 | `ANSIBLE_BASE_CACHE_BROADCAST_QUEUE` | str | `'broadcast'` | Dispatcherd queue name for fan-out to all nodes |
-| `CLUSTER_HOST_ID` | str | — | Unique node identifier; used by the self-invalidation guard |
+| `CLUSTER_HOST_ID` | str | — | Unique node identifier; required for the self-invalidation guard. If unset, a warning is logged and the originating node will also clear its own cache after broadcasting. |
 
 ### Consumer Setup
 

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -196,7 +196,7 @@ python3-saml==1.16.0
     # via -r requirements/requirements_authentication.in
 pyyaml==6.0.3
     # via drf-spectacular
-redis==7.1.0
+redis==7.4.0
     # via
     #   -r requirements/requirements_redis_client.in
     #   django-redis

--- a/requirements/requirements_redis_client.in
+++ b/requirements/requirements_redis_client.in
@@ -1,2 +1,2 @@
 django-redis
-redis
+redis>=7.4.0,<8.0.0  # 8.0.0 breaks Unix socket connections (https://github.com/redis/redis-py/issues/4086)

--- a/test_app/tests/lib/cache/test_redis_cache.py
+++ b/test_app/tests/lib/cache/test_redis_cache.py
@@ -5,7 +5,7 @@ from django.core.cache.backends.redis import RedisCache
 from django.test import override_settings
 from redis.exceptions import ConnectionError, ResponseError, TimeoutError
 
-from ansible_base.lib.cache.redis_cache import CONNECTION_INTERRUPTED_SENTINEL, DABRedisCache, optionally_ignore_exceptions
+from ansible_base.lib.cache.redis_cache import CONNECTION_INTERRUPTED_SENTINEL, DABRedisCache, _broadcast_guard, optionally_ignore_exceptions
 
 
 def test_dab_redis_cache_inherits_redis_cache():
@@ -138,3 +138,278 @@ def test_method_raises_when_disabled(method_name, args):
     with mock.patch.object(RedisCache, method_name, side_effect=ConnectionError("redis down")):
         with pytest.raises(ConnectionError):
             getattr(cache, method_name)(*args)
+
+
+# ---------------------------------------------------------------------------
+# Auto-sync broadcast tests (ANSIBLE_BASE_REDIS_AUTO_INVALIDATE)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=False)
+def _reset_broadcast_guard():
+    """Ensure the re-entrancy guard is reset between tests."""
+    _broadcast_guard.active = False
+    yield
+    _broadcast_guard.active = False
+
+
+def test_auto_invalidate_disabled_by_default(_reset_broadcast_guard):
+    """No broadcast should occur when ANSIBLE_BASE_REDIS_AUTO_INVALIDATE is not set (defaults to False)."""
+    cache = _make_cache()
+    mock_task = mock.MagicMock()
+    with (
+        mock.patch.object(RedisCache, 'set', return_value=None),
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        cache.set("key", "value")
+    mock_task.apply_async.assert_not_called()
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+@pytest.mark.parametrize(
+    "method_name, args, expected_keys",
+    [
+        ("set", ("mykey", "value"), ["mykey"]),
+        ("add", ("mykey", "value"), ["mykey"]),
+        ("delete", ("mykey",), ["mykey"]),
+    ],
+)
+def test_write_operations_broadcast_when_enabled(method_name, args, expected_keys, _reset_broadcast_guard):
+    """add, set, and delete should call broadcast_cache_invalidation.apply_async when auto-invalidation is enabled."""
+    cache = _make_cache()
+    mock_task = mock.MagicMock()
+    # add() returns True to indicate key was actually added (new key)
+    return_value = True if method_name == 'add' else None
+    with (
+        mock.patch.object(RedisCache, method_name, return_value=return_value),
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        getattr(cache, method_name)(*args)
+
+    mock_task.apply_async.assert_called_once_with(
+        args=[expected_keys],
+        kwargs={'origin_node': 'node-a'},
+    )
+
+
+@override_settings(ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+def test_broadcast_skips_self_invalidation():
+    """broadcast_cache_invalidation should skip cache clearing when origin_node matches CLUSTER_HOST_ID."""
+    from ansible_base.lib.cache.tasks import broadcast_cache_invalidation
+
+    if broadcast_cache_invalidation is None:
+        pytest.skip("dispatcherd not installed")
+
+    with mock.patch('ansible_base.lib.cache.tasks.clear_cache') as mock_clear:
+        broadcast_cache_invalidation(['key1'], origin_node='node-a')
+
+    mock_clear.assert_not_called()
+
+
+@override_settings(ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-b')
+def test_broadcast_processes_on_different_node():
+    """broadcast_cache_invalidation should call clear_cache when origin_node differs from CLUSTER_HOST_ID."""
+    from ansible_base.lib.cache.tasks import broadcast_cache_invalidation
+
+    if broadcast_cache_invalidation is None:
+        pytest.skip("dispatcherd not installed")
+
+    with mock.patch('ansible_base.lib.cache.tasks.clear_cache') as mock_clear:
+        broadcast_cache_invalidation(['key1', 'key2'], origin_node='node-a')
+
+    mock_clear.assert_called_once_with(['key1', 'key2'])
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True)
+def test_no_broadcast_without_dispatcherd(_reset_broadcast_guard):
+    """When dispatcherd is not installed, the cache operation should succeed and log a warning once."""
+    import ansible_base.lib.cache.redis_cache as rc
+
+    original = rc._dispatcherd_warning_logged
+    rc._dispatcherd_warning_logged = False
+    try:
+        cache = _make_cache()
+        with (
+            mock.patch.object(RedisCache, 'set', return_value=None),
+            mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', False),
+            mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', None),
+            mock.patch('ansible_base.lib.cache.redis_cache.logger') as mock_logger,
+        ):
+            cache.set("key1", "value1")
+            cache.set("key2", "value2")
+
+        # Warning should be logged only once, not per-operation
+        warning_calls = [call for call in mock_logger.warning.call_args_list if "dispatcherd is not installed" in call[0][0]]
+        assert len(warning_calls) == 1
+    finally:
+        rc._dispatcherd_warning_logged = original
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+def test_reentrancy_guard_prevents_infinite_loop(_reset_broadcast_guard):
+    """When _broadcast_guard.active is True, no broadcast should occur (prevents infinite loops)."""
+    cache = _make_cache()
+    _broadcast_guard.active = True
+    mock_task = mock.MagicMock()
+    with (
+        mock.patch.object(RedisCache, 'delete', return_value=None),
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        cache.delete("key")
+
+    mock_task.apply_async.assert_not_called()
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+def test_broadcast_failure_does_not_break_cache_operation(_reset_broadcast_guard):
+    """If apply_async raises, the cache operation itself should still succeed."""
+    cache = _make_cache()
+    mock_task = mock.MagicMock()
+    mock_task.apply_async.side_effect = RuntimeError("pg_notify unavailable")
+    with (
+        mock.patch.object(RedisCache, 'set', return_value=None) as mock_set,
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        cache.set("key", "value")
+
+    # The underlying set was still called despite broadcast failure
+    mock_set.assert_called_once()
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+@pytest.mark.parametrize(
+    "method_name, args",
+    [
+        ("get", ("key",)),
+        ("get_many", (["key1", "key2"],)),
+        ("has_key", ("key",)),
+    ],
+)
+def test_read_operations_do_not_broadcast(method_name, args, _reset_broadcast_guard):
+    """Read-only operations should never trigger broadcast."""
+    cache = _make_cache()
+    mock_task = mock.MagicMock()
+    with (
+        mock.patch.object(RedisCache, method_name, return_value=None),
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        getattr(cache, method_name)(*args)
+
+    mock_task.apply_async.assert_not_called()
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+@pytest.mark.parametrize(
+    "method_name, args",
+    [
+        ("touch", ("key",)),
+        ("incr", ("key",)),
+        ("set_many", ({"key": "value"},)),
+        ("delete_many", (["key1", "key2"],)),
+        ("clear", ()),
+    ],
+)
+def test_bulk_and_mutate_operations_do_not_broadcast(method_name, args, _reset_broadcast_guard):
+    """Bulk writes (set_many, delete_many, clear) and TTL/counter mutations (touch, incr)
+    intentionally do not broadcast. See redis_cache.py for rationale."""
+    cache = _make_cache()
+    mock_task = mock.MagicMock()
+    with (
+        mock.patch.object(RedisCache, method_name, return_value=None),
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        getattr(cache, method_name)(*args)
+
+    mock_task.apply_async.assert_not_called()
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+def test_add_does_not_broadcast_when_key_exists(_reset_broadcast_guard):
+    """add() should NOT broadcast when the key already exists (super().add() returns False)."""
+    cache = _make_cache()
+    mock_task = mock.MagicMock()
+    with (
+        mock.patch.object(RedisCache, 'add', return_value=False),
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        result = cache.add("existing-key", "value")
+
+    assert result is False
+    mock_task.apply_async.assert_not_called()
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True)
+def test_empty_cluster_host_id_warns(_reset_broadcast_guard):
+    """When CLUSTER_HOST_ID is not set, a warning should be logged about ineffective self-invalidation guard."""
+    import ansible_base.lib.cache.redis_cache as rc
+
+    original = rc._cluster_host_id_warning_logged
+    rc._cluster_host_id_warning_logged = False
+    try:
+        cache = _make_cache()
+        mock_task = mock.MagicMock()
+        with (
+            mock.patch.object(RedisCache, 'set', return_value=None),
+            mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+            mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+            mock.patch('ansible_base.lib.cache.redis_cache.logger') as mock_logger,
+        ):
+            cache.set("key", "value")
+
+        warning_calls = [call for call in mock_logger.warning.call_args_list if "CLUSTER_HOST_ID" in call[0][0]]
+        assert len(warning_calls) == 1
+    finally:
+        rc._cluster_host_id_warning_logged = original
+
+
+@override_settings(
+    DJANGO_REDIS_IGNORE_EXCEPTIONS=True,
+    ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True,
+    ANSIBLE_BASE_CACHE_BROADCAST_QUEUE='my_custom_queue',
+    CLUSTER_HOST_ID='node-a',
+)
+def test_broadcast_queue_setting():
+    """The broadcast queue name should be read from ANSIBLE_BASE_CACHE_BROADCAST_QUEUE."""
+    from ansible_base.lib.cache.tasks import HAS_DISPATCHERD
+
+    if not HAS_DISPATCHERD:
+        pytest.skip("dispatcherd not installed")
+
+    from ansible_base.lib.cache.tasks import _get_broadcast_queue
+
+    assert _get_broadcast_queue() == 'my_custom_queue'
+
+
+def test_broadcast_queue_defaults_to_broadcast():
+    """When ANSIBLE_BASE_CACHE_BROADCAST_QUEUE is not set, the queue should default to 'broadcast'."""
+    from ansible_base.lib.cache.tasks import HAS_DISPATCHERD
+
+    if not HAS_DISPATCHERD:
+        pytest.skip("dispatcherd not installed")
+
+    from ansible_base.lib.cache.tasks import _get_broadcast_queue
+
+    assert _get_broadcast_queue() == 'broadcast'
+
+
+@override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
+def test_reentrancy_guard_resets_after_broadcast(_reset_broadcast_guard):
+    """The re-entrancy guard should be reset after a broadcast, allowing subsequent operations to broadcast."""
+    cache = _make_cache()
+    mock_task = mock.MagicMock()
+    with (
+        mock.patch.object(RedisCache, 'set', return_value=None),
+        mock.patch('ansible_base.lib.cache.tasks.HAS_DISPATCHERD', True),
+        mock.patch('ansible_base.lib.cache.tasks.broadcast_cache_invalidation', mock_task),
+    ):
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+
+    assert mock_task.apply_async.call_count == 2

--- a/test_app/tests/lib/cache/test_redis_cache.py
+++ b/test_app/tests/lib/cache/test_redis_cache.py
@@ -1,3 +1,5 @@
+import importlib
+import sys
 from unittest import mock
 
 import pytest
@@ -153,6 +155,47 @@ def _reset_broadcast_guard():
     _broadcast_guard.active = False
 
 
+@pytest.fixture()
+def mock_dispatcherd():
+    """Mock the dispatcherd package and reload tasks.py so the try block succeeds.
+
+    This allows testing broadcast_cache_invalidation and _get_broadcast_queue
+    even when dispatcherd is not installed. The @task decorator is replaced with
+    a minimal stub that adds .apply_async and .delay as MagicMocks.
+    """
+    import ansible_base.lib.cache.tasks as tasks_module
+
+    def fake_task(**kwargs):
+        def decorator(fn):
+            fn.apply_async = mock.MagicMock()
+            fn.delay = mock.MagicMock()
+            return fn
+
+        return decorator
+
+    mock_publish = mock.MagicMock()
+    mock_publish.task = fake_task
+
+    saved = {}
+    for mod_name in ('dispatcherd', 'dispatcherd.publish'):
+        saved[mod_name] = sys.modules.get(mod_name)
+
+    sys.modules['dispatcherd'] = mock.MagicMock()
+    sys.modules['dispatcherd.publish'] = mock_publish
+
+    importlib.reload(tasks_module)
+
+    yield tasks_module
+
+    for mod_name, original in saved.items():
+        if original is None:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = original
+
+    importlib.reload(tasks_module)
+
+
 def test_auto_invalidate_disabled_by_default(_reset_broadcast_guard):
     """No broadcast should occur when ANSIBLE_BASE_REDIS_AUTO_INVALIDATE is not set (defaults to False)."""
     cache = _make_cache()
@@ -195,29 +238,19 @@ def test_write_operations_broadcast_when_enabled(method_name, args, expected_key
 
 
 @override_settings(ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')
-def test_broadcast_skips_self_invalidation():
+def test_broadcast_skips_self_invalidation(mock_dispatcherd):
     """broadcast_cache_invalidation should skip cache clearing when origin_node matches CLUSTER_HOST_ID."""
-    from ansible_base.lib.cache.tasks import broadcast_cache_invalidation
-
-    if broadcast_cache_invalidation is None:
-        pytest.skip("dispatcherd not installed")
-
-    with mock.patch('ansible_base.lib.cache.tasks.clear_cache') as mock_clear:
-        broadcast_cache_invalidation(['key1'], origin_node='node-a')
+    with mock.patch.object(mock_dispatcherd, 'clear_cache') as mock_clear:
+        mock_dispatcherd.broadcast_cache_invalidation(['key1'], origin_node='node-a')
 
     mock_clear.assert_not_called()
 
 
 @override_settings(ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-b')
-def test_broadcast_processes_on_different_node():
+def test_broadcast_processes_on_different_node(mock_dispatcherd):
     """broadcast_cache_invalidation should call clear_cache when origin_node differs from CLUSTER_HOST_ID."""
-    from ansible_base.lib.cache.tasks import broadcast_cache_invalidation
-
-    if broadcast_cache_invalidation is None:
-        pytest.skip("dispatcherd not installed")
-
-    with mock.patch('ansible_base.lib.cache.tasks.clear_cache') as mock_clear:
-        broadcast_cache_invalidation(['key1', 'key2'], origin_node='node-a')
+    with mock.patch.object(mock_dispatcherd, 'clear_cache') as mock_clear:
+        mock_dispatcherd.broadcast_cache_invalidation(['key1', 'key2'], origin_node='node-a')
 
     mock_clear.assert_called_once_with(['key1', 'key2'])
 
@@ -375,28 +408,14 @@ def test_empty_cluster_host_id_warns(_reset_broadcast_guard):
     ANSIBLE_BASE_CACHE_BROADCAST_QUEUE='my_custom_queue',
     CLUSTER_HOST_ID='node-a',
 )
-def test_broadcast_queue_setting():
+def test_broadcast_queue_setting(mock_dispatcherd):
     """The broadcast queue name should be read from ANSIBLE_BASE_CACHE_BROADCAST_QUEUE."""
-    from ansible_base.lib.cache.tasks import HAS_DISPATCHERD
-
-    if not HAS_DISPATCHERD:
-        pytest.skip("dispatcherd not installed")
-
-    from ansible_base.lib.cache.tasks import _get_broadcast_queue
-
-    assert _get_broadcast_queue() == 'my_custom_queue'
+    assert mock_dispatcherd._get_broadcast_queue() == 'my_custom_queue'
 
 
-def test_broadcast_queue_defaults_to_broadcast():
+def test_broadcast_queue_defaults_to_broadcast(mock_dispatcherd):
     """When ANSIBLE_BASE_CACHE_BROADCAST_QUEUE is not set, the queue should default to 'broadcast'."""
-    from ansible_base.lib.cache.tasks import HAS_DISPATCHERD
-
-    if not HAS_DISPATCHERD:
-        pytest.skip("dispatcherd not installed")
-
-    from ansible_base.lib.cache.tasks import _get_broadcast_queue
-
-    assert _get_broadcast_queue() == 'broadcast'
+    assert mock_dispatcherd._get_broadcast_queue() == 'broadcast'
 
 
 @override_settings(DJANGO_REDIS_IGNORE_EXCEPTIONS=True, ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True, CLUSTER_HOST_ID='node-a')


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - Add auto-sync cache invalidation to `DABRedisCache`. When `ANSIBLE_BASE_REDIS_AUTO_INVALIDATE` is `True`, cache write operations (`add`, `set`, `delete`) automatically broadcast invalidation to other cluster nodes via `dispatcherd`.
- Why is this change needed?
  - AAP is migrating from centralized Redis to sidecar Redis. Each node has its own local Redis, so cache writes on one node must invalidate stale copies on other nodes.
- How does this change address the issue?
  - `DABRedisCache` methods call `_broadcast_invalidation()` after local writes, which publishes a dispatcherd task (`broadcast_cache_invalidation`) to the configured broadcast queue. The receiving side calls `clear_cache()` to delete the keys locally, with a self-invalidation guard (via `origin_node` / `CLUSTER_HOST_ID`) to prevent the originator from deleting the value it just set.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

Unit tests:

### Prerequisites
- No live Redis required — all tests use mocks
- `dispatcherd` is optional; 4 tests skip when it's not installed

### Steps to Test
1. `tox -m lint` — verify linting passes
2. `pytest test_app/tests/lib/cache/test_redis_cache.py test_app/tests/lib/cache/test_cache_tasks.py -v` — run cache tests
3. Verify default behavior is unchanged: with `ANSIBLE_BASE_REDIS_AUTO_INVALIDATE` unset (defaults to `False`), no broadcast occurs on any cache operation

### Expected Results
- All linters pass
- 60+ tests pass, 4 skip (dispatcherd-dependent)
- No regressions in existing cache behavior

## Additional Context

### Design decisions
  
- **Self-invalidation guard**: Each broadcast includes the originating node's `CLUSTER_HOST_ID`. The receiving task skips clearing when the origin matches the local node. Without this, JWT cache (60ms–4000ms to create per P3) would be immediately deleted on the originator after every `set()`, making the cache useless.
- **Re-entrancy guard**: `threading.local()` flag prevents infinite loops when `clear_cache()` → `cache.delete_many()` calls back into `DABRedisCache`.
- **`add()` gated on result**: Only broadcasts when the key was actually added (`super().add()` returns `True`). Prevents unnecessary invalidation on other nodes when the key already exists.
- **Bulk ops excluded by design**: `set_many`, `delete_many`, `clear` do not broadcast per AC scope. All Gateway cache data types use individual keys. `clear` is handled by AAP-65889.
- **Log-once warnings**: Missing dispatcherd and missing `CLUSTER_HOST_ID` warnings are logged once to avoid flooding logs under load.
- **dispatcherd optional**: `dispatcherd` is not a DAB dependency. Import is guarded with `try/except`; `HAS_DISPATCHERD` flag controls availability.

### New settings

| Setting | Type | Default | Purpose |
|---------|------|---------|---------|
| `ANSIBLE_BASE_REDIS_AUTO_INVALIDATE` | bool | `False` | Enable auto-sync broadcasting |
| `ANSIBLE_BASE_CACHE_BROADCAST_QUEUE` | str | `'broadcast'` | Dispatcherd queue name for fan-out |

### Required Actions

- [x] Requires documentation updates
  - `docs/lib/cache_invalidation.md` updated in this PR
- [x] Requires downstream repository changes
  - **aap-gateway**: Companion PR adds `ANSIBLE_BASE_REDIS_AUTO_INVALIDATE=True` and `ANSIBLE_BASE_CACHE_BROADCAST_QUEUE='gateway_broadcast'` to `defaults.py`
  - **AAP-65886**: Must switch Gateway's CACHES backend to `DABRedisCache` for auto-sync to activate
- [ ] Blocked by PR/MR: AAP-65883 (shared cache invalidation job) — currently in Review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional automatic cross-node Redis cache invalidation with configurable broadcast queue and opt-in setting.

* **Bug Fixes**
  * Broadcasts only on successful single-key writes (add/set/delete); skipped for bulk ops and self-origin. Broadcast failures no longer break cache writes; one-time warnings and a thread-local guard prevent re-entrancy loops.

* **Documentation**
  * Added docs describing configuration and operational behavior.

* **Tests**
  * New tests for broadcast behavior, guards, and failure handling.

* **Chores**
  * Constrained Redis client to >=7.4.0,<8.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->