### PR TITLE
[AAP-80761] Catch ParseError in OAuth2 extract_body

### DIFF
--- a/ansible_base/oauth2_provider/authentication.py
+++ b/ansible_base/oauth2_provider/authentication.py
@@ -4,7 +4,7 @@ import logging
 from django.utils.encoding import smart_str
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from oauth2_provider.oauth2_backends import OAuthLibCore as _OAuthLibCore
-from rest_framework.exceptions import UnsupportedMediaType
+from rest_framework.exceptions import ParseError, UnsupportedMediaType
 
 from ansible_base.lib.logging import log_auth_event
 from ansible_base.lib.utils.hashing import hash_string
@@ -14,9 +14,11 @@ logger = logging.getLogger('ansible_base.oauth2_provider.authentication')
 
 class OAuthLibCore(_OAuthLibCore):
     def extract_body(self, request):
+        # request.POST.items() can fail for non-form content types; return
+        # empty so OAuth2 falls back to the Authorization header.
         try:
             return request.POST.items()
-        except UnsupportedMediaType:
+        except (UnsupportedMediaType, ParseError):
             return ()
 
     def _extract_params(self, request):

--- a/test_app/tests/oauth2_provider/test_authentication.py
+++ b/test_app/tests/oauth2_provider/test_authentication.py
@@ -279,6 +279,54 @@ def test_oauth2_unsupported_media_type(user, user_api_client, only_oauth_scope_p
     assert response.status_code == 200, response.status_code
 
 
+def test_oauth2_extract_body_handles_parse_error():
+    """
+    Regression test: large multipart uploads with Content-Transfer-Encoding: base64
+    can trigger a ParseError in Django's multipart parser when extract_body() calls
+    request.POST.items(). The ParseError must be caught so OAuth2 auth falls back to
+    the Authorization header.
+    """
+    from unittest import mock
+
+    from rest_framework.exceptions import ParseError
+
+    from ansible_base.oauth2_provider.authentication import OAuthLibCore
+
+    backend = OAuthLibCore.__new__(OAuthLibCore)
+    request = mock.MagicMock()
+    request.POST.items.side_effect = ParseError('Multipart form parse error - Could not decode base64 data.')
+
+    result = backend.extract_body(request)
+    assert result == (), f"Expected empty tuple when ParseError is raised, got {result!r}"
+
+
+def test_oauth2_multipart_parse_error_full_request(unauthenticated_api_client, oauth2_admin_access_token):
+    """
+    End-to-end regression test: ensure a multipart upload with a bearer token
+    succeeds even when the multipart body triggers a ParseError during OAuth2
+    body extraction.
+    """
+    from unittest import mock
+
+    from rest_framework.exceptions import ParseError
+
+    url = get_relative_url("animal-upload")
+    token = oauth2_admin_access_token[1]
+
+    def items_raises_parse_error(*args, **kwargs):
+        raise ParseError('Multipart form parse error - Could not decode base64 data.')
+
+    with mock.patch('django.http.request.QueryDict.items', side_effect=items_raises_parse_error):
+        response = unauthenticated_api_client.post(
+            url,
+            data=b'\x00\x01\x02\x03',
+            content_type='application/octet-stream',
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200, f"Expected 200 but got {response.status_code}"
+
+
 def test_oauth2_authentication_creates_activitystream_entry(
     unauthenticated_api_client,
     oauth2_admin_access_token,


### PR DESCRIPTION
## Description
- Large file uploads (e.g. collection publishes) can fail with a 502 because `extract_body()` tries to parse the multipart body looking for an OAuth2 token. If the body contains base64-encoded content that is malformed or truncated, Django raises a `ParseError` that was not being caught.
- The token is always in the `Authorization` header for these requests, so catching `ParseError` and returning empty is the correct behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- PostgreSQL running (`make postgres`)

### Steps to Test
1. `pytest test_app/tests/oauth2_provider/test_authentication.py -v`
2. All 37 tests should pass, including the two new regression tests.

### Expected Results
- `test_oauth2_extract_body_handles_parse_error` confirms `ParseError` is caught in `extract_body()`
- `test_oauth2_multipart_parse_error_full_request` confirms end-to-end OAuth2 auth succeeds when the multipart body triggers a `ParseError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth2 authentication now continues to work when request body parsing fails, falling back to the `Authorization` header.
  * Improved handling for requests with unsupported content types or malformed multipart data.

* **Tests**
  * Added regression coverage for parsing errors during OAuth2 body extraction.
  * Added an end-to-end check confirming valid Bearer token requests still succeed after multipart parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->