### PR TITLE
[AAP-79302] fix: normalize SAML response attrs in claims pipeline

### DIFF
--- a/ansible_base/authentication/authenticator_plugins/saml.py
+++ b/ansible_base/authentication/authenticator_plugins/saml.py
@@ -339,6 +339,12 @@ class AuthenticatorPlugin(SocialAuthMixin, SocialAuthValidateCallbackMixin, SAML
     def get_user_groups(self, extra_groups=[]):
         return extra_groups
 
+    def get_claims_attrs(self, response):
+        # SAML responses nest identity attributes under response["attributes"].
+        # Return the inner dict so that attribute-based authenticator map triggers
+        # evaluate against the flat claims dict rather than the full SAML envelope.
+        return response.get("attributes", response)
+
     def get_alternative_uid(self, **kwargs):
         if uid := kwargs.get("uid", None):
             if ":" in uid:

--- a/ansible_base/authentication/social_auth.py
+++ b/ansible_base/authentication/social_auth.py
@@ -175,6 +175,17 @@ class SocialAuthMixin:
         """
         return []
 
+    def get_claims_attrs(self, response):
+        """
+        Extract the attributes dict to use for authenticator map trigger evaluation.
+
+        The default implementation returns the response unchanged (suitable for OIDC
+        and other protocols where claims sit at the top level of the response).
+        Backends whose IdP wraps claims in a nested structure should override this
+        method to extract the appropriate sub-dict.
+        """
+        return response
+
     def ensure_strategy_in_args(self, args):
         if len(args) == 0:
             args = (AuthenticatorStrategy(storage=AuthenticatorStorage()),)
@@ -264,6 +275,7 @@ def create_user_claims_pipeline(*args, backend, response, **kwargs):
 
     logger.debug(f'updating user claims with groups claim "{groups_claim}": {extra_groups}')
 
-    user = update_user_claims(kwargs["user"], backend.database_instance, backend.get_user_groups(extra_groups), attrs=response)
+    claims_attrs = backend.get_claims_attrs(response)
+    user = update_user_claims(kwargs["user"], backend.database_instance, backend.get_user_groups(extra_groups), attrs=claims_attrs)
     if user is None:
         return SOCIAL_AUTH_PIPELINE_FAILED_STATUS

--- a/test_app/tests/authentication/authenticator_plugins/test_saml.py
+++ b/test_app/tests/authentication/authenticator_plugins/test_saml.py
@@ -538,6 +538,27 @@ def test_saml_callback_url_is_acs_url(rsa_keypair_with_cert):
     assert authenticator_object.generate_saml_config()['sp']['assertionConsumerService']['url'] == callback_url
 
 
+def test_saml_get_claims_attrs_extracts_attributes_dict():
+    """SAMLAuthenticatorPlugin.get_claims_attrs() returns the inner 'attributes' dict."""
+    from ansible_base.authentication.authenticator_plugins.saml import AuthenticatorPlugin
+
+    plugin = AuthenticatorPlugin.__new__(AuthenticatorPlugin)
+    saml_response = {
+        "attributes": {"is_superuser": ["true"], "email": ["user@example.com"]},
+        "other_key": "ignored",
+    }
+    assert plugin.get_claims_attrs(saml_response) == saml_response["attributes"]
+
+
+def test_saml_get_claims_attrs_falls_back_to_response_when_no_attributes():
+    """SAMLAuthenticatorPlugin.get_claims_attrs() falls back to full response when no 'attributes' key."""
+    from ansible_base.authentication.authenticator_plugins.saml import AuthenticatorPlugin
+
+    plugin = AuthenticatorPlugin.__new__(AuthenticatorPlugin)
+    response_no_attrs = {"username": "alice", "email": "alice@example.com"}
+    assert plugin.get_claims_attrs(response_no_attrs) is response_no_attrs
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "redirect_is_https",

--- a/test_app/tests/authentication/test_social_auth.py
+++ b/test_app/tests/authentication/test_social_auth.py
@@ -612,6 +612,92 @@ def test_create_user_claims_pipeline(mock_update_user_claims, groups_claim, user
     assert call_args[1]['attrs'] == rData
 
 
+def test_get_claims_attrs_default_passthrough():
+    """
+    SocialAuthMixin.get_claims_attrs() returns the response unchanged by default.
+    This is the correct behaviour for OIDC and other flat-response backends,
+    including the edge case where the response happens to contain an
+    "attributes" key — the base mixin must not silently extract it.
+    """
+
+    class MockBackend(SocialAuthMixin):
+        database_instance = None
+
+        def __init__(self):
+            pass
+
+    backend = MockBackend()
+    response = {"sub": "123", "email": "user@example.com", "attributes": {"some": "custom"}}
+    assert backend.get_claims_attrs(response) is response
+
+
+@mock.patch("ansible_base.authentication.utils.claims.update_user_claims")
+def test_create_user_claims_pipeline_calls_get_claims_attrs(mock_update_user_claims):
+    """
+    create_user_claims_pipeline delegates response normalization to
+    backend.get_claims_attrs(), so each backend controls how its own
+    response is interpreted.
+    """
+
+    class MockBackend(SocialAuthMixin):
+        database_instance = None
+        _normalized = {"is_superuser": ["true"]}
+
+        def __init__(self):
+            pass
+
+        def get_claims_attrs(self, response):
+            return self._normalized
+
+        def get_user_groups(self, extra_groups=[]):
+            return extra_groups
+
+    backend = MockBackend()
+    raw_response = {"attributes": backend._normalized, "session_index": "_abc"}
+
+    create_user_claims_pipeline(backend=backend, response=raw_response, user={"username": "saml_user"})
+
+    assert mock_update_user_claims.called
+    call_args = mock_update_user_claims.call_args
+    assert call_args[1]["attrs"] is backend._normalized
+
+
+@mock.patch("ansible_base.authentication.utils.claims.update_user_claims")
+def test_create_user_claims_pipeline_saml_groups_extracted(mock_update_user_claims):
+    """
+    Groups hoisted to the top-level response by the SAML backend's extra_data()
+    are extracted before get_claims_attrs() is called, so they still reach
+    update_user_claims as the groups argument.
+    """
+
+    class MockBackend(SocialAuthMixin):
+        database_instance = None
+
+        def __init__(self):
+            self.groups_claim = "Group"
+
+        def get_claims_attrs(self, response):
+            return response.get("attributes", response)
+
+        def get_user_groups(self, extra_groups=[]):
+            return extra_groups
+
+    backend = MockBackend()
+
+    saml_response = {
+        "attributes": {"is_superuser": ["true"]},
+        "Group": ["admins", "operators"],
+        "session_index": "_abc123",
+    }
+
+    create_user_claims_pipeline(backend=backend, response=saml_response, user={"username": "saml_user"})
+
+    assert mock_update_user_claims.called
+    call_args = mock_update_user_claims.call_args
+    groups_arg = call_args[0][2]
+    assert sorted(groups_arg) == ["admins", "operators"]
+
+
 @pytest.mark.django_db
 @mock.patch("ansible_base.authentication.social_auth.log_auth_event")
 def test_social_auth_mixin_start_no_redirect(mock_logger):

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -935,6 +935,36 @@ def test_update_user_claims_attrs_override(user, local_authenticator_map):
     assert map_results[0][str(local_authenticator_map.pk)] is True
 
 
+def test_update_user_claims_saml_attrs_override(user, local_authenticator_map):
+    """
+    Verify that SAML-style attrs (list values) are correctly matched by
+    attribute-based triggers when passed via the attrs parameter.
+
+    SAML identity providers return attribute values as lists
+    (e.g., ["true"] instead of "true"). The trigger evaluator should handle
+    both formats via _normalize_user_value().
+    """
+    local_authenticator_map.triggers = {"attributes": {"is_superuser": {"contains": "true"}}}
+    local_authenticator_map.save()
+    authenticator = local_authenticator_map.authenticator
+    authenticator_user = AuthenticatorUser(
+        provider=authenticator,
+        user=user,
+        extra_data={"id": "saml-uid", "token_type": "Bearer"},
+    )
+    authenticator_user.save()
+
+    # SAML attrs have list values — this is what the pipeline now passes
+    # after extracting response["attributes"]
+    saml_attrs = {"is_superuser": ["true"], "email": ["user@example.com"]}
+    result = claims.update_user_claims(user, authenticator, [], attrs=saml_attrs)
+    assert result is user
+
+    authenticator_user.refresh_from_db()
+    map_results = authenticator_user.last_login_map_results
+    assert map_results[0][str(local_authenticator_map.pk)] is True
+
+
 @pytest.mark.parametrize("enabled", [True, False])
 def test_create_claims_with_map_enabled_or_disabled(enabled, local_authenticator):
     # Create an AuthenticatorMap object with the parameterized "enabled" value


### PR DESCRIPTION
## Description

- **What:** Adds `get_claims_attrs(response)` to `SocialAuthMixin` and overrides it in the SAML backend to extract `response["attributes"]` before trigger evaluation.
- **Why:** PR #1022 introduced `attrs=response` to fix OIDC attribute-based map evaluation. OIDC responses carry claims at the top level, but SAML responses nest them under `response["attributes"]`. This caused all attribute-based authenticator maps to be **skipped** for SAML logins — triggers couldn't find `is_superuser`, role mappings, etc. at the top level.
- **How:** Rather than using a response-shape heuristic (checking for an `"attributes"` key), each backend now explicitly owns its response normalization via `get_claims_attrs()`. The default implementation returns the response unchanged (correct for OIDC and all other flat-response backends). The SAML backend overrides it to extract `response.get("attributes", response)`. The pipeline calls `backend.get_claims_attrs(response)` before passing attrs to `update_user_claims()`.

## Root Cause

The SAML plugin's `extra_data()` method already knows about the nesting:

```python
attrs = response["attributes"] if "attributes" in response else {}
```

But `create_user_claims_pipeline` was passing the **raw** `response` to `update_user_claims()`, so `create_claims()` evaluated triggers against the full SAML envelope instead of the flattened attributes. Result: every attribute-based map showed `"skipped"` in `last_login_map_results`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases

## Testing Instructions

### Unit Tests (no DB required)

```bash
DJANGO_SETTINGS_MODULE=test_app.settings pytest -xvs \
  test_app/tests/authentication/test_social_auth.py::test_create_user_claims_pipeline \
  test_app/tests/authentication/test_social_auth.py::test_get_claims_attrs_default_passthrough \
  test_app/tests/authentication/test_social_auth.py::test_create_user_claims_pipeline_calls_get_claims_attrs \
  test_app/tests/authentication/test_social_auth.py::test_create_user_claims_pipeline_saml_groups_extracted
```

### Integration Tests (requires PostgreSQL via tox)

```bash
tox -- test_app/tests/authentication/utils/test_claims.py::test_update_user_claims_saml_attrs_override
```

### Manual Verification

1. Configure a SAML authenticator with an attribute-based map trigger (e.g., `is_superuser: {contains: "true"}`)
2. Log in via SAML as a user whose IdP returns matching attributes
3. Verify the user is granted the expected superuser/role/org membership

---
**Note:** This PR was developed with assistance from Claude AI assistant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved SAML authentication so attribute-based authenticators evaluate against the actual claims payload (rather than the full SAML envelope), fixing cases where attribute triggers didn’t match.

* **New Features**
  * Added a backend hook to customize how identity provider responses are normalized into claim attributes before updating user claims.

* **Tests**
  * Added unit/regression coverage for claim normalization, pipeline delegation, and SAML attribute-based trigger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->