### PR TITLE
AAP-78182 Skip unregistered ResourceType entries during post_migrate

### DIFF
--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -76,8 +76,12 @@ def initialize_resources(sender, **kwargs):
 
         # Create resources
         for r_type in ResourceType.objects.all():
-            resource_model = apps.get_model(r_type.content_type.app_label, r_type.content_type.model)
-            resource_config = registry.get_config_for_model(resource_model)
+            try:
+                resource_model = apps.get_model(r_type.content_type.app_label, r_type.content_type.model)
+                resource_config = registry.get_config_for_model(resource_model)
+            except (KeyError, LookupError):
+                logger.warning(f"skipping resource type '{r_type.name}': model is not in the resource registry")
+                continue
 
             logger.info(f"adding unmigrated resources for {r_type.name}")
 

--- a/test_app/tests/resource_registry/test_migration.py
+++ b/test_app/tests/resource_registry/test_migration.py
@@ -1,6 +1,8 @@
 import pytest
+from django.contrib.contenttypes.models import ContentType
 
-from ansible_base.resource_registry.models import Resource
+from ansible_base.resource_registry.apps import initialize_resources
+from ansible_base.resource_registry.models import Resource, ResourceType
 
 
 @pytest.mark.django_db
@@ -10,3 +12,27 @@ def test_existing_resources_created_in_post_migration():
     created successfully.
     """
     assert Resource.objects.filter(name="migration resource", content_type__resource_type__name="aap.resourcemigrationtestmodel").exists()
+
+
+@pytest.mark.django_db
+def test_unregistered_resource_type_skipped_on_post_migration():
+    """
+    Test that ResourceType entries whose model is not in the current
+    RESOURCE_LIST are skipped (not crashed on) during post_migrate.
+
+    This prevents a KeyError in initialize_resources when iterating over
+    ResourceType.objects.all() and calling registry.get_config_for_model()
+    for a model that has been removed from the registry between upgrades.
+    """
+    registered_count = ResourceType.objects.count()
+
+    stale_ct = ContentType.objects.create(app_label="main", model="stalemodel")
+    ResourceType.objects.create(content_type=stale_ct, externally_managed=False, name="awx.stalemodel")
+
+    assert ResourceType.objects.count() == registered_count + 1
+
+    # Should not raise KeyError
+    initialize_resources(sender=None)
+
+    # Stale entry is still present (not deleted) but was skipped without error
+    assert ResourceType.objects.filter(name="awx.stalemodel").exists()


### PR DESCRIPTION
## Summary

Fixes #1018

Skip `ResourceType` entries whose model is not in the current `RESOURCE_LIST` during the "Create resources" phase of `initialize_resources`, instead of crashing with a `KeyError`.

## Problem

When a model is removed from `RESOURCE_LIST` between upgrades, its `ResourceType` row persists in the database. Phase 2 of `initialize_resources` iterates `ResourceType.objects.all()` and calls `registry.get_config_for_model()`, which raises `KeyError` for models no longer in the registry.

This was observed during AAP controller upgrades (4.7.8 → 4.8.0) where `JobTemplate` was removed from `RESOURCE_LIST` but its `ResourceType` row remained, causing the migration job to fail repeatedly with:

```
KeyError: 'main.JobTemplate'
```

## Approach

Catch `KeyError` in Phase 2 and `continue` with a warning log, rather than deleting stale `ResourceType` rows. Deletion was considered but rejected because in multi-service deployments (e.g., AAP gateway + controller sharing a database), other services may have legitimately created `ResourceType` entries that are not in the current service's `RESOURCE_LIST`.

## Changes

- `ansible_base/resource_registry/apps.py`: Wrap `registry.get_config_for_model()` in a try/except `KeyError` — log a warning and skip the entry.
- `test_app/tests/resource_registry/test_migration.py`: Add test that creates an unregistered `ResourceType` entry and verifies `initialize_resources` completes without raising `KeyError`.

## Test plan

- [ ] Existing `test_existing_resources_created_in_post_migration` still passes
- [ ] New `test_unregistered_resource_type_skipped_on_post_migration` passes
- [ ] Manually verified fix resolves the `KeyError: 'main.JobTemplate'` on AAP 2.7 upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-migration resource initialization to gracefully handle missing or unregistered model references by logging a warning and skipping the affected resource type instead of failing the migration.
  * Added a test that verifies unregistered resource types are skipped and that existing stale entries remain after post-migration initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->