### PR TITLE
[AAP-76815] Add extra_fields query param and page_size support to resource list endpoint

### DIFF
--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -27,10 +27,20 @@ class ResourceDataField(serializers.JSONField):
 
 
 class ResourceListSerializer(serializers.ModelSerializer):
+    ALLOWED_EXTRA_FIELDS = {"resource_data"}
+
     has_serializer = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     resource_type = serializers.CharField(required=False)
     resource_data = ResourceDataField(source="*", write_only=True, required=False, default={})
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        request = self.context.get("request")
+        if request:
+            requested = set(request.query_params.get("extra_fields", "").split(",")) - {""}
+            for field_name in requested & self.ALLOWED_EXTRA_FIELDS:
+                self.fields[field_name].write_only = False
 
     class Meta:
         model = Resource

--- a/ansible_base/resource_registry/serializers.py
+++ b/ansible_base/resource_registry/serializers.py
@@ -27,7 +27,7 @@ class ResourceDataField(serializers.JSONField):
 
 
 class ResourceListSerializer(serializers.ModelSerializer):
-    ALLOWED_EXTRA_FIELDS = {"resource_data"}
+    ALLOWED_EXTRA_FIELDS = frozenset({"resource_data"})
 
     has_serializer = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
@@ -37,10 +37,12 @@ class ResourceListSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         request = self.context.get("request")
-        if request:
-            requested = set(request.query_params.get("extra_fields", "").split(",")) - {""}
-            for field_name in requested & self.ALLOWED_EXTRA_FIELDS:
-                self.fields[field_name].write_only = False
+        extra_fields = request.query_params.get("extra_fields", "") if request else ""
+        if extra_fields:
+            requested = set(extra_fields.split(","))
+            for field_name in requested.intersection(self.ALLOWED_EXTRA_FIELDS):
+                if field_name in self.fields:
+                    self.fields[field_name].write_only = False
 
     class Meta:
         model = Resource

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -14,6 +14,7 @@ from rest_framework.viewsets import GenericViewSet, mixins
 
 from ansible_base.lib.utils.response import CSVStreamResponse, get_relative_url
 from ansible_base.lib.utils.schema import extend_schema_if_available
+from ansible_base.lib.utils.settings import get_setting
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 from ansible_base.lib.utils.views.permissions import try_add_oauth2_scope_permission
 from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
@@ -54,7 +55,10 @@ class ResourcesPagination(PageNumberPagination):
     # isn't set, the default is no pagination.
     page_size = 50
     page_size_query_param = "page_size"
-    max_page_size = DEFAULT_MAX_PAGE_SIZE
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.max_page_size = get_setting('RESOURCE_LIST_MAX_PAGE_SIZE', DEFAULT_MAX_PAGE_SIZE)
 
 
 class ResourceAPIMixin:

--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, mixins
 
 from ansible_base.lib.utils.response import CSVStreamResponse, get_relative_url
+from ansible_base.lib.utils.schema import extend_schema_if_available
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 from ansible_base.lib.utils.views.permissions import try_add_oauth2_scope_permission
 from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
@@ -22,6 +23,7 @@ from ansible_base.resource_registry.serializers import ResourceListSerializer, R
 from ansible_base.rest_filters.rest_framework.field_lookup_backend import FieldLookupBackend
 from ansible_base.rest_filters.rest_framework.order_backend import OrderByBackend
 from ansible_base.rest_filters.rest_framework.type_filter_backend import TypeFilterBackend
+from ansible_base.rest_pagination.default_paginator import DEFAULT_MAX_PAGE_SIZE
 
 logger = logging.getLogger('ansible_base.resource_registry.views')
 
@@ -51,6 +53,8 @@ class ResourcesPagination(PageNumberPagination):
     # PageNumberPagination by itself doesn't work in some apps because when api_settings.PAGE_SIZE
     # isn't set, the default is no pagination.
     page_size = 50
+    page_size_query_param = "page_size"
+    max_page_size = DEFAULT_MAX_PAGE_SIZE
 
 
 class ResourceAPIMixin:
@@ -67,6 +71,7 @@ class ResourceAPIMixin:
     - Use Page/Number pagination
     """
 
+    rest_filters_reserved_names = ("extra_fields",)
     filter_backends = (FieldLookupBackend, TypeFilterBackend, OrderByBackend)
     permission_classes = try_add_oauth2_scope_permission(
         [
@@ -101,6 +106,14 @@ class ResourceViewSet(
             return ResourceListSerializer
 
         return super().get_serializer_class()
+
+    @extend_schema_if_available(
+        description="List all resources. Accepts an optional 'extra_fields' query parameter "
+        "(comma-separated) to include additional fields in the response. "
+        f"Supported values: {', '.join(sorted(ResourceListSerializer.ALLOWED_EXTRA_FIELDS))}.",
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
     def perform_destroy(self, instance):
         instance.delete_resource()

--- a/test_app/tests/resource_registry/test_resources_api.py
+++ b/test_app/tests/resource_registry/test_resources_api.py
@@ -476,3 +476,60 @@ def test_user_social_auth_exception(admin_api_client, django_user_model, saml_au
         with expected_log('ansible_base.resource_registry.utils.sso_provider.logger', 'warning', "Failed to parse server url from"):
             resp = admin_api_client.get(url)
             assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_resources_list_excludes_resource_data_by_default(admin_api_client, user):
+    """Test that resource_data is not included in list responses by default."""
+    url = get_relative_url("resource-list")
+    resp = admin_api_client.get(url)
+    assert resp.status_code == 200
+    for result in resp.data["results"]:
+        assert "resource_data" not in result
+
+
+@pytest.mark.django_db
+def test_resources_list_includes_resource_data_with_extra_fields(admin_api_client, user):
+    """Test that resource_data is included when extra_fields=resource_data is passed."""
+    url = get_relative_url("resource-list")
+    resp = admin_api_client.get(url, {"extra_fields": "resource_data"})
+    assert resp.status_code == 200
+    assert resp.data["count"] > 0
+    for result in resp.data["results"]:
+        assert "resource_data" in result
+
+
+@pytest.mark.django_db
+def test_resources_list_ignores_unknown_extra_fields(admin_api_client, user):
+    """Test that unknown extra_fields values are silently ignored."""
+    url = get_relative_url("resource-list")
+    resp = admin_api_client.get(url, {"extra_fields": "nonexistent_field"})
+    assert resp.status_code == 200
+    for result in resp.data["results"]:
+        assert "resource_data" not in result
+        assert "nonexistent_field" not in result
+
+
+@pytest.mark.django_db
+def test_resources_list_extra_fields_mixed_valid_and_invalid(admin_api_client, user):
+    """Test that valid extra_fields are included and unknown ones are ignored."""
+    url = get_relative_url("resource-list")
+    resp = admin_api_client.get(url, {"extra_fields": "resource_data,nonexistent_field"})
+    assert resp.status_code == 200
+    assert resp.data["count"] > 0
+    for result in resp.data["results"]:
+        assert "resource_data" in result
+        assert "nonexistent_field" not in result
+
+
+@pytest.mark.django_db
+def test_resources_list_page_size(admin_api_client, django_user_model):
+    """Test that page_size query parameter is respected."""
+    for i in range(5):
+        django_user_model.objects.create(username=f"pagesizeuser{i}")
+
+    url = get_relative_url("resource-list")
+    resp = admin_api_client.get(url, {"page_size": "3"})
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 3
+    assert resp.data["next"] is not None


### PR DESCRIPTION
## Summary
- Add `extra_fields` query parameter to `ResourceListSerializer` with an `ALLOWED_EXTRA_FIELDS` whitelist — when `?extra_fields=resource_data` is passed, `resource_data` is included in list responses. Unknown field names are silently ignored. Default behavior unchanged (remains `write_only`).
- Enable `page_size` override on `ResourcesPagination` (capped at `DEFAULT_MAX_PAGE_SIZE`)
- Add `rest_filters_reserved_names` to `ResourceAPIMixin` so `FieldLookupBackend` doesn't reject `extra_fields` as an unknown field
- Add OpenAPI schema description for the `extra_fields` parameter via `extend_schema_if_available`

## Motivation
`migrate_service_data` currently makes an individual GET for every resource because the list endpoint doesn't return `resource_data`. This causes ~71K API calls at production scale. With this change, Gateway can fetch `resource_data` in bulk via the list endpoint.

## Test plan
- [x] `test_resources_list_excludes_resource_data_by_default` — default list still omits `resource_data`
- [x] `test_resources_list_includes_resource_data_with_extra_fields` — `?extra_fields=resource_data` includes it
- [x] `test_resources_list_ignores_unknown_extra_fields` — unknown values silently ignored
- [x] `test_resources_list_extra_fields_mixed_valid_and_invalid` — valid fields included, unknown ignored in same request
- [x] `test_resources_list_page_size` — `page_size` query param is respected
- [x] Validated end-to-end in aap-dev cluster: `register-services` completed successfully with all 3 services

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource list responses exclude detailed resource data by default and allow including it via an optional query parameter (e.g., extra_fields=resource_data).
  * Pagination now supports a page_size query parameter with an enforced maximum to control results per page.
  * API documentation/schema updated to describe the optional extra_fields parameter.

* **Tests**
  * Added API tests covering extra_fields behavior and pagination responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->