### PR TITLE
[AAP-82627][devel Backport][AAP-80449] Optimize UserAccessViewSet: IN subquery → EXISTS semi-join

### DIFF
--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -5,7 +5,7 @@ from typing import Type
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
-from django.db.models import Model
+from django.db.models import Exists, Model, OuterRef, Q
 from django.utils.translation import gettext_lazy as _
 from rest_framework import permissions
 from rest_framework.exceptions import NotFound, ValidationError
@@ -401,20 +401,36 @@ class UserAccessViewSet(
         if permission:
             obj_eval_qs = evaluation_cls.objects.filter(codename=permission.codename, object_id=obj.pk, content_type_id=ct.id)
         else:
-            # All relevant evaluations for the object
             obj_eval_qs = evaluation_cls.objects.filter(object_id=obj.pk, content_type_id=ct.id)
-        obj_assignment_qs = assignment_cls.objects.filter(**{f'object_role__{reverse_name}__in': obj_eval_qs})
+
+        # Use EXISTS subqueries instead of filter(role_assignments__in=...).distinct()
+        # to avoid a Cartesian product explosion in the RBAC join chain.
+        # At scale (100K+ role assignments, 485K+ role evaluations), the IN pattern
+        # produces 500M+ intermediate rows; EXISTS short-circuits per actor.
+        actor_field = 'user_id' if actor_cls._meta.model_name == 'user' else 'team_id'
+
+        obj_exists = assignment_cls.objects.filter(
+            **{actor_field: OuterRef('pk'), f'object_role__{reverse_name}__in': obj_eval_qs},
+        )
 
         if permission:
-            global_assignment_qs = assignment_cls.objects.filter(content_type=None, role_definition__permissions=permission)
+            global_exists = assignment_cls.objects.filter(
+                **{actor_field: OuterRef('pk')},
+                content_type=None,
+                role_definition__permissions=permission,
+            )
         else:
-            global_assignment_qs = assignment_cls.objects.filter(content_type=None, role_definition__permissions__content_type=ct)
+            global_exists = assignment_cls.objects.filter(
+                **{actor_field: OuterRef('pk')},
+                content_type=None,
+                role_definition__permissions__content_type=ct,
+            )
 
-        assignment_qs = obj_assignment_qs | global_assignment_qs
-        actor_qs = actor_cls.objects.filter(role_assignments__in=assignment_qs)
+        filters = Exists(obj_exists) | Exists(global_exists)
         if actor_cls._meta.model_name == 'user':
-            actor_qs |= actor_cls.objects.filter(is_superuser=True)
-        return actor_qs.distinct()
+            filters = filters | Q(is_superuser=True)
+
+        return actor_cls.objects.filter(filters)
 
     def get_serializer(self, *args, **kwargs):
         """Awkwardly override this method, because eda-server uses a custom base viewset class.

--- a/test_app/tests/rbac/api/test_access_lists.py
+++ b/test_app/tests/rbac/api/test_access_lists.py
@@ -141,6 +141,22 @@ def test_no_duplicates_team(team, inv_rd, inventory, org_inv_rd, admin_api_clien
 
 
 @pytest.mark.django_db
+def test_user_access_list_permission_filtered(admin_api_client, inv_rd, inventory):
+    """Test user access list when URL uses a permission slug instead of a content type slug.
+
+    This exercises the if-permission branch in get_queryset() for global_exists."""
+    url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.view_inventory'})
+
+    u1 = User.objects.create(username='perm-filtered-user')
+    inv_rd.give_permission(u1, inventory)
+
+    response = admin_api_client.get(url)
+    assert response.status_code == 200
+    usernames = [u['username'] for u in response.data['results']]
+    assert u1.username in usernames
+
+
+@pytest.mark.django_db
 def test_org_admin_role_user_access_bug(organization, org_admin_rd):
     """
     Test for AAP-52187: Org admin gets 403 on role_user_access despite having proper permissions.

--- a/test_app/tests/rbac/api/test_access_lists.py
+++ b/test_app/tests/rbac/api/test_access_lists.py
@@ -141,14 +141,14 @@ def test_no_duplicates_team(team, inv_rd, inventory, org_inv_rd, admin_api_clien
 
 
 @pytest.mark.django_db
-def test_user_access_list_permission_filtered(admin_api_client, inv_rd, inventory):
+def test_user_access_list_permission_filtered(admin_api_client, global_inv_rd, inventory):
     """Test user access list when URL uses a permission slug instead of a content type slug.
 
-    This exercises the if-permission branch in get_queryset() for global_exists."""
+    Uses a global role assignment so the user is found via global_exists, not obj_exists."""
     url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.view_inventory'})
 
-    u1 = User.objects.create(username='perm-filtered-user')
-    inv_rd.give_permission(u1, inventory)
+    u1 = User.objects.create(username='global-perm-user')
+    global_inv_rd.give_global_permission(u1)
 
     response = admin_api_client.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

- Replace `filter(role_assignments__in=...).distinct()` with `Exists(OuterRef)` subqueries in `UserAccessViewSet.get_queryset()`
- Eliminates a Cartesian product explosion (500M+ intermediate rows) in the RBAC join chain at scale
- Execution drops from **257 seconds to 0.1 seconds** — 1000x faster, verified identical result sets

## Context

Forward-port of [ansible-automation-platform/django-ansible-base#194](https://github.com/ansible-automation-platform/django-ansible-base/pull/194) (stable-2.6).

The current `filter(role_assignments__in=assignment_qs)` with `|` (OR) and `.distinct()` causes Django to generate a LEFT OUTER JOIN with DISTINCT on all `auth_user` columns. At scale (100K+ role assignments × 485K+ role evaluations × 175 permissions), this produces 513M+ intermediate rows, then filters 99.997% away. Every `role_user_access` and `role_team_access` endpoint times out at uwsgi harakiri. Confirmed at multiple customer sites.

EXISTS semi-joins short-circuit per actor instead of materializing the full join. No `.distinct()` needed since EXISTS is a boolean predicate per row.

Follows the same proven pattern as #1041 (`visible_items()` EXISTS optimization).

Fixes: AAP-80449

## Test plan

- [ ] All existing DAB RBAC tests pass (no functional change)
- [ ] All AWX RBAC functional tests pass
- [ ] At scale: `role_user_access` endpoint responds in <1s instead of timing out at 100s
- [ ] `role_team_access` endpoint similarly improved (inherits from same viewset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Elijah DeLee <kdelee@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-list results by refining how object-level and role-based permissions are evaluated.
  * Corrected global permission handling, including cases where no specific permission is provided and when a permission/content-type slug is used.
  * Preserved superuser visibility in user access listings.
* **Tests**
  * Added coverage to verify access-list behavior when `model_name` is provided as a permission/view slug (e.g., `aap.view_inventory`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->