### PR TITLE
Fix role_team_access 500: Team model lacks encrypted_fields

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.serializers import ValidationError
 
 from ansible_base.lib.abstract_models.common import get_url_for_object
-from ansible_base.lib.serializers.common import AbstractCommonModelSerializer, CommonModelSerializer, ImmutableCommonModelSerializer
+from ansible_base.lib.serializers.common import CommonModelSerializer, ImmutableCommonModelSerializer
 from ansible_base.lib.utils.auth import get_team_model
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition, RoleTeamAssignment, RoleUserAssignment
@@ -331,7 +331,7 @@ class UserAccessListMixin(AccessListMixin, serializers.ModelSerializer):
     _expected_fields = ['id', 'url', 'related', 'username', 'is_superuser', 'first_name', 'last_name', 'object_role_assignments']
 
 
-class TeamAccessListMixin(AccessListMixin, AbstractCommonModelSerializer):
+class TeamAccessListMixin(AccessListMixin, serializers.ModelSerializer):
     object_role_assignments = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     related = serializers.SerializerMethodField('_get_related')


### PR DESCRIPTION
## Summary

- `TeamAccessListMixin` inherited from `AbstractCommonModelSerializer`, whose `to_representation()` accesses `obj.encrypted_fields` unconditionally
- The Team model (in AWX and other consumers) does not define `encrypted_fields`, causing `AttributeError: 'Team' object has no attribute 'encrypted_fields'` on every `role_team_access` request
- Switch to `serializers.ModelSerializer`, matching the pattern already used by `UserAccessListMixin` for the same reason — the actor model is not a DAB `AbstractCommonModel`

## Test plan

- [x] All 6 existing access list tests pass (`test_app/tests/rbac/api/test_access_lists.py`)
- [ ] Verify `role_team_access/<model_name>/<pk>/` returns 200 instead of 500 on a running controller
- [ ] Scale Lab validation: `ta JT org_admin` endpoint should go from 100% fail to passing

Closes: AAP-82540

🤖 Generated with [Claude Code](https://claude.com/claude-code)