### PR TITLE
Revert 1042 1038 and 1025

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -16,7 +16,6 @@ from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.rbac.permission_registry import permission_registry  # careful for circular imports
 from ansible_base.rbac.policies import check_content_obj_permission, visible_users
-from ansible_base.rbac.service_api.serializers import ObjectAnsibleIdField
 from ansible_base.rbac.validators import check_locally_managed, validate_permissions_for_model
 
 from ..models import DABContentType, DABPermission
@@ -73,28 +72,9 @@ class RoleDefinitionDetailSerializer(RoleDefinitionSerializer):
     content_type = serializers.SlugRelatedField(slug_field='api_slug', read_only=True)
 
 
-class _ReadOnlyObjectAnsibleIdField(ObjectAnsibleIdField):
-    """ObjectAnsibleIdField with annotation-optimized reads but UUID pass-through on writes.
-
-    The base ObjectAnsibleIdField.to_internal_value resolves UUID -> object_id,
-    but the RBAC API serializer has its own resolution in get_object_from_data
-    that expects the raw UUID string.
-    """
-
-    def to_internal_value(self, value):
-        if not value:
-            return None
-        try:
-            import uuid
-
-            return str(uuid.UUID(str(value)))
-        except ValueError:
-            raise serializers.ValidationError("Must be a valid UUID.")
-
-
 class BaseAssignmentSerializer(CommonModelSerializer):
     content_type = serializers.SlugRelatedField(slug_field='api_slug', read_only=True)
-    object_ansible_id = _ReadOnlyObjectAnsibleIdField(
+    object_ansible_id = serializers.UUIDField(
         required=False,
         help_text=_('The resource id of the object this role applies to. An alternative to the object_id field.'),
         allow_null=True,  # for ease of use of the browseable API

--- a/ansible_base/rbac/api/service_cursor_paginator.py
+++ b/ansible_base/rbac/api/service_cursor_paginator.py
@@ -1,8 +1,0 @@
-from rest_framework.pagination import CursorPagination
-
-
-class ServiceCursorPagination(CursorPagination):
-    page_size = 50
-    ordering = '-id'  # Order by 'id' to ensure consistent pagination results
-    page_size_query_param = 'page_size'
-    max_page_size = 1000

--- a/ansible_base/rbac/api/service_cursor_paginator.py
+++ b/ansible_base/rbac/api/service_cursor_paginator.py
@@ -3,6 +3,6 @@ from rest_framework.pagination import CursorPagination
 
 class ServiceCursorPagination(CursorPagination):
     page_size = 50
-    ordering = 'id'
+    ordering = '-id'  # Order by 'id' to ensure consistent pagination results
     page_size_query_param = 'page_size'
     max_page_size = 1000

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -33,7 +33,6 @@ from ansible_base.rbac.evaluations import has_super_permission
 from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
 from ansible_base.rbac.policies import check_can_remove_assignment
-from ansible_base.rbac.service_api.views import resource_ansible_id_expr
 from ansible_base.rbac.validators import check_locally_managed, permissions_allowed_for_role, system_roles_enabled
 from ansible_base.rest_filters.rest_framework import ansible_id_backend
 
@@ -42,7 +41,6 @@ from ..policies import check_content_obj_permission
 from ..remote import RemoteObject, get_resource_prefix
 from ..sync import maybe_reverse_sync_assignment, maybe_reverse_sync_role_definition, maybe_reverse_sync_unassignment
 from .queries import assignment_qs_user_to_obj, assignment_qs_user_to_obj_perm
-from .service_cursor_paginator import ServiceCursorPagination
 
 
 def list_combine_values(data: dict[Type[Model], list[str]]) -> list[str]:
@@ -173,13 +171,10 @@ class BaseAssignmentViewSet(AnsibleBaseDjangoAppApiView, ModelViewSet):
     # PUT and PATCH are not allowed because these are immutable
     http_method_names = ['get', 'post', 'head', 'options', 'delete']
     prefetch_related = ()
-    pagination_class = ServiceCursorPagination
 
     def get_queryset(self):
         model = self.serializer_class.Meta.model
-        return model.objects.prefetch_related(*self.prefetch_related, *assignment_prefetch_base).annotate(
-            _object_ansible_id_annotation=resource_ansible_id_expr()
-        )
+        return model.objects.prefetch_related(*self.prefetch_related, *assignment_prefetch_base)
 
     def filter_queryset(self, qs):
         model = self.serializer_class.Meta.model

--- a/ansible_base/rbac/service_api/views.py
+++ b/ansible_base/rbac/service_api/views.py
@@ -13,7 +13,6 @@ from ansible_base.resource_registry.views import HasResourceRegistryPermissions
 from ansible_base.rest_filters.rest_framework import ansible_id_backend
 from ansible_base.rest_filters.rest_framework.ansible_id_backend import ServiceFilterBackend
 
-from ..api.service_cursor_paginator import ServiceCursorPagination
 from ..models import DABContentType, DABPermission, RoleTeamAssignment, RoleUserAssignment
 from . import serializers as service_serializers
 
@@ -54,8 +53,6 @@ class BaseSerivceRoleAssignmentViewSet(
     GenericViewSet,
 ):
     """List of assignments for cross-service communication"""
-
-    pagination_class = ServiceCursorPagination
 
     permission_classes = try_add_oauth2_scope_permission(
         [

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from io import StringIO, TextIOBase
-from urllib.parse import parse_qs, urlparse
 
 from asgiref.sync import sync_to_async
 from django.conf import settings
@@ -137,55 +136,41 @@ class RemoteAssignmentFetcher:
 
         Returns True if all pages were fetched successfully, False on any error.
         """
-        next_url = None
+        page = 1
         try:
             while True:
-                resp = self._fetch_page(list_fn, next_url)
-                if resp is None or resp.status_code != 200:
-                    logger.warning(f"Failed to fetch {assignment_type} assignments batch {next_url}: HTTP {resp.status_code if resp else 'No Response'}")
+                filters = {'page': page, 'page_size': self.page_size}
+                if self.service_filter:
+                    filters['content_type__service'] = self.service_filter
+                resp = list_fn(filters=filters)
+                if resp.status_code != 200:
+                    logger.warning(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {resp.status_code}")
                     return False
-                data = resp.json()
-                self._process_assignments(data.get('results') or [], actor_id_key, assignment_type)
 
-                next_url = data.get('next')
-                if not next_url:
+                data = resp.json()
+                for assignment in data.get('results') or []:
+                    role_name = assignment['role_definition']
+                    if role_name not in self.local_role_names:
+                        logger.debug(f"Skipping remote {assignment_type} assignment with unknown local role: {role_name}")
+                        continue
+                    ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
+                    self.assignments.add(
+                        AssignmentTuple(
+                            actor_ansible_id=assignment[actor_id_key],
+                            ansible_id_or_pk=ansible_id_or_pk,
+                            role_definition_name=role_name,
+                            assignment_type=assignment_type,
+                        )
+                    )
+
+                if not data.get('next'):
                     return True
-                logger.debug(f"Fetching next batch {next_url} of {assignment_type} assignments")
+
+                page += 1
+                logger.debug(f"Fetching next page {page} of {assignment_type} assignments")
         except Exception:
             logger.exception(f"Failed to fetch remote {assignment_type} assignments")
             return False
-
-    def _build_filters(self, **extra):
-        filters = {'page_size': self.page_size}
-        if self.service_filter:
-            filters['content_type__service'] = self.service_filter
-        filters.update(extra)
-        return filters
-
-    def _fetch_page(self, list_fn, next_url):
-        if next_url is None:
-            return list_fn(filters=self._build_filters())
-        cursor = parse_qs(urlparse(next_url).query).get('cursor', [None])[0]
-        if cursor is None:
-            logger.warning(f"Pagination URL missing cursor parameter: {next_url}")
-            return None
-        return list_fn(filters=self._build_filters(cursor=cursor))
-
-    def _process_assignments(self, assignments_data, actor_id_key, assignment_type):
-        for assignment in assignments_data:
-            role_name = assignment['role_definition']
-            if role_name not in self.local_role_names:
-                logger.debug(f"Skipping remote {assignment_type} assignment with unknown local role: {role_name}")
-                continue
-            ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
-            self.assignments.add(
-                AssignmentTuple(
-                    actor_ansible_id=assignment[actor_id_key],
-                    ansible_id_or_pk=ansible_id_or_pk,
-                    role_definition_name=role_name,
-                    assignment_type=assignment_type,
-                )
-            )
 
 
 def get_remote_assignments(api_client: ResourceAPIClient, page_size: int | None = None, service_filter: str | None = None) -> RemoteAssignmentResult:

--- a/docs/apps/resource_registry.md
+++ b/docs/apps/resource_registry.md
@@ -265,6 +265,7 @@ This purely a list and retrieve view. It displays all the resource types that ar
 
 ```json
 {
+    "count": 1,
     "next": null,
     "previous": null,
     "results": [

--- a/test_app/tests/rbac/api/test_ansible_id_assignments.py
+++ b/test_app/tests/rbac/api/test_ansible_id_assignments.py
@@ -105,24 +105,6 @@ def test_invalid_ansible_id(admin_api_client, org_inv_rd, rando):
 
 
 @pytest.mark.django_db
-def test_invalid_ansible_id_is_Invalid_UUID(admin_api_client, org_inv_rd, rando):
-    url = get_relative_url('roleuserassignment-list')
-    bad_ansible_id = "not-a-uuid"
-    data = dict(role_definition=org_inv_rd.id, user=rando.id, object_ansible_id=bad_ansible_id)
-    response = admin_api_client.post(url, data=data, format="json")
-    assert response.status_code == 400, response.data
-    assert 'Must be a valid UUID' in str(response.data['object_ansible_id'])
-
-
-def test_object_ansible_id_field_falsy_returns_none():
-    from ansible_base.rbac.api.serializers import _ReadOnlyObjectAnsibleIdField
-
-    field = _ReadOnlyObjectAnsibleIdField()
-    assert field.to_internal_value("") is None
-    assert field.to_internal_value(None) is None
-
-
-@pytest.mark.django_db
 def test_object_ansible_id_bad_type(admin_api_client, inv_rd, rando, organization):
     """If giving object_id, type is implied from role definition.
 

--- a/test_app/tests/rbac/api/test_rbac_serializers.py
+++ b/test_app/tests/rbac/api/test_rbac_serializers.py
@@ -1,9 +1,7 @@
 import pytest
-from django.contrib.contenttypes.models import ContentType
 from django.test.utils import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.resource_registry.models import Resource
 from test_app.models import Inventory, User
 
 
@@ -83,20 +81,6 @@ class TestAssignmentPermission:
         response = user_api_client.post(url, data=create_data)
         assert response.status_code == 201
         assert rando.has_obj_perm(inventory_2, 'change')
-
-    def test_user_without_permissions(self, organization_2, org_admin_rd, org_admin, user_api_client):
-        url = get_relative_url('roleuserassignment-list')
-        rando = User.objects.create(username='rando')
-        resource = Resource.objects.get(object_id=organization_2.pk, content_type=ContentType.objects.get_for_model(organization_2).pk)
-
-        create_data = {'object_ansible_id': str(resource.ansible_id), 'user': rando.id, 'role_definition': org_admin_rd.id}
-
-        # user can not determine organization object exists because they have no permissions to it
-        assert not org_admin.has_obj_perm(organization_2, 'view')  # sanity
-        response = user_api_client.post(url, data=create_data)
-        assert response.status_code == 400
-        assert not rando.has_obj_perm(organization_2, 'change')
-        assert 'object does not exist' in str(response.data['object_ansible_id'])
 
     def test_object_not_found(self, inv_rd, org_admin, user_api_client):
         url = get_relative_url('roleuserassignment-list')

--- a/test_app/tests/rbac/api/test_rbac_views.py
+++ b/test_app/tests/rbac/api/test_rbac_views.py
@@ -130,7 +130,7 @@ def test_filtering_related_assignments(user_api_client, user, rando, inventory, 
     url = get_relative_url('roledefinition-user_assignments-list', kwargs={'pk': inv_rd.id})
     response = user_api_client.get(url)
     assert response.status_code == 200, response.data
-    assert len(response.data['results']) == 0
+    assert response.data['count'] == 0
 
     user_assignment = inv_rd.give_permission(user, inventory)
     response = user_api_client.get(url)

--- a/test_app/tests/rbac/remote/test_public_api_compat.py
+++ b/test_app/tests/rbac/remote/test_public_api_compat.py
@@ -130,7 +130,7 @@ def test_give_permission_to_remote_object_uuid(admin_api_client, rando, foo_type
     service_url = get_relative_url('serviceuserassignment-list')
     response = admin_api_client.get(service_url + f'?user={rando.id}', format="json")
     assert response.status_code == 200, response.data
-    assert len(response.data['results']) == 1
+    assert response.data['count'] == 1
     assignment_data = response.data['results'][0]
     assert assignment_data['object_id'] == str(assignment.object_id)
 

--- a/test_app/tests/rbac/remote/test_service_api.py
+++ b/test_app/tests/rbac/remote/test_service_api.py
@@ -305,12 +305,12 @@ def test_filter_assignment_list(admin_api_client, rando, inv_rd, view_inv_rd, or
     url = get_relative_url('serviceuserassignment-list')
     response = admin_api_client.get(url + f'?user={rando.id}', format="json")
     assert response.status_code == 200, response.data
-    assert len(response.data['results']) == 3  # user rando has 3 rol assignments
+    assert response.data['count'] == 3  # user rando has 3 rol assignments
 
     # Get just one single assignment
     response = admin_api_client.get(url + f'?assignment={str(rando.resource.ansible_id)},{inv_rd.name},{inventory.id}', format="json")
     assert response.status_code == 200, response.data
-    assert len(response.data['results']) == 1
+    assert response.data['count'] == 1
     assert response.data['results'][0]['role_definition'] == inv_rd.name
 
     # Assure we can get two assignments at the same time
@@ -323,7 +323,7 @@ def test_filter_assignment_list(admin_api_client, rando, inv_rd, view_inv_rd, or
         format="json",
     )
     assert response.status_code == 200, response.data
-    assert len(response.data['results']) == 2
+    assert response.data['count'] == 2
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/test_ansible_id_alias_filter.py
+++ b/test_app/tests/rbac/test_ansible_id_alias_filter.py
@@ -34,31 +34,31 @@ class TestAnsibleIdAliasFilterBackend:
 
         # make sure > 1 assignments total to ensure filtering is not returning undesired results
         response = admin_api_client.get(url)
-        assert len(response.data["results"]) > 1, response.data
+        assert response.data["count"] > 1, response.data
 
         # filter by user_ansible_id
         query_params = {'user_ansible_id': user_resource.ansible_id}
         response = admin_api_client.get(url + '?' + urlencode(query_params))
         assert response.status_code == 200, response.data
-        assert len(response.data["results"]) == 2, response.data
+        assert response.data["count"] == 2, response.data
 
         # filter by object_ansible_id
         query_params = {'object_ansible_id': organization_resource.ansible_id}
         response = admin_api_client.get(url + '?' + urlencode(query_params))
         assert response.status_code == 200, response.data
-        assert len(response.data["results"]) == 2, response.data
+        assert response.data["count"] == 2, response.data
 
         # filter by both user_ansible_id and object_ansible_id
         query_params = {'user_ansible_id': user_resource.ansible_id, 'object_ansible_id': organization_resource.ansible_id}
         response = admin_api_client.get(url + '?' + urlencode(query_params))
         assert response.status_code == 200, response.data
-        assert len(response.data["results"]) == 1, response.data
+        assert response.data["count"] == 1, response.data
 
         # filter by random user id
         query_params = {'user': random_user.id}
         response = admin_api_client.get(url + '?' + urlencode(query_params))
         assert response.status_code == 200, response.data
-        assert len(response.data["results"]) == 1, response.data
+        assert response.data["count"] == 1, response.data
 
     def test_filter_by_user_id(self, admin_api_client, inv_rd, inventory, random_user):
         '''
@@ -76,13 +76,13 @@ class TestAnsibleIdAliasFilterBackend:
         query_params = {'user': random_user.id}
         response = admin_api_client.get(url + '?' + urlencode(query_params))
         assert response.status_code == 200, response.data
-        assert len(response.data["results"]) == 1, response.data
+        assert response.data["count"] == 1, response.data
 
         # filter by user_ansible_id
         query_params = {'user_ansible_id': user_resource.ansible_id}
         response = admin_api_client.get(url + '?' + urlencode(query_params))
         assert response.status_code == 200, response.data
-        assert len(response.data["results"]) == 1, response.data
+        assert response.data["count"] == 1, response.data
 
     def test_filter_team_ansible_id(self, admin_api_client, team, inv_rd, inventory):
         '''
@@ -98,7 +98,7 @@ class TestAnsibleIdAliasFilterBackend:
         query_params = {'team_ansible_id': team_resource.ansible_id}
         response = admin_api_client.get(url + '?' + urlencode(query_params))
         assert response.status_code == 200, response.data
-        assert len(response.data["results"]) == 1, response.data
+        assert response.data["count"] == 1, response.data
 
     @pytest.mark.parametrize("ansible_id_type", ["user", "team", "object"])
     def test_invalid_ansible_id_format(self, admin_api_client, ansible_id_type):

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -456,7 +456,7 @@ def test_get_remote_assignments_incomplete_on_failure(failure_mode):
     page1 = _mock_response(
         body={
             "results": [{"user_ansible_id": "u1", "object_ansible_id": "o1", "role_definition": "Team Member"}],
-            "next": "http://example.com/?cursor=abc123",
+            "next": "http://example.com/page2",
         }
     )
 
@@ -552,7 +552,7 @@ def test_get_remote_assignments_filters_unknown_roles(static_api_client):
 
 @pytest.mark.django_db
 def test_remote_assignment_fetcher_passes_page_size():
-    """First page should be fetched with no filters (cursor pagination)."""
+    """page_size should be included in the pagination filters."""
     api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
     ok = _mock_response()
     api_client.list_user_assignments.return_value = ok
@@ -560,8 +560,39 @@ def test_remote_assignment_fetcher_passes_page_size():
 
     RemoteAssignmentFetcher(api_client, page_size=100).fetch()
 
-    api_client.list_user_assignments.assert_called_with(filters={'page_size': 100})
-    api_client.list_team_assignments.assert_called_with(filters={'page_size': 100})
+    api_client.list_user_assignments.assert_called_with(filters={'page': 1, 'page_size': 100})
+    api_client.list_team_assignments.assert_called_with(filters={'page': 1, 'page_size': 100})
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_passes_service_filter_in_pagination():
+    """service_filter should be included as content_type__service in pagination filters."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    ok = _mock_response()
+    api_client.list_user_assignments.return_value = ok
+    api_client.list_team_assignments.return_value = ok
+
+    RemoteAssignmentFetcher(api_client, page_size=100, service_filter='controller').fetch()
+
+    expected_filters = {'page': 1, 'page_size': 100, 'content_type__service': 'controller'}
+    api_client.list_user_assignments.assert_called_with(filters=expected_filters)
+    api_client.list_team_assignments.assert_called_with(filters=expected_filters)
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_omits_service_filter_when_none():
+    """When service_filter is None, content_type__service should not be in filters."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    ok = _mock_response()
+    api_client.list_user_assignments.return_value = ok
+    api_client.list_team_assignments.return_value = ok
+
+    RemoteAssignmentFetcher(api_client, page_size=100, service_filter=None).fetch()
+
+    api_client.list_user_assignments.assert_called_with(filters={'page': 1, 'page_size': 100})
+    assert 'content_type__service' not in api_client.list_user_assignments.call_args.kwargs.get(
+        'filters', api_client.list_user_assignments.call_args[1].get('filters', {})
+    )
 
 
 @pytest.mark.django_db
@@ -577,8 +608,7 @@ def test_remote_assignment_fetcher_reads_page_size_from_settings():
         assert fetcher.page_size == 200
         fetcher.fetch()
 
-    api_client.list_user_assignments.assert_called_with(filters={'page_size': 200})
-    api_client.list_team_assignments.assert_called_with(filters={'page_size': 200})
+    api_client.list_user_assignments.assert_called_with(filters={'page': 1, 'page_size': 200})
 
 
 @mock.patch('ansible_base.resource_registry.tasks.sync.get_remote_assignments')
@@ -602,20 +632,6 @@ def test_sync_executor_passes_service_filter(mock_local, mock_remote, static_api
     executor._sync_assignments()
     mock_remote.assert_called_once_with(static_api_client, page_size=None, service_filter='controller')
     mock_local.assert_called_once_with(service='controller')
-
-
-def test_fetch_page_preserves_service_filter_on_cursor_pages():
-    """_fetch_page must include content_type__service on cursor-based pagination pages."""
-    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
-    fetcher = RemoteAssignmentFetcher(api_client, page_size=100, service_filter='controller')
-
-    mock_list_fn = mock.Mock()
-    mock_list_fn.return_value = mock.Mock(status_code=200)
-    mock_list_fn.return_value.json.return_value = {'results': [], 'next': None}
-
-    fetcher._fetch_page(mock_list_fn, 'http://example.com/api/?cursor=abc123&page_size=100')
-    call_filters = mock_list_fn.call_args.kwargs['filters']
-    assert call_filters.get('content_type__service') == 'controller', "Service filter must be preserved on cursor pages"
 
 
 @mock.patch("ansible_base.resource_registry.tasks.sync.get_resource_server_client")
@@ -652,11 +668,11 @@ def test_create_api_client_default_jwt_expiration(mock_get_client):
 
 
 @pytest.mark.django_db
-def test_remote_assignment_fetcher_sends_cursor_on_subsequent_pages():
-    """Subsequent pages should extract the cursor from the next URL."""
+def test_remote_assignment_fetcher_sends_page_size_on_all_pages():
+    """page_size should be included in filters on every page, not just the first."""
     api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
 
-    page1 = _mock_response(body={"results": [], "next": "http://example.com/api/assignments/?cursor=abc123"})
+    page1 = _mock_response(body={"results": [], "next": "http://example.com/page2"})
     page2 = _mock_response(body={"results": [], "next": None})
     api_client.list_user_assignments.side_effect = [page1, page2]
     api_client.list_team_assignments.return_value = _mock_response()
@@ -665,8 +681,8 @@ def test_remote_assignment_fetcher_sends_cursor_on_subsequent_pages():
 
     user_calls = api_client.list_user_assignments.call_args_list
     assert len(user_calls) == 2
-    assert user_calls[0] == mock.call(filters={'page_size': 100})
-    assert user_calls[1] == mock.call(filters={'cursor': 'abc123', 'page_size': 100})
+    assert user_calls[0] == mock.call(filters={'page': 1, 'page_size': 100})
+    assert user_calls[1] == mock.call(filters={'page': 2, 'page_size': 100})
 
 
 @pytest.mark.django_db
@@ -688,6 +704,55 @@ def test_get_remote_assignments_handles_null_results():
 
     # Should complete successfully without TypeError
     assert result.is_complete is True
+    assert len(result.assignments) == 0
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_multi_page_with_assignments():
+    """Multi-page pagination collects assignments across pages and increments page number."""
+    from ansible_base.rbac.models import RoleDefinition
+
+    RoleDefinition.objects.create(name='MultiPageRole', managed=True)
+
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    page1 = _mock_response(
+        body={
+            'results': [
+                {'user_ansible_id': 'u1', 'object_ansible_id': 'obj1', 'role_definition': 'MultiPageRole'},
+            ],
+            'next': 'http://example.com/page2',
+        }
+    )
+    page2 = _mock_response(
+        body={
+            'results': [
+                {'user_ansible_id': 'u2', 'object_ansible_id': 'obj2', 'role_definition': 'MultiPageRole'},
+            ],
+            'next': None,
+        }
+    )
+    api_client.list_user_assignments.side_effect = [page1, page2]
+    api_client.list_team_assignments.return_value = _mock_response()
+
+    result = RemoteAssignmentFetcher(api_client, page_size=1).fetch()
+
+    assert result.is_complete is True
+    assert len(result.assignments) == 2
+    user_calls = api_client.list_user_assignments.call_args_list
+    assert len(user_calls) == 2
+    assert user_calls[0] == mock.call(filters={'page': 1, 'page_size': 1})
+    assert user_calls[1] == mock.call(filters={'page': 2, 'page_size': 1})
+
+
+@pytest.mark.django_db
+def test_remote_assignment_fetcher_http_error_returns_incomplete():
+    """Non-200 status code marks result as incomplete with warning."""
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    api_client.list_user_assignments.return_value = _mock_response(status_code=500)
+
+    result = RemoteAssignmentFetcher(api_client).fetch()
+
+    assert result.is_complete is False
     assert len(result.assignments) == 0
 
 

--- a/test_app/tests/resource_registry/test_resources_api_rest_client.py
+++ b/test_app/tests/resource_registry/test_resources_api_rest_client.py
@@ -309,7 +309,7 @@ def test_list_user_assignments(resource_client, org_admin_rd, user, organization
 
     assert resp.status_code == 200
     data = resp.json()
-    assert len(data["results"]) >= 1
+    assert data["count"] >= 1
 
     # Find our assignment in the results
     assignment_found = False
@@ -333,7 +333,7 @@ def test_list_team_assignments(resource_client, inv_rd, team, inventory):
 
     assert resp.status_code == 200
     data = resp.json()
-    assert len(data["results"]) >= 1
+    assert data["count"] >= 1
 
     # Find our assignment in the results
     assignment_found = False


### PR DESCRIPTION
Revert #1042 and #1038 and #1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service listing pagination to traverse results using descending IDs for more consistent ordering.
  * Updated RBAC pagination behavior and related responses to rely on `count` for accurate filtering totals.
  * Improved remote resource assignment synchronization by switching from cursor-based pagination to explicit page-based retrieval.
  * Simplified `object_ansible_id` input handling to use standard UUID field parsing/validation.
* **Documentation**
  * Updated the resource registry REST response example to include the `count` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->