### PR TITLE
[AAP-80508] feat: Enhance OIDC discovery with revocation and PKCE metadata

### DIFF
--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -36,7 +36,7 @@ oauth_urls = [
     # OIDC endpoints
     # URL patterns below must match installed django-oauth-toolkit version, otherwise discovery fails
     # See https://github.com/django-oauth/django-oauth-toolkit/blob/2.3.0/oauth2_provider/urls.py#L35
-    re_path(r"^\.well-known/openid-configuration/$", oauth_views.ConnectDiscoveryInfoView.as_view(), name="oidc-connect-discovery-info"),
+    re_path(r"^\.well-known/openid-configuration/$", oauth2_provider_views.DiscoveryInfoView.as_view(), name="oidc-connect-discovery-info"),
     re_path(r"^\.well-known/jwks\.json$", oauth_views.JwksInfoView.as_view(), name="jwks-info"),
     re_path(r"^userinfo/$", oauth_views.UserInfoView.as_view(), name="user-info"),
     re_path(r"^logout/$", oauth_views.RPInitiatedLogoutView.as_view(), name="rp-initiated-logout"),
@@ -44,5 +44,10 @@ oauth_urls = [
 
 
 root_urls = [
+    # Catch-all for unhandled /.well-known/ paths. Without this, Django falls
+    # through to the UI root and returns the login page HTML instead of a 404.
+    # Registered endpoints (e.g. /o/.well-known/openid-configuration/) are
+    # matched first under the /o/ prefix, so they are unaffected.
+    re_path(r"^\.well-known/", oauth2_provider_views.NotFoundView.as_view()),
     re_path(r"^o/", include((oauth_urls, 'oauth2_provider'))),
 ]

--- a/ansible_base/oauth2_provider/views/__init__.py
+++ b/ansible_base/oauth2_provider/views/__init__.py
@@ -1,4 +1,6 @@
 from .application import OAuth2ApplicationViewSet  # noqa: F401
 from .authorization_root import ApiOAuthAuthorizationRootView  # noqa: F401
+from .not_found import NotFoundView  # noqa: F401
+from .oidc import DiscoveryInfoView  # noqa: F401
 from .token import OAuth2TokenViewSet, TokenView  # noqa: F401
 from .user_mixin import DABOAuth2UserViewsetMixin  # noqa: F401

--- a/ansible_base/oauth2_provider/views/not_found.py
+++ b/ansible_base/oauth2_provider/views/not_found.py
@@ -1,0 +1,9 @@
+from django.http import JsonResponse
+from django.views import View
+
+
+class NotFoundView(View):
+    """Return a JSON 404 for unhandled paths."""
+
+    def dispatch(self, request, *args, **kwargs):
+        return JsonResponse({"error": "not_found"}, status=404)

--- a/ansible_base/oauth2_provider/views/oidc.py
+++ b/ansible_base/oauth2_provider/views/oidc.py
@@ -1,0 +1,24 @@
+import json
+
+from django.urls import reverse
+from oauth2_provider.views.oidc import ConnectDiscoveryInfoView
+
+
+class DiscoveryInfoView(ConnectDiscoveryInfoView):
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+
+        if response.status_code != 200:
+            return response
+
+        data = json.loads(response.content)
+        # Uses build_absolute_uri() consistent with how the parent ConnectDiscoveryInfoView
+        # builds authorization_endpoint, token_endpoint, etc. Host header injection is
+        # mitigated by Django's ALLOWED_HOSTS (enforced when DEBUG=False).
+        data["revocation_endpoint"] = request.build_absolute_uri(reverse("oauth2_provider:revoke-token"))
+        # should be removed once DAB upgrades from django-oauth-toolkit 2.3.0 to >=2.4.0,
+        # which adds code_challenge_methods_supported to ConnectDiscoveryInfoView natively.
+        data["code_challenge_methods_supported"] = ["S256", "plain"]
+
+        response.content = json.dumps(data)
+        return response

--- a/test_app/tests/oauth2_provider/views/test_openid_configuration.py
+++ b/test_app/tests/oauth2_provider/views/test_openid_configuration.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 from django.conf import settings
+from django.http import HttpResponse
 from django.test import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
@@ -22,6 +25,49 @@ def test_oauth2_provider_openid_configuration_valid_issuer_url(client):
 
 
 @pytest.mark.django_db
+def test_oauth2_provider_openid_configuration_revocation_endpoint(client):
+    """
+    The OIDC discovery document should include a revocation_endpoint
+    pointing to /o/revoke_token/.
+    """
+    with override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, 'OIDC_ENABLED': True}):
+        url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
+        response = client.get(url)
+        assert response.status_code == 200
+        response_json = response.json()
+        assert 'revocation_endpoint' in response_json, "revocation_endpoint missing from OIDC discovery document"
+        assert response_json['revocation_endpoint'].endswith('/o/revoke_token/')
+
+
+@pytest.mark.django_db
+def test_oauth2_provider_openid_configuration_code_challenge_methods(client):
+    """
+    The OIDC discovery document should include code_challenge_methods_supported
+    advertising S256 and plain (RFC 7636).
+    """
+    with override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, 'OIDC_ENABLED': True}):
+        url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
+        response = client.get(url)
+        assert response.status_code == 200
+        response_json = response.json()
+        assert 'code_challenge_methods_supported' in response_json, "code_challenge_methods_supported missing from OIDC discovery document"
+        methods = response_json['code_challenge_methods_supported']
+        assert 'S256' in methods
+        assert 'plain' in methods
+
+
+@pytest.mark.django_db
+def test_well_known_catch_all_returns_404(client):
+    """
+    Unhandled /.well-known/ paths should return 404, not a login page.
+    """
+    response = client.get("/.well-known/something-unknown")
+    assert response.status_code == 404
+    assert response["Content-Type"] == "application/json"
+    assert response.json() == {"error": "not_found"}
+
+
+@pytest.mark.django_db
 def test_oauth2_provider_openid_configuration_requires_oidc_enabled(client):
     """
     As an anonymous user, accessing /o/.well-known/openid-configuration/ should fail
@@ -31,3 +77,19 @@ def test_oauth2_provider_openid_configuration_requires_oidc_enabled(client):
         url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
         response = client.get(url)
         assert response.status_code != 200, f"Expected non-200 when OIDC is disabled, got {response.status_code}"
+
+
+@pytest.mark.django_db
+def test_oauth2_provider_openid_configuration_non_200_response_returned_unchanged(client):
+    """
+    When the parent ConnectDiscoveryInfoView returns a non-200 response,
+    DiscoveryInfoView should return it unchanged without attempting
+    to parse or modify the response body.
+    """
+    error_response = HttpResponse("Service Unavailable", status=503)
+    with override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, 'OIDC_ENABLED': True}):
+        with patch('oauth2_provider.views.oidc.ConnectDiscoveryInfoView.get', return_value=error_response):
+            url = get_relative_url("oauth2_provider:oidc-connect-discovery-info")
+            response = client.get(url)
+            assert response.status_code == 503
+            assert 'revocation_endpoint' not in response.content.decode()


### PR DESCRIPTION

## Description
Add DABConnectDiscoveryInfoView extending DOT's ConnectDiscoveryInfoView to include revocation_endpoint and code_challenge_methods_supported in the OIDC discovery response. These fields are not provided by django-oauth-toolkit 2.3.0 but are needed by MCP/OAuth2.1 clients.

Add WellKnownNotFoundView to return JSON 404 for unhandled /.well-known/ paths instead of 200 and falling through to the login page.

issue: https://issues.redhat.com/browse/AAP-80741
issue: https://issues.redhat.com/browse/AAP-80508

Related: https://github.com/ansible/jewel/pull/144

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

# Tests

 1. Verifies the OIDC discovery document includes a revocation_endpoint pointing to the token revocation URL
  2. Verifies the discovery document advertises PKCE support with code_challenge_methods_supported (S256 and plain)
  3. Verifies that unhandled /.well-known/ paths return a JSON 404 instead of falling through to the login page
  4. Verifies that when the upstream view returns a non-200 response (e.g. OIDC disabled), our view passes it through unchanged without crashing on JSON
  parsing

# Testing with gateway

## Test 1
1. start gateway
2. in terminal run
curl -k -v https://localhost/.well-known/oauth-authorization-server/o

Expected result:
1. should receive http status 404 with body {"error": "not_found"}

## Test 2
1. in terminal run:
curl -k https://localhost/o/.well-known/openid-configuration/

Expected result:
1. json content with included fields:
    "revocation_endpoint": "https://aap.foo.redhat.com/o/revoke_token/"
    "code_challenge_methods_supported": ["S256", "plain"] 


### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Updated OIDC discovery output to include an absolute `revocation_endpoint` and advertise supported `code_challenge_methods` (`S256` and `plain`).
* **Bug Fixes**
  * Improved handling of unknown `/.well-known/` paths to return a consistent JSON 404 response instead of falling through to the login UI.
* **Tests**
  * Added/extended test coverage for discovery response fields, correct 404 behavior, and unchanged handling of non-200 discovery responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
