### PR TITLE
[AAP-82091] Add Allow header to NotFoundView .well-known catch-all

### DIFF
--- a/ansible_base/oauth2_provider/views/not_found.py
+++ b/ansible_base/oauth2_provider/views/not_found.py
@@ -6,4 +6,6 @@ class NotFoundView(View):
     """Return a JSON 404 for unhandled paths."""
 
     def dispatch(self, request, *args, **kwargs):
-        return JsonResponse({"error": "not_found"}, status=404)
+        response = JsonResponse({"error": "not_found"}, status=404)
+        response["Allow"] = "GET, HEAD, OPTIONS"
+        return response


### PR DESCRIPTION
## Summary
- Adds `Allow` header to `NotFoundView` response so OPTIONS requests return proper HTTP headers

## Problem
The `NotFoundView` added in PR #1040 for the `.well-known/` catch-all is a plain Django `View` that returns `JsonResponse({"error": "not_found"}, status=404)` without an `Allow` header. This breaks jewel's `test_docs.py` API schema tests which send OPTIONS to every discovered URL pattern and expect an `Allow` header.

## Fix
Add `response["Allow"] = "GET, HEAD, OPTIONS"` to the response. This keeps the view as a plain Django View (not DRF), so it stays out of the OpenAPI schema — which is the correct behavior for a catch-all 404 route.

## Test plan
- [ ] `GATEWAY_TEST_DIRS="" tox -e py312 -- aap_gateway_api/tests/views/api/v1/docs/test_docs.py -v` passes in jewel

## References
- JIRA: https://issues.redhat.com/browse/AAP-82091
- Introduced by: #1040
- Failing CI: https://github.com/ansible/jewel/actions/runs/28816255495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unhandled paths now return a proper `Allow` header alongside the JSON 404 response, improving HTTP compliance and making supported methods clearer to clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->