### PR TITLE
[AAP-75091] Make related_fields() namespace-aware for URL resolution

### DIFF
--- a/ansible_base/lib/abstract_models/common.py
+++ b/ansible_base/lib/abstract_models/common.py
@@ -222,6 +222,11 @@ class AbstractCommonModel(models.Model):
 
     def related_fields(self, request):
         response = {}
+
+        namespace = None
+        if request and hasattr(request, 'resolver_match') and request.resolver_match:
+            namespace = request.resolver_match.namespace
+
         # See docs/lib/default_models.md
         # Automatically add all of the ForeignKeys for the model as related fields
         for field in self._meta.concrete_fields:
@@ -237,10 +242,15 @@ class AbstractCommonModel(models.Model):
             if fk_id is not None:
                 related_model = field.related_model
                 basename = get_cls_view_basename(related_model)
+                view_name = f'{basename}-detail'
                 try:
-                    response[field.name] = get_relative_url(f'{basename}-detail', kwargs={'pk': fk_id})
+                    response[field.name] = get_relative_url(view_name, kwargs={'pk': fk_id})
                 except NoReverseMatch:
-                    pass
+                    if namespace:
+                        try:
+                            response[field.name] = get_relative_url(f'{namespace}:{view_name}', kwargs={'pk': fk_id})
+                        except NoReverseMatch:
+                            pass
 
         basename = get_cls_view_basename(self.__class__)
 
@@ -255,7 +265,13 @@ class AbstractCommonModel(models.Model):
             try:
                 response[field_name] = get_relative_url(reverse_view, kwargs={'pk': self.pk})
             except NoReverseMatch:
-                missing_relations.append(reverse_view)
+                if namespace:
+                    try:
+                        response[field_name] = get_relative_url(f'{namespace}:{reverse_view}', kwargs={'pk': self.pk})
+                    except NoReverseMatch:
+                        missing_relations.append(reverse_view)
+                else:
+                    missing_relations.append(reverse_view)
 
         if missing_relations and settings.DEBUG:
             logger.error(f"Wanted to add {', '.join(missing_relations)} for {self.__class__} but view was missing")

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -110,7 +110,7 @@ def test_related_fields_view_resolution(shut_up_logging):
 
 
 @pytest.mark.django_db
-def test_related_fields_namespace_retry(shut_up_logging):
+def test_related_fields_namespace_retry(shut_up_logging, system_user):
     """When bare reverse fails but namespaced reverse succeeds, the field should be included."""
     from types import SimpleNamespace
 
@@ -129,6 +129,7 @@ def test_related_fields_namespace_retry(shut_up_logging):
         result = model.related_fields(request)
 
     assert len(result) > 0, "Namespaced retry should have resolved at least one URL"
+    assert 'created_by' in result, "FK namespace retry should have resolved created_by"
 
 
 @pytest.mark.django_db
@@ -179,6 +180,7 @@ def test_related_fields_bare_reverse_preferred_over_namespace(shut_up_logging, u
     result = model.related_fields(request)
 
     bare_result = model.related_fields(None)
+    assert bare_result, "Expected bare reverse to resolve at least one related field"
     for key in bare_result:
         assert bare_result[key] == result[key], "Bare URL should be used when it resolves"
 

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -133,6 +133,26 @@ def test_related_fields_namespace_retry(shut_up_logging, system_user):
 
 
 @pytest.mark.django_db
+def test_related_fields_namespace_retry_both_fail(shut_up_logging, system_user):
+    """When both bare and namespaced reverse fail, fields should be silently skipped."""
+    from types import SimpleNamespace
+
+    from django.urls.exceptions import NoReverseMatch
+
+    model = RelatedFieldsTestModel.objects.create()
+
+    request = SimpleNamespace(resolver_match=SimpleNamespace(namespace='galaxy:api:ui_v2'))
+
+    def fake_get_relative_url(view_name, **kwargs):
+        raise NoReverseMatch(f"'{view_name}' not found")
+
+    with patch('ansible_base.lib.abstract_models.common.get_relative_url', side_effect=fake_get_relative_url):
+        result = model.related_fields(request)
+
+    assert result == {}
+
+
+@pytest.mark.django_db
 def test_related_fields_no_namespace_retry_without_request(shut_up_logging):
     """When request is None, bare reverse failures should be silently skipped (existing behavior)."""
     from django.urls.exceptions import NoReverseMatch

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -110,6 +110,80 @@ def test_related_fields_view_resolution(shut_up_logging):
 
 
 @pytest.mark.django_db
+def test_related_fields_namespace_retry(shut_up_logging):
+    """When bare reverse fails but namespaced reverse succeeds, the field should be included."""
+    from types import SimpleNamespace
+
+    from django.urls.exceptions import NoReverseMatch
+
+    model = RelatedFieldsTestModel.objects.create()
+
+    request = SimpleNamespace(resolver_match=SimpleNamespace(namespace='galaxy:api:ui_v2'))
+
+    def fake_get_relative_url(view_name, **kwargs):
+        if ':' not in view_name:
+            raise NoReverseMatch(f"'{view_name}' is not a registered namespace")
+        return f'/api/_ui/v2/{view_name.split(":")[-1].replace("-detail", "s/")}' if 'detail' in view_name else f'/api/_ui/v2/{view_name}/'
+
+    with patch('ansible_base.lib.abstract_models.common.get_relative_url', side_effect=fake_get_relative_url):
+        result = model.related_fields(request)
+
+    assert len(result) > 0, "Namespaced retry should have resolved at least one URL"
+
+
+@pytest.mark.django_db
+def test_related_fields_no_namespace_retry_without_request(shut_up_logging):
+    """When request is None, bare reverse failures should be silently skipped (existing behavior)."""
+    from django.urls.exceptions import NoReverseMatch
+
+    model = RelatedFieldsTestModel.objects.create()
+
+    def fake_get_relative_url(view_name, **kwargs):
+        raise NoReverseMatch(f"'{view_name}' not found")
+
+    with patch('ansible_base.lib.abstract_models.common.get_relative_url', side_effect=fake_get_relative_url):
+        result = model.related_fields(None)
+
+    assert result == {}
+
+
+@pytest.mark.django_db
+def test_related_fields_no_namespace_retry_without_namespace(shut_up_logging):
+    """When request has no namespace, bare reverse failures should be silently skipped."""
+    from types import SimpleNamespace
+
+    from django.urls.exceptions import NoReverseMatch
+
+    model = RelatedFieldsTestModel.objects.create()
+
+    request = SimpleNamespace(resolver_match=SimpleNamespace(namespace=''))
+
+    def fake_get_relative_url(view_name, **kwargs):
+        raise NoReverseMatch(f"'{view_name}' not found")
+
+    with patch('ansible_base.lib.abstract_models.common.get_relative_url', side_effect=fake_get_relative_url):
+        result = model.related_fields(request)
+
+    assert result == {}
+
+
+@pytest.mark.django_db
+def test_related_fields_bare_reverse_preferred_over_namespace(shut_up_logging, user):
+    """When bare reverse succeeds, the namespace retry should not be attempted."""
+    from types import SimpleNamespace
+
+    model = RelatedFieldsTestModel.objects.create()
+
+    request = SimpleNamespace(resolver_match=SimpleNamespace(namespace='myapp'))
+
+    result = model.related_fields(request)
+
+    bare_result = model.related_fields(None)
+    for key in bare_result:
+        assert bare_result[key] == result[key], "Bare URL should be used when it resolves"
+
+
+@pytest.mark.django_db
 def test_resave_of_model_with_no_created(expected_log, system_user):
     # Create a random model and save it without warning and no system user
     model = Organization()

--- a/test_app/tests/lib/abstract_models/test_common.py
+++ b/test_app/tests/lib/abstract_models/test_common.py
@@ -1,4 +1,5 @@
 from functools import partial
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db import connection
 from django.test import override_settings
 from django.test.client import RequestFactory
+from django.urls.exceptions import NoReverseMatch
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
@@ -112,10 +114,6 @@ def test_related_fields_view_resolution(shut_up_logging):
 @pytest.mark.django_db
 def test_related_fields_namespace_retry(shut_up_logging, system_user):
     """When bare reverse fails but namespaced reverse succeeds, the field should be included."""
-    from types import SimpleNamespace
-
-    from django.urls.exceptions import NoReverseMatch
-
     model = RelatedFieldsTestModel.objects.create()
 
     request = SimpleNamespace(resolver_match=SimpleNamespace(namespace='galaxy:api:ui_v2'))
@@ -155,8 +153,6 @@ def test_related_fields_namespace_retry_both_fail(shut_up_logging, system_user):
 @pytest.mark.django_db
 def test_related_fields_no_namespace_retry_without_request(shut_up_logging):
     """When request is None, bare reverse failures should be silently skipped (existing behavior)."""
-    from django.urls.exceptions import NoReverseMatch
-
     model = RelatedFieldsTestModel.objects.create()
 
     def fake_get_relative_url(view_name, **kwargs):
@@ -171,10 +167,6 @@ def test_related_fields_no_namespace_retry_without_request(shut_up_logging):
 @pytest.mark.django_db
 def test_related_fields_no_namespace_retry_without_namespace(shut_up_logging):
     """When request has no namespace, bare reverse failures should be silently skipped."""
-    from types import SimpleNamespace
-
-    from django.urls.exceptions import NoReverseMatch
-
     model = RelatedFieldsTestModel.objects.create()
 
     request = SimpleNamespace(resolver_match=SimpleNamespace(namespace=''))
@@ -191,8 +183,6 @@ def test_related_fields_no_namespace_retry_without_namespace(shut_up_logging):
 @pytest.mark.django_db
 def test_related_fields_bare_reverse_preferred_over_namespace(shut_up_logging, user):
     """When bare reverse succeeds, the namespace retry should not be attempted."""
-    from types import SimpleNamespace
-
     model = RelatedFieldsTestModel.objects.create()
 
     request = SimpleNamespace(resolver_match=SimpleNamespace(namespace='myapp'))


### PR DESCRIPTION
## Summary

- Fix `related_fields()` in `AbstractCommonModel` to retry URL resolution with the request's namespace prefix when bare `reverse('{basename}-detail')` fails with `NoReverseMatch`
- Fixes missing `user`, `role_definition`, and `created_by` fields in the `related` dict of the `role_user_assignments` API when DAB views are registered under Django URL namespaces (e.g. galaxy_ng's `namespace="ui_v2"`)
- Add 4 tests covering namespace retry, no-request, no-namespace, and bare-preferred scenarios

## Problem

When a consuming app registers DAB views under a Django URL namespace — e.g. `path("_ui/v2/", include(urls, namespace="ui_v2"))` — the bare `reverse('user-detail')` call in `related_fields()` fails with `NoReverseMatch` because the actual URL name is `galaxy:ui_v2:user-detail`. The exception is silently caught and the field is dropped from the response.

This causes the `_ui/v2/role_user_assignments/` API to return:
```json
{"related": {"content_object": "/api/galaxy/v3/namespaces/..."}}
```
instead of:
```json
{"related": {"content_object": "...", "user": "...", "role_definition": "...", "created_by": "..."}}
```

`content_object` works because Pulp models define `get_absolute_url()` which bypasses the `reverse()` path entirely.

## Fix

Extract `request.resolver_match.namespace` at the top of `related_fields()` and use it as a fallback when the bare reverse fails:

1. Try `reverse('{basename}-detail')` (bare, existing behavior)
2. On `NoReverseMatch`, if a namespace is available, retry with `reverse('{namespace}:{basename}-detail')`

Applied to both the FK loop and the reverse-relations loop.

## Impact

- **AWX/Controller**: No impact — AWX includes DAB URLs without namespaces, so bare reverse always succeeds and the retry is never triggered
- **galaxy_ng**: Fixes the bug — the namespace retry correctly resolves `galaxy:ui_v2:user-detail` etc.
- **Other consumers**: No impact for non-namespaced deployments; beneficial for any future namespaced deployments

## Test plan

- [x] `test_related_fields_namespace_retry` — namespace fallback works when bare reverse fails
- [x] `test_related_fields_no_namespace_retry_without_request` — existing behavior preserved when request is None
- [x] `test_related_fields_no_namespace_retry_without_namespace` — existing behavior preserved when namespace is empty
- [x] `test_related_fields_bare_reverse_preferred_over_namespace` — bare URLs used when they resolve
- [x] Full `test_common.py` suite (35 tests) passes
- [x] Serializer `test_common.py` suite (17 tests) passes — no regressions
- [x] flake8, black, isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved related link URL resolution when a page is using a view namespace.
  * Added a retry that uses the namespaced route when the initial (non-namespaced) lookup fails.
  * Avoided prematurely treating reverse links as missing when a namespaced match is available.
* **Tests**
  * Added/extended test coverage for namespace-aware URL resolution, including scenarios with no request, an empty namespace, and successful direct lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->