### PR TITLE
  [AAP-80699] Add cursor pagination to service-index role assignment endpoints

### DIFF
--- a/ansible_base/rbac/service_api/views.py
+++ b/ansible_base/rbac/service_api/views.py
@@ -12,6 +12,7 @@ from ansible_base.resource_registry.models import Resource
 from ansible_base.resource_registry.views import HasResourceRegistryPermissions
 from ansible_base.rest_filters.rest_framework import ansible_id_backend
 
+from ..api.service_cursor_paginator import ServiceCursorPagination
 from ..models import DABContentType, DABPermission, RoleTeamAssignment, RoleUserAssignment
 from . import serializers as service_serializers
 
@@ -52,6 +53,8 @@ class BaseSerivceRoleAssignmentViewSet(
     GenericViewSet,
 ):
     """List of assignments for cross-service communication"""
+
+    pagination_class = ServiceCursorPagination
 
     permission_classes = try_add_oauth2_scope_permission(
         [

--- a/test_app/tests/rbac/remote/test_public_api_compat.py
+++ b/test_app/tests/rbac/remote/test_public_api_compat.py
@@ -130,7 +130,7 @@ def test_give_permission_to_remote_object_uuid(admin_api_client, rando, foo_type
     service_url = get_relative_url('serviceuserassignment-list')
     response = admin_api_client.get(service_url + f'?user={rando.id}', format="json")
     assert response.status_code == 200, response.data
-    assert response.data['count'] == 1
+    assert len(response.data['results']) == 1
     assignment_data = response.data['results'][0]
     assert assignment_data['object_id'] == str(assignment.object_id)
 

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -305,12 +305,12 @@ def test_filter_assignment_list(admin_api_client, rando, inv_rd, view_inv_rd, or
     url = get_relative_url('serviceuserassignment-list')
     response = admin_api_client.get(url + f'?user={rando.id}', format="json")
     assert response.status_code == 200, response.data
-    assert response.data['count'] == 3  # user rando has 3 rol assignments
+    assert len(response.data['results']) == 3  # user rando has 3 rol assignments
 
     # Get just one single assignment
     response = admin_api_client.get(url + f'?assignment={str(rando.resource.ansible_id)},{inv_rd.name},{inventory.id}', format="json")
     assert response.status_code == 200, response.data
-    assert response.data['count'] == 1
+    assert len(response.data['results']) == 1
     assert response.data['results'][0]['role_definition'] == inv_rd.name
 
     # Assure we can get two assignments at the same time
@@ -323,7 +323,7 @@ def test_filter_assignment_list(admin_api_client, rando, inv_rd, view_inv_rd, or
         format="json",
     )
     assert response.status_code == 200, response.data
-    assert response.data['count'] == 2
+    assert len(response.data['results']) == 2
 
 
 @pytest.mark.django_db

--- a/test_app/tests/resource_registry/test_resources_api_rest_client.py
+++ b/test_app/tests/resource_registry/test_resources_api_rest_client.py
@@ -309,7 +309,7 @@ def test_list_user_assignments(resource_client, org_admin_rd, user, organization
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] >= 1
+    assert len(data["results"]) >= 1
 
     # Find our assignment in the results
     assignment_found = False
@@ -333,7 +333,7 @@ def test_list_team_assignments(resource_client, inv_rd, team, inventory):
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] >= 1
+    assert len(data["results"]) >= 1
 
     # Find our assignment in the results
     assignment_found = False


### PR DESCRIPTION
    BaseSerivceRoleAssignmentViewSet used the global PageNumberPagination
    default while BaseAssignmentViewSet already used ServiceCursorPagination.
    This caused Gateway's migrate_service_data to receive page-number next
    URLs from service-index endpoints. Apply the same cursor pagination
    class to both viewsets for consistency.

    Update tests to use len(results) instead of response count since cursor
    pagination does not include a count field.

    Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service role assignment lists now use cursor-based pagination for more consistent page navigation and results handling.

* **Tests**
  * Updated API and client tests to verify returned items from paginated results instead of relying on total counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->