### PR TITLE
feature(aap-79673): add view_team to organization member

### DIFF
--- a/ansible_base/rbac/managed.py
+++ b/ansible_base/rbac/managed.py
@@ -180,6 +180,12 @@ class OrganizationMember(OrganizationMixin, ManagedActionBase):
     description = gettext_noop("Has member permission to a single organization")
     action = 'member_organization'
 
+    def get_permissions(self, apps) -> set[str]:
+        perms = super().get_permissions(apps)
+        team_model_name = apps.get_model(settings.ANSIBLE_BASE_TEAM_MODEL)._meta.model_name
+        perms.add(f'view_{team_model_name}')
+        return perms
+
 
 class TeamAdmin(TeamMixin, ManagedAdminBase):
     name = gettext_noop("Team Admin")

--- a/test_app/tests/rbac/test_managed.py
+++ b/test_app/tests/rbac/test_managed.py
@@ -2,8 +2,8 @@ import pytest
 from django.apps import apps
 
 from ansible_base.rbac import permission_registry
-from ansible_base.rbac.managed import managed_role_templates
-from ansible_base.rbac.models import DABPermission, RoleDefinition
+from ansible_base.rbac.managed import OrganizationMember, managed_role_templates
+from ansible_base.rbac.models import DABPermission, RoleDefinition, RoleEvaluation
 from ansible_base.rbac.validators import validate_permissions_for_model
 
 
@@ -48,3 +48,83 @@ def test_create_all_managed_roles():
     "This is a method that may be called in migrations, etc."
     assert not RoleDefinition.objects.filter(name='Cow Mooer').exists()
     permission_registry.create_managed_roles(apps)
+
+
+@pytest.mark.django_db
+def test_org_member_can_see_teams_in_org(rando, organization, team, org_member_rd):
+    """Organization members should be able to view teams within that organization"""
+    Team = permission_registry.team_model
+    assert set(RoleEvaluation.accessible_objects(Team, rando, 'view_team')) == set()
+
+    org_member_rd.give_permission(rando, organization)
+
+    assert set(RoleEvaluation.accessible_objects(Team, rando, 'view_team')) == {team}
+
+
+@pytest.mark.django_db
+def test_org_member_cannot_see_teams_in_other_org(rando, organization, team, org_member_rd):
+    """Organization members should not see teams from other organizations"""
+    from test_app.models import Organization as OrgModel
+
+    Team = permission_registry.team_model
+    other_org = OrgModel.objects.create(name='other-org')
+    other_team = Team.objects.create(name='other-team', organization=other_org)
+
+    org_member_rd.give_permission(rando, organization)
+
+    visible = set(RoleEvaluation.accessible_objects(Team, rando, 'view_team'))
+    assert other_team not in visible
+
+
+@pytest.mark.django_db
+def test_create_managed_roles_update_perms_refreshes_existing_role():
+    """When create_managed_roles is called with update_perms=True,
+    it should update permissions on roles that already exist."""
+    org_member_rd = RoleDefinition.objects.managed.org_member
+    original_perms = set(org_member_rd.permissions.values_list('codename', flat=True))
+
+    # Add a spurious permission to simulate drift
+    extra_perm = DABPermission.objects.get(codename='view_organization')
+    view_team_perm = DABPermission.objects.get(codename='view_team')
+    org_member_rd.permissions.add(view_team_perm)
+    assert 'view_team' in set(org_member_rd.permissions.values_list('codename', flat=True))
+
+    # Without update_perms, the existing role is not touched
+    permission_registry.create_managed_roles(apps, update_perms=False)
+    org_member_rd.refresh_from_db()
+    assert 'view_team' in set(org_member_rd.permissions.values_list('codename', flat=True))
+
+    # With update_perms=True, permissions are reset to the managed definition
+    permission_registry.create_managed_roles(apps, update_perms=True)
+    org_member_rd.refresh_from_db()
+    assert set(org_member_rd.permissions.values_list('codename', flat=True)) == original_perms
+
+    RoleDefinition.objects.managed.clear()
+
+
+@pytest.mark.django_db
+def test_create_managed_roles_update_perms_adds_new_permission():
+    """When a managed role constructor's permissions change and
+    create_managed_roles is called with update_perms=True, the new
+    permission should be added to the existing role definition."""
+    org_member_rd = RoleDefinition.objects.managed.org_member
+    original_perms = set(org_member_rd.permissions.values_list('codename', flat=True))
+    assert 'change_organization' not in original_perms
+
+    # Swap in a constructor that returns an expanded permission set
+    class OrgMemberWithChange(OrganizationMember):
+        def get_permissions(self, apps) -> set[str]:
+            return super().get_permissions(apps) | {'change_organization'}
+
+    old_constructor = permission_registry._managed_roles.get('org_member')
+    permission_registry._managed_roles['org_member'] = OrgMemberWithChange()
+
+    try:
+        permission_registry.create_managed_roles(apps, update_perms=True)
+        org_member_rd.refresh_from_db()
+        new_perms = set(org_member_rd.permissions.values_list('codename', flat=True))
+        assert 'change_organization' in new_perms
+    finally:
+        if old_constructor:
+            permission_registry._managed_roles['org_member'] = old_constructor
+        RoleDefinition.objects.managed.clear()


### PR DESCRIPTION
## Type of Change

The story I care about:

 - User is added as an organization member
 - User create a job template, or generally has admin access to this job template
 - User practically needs a way to give permission to teams

This seems to not be satisfied now. However, I am opinionated about how to solve this, and there is a competing story going around.

Competing story: When you are added as a member of a team, you can see all other teams in that team's organization.

This violates the directionality of DAB RBAC. Sure, lots of people probably aren't going to care, but if you understand the code structure of DAB RBAC with the resource tree, this is an uncompromising point. We just can't do it.

This solves the problem _very_ close to the app layer (like, aap-gateway as opposed to DAB), by modifying `Organization Member` role to provide view_team permission. According to the resource tree, this gives all members of the organization permission to view teams in that organization. This respects the intended directionality of permissions.

Ultimately, I have said before, the organization member role permissions should be customizable. But that's not a quick fix. We _might_ be able to shove this into a setting... but that would still introduce a coordination problem.

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
