### PR TITLE
Register read_only_base shortname in managed_role_templates

### DIFF
--- a/ansible_base/rbac/managed.py
+++ b/ansible_base/rbac/managed.py
@@ -203,6 +203,7 @@ managed_role_templates = {
     'team_member': TeamMember,
     # These are not fully functional on their own, but can be easily subclassed
     'admin_base': ManagedAdminBase,
+    'read_only_base': ManagedReadOnlyBase,
     'action_base': ManagedActionBase,
 }
 

--- a/test_app/tests/rbac/test_managed.py
+++ b/test_app/tests/rbac/test_managed.py
@@ -2,7 +2,7 @@ import pytest
 from django.apps import apps
 
 from ansible_base.rbac import permission_registry
-from ansible_base.rbac.managed import managed_role_templates
+from ansible_base.rbac.managed import ManagedReadOnlyBase, get_managed_role_constructors, managed_role_templates
 from ansible_base.rbac.models import DABPermission, RoleDefinition
 from ansible_base.rbac.validators import validate_permissions_for_model
 
@@ -48,3 +48,31 @@ def test_create_all_managed_roles():
     "This is a method that may be called in migrations, etc."
     assert not RoleDefinition.objects.filter(name='Cow Mooer').exists()
     permission_registry.create_managed_roles(apps)
+
+
+def test_read_only_base_is_registered_as_shortname():
+    """read_only_base must be usable as a shortname in ANSIBLE_BASE_MANAGED_ROLE_REGISTRY."""
+    assert 'read_only_base' in managed_role_templates
+    assert managed_role_templates['read_only_base'] is ManagedReadOnlyBase
+
+
+@pytest.mark.django_db
+def test_read_only_base_shortname_creates_view_only_role():
+    """A consuming app can declare a read-only managed role via the registry shortname."""
+    registry_entry = {
+        'my_viewer': {
+            'shortname': 'read_only_base',
+            'name': 'Cow Viewer',
+            'model_name': 'test_app.Cow',
+        }
+    }
+    constructors = get_managed_role_constructors(apps, registry_entry)
+    assert 'my_viewer' in constructors
+
+    constructor = constructors['my_viewer']
+    assert constructor.name == 'Cow Viewer'
+    assert isinstance(constructor, ManagedReadOnlyBase)
+
+    perms = constructor.get_permissions(apps)
+    assert all('.view' in p for p in perms), f"Expected only view permissions, got: {perms}"
+    assert any('view_cow' in p for p in perms)


### PR DESCRIPTION
ManagedReadOnlyBase existed as a class but was not accessible via the ANSIBLE_BASE_MANAGED_ROLE_REGISTRY shortname system, forcing consuming apps to instantiate and register it manually in their AppConfig.ready().

Adding 'read_only_base' to managed_role_templates lets apps declare read-only managed roles through settings alone, consistent with how admin_base and action_base are already exposed.

Assisted-by: Claude Code (claude-sonnet-4-6)

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
