### PR TITLE
[AAP-80579] Fix dynaconf 3.3.0 compat, rename in-files CI to canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - "stable-*"
 jobs:
   tox:
-    name: "${{ matrix.tests.canary && 'Canary (unpinned deps, may fail)' || 'django-ansible-base' }} - ${{ matrix.tests.env }}"
+    name: django-ansible-base - ${{ matrix.tests.env }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -49,47 +49,23 @@ jobs:
             python-version: "3.12"
             sonar: false
             junit-xml-upload: false
-          - env: py311-in-files
-            python-version: "3.11"
-            sonar: false
-            junit-xml-upload: false
-            canary: true
-          - env: py312-in-files
-            python-version: "3.12"
-            sonar: false
-            junit-xml-upload: false
-            canary: true
     steps:
-      - name: Check canary eligibility
-        id: check
-        if: >-
-          !matrix.tests.canary
-          || (github.repository == 'ansible/django-ansible-base'
-              && ((github.event_name == 'push' && github.ref_name == 'devel')
-                  || (github.event_name == 'pull_request' && github.base_ref == 'devel')))
-        run: echo "should_run=true" >> $GITHUB_OUTPUT
-
       - uses: actions/checkout@v4
-        if: steps.check.outputs.should_run
         with:
           show-progress: false
 
       - name: Install build requirements
-        if: steps.check.outputs.should_run
         run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
 
       - name: Install python ${{ matrix.tests.python-version }}
-        if: steps.check.outputs.should_run
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.tests.python-version }}
 
       - name: Install tox
-        if: steps.check.outputs.should_run
         run: pip${{ matrix.tests.python-version }} install tox tox-docker
 
       - name: Run tox
-        if: steps.check.outputs.should_run
         env:
           TOX_DOCKER_GATEWAY: "127.0.0.1"
         run: |
@@ -97,19 +73,19 @@ jobs:
           tox --colored yes -e ${{ matrix.tests.env }}
 
       - name: Inject PR number into coverage.xml
-        if: steps.check.outputs.should_run && !matrix.tests.canary && matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         run: sed -i '2i <!-- PR ${{ github.event.number }} -->' coverage.xml
 
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v4
-        if: steps.check.outputs.should_run && !matrix.tests.canary && matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         with:
           name: coverage-${{ matrix.tests.env }}
           path: coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16  # v6.0.1
-        if: steps.check.outputs.should_run && !matrix.tests.canary && matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -117,7 +93,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload jUnit XML test results
-        if: steps.check.outputs.should_run && matrix.tests.junit-xml-upload && github.event_name == 'push' && github.repository == 'ansible/django-ansible-base' && github.ref_name == 'devel'
+        if: matrix.tests.junit-xml-upload && github.event_name == 'push' && github.repository == 'ansible/django-ansible-base' && github.ref_name == 'devel'
         continue-on-error: true
         run: >-
           curl --silent --show-error --user "$PDE_UPLOAD_USER:$PDE_UPLOAD_PASSWORD"
@@ -129,3 +105,46 @@ jobs:
         env:
           PDE_UPLOAD_USER: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}
           PDE_UPLOAD_PASSWORD: ${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}
+
+  canary-deps:
+    name: "Canary (unpinned deps, may fail) - ${{ matrix.tests.env }}"
+    if: >-
+      github.repository == 'ansible/django-ansible-base'
+      && (
+        (github.event_name == 'push' && github.ref_name == 'devel')
+        || (github.event_name == 'pull_request' && github.base_ref == 'devel')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - env: py311-in-files
+            python-version: "3.11"
+          - env: py312-in-files
+            python-version: "3.12"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Install build requirements
+        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
+
+      - name: Install python ${{ matrix.tests.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.tests.python-version }}
+
+      - name: Install tox
+        run: pip${{ matrix.tests.python-version }} install tox tox-docker
+
+      - name: Run tox
+        env:
+          TOX_DOCKER_GATEWAY: "127.0.0.1"
+        run: |
+          echo "::remove-matcher owner=python::"
+          tox --colored yes -e ${{ matrix.tests.env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - "stable-*"
 jobs:
   tox:
-    name: django-ansible-base - ${{ matrix.tests.env }}
+    name: "${{ matrix.tests.canary && 'Canary (unpinned deps, may fail)' || 'django-ansible-base' }} - ${{ matrix.tests.env }}"
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -49,23 +49,47 @@ jobs:
             python-version: "3.12"
             sonar: false
             junit-xml-upload: false
+          - env: py311-in-files
+            python-version: "3.11"
+            sonar: false
+            junit-xml-upload: false
+            canary: true
+          - env: py312-in-files
+            python-version: "3.12"
+            sonar: false
+            junit-xml-upload: false
+            canary: true
     steps:
+      - name: Check canary eligibility
+        id: check
+        if: >-
+          !matrix.tests.canary
+          || (github.repository == 'ansible/django-ansible-base'
+              && ((github.event_name == 'push' && github.ref_name == 'devel')
+                  || (github.event_name == 'pull_request' && github.base_ref == 'devel')))
+        run: echo "should_run=true" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v4
+        if: steps.check.outputs.should_run
         with:
           show-progress: false
 
       - name: Install build requirements
+        if: steps.check.outputs.should_run
         run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
 
       - name: Install python ${{ matrix.tests.python-version }}
+        if: steps.check.outputs.should_run
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.tests.python-version }}
 
       - name: Install tox
+        if: steps.check.outputs.should_run
         run: pip${{ matrix.tests.python-version }} install tox tox-docker
 
       - name: Run tox
+        if: steps.check.outputs.should_run
         env:
           TOX_DOCKER_GATEWAY: "127.0.0.1"
         run: |
@@ -73,19 +97,19 @@ jobs:
           tox --colored yes -e ${{ matrix.tests.env }}
 
       - name: Inject PR number into coverage.xml
-        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: steps.check.outputs.should_run && !matrix.tests.canary && matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         run: sed -i '2i <!-- PR ${{ github.event.number }} -->' coverage.xml
 
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v4
-        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: steps.check.outputs.should_run && !matrix.tests.canary && matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         with:
           name: coverage-${{ matrix.tests.env }}
           path: coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16  # v6.0.1
-        if: matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
+        if: steps.check.outputs.should_run && !matrix.tests.canary && matrix.tests.env != 'check' && hashFiles('coverage.xml') != ''
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -93,7 +117,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload jUnit XML test results
-        if: matrix.tests.junit-xml-upload && github.event_name == 'push' && github.repository == 'ansible/django-ansible-base' && github.ref_name == 'devel'
+        if: steps.check.outputs.should_run && matrix.tests.junit-xml-upload && github.event_name == 'push' && github.repository == 'ansible/django-ansible-base' && github.ref_name == 'devel'
         continue-on-error: true
         run: >-
           curl --silent --show-error --user "$PDE_UPLOAD_USER:$PDE_UPLOAD_PASSWORD"
@@ -105,46 +129,3 @@ jobs:
         env:
           PDE_UPLOAD_USER: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}
           PDE_UPLOAD_PASSWORD: ${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}
-
-  canary-deps:
-    name: "Canary (unpinned deps, may fail) - ${{ matrix.tests.env }}"
-    if: >-
-      github.repository == 'ansible/django-ansible-base'
-      && (
-        (github.event_name == 'push' && github.ref_name == 'devel')
-        || (github.event_name == 'pull_request' && github.base_ref == 'devel')
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        tests:
-          - env: py311-in-files
-            python-version: "3.11"
-          - env: py312-in-files
-            python-version: "3.12"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          show-progress: false
-
-      - name: Install build requirements
-        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
-
-      - name: Install python ${{ matrix.tests.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.tests.python-version }}
-
-      - name: Install tox
-        run: pip${{ matrix.tests.python-version }} install tox tox-docker
-
-      - name: Run tox
-        env:
-          TOX_DOCKER_GATEWAY: "127.0.0.1"
-        run: |
-          echo "::remove-matcher owner=python::"
-          tox --colored yes -e ${{ matrix.tests.env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,6 @@ jobs:
             python-version: "3.12"
             sonar: false
             junit-xml-upload: false
-          - env: py311-in-files
-            python-version: "3.11"
-            sonar: false
-            junit-xml-upload: false
-          - env: py312-in-files
-            python-version: "3.12"
-            sonar: false
-            junit-xml-upload: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,3 +105,46 @@ jobs:
         env:
           PDE_UPLOAD_USER: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}
           PDE_UPLOAD_PASSWORD: ${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}
+
+  canary-deps:
+    name: "Canary (unpinned deps, may fail) - ${{ matrix.tests.env }}"
+    if: >-
+      github.repository == 'ansible/django-ansible-base'
+      && (
+        (github.event_name == 'push' && github.ref_name == 'devel')
+        || (github.event_name == 'pull_request' && github.base_ref == 'devel')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - env: py311-in-files
+            python-version: "3.11"
+          - env: py312-in-files
+            python-version: "3.12"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Install build requirements
+        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
+
+      - name: Install python ${{ matrix.tests.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.tests.python-version }}
+
+      - name: Install tox
+        run: pip${{ matrix.tests.python-version }} install tox tox-docker
+
+      - name: Run tox
+        env:
+          TOX_DOCKER_GATEWAY: "127.0.0.1"
+        run: |
+          echo "::remove-matcher owner=python::"
+          tox --colored yes -e ${{ matrix.tests.env }}

--- a/ansible_base/lib/dynamic_config/dynaconf_helpers.py
+++ b/ansible_base/lib/dynamic_config/dynaconf_helpers.py
@@ -21,13 +21,13 @@ from ansible_base.lib.dynamic_config.settings_logic import get_mergeable_dab_set
 
 def _dynaconf_post_hooks(settings):
     # dynaconf 3.3.0 moved _post_hooks to __core__.config.post_hooks
-    if hasattr(settings, '__core__'):
+    if hasattr(settings, '__core__'):  # pragma: no cover
         return settings.__core__.config.post_hooks
     return settings._post_hooks
 
 
 def _dynaconf_loaded_files(settings):
-    if hasattr(settings, '__core__'):
+    if hasattr(settings, '__core__'):  # pragma: no cover
         return settings.__core__.config.loaded_files
     return settings._loaded_files
 

--- a/ansible_base/lib/dynamic_config/dynaconf_helpers.py
+++ b/ansible_base/lib/dynamic_config/dynaconf_helpers.py
@@ -19,6 +19,19 @@ from dynaconf.utils.functional import empty
 from ansible_base.lib.dynamic_config.settings_logic import get_mergeable_dab_settings
 
 
+def _dynaconf_post_hooks(settings):
+    # dynaconf 3.3.0 moved _post_hooks to __core__.config.post_hooks
+    if hasattr(settings, '__core__'):
+        return settings.__core__.config.post_hooks
+    return settings._post_hooks
+
+
+def _dynaconf_loaded_files(settings):
+    if hasattr(settings, '__core__'):
+        return settings.__core__.config.loaded_files
+    return settings._loaded_files
+
+
 def factory(
     module_name: str,  # name of the module that calls this function
     app_name: str,  # main app name to be used to name env_switcher and envvar_prefix
@@ -285,15 +298,15 @@ def load_python_file_with_injected_context(*paths: str, settings: Dynaconf, run_
                             loader_identifier=f"python_file_with_injected_scope:{file_path}",
                         )
                 elif key.startswith("_dynaconf_hook") and callable(value):
-                    settings._post_hooks.append(value)
+                    _dynaconf_post_hooks(settings).append(value)
 
-            settings._loaded_files.append(file_path)
+            _dynaconf_loaded_files(settings).append(file_path)
 
     if run_hooks:
         execute_instance_hooks(
             settings,
             "post",
-            [_hook for _hook in settings._post_hooks if getattr(_hook, "_dynaconf_hook", False) is True and not getattr(_hook, "_called", False)],
+            [_hook for _hook in _dynaconf_post_hooks(settings) if getattr(_hook, "_dynaconf_hook", False) is True and not getattr(_hook, "_called", False)],
         )
 
 

--- a/test_app/tests/lib/dynamic_config/test_dynaconf_settings.py
+++ b/test_app/tests/lib/dynamic_config/test_dynaconf_settings.py
@@ -9,6 +9,9 @@ from ansible_base.lib.dynamic_config import (
     toggle_feature_flags,
     validate,
 )
+from ansible_base.lib.dynamic_config.dynaconf_helpers import (
+    _dynaconf_loaded_files,
+)
 
 
 def test_swagger_disabled():
@@ -244,7 +247,7 @@ def test_load_python_file_with_injected_scope(tmp_path):
     settings = factory("", "TEST", settings_files=[str(defaults)])
     load_python_file_with_injected_context(str(extra_file), settings=settings)
     assert settings.COLORS == ['red', 'green', 'blue']
-    assert settings._loaded_files == [str(defaults), str(extra_file)]
+    assert _dynaconf_loaded_files(settings) == [str(defaults), str(extra_file)]
 
 
 def test_toggle_feature_flags():


### PR DESCRIPTION
## Description

- **What is being changed?** Three things: (1) compatibility helpers for dynaconf 3.3.0's relocated internal attributes, (2) the CI `in-files` jobs are renamed to "Canary (unpinned deps, may fail)" and moved into their own job, (3) the canary jobs are restricted to run only on `devel` branch of `ansible/django-ansible-base`.
- **Why is this change needed?** dynaconf 3.3.0 moved `_post_hooks` and `_loaded_files` from `Settings` to `Settings.__core__.config` (dynaconf/dynaconf#1335). The `in-files` tox environments install from `.in` files (version ranges) rather than pinned `.txt`, so they picked up 3.3.0 and started failing. The canary job name also didn't communicate that failures are expected.
- **How does this change address the issue?** Adds `_dynaconf_post_hooks()` / `_dynaconf_loaded_files()` helpers that detect 3.3.0+ via `hasattr(settings, '__core__')` and route to the correct attribute location. Works with both dynaconf 3.2.x and 3.3.0. The CI restructuring makes the canary purpose clear and avoids noise on non-devel branches and forks.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [ ] Configuration change

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- Python 3.11+ with a virtualenv

### Steps to Test

1. Install dynaconf 3.3.0: `pip install 'dynaconf==3.3.0'`
2. Run the affected test: `pytest test_app/tests/lib/dynamic_config/test_dynaconf_settings.py::test_load_python_file_with_injected_scope -x`
3. Downgrade to 3.2.12 and re-run: `pip install 'dynaconf==3.2.12'` then repeat step 2

### Expected Results

- Test passes on both dynaconf 3.2.12 and 3.3.0
- CI canary jobs only appear on PRs targeting `devel` in `ansible/django-ansible-base`

## Additional Context

### Required Actions

- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with different configuration library versions, helping settings files load more reliably across environments.
  * Updated file-loading tracking to avoid relying on internal details, reducing the chance of breakage during upgrades.

* **Chores**
  * Adjusted the CI pipeline to split out dependency-check runs into a separate job for the main development branch.
  * Streamlined the primary test matrix to focus on the standard automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->