### PR TITLE
Optimize visible_items() RBAC query: IN subquery → EXISTS semi-join

### DIFF
--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -395,17 +395,18 @@ class ObjectRoleFields(models.Model):
 
     @classmethod
     def _visible_items(cls, eval_cls, user, qs=None):
+        """Return a queryset of assignment records that ``user`` is allowed to see."""
         # NOTE: type casting is necessary in postgres but not sqlite3
         object_id_field = cls._meta.get_field('object_id')
+        permission_qs = eval_cls.objects.filter(
+            **eval_cls._actor_role_filter(user),
+            content_type_id=models.OuterRef('content_type_id'),
+        )
+        # alias() keeps the Cast in WHERE only (not SELECT), enabling a semi-join point lookup
         obj_filter = models.Exists(
-            eval_cls.objects.filter(
-                **eval_cls._actor_role_filter(user),
-                content_type_id=models.OuterRef('content_type_id'),
-            )
-            .alias(
+            permission_qs.alias(
                 _obj_id_text=Cast('object_id', output_field=object_id_field),
-            )
-            .filter(
+            ).filter(
                 _obj_id_text=models.OuterRef('object_id'),
             )
         )

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -395,13 +395,20 @@ class ObjectRoleFields(models.Model):
 
     @classmethod
     def _visible_items(cls, eval_cls, user, qs=None):
-        permission_qs = eval_cls.objects.filter(
-            **eval_cls._actor_role_filter(user),
-            content_type_id=models.OuterRef('content_type_id'),
-        )
         # NOTE: type casting is necessary in postgres but not sqlite3
         object_id_field = cls._meta.get_field('object_id')
-        obj_filter = models.Q(object_id__in=permission_qs.values_list(Cast('object_id', output_field=object_id_field)))
+        obj_filter = models.Exists(
+            eval_cls.objects.filter(
+                **eval_cls._actor_role_filter(user),
+                content_type_id=models.OuterRef('content_type_id'),
+            )
+            .alias(
+                _obj_id_text=Cast('object_id', output_field=object_id_field),
+            )
+            .filter(
+                _obj_id_text=models.OuterRef('object_id'),
+            )
+        )
 
         if not hasattr(user, '_singleton_permission_objs'):
             user._singleton_permission_objs = RoleDefinition.user_global_permissions(user)


### PR DESCRIPTION
## Summary

- Replace the `IN (SELECT ...)` pattern in `_visible_items()` with `EXISTS`, matching on both `content_type_id` AND `object_id` inside the subquery
- Enables semi-join optimization (stop at first match) instead of materializing all matching object_ids
- Leverages the existing `(role_id, content_type_id, object_id)` index on both `RoleEvaluation` and `RoleEvaluationUUID`
- Makes the OR between the two evaluation tables cheaper: two fast index probes instead of two large result-set materializations

### Before (IN pattern)
```sql
object_id IN (
  SELECT CAST(V0.object_id AS text)
  FROM dab_rbac_roleevaluation V0
  WHERE V0.content_type_id = outer.content_type_id
    AND V0.role_id IN (SELECT ...)
)
```
The subquery returns ALL matching `object_id` values for the content type, then the outer query checks membership.

### After (EXISTS pattern)
```sql
EXISTS (
  SELECT 1 FROM dab_rbac_roleevaluation V0
  WHERE V0.role_id IN (SELECT ...)
    AND V0.content_type_id = outer.content_type_id
    AND CAST(V0.object_id AS text) = outer.object_id
)
```
The subquery checks for existence with all three conditions, stops at the first match, and can use the composite index for the role_id + content_type_id prefix.

### Impact

Scale Lab data shows `dab_rbac_roleuserassignment_select_all_roles` at 795s total DB time (3rd-largest remaining consumer) with 1173ms median per call. This query runs on every authenticated Gateway API request via JWT token processing.

Resolves: AAP-68016

## Test plan

- [x] `test_visible_items` (integer PK models) — passed
- [x] `test_visible_items_with_uuid` (UUID PK models) — passed
- [x] 132 DAB RBAC functional tests — all passed
- [x] 306 AWX RBAC functional tests — all passed
- [ ] EXPLAIN ANALYZE on Scale Lab to measure improvement against 1173ms baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role visibility and permission evaluation so authorization results reliably match the specified actor and object context.
  * Fixed cases where cached or type-cast object identifiers could cause permissions to be incorrectly excluded or inconsistently resolved, resulting in more accurate and stable access control checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->