### PR TITLE
[AAP-80669] ServiceCursorPagination used ordering 

### DIFF
--- a/ansible_base/rbac/api/service_cursor_paginator.py
+++ b/ansible_base/rbac/api/service_cursor_paginator.py
@@ -3,6 +3,6 @@ from rest_framework.pagination import CursorPagination
 
 class ServiceCursorPagination(CursorPagination):
     page_size = 50
-    ordering = '-id'  # Order by 'id' to ensure consistent pagination results
+    ordering = 'id'
     page_size_query_param = 'page_size'
     max_page_size = 1000


### PR DESCRIPTION
  ServiceCursorPagination used ordering = '-id' (descending), which 
  conflicts with _CursorStore crash recovery in Gateway's
  migrate_service_data. Descending order means page 1 has the highest
  PKs, so advancing the cursor per-page skips lower-PK items on later
  pages. Ascending order restores compatibility with id__gt-based
  incremental resume.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cursor pagination to return results in ascending order, providing more consistent page ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->