### PR TITLE
[AAP-78674] Include id in service-index assignment serializer response

### DIFF
--- a/ansible_base/rbac/service_api/serializers.py
+++ b/ansible_base/rbac/service_api/serializers.py
@@ -73,7 +73,10 @@ class DABPermissionSerializer(serializers.ModelSerializer):
         fields = ['api_slug', 'codename', 'content_type', 'name']
 
 
-assignment_common_fields = ('created', 'created_by_ansible_id', 'object_id', 'object_ansible_id', 'content_type', 'role_definition')
+# 'id' is included so consumers can implement cursor-based pagination
+# (e.g. id__gt=<last_pk>&order_by=id) for efficient resume after
+# crashes and skip-on-reinstall in migrate_service_data.
+assignment_common_fields = ('id', 'created', 'created_by_ansible_id', 'object_id', 'object_ansible_id', 'content_type', 'role_definition')
 
 
 class BaseAssignmentSerializer(serializers.ModelSerializer):

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -4,7 +4,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition
+from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from test_app.models import Team, User
 
 
@@ -116,9 +116,31 @@ def test_list_role_user_assignments(admin_api_client, rando, inv_rd, inventory):
     assert len(candidates) == 1, response.data
     from_api = candidates[0]
 
+    # 'id' is required for cursor-based pagination in migrate_service_data
+    assert 'id' in from_api, f"'id' missing from service-index user assignment response: {from_api.keys()}"
+    assert from_api['id'] == RoleUserAssignment.objects.get(user=rando, role_definition=inv_rd, object_id=inventory.id).id
     assert int(from_api['object_id']) == inventory.id
     assert from_api['user_ansible_id'] == str(rando.resource.ansible_id)
     assert from_api['content_type'] == 'aap.inventory'
+
+
+@pytest.mark.django_db
+def test_list_role_team_assignments_includes_id(admin_api_client, inv_rd, inventory, team, member_rd, rando):
+    """Service-index team assignment responses include 'id' for cursor-based pagination."""
+    member_rd.give_permission(rando, team)
+    inv_rd.give_permission(team, inventory)
+
+    url = get_relative_url('serviceteamassignment-list')
+    response = admin_api_client.get(url + '?page_size=200', format="json")
+    assert response.status_code == 200, response.data
+
+    candidates = [a for a in response.data['results'] if a['role_definition'] == inv_rd.name]
+    assert len(candidates) == 1, response.data
+    from_api = candidates[0]
+
+    assert 'id' in from_api, f"'id' missing from service-index team assignment response: {from_api.keys()}"
+    assert from_api['id'] == RoleTeamAssignment.objects.get(team=team, role_definition=inv_rd, object_id=inventory.id).id
+    assert from_api['team_ansible_id'] == str(team.resource.ansible_id)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - Adding `id` to `assignment_common_fields` in the service-index assignment serializer so that `ServiceRoleUserAssignmentSerializer` and `ServiceRoleTeamAssignmentSerializer` include the assignment primary key in their API responses.
- Why is this change needed?
  - The gateway's `migrate_service_data` command implements PK-cursor-based pagination (`id__gt=<last_pk>&order_by=id`) for role assignment migration. Without `id` in the response, the cursor cannot advance and every run reprocesses all assignments — negating the performance benefit of cursor-based resume after crashes and skip-on-reinstall.
- How does this change address the issue?
  - With `id` in the response, the gateway can track the last-processed assignment PK per service and skip already-processed items on re-runs. On a reinstall where all assignments are synced, the API returns zero results and migration completes immediately instead of reprocessing 100K+ assignments.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
Standard DAB test environment with PostgreSQL.

### Steps to Test
1. Run the service API tests: `pytest test_app/tests/rbac/remote/test_service_api.py -v`
2. Verify `test_list_role_user_assignments` passes — asserts `id` is present and matches the DB record PK
3. Verify `test_list_role_team_assignments_includes_id` passes — same for team assignments
4. Optionally, start a test service and query `GET /api/v1/service-index/role-user-assignments/` — confirm `id` appears in each result

### Expected Results
<!-- Describe what should happen after following the steps -->

- All existing tests pass (no regressions — no test previously asserted `id` was absent)
- Two new/updated test assertions confirm `id` is present and correct in both user and team service-index assignment responses

## Additional Context
<!-- Optional but helpful information -->

### Why `id` was missing

The service-index `BaseAssignmentSerializer` inherits from `serializers.ModelSerializer` directly, not from `AbstractCommonModelSerializer` (which includes `id` automatically). The field list in `assignment_common_fields` was hand-curated for cross-service data exchange and `id` was simply not included. The RBAC public API already exposes `id` via `ImmutableCommonModelSerializer`.

### Security

No concerns. The `id` is a monotonically increasing integer PK — no sensitive information. The service-index API is restricted to service tokens (`HasResourceRegistryPermissions`), not accessible to regular users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assignment listings now include an `id` field in API responses.
  * Team assignment listings now return the assignment identifier alongside existing fields.

* **Bug Fixes**
  * Improved support for cursor-based pagination and recovery after interruptions by ensuring assignment records can be consistently resumed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->