### PR TITLE
[AAP-78190] fix: pass OIDC response as attrs for authenticator map evaluation

### DIFF
--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -264,6 +264,6 @@ def create_user_claims_pipeline(*args, backend, response, **kwargs):
 
     logger.debug(f'updating user claims with groups claim "{groups_claim}": {extra_groups}')
 
-    user = update_user_claims(kwargs["user"], backend.database_instance, backend.get_user_groups(extra_groups))
+    user = update_user_claims(kwargs["user"], backend.database_instance, backend.get_user_groups(extra_groups), attrs=response)
     if user is None:
         return SOCIAL_AUTH_PIPELINE_FAILED_STATUS

--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -572,23 +572,9 @@ def _result_suffix(result: bool) -> str:
     return "allowing" if result else "skipping"
 
 
-def update_user_claims(user: Optional[AbstractUser], database_authenticator: Authenticator, groups: list[str]) -> Optional[AbstractUser]:
-    """
-    This method takes a user, an authenticator and a list of the users associated groups.
-    It will look up the AuthenticatorUser (it must exist already) and update that User and their permissions in the system.
-    """
-    if not user:
-        return None
-
-    authenticator_user = user.authenticator_users.filter(provider=database_authenticator).first()
-    # update the auth_time field to align with the general format used for other authenticators
-    authenticator_user.extra_data = {**authenticator_user.extra_data, "auth_time": DateTimeField().to_representation(now())}
-    authenticator_user.save(update_fields=["extra_data"])
-
-    results = create_claims(database_authenticator, user.username, authenticator_user.extra_data, groups)
-
+def _apply_claim_attributes(results: dict, user, authenticator_user) -> bool:
+    """Apply claim results as attributes on user or authenticator_user. Returns True if any attribute was changed."""
     needs_save = False
-
     for attribute, attr_value in results.items():
         if attr_value is None:
             continue
@@ -605,6 +591,33 @@ def update_user_claims(user: Optional[AbstractUser], database_authenticator: Aut
             logger.debug(f"Setting new attribute {attribute} for {user.username}")
             setattr(object, attribute, attr_value)
             needs_save = True
+    return needs_save
+
+
+def update_user_claims(
+    user: Optional[AbstractUser], database_authenticator: Authenticator, groups: list[str], attrs: Optional[dict] = None
+) -> Optional[AbstractUser]:
+    """
+    This method takes a user, an authenticator and a list of the users associated groups.
+    It will look up the AuthenticatorUser (it must exist already) and update that User and their permissions in the system.
+
+    If attrs is provided, it will be used as the attributes for authenticator map
+    trigger evaluation instead of authenticator_user.extra_data. This is needed for
+    social auth (OIDC/SAML) where the identity provider's response contains the
+    claims that attribute-based maps should match against.
+    """
+    if not user:
+        return None
+
+    authenticator_user = user.authenticator_users.filter(provider=database_authenticator).first()
+    # update the auth_time field to align with the general format used for other authenticators
+    authenticator_user.extra_data = {**authenticator_user.extra_data, "auth_time": DateTimeField().to_representation(now())}
+    authenticator_user.save(update_fields=["extra_data"])
+
+    claims_attrs = attrs if attrs is not None else authenticator_user.extra_data
+    results = create_claims(database_authenticator, user.username, claims_attrs, groups)
+
+    needs_save = _apply_claim_attributes(results, user, authenticator_user)
 
     if needs_save:
         authenticator_user.save()

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -609,6 +609,7 @@ def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, user
     assert call_args[0][0] == user
     assert call_args[0][1] is None
     assert call_args[0][2].sort() == expected_groups.sort()
+    assert call_args[1]['attrs'] == rData
 
 
 @pytest.mark.django_db

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -897,6 +897,44 @@ def test_update_user_claims_groups(user, local_authenticator_map):
     assert result is user
 
 
+def test_update_user_claims_attrs_override(user, local_authenticator_map):
+    """
+    Verify that when attrs is explicitly passed to update_user_claims, it is
+    used for attribute-based trigger evaluation instead of extra_data.
+
+    This simulates the OIDC pipeline flow where the identity provider's response
+    contains claims (like preferred_username) that are NOT stored in extra_data
+    but should still be available for authenticator map attribute matching.
+    """
+    local_authenticator_map.triggers = {"attributes": {"preferred_username": {"contains": "oidc_user"}}}
+    local_authenticator_map.save()
+    authenticator = local_authenticator_map.authenticator
+    authenticator_user = AuthenticatorUser(
+        provider=authenticator,
+        user=user,
+        extra_data={"id": "some-sub-value", "token_type": "Bearer"},
+    )
+    authenticator_user.save()
+
+    # Without attrs override, the trigger won't match (preferred_username not in extra_data)
+    result = claims.update_user_claims(user, authenticator, [])
+    assert result is user  # still allowed (no "allow" map to block)
+
+    # Verify the map didn't fire by checking that last_login_map_results shows "skipped"
+    authenticator_user.refresh_from_db()
+    map_results = authenticator_user.last_login_map_results
+    assert map_results[0][str(local_authenticator_map.pk)] == "skipped"
+
+    # With attrs override containing the claim, the trigger SHOULD match
+    oidc_response = {"preferred_username": "oidc_user_1", "email": "user@example.com", "sub": "abc123"}
+    result = claims.update_user_claims(user, authenticator, [], attrs=oidc_response)
+    assert result is user
+
+    authenticator_user.refresh_from_db()
+    map_results = authenticator_user.last_login_map_results
+    assert map_results[0][str(local_authenticator_map.pk)] is True
+
+
 @pytest.mark.parametrize("enabled", [True, False])
 def test_create_claims_with_map_enabled_or_disabled(enabled, local_authenticator):
     # Create an AuthenticatorMap object with the parameterized "enabled" value


### PR DESCRIPTION
## Description

- **What:** Adds an optional `attrs` parameter to `update_user_claims()` and passes the OIDC response from `create_user_claims_pipeline` so that identity provider claims are available for attribute-based authenticator map evaluation.
- **Why:** Commit 964366e (AAP-56519) refactored `capture_oauth_email_pipeline` to fix a GitHub login IntegrityError. The old version inadvertently stored the full OIDC response into `authenticator_user.extra_data` via `get_or_create_authenticator_user(extra_data=response)`. The new version only updates the email field, so `extra_data` no longer contains OIDC claims like `preferred_username`. Since `create_claims()` reads attributes from `extra_data`, attribute-based authenticator maps broke.
- **How:** Instead of relying on `extra_data` to contain the full identity provider response, the pipeline now explicitly passes the response as the attributes dict for trigger evaluation. Non-social-auth callers (LDAP/RADIUS/database) continue using `extra_data` as before.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases

## Testing Instructions

### Prerequisites
- Running environment with an OIDC authenticator configured (e.g., Keycloak)

### Steps to Test
1. Create an authenticator map with an attribute-based trigger, e.g.: `triggers: {attributes: {preferred_username: {contains: "some_user"}}}`
2. Log in via OIDC as a user whose `preferred_username` matches
3. Verify the user is mapped to the expected org/team/role

### Expected Results
- Attribute-based authenticator maps correctly match OIDC claims
- Group-based maps continue to work as before
- `test_create_user_claims_pipeline` passes with the new `attrs` assertion
- `test_update_user_claims_attrs_override` verifies the override path

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced user claim attribute handling in the social authentication pipeline to improve claim-based user attribute matching during OAuth authentication flows.

* **Tests**
  * Added regression and integration test coverage for claim attribute evaluation and override behavior in authentication pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->