### PR TITLE
[AAP-76778] Remove FEATURE_DASHBOARD_COLLECTION_ENABLED from feature flags

### DIFF
--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -30,17 +30,3 @@
   toggle_type: install-time
   labels:
     - platform
-- name: FEATURE_DASHBOARD_COLLECTION_ENABLED
-  ui_name: Automation Dashboard
-  visibility: True
-  condition: boolean
-  value: 'False'
-  support_level: TECHNOLOGY_PREVIEW
-  description: >-
-    Enable data collection for the automation-reports dashboard integration.
-    When enabled, Controller job data is collected and stored locally in the platform
-    database to power the dashboard_reports API and automation-reports UI.
-  support_url: ''
-  toggle_type: install-time
-  labels:
-    - metrics

--- a/ansible_base/feature_flags/migrations/0008_manual_20260618.py
+++ b/ansible_base/feature_flags/migrations/0008_manual_20260618.py
@@ -1,0 +1,17 @@
+###
+# Removal of FEATURE_DASHBOARD_COLLECTION_ENABLED
+###
+
+# FileHash: 8bfb442d3ec7d633a0089423642a87e1d74c86fa21f27bbc02ae322a2852e69e
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dab_feature_flags', '0007_manual_20260615'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
Tested as part of https://github.com/ansible/metrics-service/pull/275

## Summary

- Remove the `FEATURE_DASHBOARD_COLLECTION_ENABLED` flag definition from DAB's `feature_flags.yaml`
- Dashboard collection is now enabled by default in metrics-service (companion PR: https://github.com/ansible/metrics-service/pull/275)
- The flag definition moves to metrics-service's own `feature_flags.yaml`, where `load_task_feature_flags()` re-seeds it into the AAPFlag table after every DAB purge cycle
- The empty migration `0005_manual_20260417.py` is kept to avoid breaking existing deployments

## Ticket

https://redhat.atlassian.net/browse/AAP-76778

## Test plan

- [ ] DAB test suite passes
- [x] metrics-service `load_task_feature_flags()` re-creates the flag after DAB purge
- [ ] Gateway UI still shows the flag (seeded by metrics-service, not DAB)
- [ ] Existing deployments with the flag already in DB are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the Dashboard Collection feature flag from the system configuration, including its related setup and metadata.
  * Updated the feature-flag migrations to reflect this removal, with no additional database operations introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->