### PR TITLE
Add defer_rbac_cache context manager for batched RBAC updates

### DIFF
--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -1,4 +1,6 @@
 import logging
+import threading
+from contextlib import contextmanager
 from typing import Union
 from uuid import UUID
 
@@ -108,8 +110,49 @@ def needed_updates_on_assignment(role_definition, actor, object_role, created=Fa
     return (recompute_team_ids, to_update)
 
 
+# stores state for the defer_rbac_cache annotation so that it can be accessed by function in the call chain
+# of the annotation
+class _DeferRBACCache(threading.local):
+    def __init__(self):
+        self.active = False
+        self.team_ids = set()
+        self.object_roles = set()
+
+
+_defer_rbac_cache = _DeferRBACCache()
+
+
+# allows deferring the rbac computation in cases where many object roles are updated in short order
+@contextmanager
+def defer_rbac_cache():
+    if _defer_rbac_cache.active:
+        raise RuntimeError("defer_rbac_cache cannot be nested")
+    _defer_rbac_cache.active = True
+    try:
+        yield
+    finally:
+        team_ids = _defer_rbac_cache.team_ids
+        object_roles = _defer_rbac_cache.object_roles
+        _defer_rbac_cache.active = False
+        _defer_rbac_cache.team_ids = set()
+        _defer_rbac_cache.object_roles = set()
+
+        if team_ids:
+            compute_team_member_roles(team_ids=team_ids)
+
+        if object_roles:
+            compute_object_role_permissions(object_roles=object_roles)
+
+
 def update_after_assignment(recompute_team_ids, to_update):
     "Call this with the output of needed_updates_on_assignment"
+    if _defer_rbac_cache.active:
+        if recompute_team_ids is not None:
+            _defer_rbac_cache.team_ids.update(recompute_team_ids)
+        if to_update is not None:
+            _defer_rbac_cache.object_roles.update(to_update)
+        return
+
     if recompute_team_ids is not None:
         compute_team_member_roles(team_ids=recompute_team_ids)
 

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -242,6 +242,16 @@ def test_defer_rbac_cache_without_context_manager(organization, inventory, rando
     assert rando.has_obj_perm(inventory, 'change')
 
 
+@pytest.mark.django_db
+def test_defer_rbac_cache_with_team_assignment(organization, team, rando, org_team_member_rd):
+    """defer_rbac_cache should also defer and flush team membership
+    recomputation (the team_ids path)."""
+    with defer_rbac_cache():
+        org_team_member_rd.give_permission(rando, organization)
+
+    assert rando.has_obj_perm(team, 'member_team')
+
+
 class TestEmailPolicySignal:
     """Tests for the pre_save signal that prevents unauthorized email
     changes across all services."""

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ValidationError
 
 from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleEvaluation, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.rbac.permission_registry import permission_registry
-from ansible_base.rbac.triggers import dab_post_migrate, post_migration_rbac_setup
+from ansible_base.rbac.triggers import dab_post_migrate, defer_rbac_cache, post_migration_rbac_setup
 from test_app.models import Inventory, Organization, User
 
 
@@ -173,6 +173,73 @@ def test_delete_signals_team_organization(organization, inventory, team, org_inv
         assert not RoleEvaluation.objects.filter(**org_gfk).exists()
 
     assert not RoleEvaluation.objects.filter(**inv_gfk).exists()
+
+
+@pytest.mark.django_db
+def test_defer_rbac_cache_produces_correct_evaluations(organization, inventory, rando, org_inv_rd):
+    """Calling give_permission inside defer_rbac_cache should produce
+    the same RoleEvaluation entries as calling it without deferral."""
+    inv_gfk = gfk_filter(inventory)
+    org_gfk = gfk_filter(organization)
+
+    with defer_rbac_cache():
+        org_inv_rd.give_permission(rando, organization)
+        # During deferral, evaluations should not yet exist
+        assert not RoleEvaluation.objects.filter(**inv_gfk).exists()
+
+    # After the context manager exits, evaluations should be flushed
+    assert RoleEvaluation.objects.filter(**org_gfk).exists()
+    assert RoleEvaluation.objects.filter(**inv_gfk).exists()
+    assert rando.has_obj_perm(inventory, 'change')
+
+
+@pytest.mark.django_db
+def test_defer_rbac_cache_multiple_assignments(organization, rando, inv_rd):
+    """Multiple give_permission calls inside defer_rbac_cache should
+    all produce correct evaluations after the context exits."""
+    second_org = Organization.objects.create(name='second-org')
+    inv1 = Inventory.objects.create(name='inv1', organization=organization)
+    inv2 = Inventory.objects.create(name='inv2', organization=second_org)
+
+    with defer_rbac_cache():
+        inv_rd.give_permission(rando, inv1)
+        inv_rd.give_permission(rando, inv2)
+
+    assert rando.has_obj_perm(inv1, 'change')
+    assert rando.has_obj_perm(inv2, 'change')
+
+
+def test_defer_rbac_cache_cannot_be_nested():
+    """Nesting defer_rbac_cache should raise a RuntimeError."""
+    with defer_rbac_cache():
+        with pytest.raises(RuntimeError, match="cannot be nested"):
+            with defer_rbac_cache():
+                pass
+
+
+@pytest.mark.django_db
+def test_defer_rbac_cache_empty_block(inventory):
+    """An empty defer_rbac_cache block should not trigger any
+    recomputation — it should be a no-op."""
+    from unittest.mock import patch
+
+    with patch('ansible_base.rbac.triggers.compute_object_role_permissions') as mock_compute:
+        with defer_rbac_cache():
+            pass
+
+    mock_compute.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_defer_rbac_cache_without_context_manager(organization, inventory, rando, org_inv_rd):
+    """Without defer_rbac_cache, behavior is unchanged — evaluations
+    are created immediately."""
+    inv_gfk = gfk_filter(inventory)
+
+    org_inv_rd.give_permission(rando, organization)
+
+    assert RoleEvaluation.objects.filter(**inv_gfk).exists()
+    assert rando.has_obj_perm(inventory, 'change')
 
 
 class TestEmailPolicySignal:


### PR DESCRIPTION
## Description

This PR defines a new annotation: `defer_rbac_cache`. This annotation allows to defer calling `compute_object_role_permissions`.

The annotation keeps track of the modified roles and teams and only calls compute_object_role_permissions in the end (when the surrounded function finishes).

**Why is this needed?** Because we have cases (migrate_service_data) that repeatedly call  update_after_assignment and this leads to repeated calls to compute_object_role_permissions with only one role each time.

**Why a new annotation needed? No simpler way?** We want to keep the original behavior of update_after_assignment and make the new behavior optional. Otherwise every user of functions like `give_permission` (which call update_after_assignment) would have to keep track of the modified objects and call compute_object_role_permissions manually.

**Observed performance increase**

In an environment with 1k Organizations and 10k Teams, `give_permissions` was called 2000 times to simulate the behavior of migrate_service_data.

With the new annotation it took ~30 seconds, without it ~80 seconds. Speedup: 2.6 times. This should further increase with more object roles in the database.

Alternatively, a full migration could be performed.




### Steps to Test

See above, or run a full migration in an environment with a large number of object roles.

### Expected Results

The migration should complete faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deferred RBAC cache update flow, allowing multiple permission/role changes to be batched and applied once when updates complete.
  * Supports combining multiple object permission changes in a single batch, with correct results after the batch ends.
* **Bug Fixes**
  * Ensured RBAC cache recomputation and permission evaluations occur correctly after deferred batches, including nested batches.
  * Verified that behavior remains immediate when batching is not used.
* **Tests**
  * Expanded RBAC trigger test coverage for deferred behavior, including multi-change, nested, and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->