### PR TITLE
Add per-application PKCE enforcement for OAuth2

### DIFF
--- a/ansible_base/oauth2_provider/migrations/0010_oauth2application_pkce_required.py
+++ b/ansible_base/oauth2_provider/migrations/0010_oauth2application_pkce_required.py
@@ -7,6 +7,8 @@ class Migration(migrations.Migration):
         ('dab_oauth2_provider', '0009_add_openid_roles_scopes'),
     ]
 
+    # Two-step operation: AddField(default=False) backfills existing rows with False,
+    # then AlterField(default=True) sets the default for new records only.
     operations = [
         migrations.AddField(
             model_name='oauth2application',

--- a/ansible_base/oauth2_provider/migrations/0010_oauth2application_pkce_required.py
+++ b/ansible_base/oauth2_provider/migrations/0010_oauth2application_pkce_required.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dab_oauth2_provider', '0009_add_openid_roles_scopes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='oauth2application',
+            name='pkce_required',
+            field=models.BooleanField(default=False, help_text='When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.'),
+        ),
+        migrations.AlterField(
+            model_name='oauth2application',
+            name='pkce_required',
+            field=models.BooleanField(default=True, help_text='When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.'),
+        ),
+    ]

--- a/ansible_base/oauth2_provider/migrations/0010_oauth2application_pkce_required.py
+++ b/ansible_base/oauth2_provider/migrations/0010_oauth2application_pkce_required.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='oauth2application',
             name='pkce_required',
-            field=models.BooleanField(default=True, help_text='When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.'),
+            field=models.BooleanField(default=True, verbose_name='PKCE Required', help_text='When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.'),
         ),
     ]

--- a/ansible_base/oauth2_provider/models/application.py
+++ b/ansible_base/oauth2_provider/models/application.py
@@ -90,6 +90,7 @@ class OAuth2Application(NamedCommonModel, oauth2_models.AbstractApplication, act
     skip_authorization = models.BooleanField(default=False, help_text=_('Set True to skip authorization step for completely trusted applications.'))
     pkce_required = models.BooleanField(
         default=True,
+        verbose_name=_('PKCE Required'),
         help_text=_('When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.'),
     )
     authorization_grant_type = models.CharField(

--- a/ansible_base/oauth2_provider/models/application.py
+++ b/ansible_base/oauth2_provider/models/application.py
@@ -88,6 +88,10 @@ class OAuth2Application(NamedCommonModel, oauth2_models.AbstractApplication, act
         max_length=32, choices=CLIENT_TYPES, help_text=_('Set to Public or Confidential depending on how secure the client device is.')
     )
     skip_authorization = models.BooleanField(default=False, help_text=_('Set True to skip authorization step for completely trusted applications.'))
+    pkce_required = models.BooleanField(
+        default=True,
+        help_text=_('When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.'),
+    )
     authorization_grant_type = models.CharField(
         max_length=32, choices=GRANT_TYPES, help_text=_('The Grant type the user must use for acquire tokens for this application.')
     )

--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -30,7 +30,7 @@ api_version_urls = [
 
 oauth_urls = [
     re_path(r'^$', oauth2_provider_views.ApiOAuthAuthorizationRootView.as_view(), name='oauth_authorization_root_view'),
-    re_path(r"^authorize/$", oauth_views.AuthorizationView.as_view(), name="authorize"),
+    re_path(r"^authorize/$", oauth2_provider_views.AuthorizationView.as_view(), name="authorize"),
     re_path(r"^token/$", oauth2_provider_views.TokenView.as_view(), name="token"),
     re_path(r"^revoke_token/$", oauth_views.RevokeTokenView.as_view(), name="revoke-token"),
     # OIDC endpoints

--- a/ansible_base/oauth2_provider/views/__init__.py
+++ b/ansible_base/oauth2_provider/views/__init__.py
@@ -1,4 +1,5 @@
 from .application import OAuth2ApplicationViewSet  # noqa: F401
+from .authorization import AuthorizationView  # noqa: F401
 from .authorization_root import ApiOAuthAuthorizationRootView  # noqa: F401
 from .not_found import NotFoundView  # noqa: F401
 from .oidc import DiscoveryInfoView  # noqa: F401

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -29,10 +29,4 @@ class AuthorizationView(oauth_views.AuthorizationView):
             error.redirect_uri = redirect_uri
             return self.error_response(OAuthToolkitError(error=error), application=application)
 
-        kwargs["scopes"] = scopes
-        kwargs["credentials"] = credentials
-        kwargs.update(credentials)
-        self.oauth2_data = kwargs
-        kwargs["application"] = application
-
-        return self.render_to_response(self.get_context_data(**kwargs))
+        return super().get(request, *args, **kwargs)

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -1,0 +1,34 @@
+from oauth2_provider import views as oauth_views
+from oauth2_provider.exceptions import OAuthToolkitError
+from oauth2_provider.models import get_application_model
+from oauthlib.oauth2.rfc6749.errors import InvalidRequestError
+
+from ansible_base.lib.utils.settings import get_setting
+
+
+class AuthorizationView(oauth_views.AuthorizationView):
+    def get(self, request, *args, **kwargs):
+        try:
+            scopes, credentials = self.validate_authorization_request(request)
+        except OAuthToolkitError as error:
+            return self.error_response(error, application=None)
+
+        app_model = get_application_model()
+        try:
+            application = app_model.objects.get(client_id=credentials["client_id"])
+        except app_model.DoesNotExist:
+            error = InvalidRequestError(description="Invalid client_id.")
+            return self.error_response(OAuthToolkitError(error=error), application=None)
+
+        pkce_required_globally = get_setting('OAUTH2_PROVIDER', {}).get('PKCE_REQUIRED', False)
+        if (application.pkce_required or pkce_required_globally) and "code_challenge" not in credentials:
+            error = InvalidRequestError(description="This application requires PKCE. Include a code_challenge parameter.")
+            return self.error_response(OAuthToolkitError(error=error), application=application)
+
+        kwargs["scopes"] = scopes
+        kwargs["credentials"] = credentials
+        kwargs.update(credentials)
+        self.oauth2_data = kwargs
+        kwargs["application"] = application
+
+        return self.render_to_response(self.get_context_data(**kwargs))

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -9,7 +9,7 @@ from ansible_base.lib.utils.settings import get_setting
 class AuthorizationView(oauth_views.AuthorizationView):
     def get(self, request, *args, **kwargs):
         try:
-            scopes, credentials = self.validate_authorization_request(request)
+            _, credentials = self.validate_authorization_request(request)
         except OAuthToolkitError as error:
             return self.error_response(error, application=None)
 

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -13,16 +13,20 @@ class AuthorizationView(oauth_views.AuthorizationView):
         except OAuthToolkitError as error:
             return self.error_response(error, application=None)
 
+        redirect_uri = credentials.get("redirect_uri")
+
         app_model = get_application_model()
         try:
             application = app_model.objects.get(client_id=credentials["client_id"])
         except app_model.DoesNotExist:
             error = InvalidRequestError(description="Invalid client_id.")
+            error.redirect_uri = redirect_uri
             return self.error_response(OAuthToolkitError(error=error), application=None)
 
         pkce_required_globally = get_setting('OAUTH2_PROVIDER', {}).get('PKCE_REQUIRED', False)
         if (application.pkce_required or pkce_required_globally) and "code_challenge" not in credentials:
             error = InvalidRequestError(description="This application requires PKCE. Include a code_challenge parameter.")
+            error.redirect_uri = redirect_uri
             return self.error_response(OAuthToolkitError(error=error), application=application)
 
         kwargs["scopes"] = scopes

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -13,20 +13,32 @@ class AuthorizationView(oauth_views.AuthorizationView):
         except OAuthToolkitError as error:
             return self.error_response(error, application=None)
 
-        redirect_uri = credentials.get("redirect_uri")
+        error_response = self._check_pkce_required(credentials["client_id"], credentials)
+        if error_response is not None:
+            return error_response
 
+        return super().get(request, *args, **kwargs)
+
+    def _check_pkce_required(self, client_id, credentials):
         app_model = get_application_model()
         try:
-            application = app_model.objects.get(client_id=credentials["client_id"])
+            application = app_model.objects.get(client_id=client_id)
         except app_model.DoesNotExist:
-            error = InvalidRequestError(description="Invalid client_id.")
-            error.redirect_uri = redirect_uri
-            return self.error_response(OAuthToolkitError(error=error), application=None)
+            return None
 
         pkce_required_globally = get_setting('OAUTH2_PROVIDER', {}).get('PKCE_REQUIRED', False)
         if (application.pkce_required or pkce_required_globally) and "code_challenge" not in credentials:
+            redirect_uri = credentials.get("redirect_uri")
             error = InvalidRequestError(description="This application requires PKCE. Include a code_challenge parameter.")
             error.redirect_uri = redirect_uri
             return self.error_response(OAuthToolkitError(error=error), application=application)
 
-        return super().get(request, *args, **kwargs)
+        return None
+
+    def form_valid(self, form):
+        credentials = {k: form.cleaned_data.get(k) for k in ("code_challenge", "code_challenge_method", "redirect_uri") if form.cleaned_data.get(k)}
+        error_response = self._check_pkce_required(form.cleaned_data["client_id"], credentials)
+        if error_response is not None:
+            return error_response
+
+        return super().form_valid(form)

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -7,7 +7,28 @@ from ansible_base.lib.utils.settings import get_setting
 
 
 class AuthorizationView(oauth_views.AuthorizationView):
+    """
+    Extends DOT's AuthorizationView to add per-application PKCE enforcement.
+
+    DOT only supports a global PKCE_REQUIRED setting. This subclass adds an
+    application-level ``pkce_required`` field check so individual apps can
+    require PKCE even when the global setting is off. When global PKCE_REQUIRED
+    is True, DOT already enforces PKCE for all apps and this class defers to it.
+
+    Overrides:
+      - get(): pre-validates the request to extract credentials, then runs the
+        per-app PKCE check before delegating to super().get(). This causes
+        validate_authorization_request() to run twice (ours + DOT's), but the
+        call is idempotent and avoids copying DOT's get() internals.
+      - form_valid(): runs the same per-app PKCE check on POST submissions
+        before delegating to super().form_valid().
+    """
+
     def get(self, request, *args, **kwargs):
+        # Intentional double call: validate_authorization_request() runs here
+        # to extract credentials for the per-app PKCE check, then again inside
+        # super().get(). The call is idempotent (read-only, no side effects),
+        # and this avoids copying DOT's get() internals.
         try:
             _, credentials = self.validate_authorization_request(request)
         except OAuthToolkitError as error:
@@ -20,10 +41,11 @@ class AuthorizationView(oauth_views.AuthorizationView):
         return super().get(request, *args, **kwargs)
 
     def _check_pkce_required(self, client_id, credentials):
+        """Return an error response if the app requires PKCE and no code_challenge was provided, else None."""
         application = get_application_model().objects.get(client_id=client_id)
 
         pkce_required_globally = get_setting('OAUTH2_PROVIDER', {}).get('PKCE_REQUIRED', False)
-        if (application.pkce_required or pkce_required_globally) and not credentials.get("code_challenge"):
+        if not pkce_required_globally and application.pkce_required and not credentials.get("code_challenge"):
             redirect_uri = credentials.get("redirect_uri")
             error = InvalidRequestError(
                 description="This application requires PKCE. Include a code_challenge parameter.",

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -25,14 +25,17 @@ class AuthorizationView(oauth_views.AuthorizationView):
         pkce_required_globally = get_setting('OAUTH2_PROVIDER', {}).get('PKCE_REQUIRED', False)
         if (application.pkce_required or pkce_required_globally) and not credentials.get("code_challenge"):
             redirect_uri = credentials.get("redirect_uri")
-            error = InvalidRequestError(description="This application requires PKCE. Include a code_challenge parameter.")
+            error = InvalidRequestError(
+                description="This application requires PKCE. Include a code_challenge parameter.",
+                state=credentials.get("state"),
+            )
             error.redirect_uri = redirect_uri
             return self.error_response(OAuthToolkitError(error=error), application=application)
 
         return None
 
     def form_valid(self, form):
-        credentials = {k: form.cleaned_data.get(k) for k in ("code_challenge", "code_challenge_method", "redirect_uri") if form.cleaned_data.get(k)}
+        credentials = {k: form.cleaned_data.get(k) for k in ("code_challenge", "code_challenge_method", "redirect_uri", "state") if form.cleaned_data.get(k)}
         error_response = self._check_pkce_required(form.cleaned_data["client_id"], credentials)
         if error_response is not None:
             return error_response

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -27,7 +27,7 @@ class AuthorizationView(oauth_views.AuthorizationView):
             return None
 
         pkce_required_globally = get_setting('OAUTH2_PROVIDER', {}).get('PKCE_REQUIRED', False)
-        if (application.pkce_required or pkce_required_globally) and "code_challenge" not in credentials:
+        if (application.pkce_required or pkce_required_globally) and not credentials.get("code_challenge"):
             redirect_uri = credentials.get("redirect_uri")
             error = InvalidRequestError(description="This application requires PKCE. Include a code_challenge parameter.")
             error.redirect_uri = redirect_uri

--- a/ansible_base/oauth2_provider/views/authorization.py
+++ b/ansible_base/oauth2_provider/views/authorization.py
@@ -20,11 +20,7 @@ class AuthorizationView(oauth_views.AuthorizationView):
         return super().get(request, *args, **kwargs)
 
     def _check_pkce_required(self, client_id, credentials):
-        app_model = get_application_model()
-        try:
-            application = app_model.objects.get(client_id=client_id)
-        except app_model.DoesNotExist:
-            return None
+        application = get_application_model().objects.get(client_id=client_id)
 
         pkce_required_globally = get_setting('OAUTH2_PROVIDER', {}).get('PKCE_REQUIRED', False)
         if (application.pkce_required or pkce_required_globally) and not credentials.get("code_challenge"):

--- a/test_app/tests/oauth2_provider/views/test_application.py
+++ b/test_app/tests/oauth2_provider/views/test_application.py
@@ -168,6 +168,74 @@ def test_oauth2_provider_application_create_no_app_url(request, client_fixture, 
         assert created_app.organization == organization
 
 
+def test_oauth2_provider_application_create_pkce_default(admin_api_client, randname, organization):
+    """
+    Creating an application without specifying pkce_required should default to True.
+    """
+    url = get_relative_url("application-list")
+    name = randname("Test Application")
+    response = admin_api_client.post(
+        url,
+        data={
+            'name': name,
+            'organization': organization.pk,
+            'redirect_uris': 'https://example.com/callback',
+            'authorization_grant_type': 'authorization-code',
+            'client_type': 'confidential',
+        },
+        format='json',
+    )
+    assert response.status_code == 201, response.data
+    assert response.data['pkce_required'] is True
+    created_app = OAuth2Application.objects.get(client_id=response.data['client_id'])
+    assert created_app.pkce_required is True
+
+
+def test_oauth2_provider_application_create_pkce_not_required(admin_api_client, randname, organization):
+    """
+    Creating an application with pkce_required=False should be honored.
+    """
+    url = get_relative_url("application-list")
+    name = randname("Test Application")
+    response = admin_api_client.post(
+        url,
+        data={
+            'name': name,
+            'organization': organization.pk,
+            'redirect_uris': 'https://example.com/callback',
+            'authorization_grant_type': 'authorization-code',
+            'client_type': 'confidential',
+            'pkce_required': False,
+        },
+        format='json',
+    )
+    assert response.status_code == 201, response.data
+    assert response.data['pkce_required'] is False
+    created_app = OAuth2Application.objects.get(client_id=response.data['client_id'])
+    assert created_app.pkce_required is False
+
+
+def test_oauth2_provider_application_update_pkce_required(admin_api_client, oauth2_application):
+    """
+    Updating pkce_required via PATCH should be honored.
+    """
+    app = oauth2_application[0]
+    assert app.pkce_required is True
+    url = get_relative_url("application-detail", args=[app.pk])
+
+    response = admin_api_client.patch(url, data={'pkce_required': False})
+    assert response.status_code == 200
+    assert response.data['pkce_required'] is False
+    app.refresh_from_db()
+    assert app.pkce_required is False
+
+    response = admin_api_client.patch(url, data={'pkce_required': True})
+    assert response.status_code == 200
+    assert response.data['pkce_required'] is True
+    app.refresh_from_db()
+    assert app.pkce_required is True
+
+
 def test_oauth2_provider_application_create_malformed_app_url(admin_api_client):
     """
     Validate malformed URL for app_url throws a 400

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -93,7 +93,8 @@ def test_oauth2_provider_authorize_view_flow(user_api_client, oauth2_application
 
 def test_authorize_pkce_required_without_challenge(user_api_client, oauth2_app_pkce_required):
     """
-    When pkce_required=True and the client omits code_challenge, the request should be rejected.
+    When pkce_required=True and the client omits code_challenge, the request should be rejected
+    with a 302 redirect containing error=invalid_request per RFC 6749 §4.1.2.1.
     """
     app = oauth2_app_pkce_required[0]
     url = get_relative_url("oauth2_provider:authorize")
@@ -104,7 +105,8 @@ def test_authorize_pkce_required_without_challenge(user_api_client, oauth2_app_p
         'redirect_uri': app.redirect_uris,
     }
     response = user_api_client.get(url + '?' + urlencode(query_params))
-    assert response.status_code == 400
+    assert response.status_code == 302
+    assert 'error=invalid_request' in response.url
 
 
 def test_authorize_pkce_required_with_challenge(user_api_client, oauth2_app_pkce_required):
@@ -180,7 +182,8 @@ def test_authorize_application_not_found(user_api_client, oauth2_app_pkce_requir
     mock_model.objects.get.side_effect = OAuth2Application.DoesNotExist
     with mock.patch(target, return_value=mock_model):
         response = user_api_client.get(url + '?' + urlencode(query_params))
-    assert response.status_code == 400
+    assert response.status_code == 302
+    assert 'error=invalid_request' in response.url
 
 
 def test_authorize_global_pkce_overrides_app_setting(user_api_client, oauth2_app_pkce_not_required):

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -107,6 +107,26 @@ def test_authorize_pkce_required_without_challenge(user_api_client, oauth2_app_p
     assert 'error=invalid_request' in response.url
 
 
+def test_authorize_pkce_required_with_empty_challenge(user_api_client, oauth2_app_pkce_required):
+    """
+    When pkce_required=True and the client sends an empty code_challenge, the request should
+    be rejected. An empty string is not a valid code_challenge per RFC 9126 / OAuth 2.1 §7.6.1.
+    """
+    app = oauth2_app_pkce_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+        'code_challenge': '',
+        'code_challenge_method': 'S256',
+    }
+    response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code == 302
+    assert 'error=invalid_request' in response.url
+
+
 def test_authorize_pkce_required_with_challenge(user_api_client, oauth2_app_pkce_required):
     """
     When pkce_required=True and the client sends code_challenge, the request should succeed.

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from django.conf import settings
 from django.test import override_settings
@@ -161,27 +159,21 @@ def test_authorize_pkce_not_required_with_challenge(user_api_client, oauth2_app_
     assert response.status_code == 200
 
 
-def test_authorize_application_not_found(user_api_client, oauth2_app_pkce_required):
+def test_authorize_post_pkce_required_without_challenge(user_api_client, oauth2_app_pkce_required):
     """
-    If the application lookup fails after validate_authorization_request passes,
-    the request should be rejected.
+    When pkce_required=True and the POST form submission omits code_challenge,
+    the request should be rejected with a 302 redirect containing error=invalid_request.
     """
     app = oauth2_app_pkce_required[0]
     url = get_relative_url("oauth2_provider:authorize")
-    query_params = {
+    post_data = {
         'client_id': app.client_id,
         'response_type': 'code',
         'scope': 'read',
         'redirect_uri': app.redirect_uris,
-        'code_challenge': 'some-challenge-value',
-        'code_challenge_method': 'S256',
+        'allow': 'Authorize',
     }
-    target = 'ansible_base.oauth2_provider.views.authorization.get_application_model'
-    mock_model = mock.MagicMock()
-    mock_model.DoesNotExist = OAuth2Application.DoesNotExist
-    mock_model.objects.get.side_effect = OAuth2Application.DoesNotExist
-    with mock.patch(target, return_value=mock_model):
-        response = user_api_client.get(url + '?' + urlencode(query_params))
+    response = user_api_client.post(url, data=post_data)
     assert response.status_code == 302
     assert 'error=invalid_request' in response.url
 

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -1,6 +1,40 @@
+from unittest import mock
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
 from django.utils.http import urlencode
 
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.oauth2_provider.models import OAuth2Application
+
+
+@pytest.fixture
+def oauth2_app_pkce_required(randname):
+    app = OAuth2Application(
+        name=randname("PKCE Required App"),
+        redirect_uris="https://example.com/callback",
+        authorization_grant_type="authorization-code",
+        client_type="confidential",
+        pkce_required=True,
+    )
+    secret = app.client_secret
+    app.save()
+    return (app, secret)
+
+
+@pytest.fixture
+def oauth2_app_pkce_not_required(randname):
+    app = OAuth2Application(
+        name=randname("PKCE Not Required App"),
+        redirect_uris="https://example.com/callback",
+        authorization_grant_type="authorization-code",
+        client_type="confidential",
+        pkce_required=False,
+    )
+    secret = app.client_secret
+    app.save()
+    return (app, secret)
 
 
 def test_oauth2_provider_authorize_view_as_admin(admin_api_client):
@@ -55,3 +89,137 @@ def test_oauth2_provider_authorize_view_flow(user_api_client, oauth2_application
     # On success, it takes us to the redirect_uri with the code
     assert 'code=' in response.url, response.url
     assert 'error=' not in response.url, response.url
+
+
+def test_authorize_pkce_required_without_challenge(user_api_client, oauth2_app_pkce_required):
+    """
+    When pkce_required=True and the client omits code_challenge, the request should be rejected.
+    """
+    app = oauth2_app_pkce_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+    }
+    response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code == 400
+
+
+def test_authorize_pkce_required_with_challenge(user_api_client, oauth2_app_pkce_required):
+    """
+    When pkce_required=True and the client sends code_challenge, the request should succeed.
+    """
+    app = oauth2_app_pkce_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+        'code_challenge': 'some-challenge-value',
+        'code_challenge_method': 'S256',
+    }
+    response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code == 200
+
+
+def test_authorize_pkce_not_required_without_challenge(user_api_client, oauth2_app_pkce_not_required):
+    """
+    When pkce_required=False and the client omits code_challenge, the request should succeed.
+    """
+    app = oauth2_app_pkce_not_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+    }
+    response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code == 200
+
+
+def test_authorize_pkce_not_required_with_challenge(user_api_client, oauth2_app_pkce_not_required):
+    """
+    When pkce_required=False and the client sends code_challenge, the request should succeed.
+    """
+    app = oauth2_app_pkce_not_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+        'code_challenge': 'some-challenge-value',
+        'code_challenge_method': 'S256',
+    }
+    response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code == 200
+
+
+def test_authorize_application_not_found(user_api_client, oauth2_app_pkce_required):
+    """
+    If the application lookup fails after validate_authorization_request passes,
+    the request should be rejected.
+    """
+    app = oauth2_app_pkce_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+        'code_challenge': 'some-challenge-value',
+        'code_challenge_method': 'S256',
+    }
+    target = 'ansible_base.oauth2_provider.views.authorization.get_application_model'
+    mock_model = mock.MagicMock()
+    mock_model.DoesNotExist = OAuth2Application.DoesNotExist
+    mock_model.objects.get.side_effect = OAuth2Application.DoesNotExist
+    with mock.patch(target, return_value=mock_model):
+        response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code == 400
+
+
+def test_authorize_global_pkce_overrides_app_setting(user_api_client, oauth2_app_pkce_not_required):
+    """
+    When global PKCE_REQUIRED=True, PKCE should be enforced even if the app has pkce_required=False.
+    DOT enforces the global setting during validate_authorization_request() and returns a 302
+    redirect with an error, so the request never reaches the per-app check.
+    """
+    app = oauth2_app_pkce_not_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+    }
+    global_pkce_settings = {**settings.OAUTH2_PROVIDER, 'PKCE_REQUIRED': True}
+    with override_settings(OAUTH2_PROVIDER=global_pkce_settings):
+        response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code != 200
+    if response.status_code == 302:
+        assert 'error' in response.url
+
+
+def test_authorize_global_pkce_with_challenge(user_api_client, oauth2_app_pkce_not_required):
+    """
+    When global PKCE_REQUIRED=True and the client sends code_challenge, the request should succeed.
+    """
+    app = oauth2_app_pkce_not_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    query_params = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+        'code_challenge': 'some-challenge-value',
+        'code_challenge_method': 'S256',
+    }
+    global_pkce_settings = {**settings.OAUTH2_PROVIDER, 'PKCE_REQUIRED': True}
+    with override_settings(OAUTH2_PROVIDER=global_pkce_settings):
+        response = user_api_client.get(url + '?' + urlencode(query_params))
+    assert response.status_code == 200

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -92,7 +92,7 @@ def test_oauth2_provider_authorize_view_flow(user_api_client, oauth2_application
 def test_authorize_pkce_required_without_challenge(user_api_client, oauth2_app_pkce_required):
     """
     When pkce_required=True and the client omits code_challenge, the request should be rejected
-    with a 302 redirect containing error=invalid_request per RFC 6749 §4.1.2.1.
+    with a 302 redirect containing error=invalid_request and state per RFC 6749 §4.1.2.1.
     """
     app = oauth2_app_pkce_required[0]
     url = get_relative_url("oauth2_provider:authorize")
@@ -101,10 +101,12 @@ def test_authorize_pkce_required_without_challenge(user_api_client, oauth2_app_p
         'response_type': 'code',
         'scope': 'read',
         'redirect_uri': app.redirect_uris,
+        'state': 'test-state-value',
     }
     response = user_api_client.get(url + '?' + urlencode(query_params))
     assert response.status_code == 302
     assert 'error=invalid_request' in response.url
+    assert 'state=test-state-value' in response.url
 
 
 def test_authorize_pkce_required_with_empty_challenge(user_api_client, oauth2_app_pkce_required):

--- a/test_app/tests/oauth2_provider/views/test_authorize.py
+++ b/test_app/tests/oauth2_provider/views/test_authorize.py
@@ -200,6 +200,28 @@ def test_authorize_post_pkce_required_without_challenge(user_api_client, oauth2_
     assert 'error=invalid_request' in response.url
 
 
+def test_authorize_post_pkce_required_with_challenge(user_api_client, oauth2_app_pkce_required):
+    """
+    When pkce_required=True and the POST form submission includes code_challenge,
+    the request should succeed.
+    """
+    app = oauth2_app_pkce_required[0]
+    url = get_relative_url("oauth2_provider:authorize")
+    post_data = {
+        'client_id': app.client_id,
+        'response_type': 'code',
+        'scope': 'read',
+        'redirect_uri': app.redirect_uris,
+        'allow': 'Authorize',
+        'code_challenge': 'some-challenge-value',
+        'code_challenge_method': 'S256',
+    }
+    response = user_api_client.post(url, data=post_data)
+    assert response.status_code == 302
+    assert 'code=' in response.url
+    assert 'error=' not in response.url
+
+
 def test_authorize_global_pkce_overrides_app_setting(user_api_client, oauth2_app_pkce_not_required):
     """
     When global PKCE_REQUIRED=True, PKCE should be enforced even if the app has pkce_required=False.
@@ -217,9 +239,8 @@ def test_authorize_global_pkce_overrides_app_setting(user_api_client, oauth2_app
     global_pkce_settings = {**settings.OAUTH2_PROVIDER, 'PKCE_REQUIRED': True}
     with override_settings(OAUTH2_PROVIDER=global_pkce_settings):
         response = user_api_client.get(url + '?' + urlencode(query_params))
-    assert response.status_code != 200
-    if response.status_code == 302:
-        assert 'error' in response.url
+    assert response.status_code == 302
+    assert 'error=invalid_request' in response.url
 
 
 def test_authorize_global_pkce_with_challenge(user_api_client, oauth2_app_pkce_not_required):


### PR DESCRIPTION
## Description
Adds a pkce_required boolean field to OAuth2Application enabling per-application PKCE enforcement at the authorize endpoint. New apps default to pkce_required=True; existing apps receive False via migration to preserve current behavior. The global PKCE_REQUIRED setting acts as a floor — when True, PKCE is enforced regardless of the per-app setting.

This is a requirement for ANSTRAT-2250 (MCP Server OAuth 2.1 Integration) to move forward.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
A running AAP instance with the gateway accessible.
A client compatible with OAuth 2.1 or a script that simulates a client

### Steps to Test
1. Create an OAuth2 application with pkce_required=true via the API
2. Hit /o/authorize/ without code_challenge — should get 400
3. Hit /o/authorize/ with code_challenge and code_challenge_method=S256 — should get 200
4. Create an application with pkce_required=false, repeat steps 2-3 — both should succeed

### Expected Results
PKCE is enforced only for apps with pkce_required=true or when global PKCE_REQUIRED=True. Existing apps are unaffected. All tests pass.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [x] Requires documentation updates
  The new application-level field will need to be documented.  Documentation on the global pkce_enabled setting will also need to be updated
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [x] Requires coordination with other teams
  UI and gateway
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `pkce_required` option to OAuth2 applications (defaulting to enabled) to require `code_challenge` for authorization-code requests.
  * Authorization endpoint now enforces PKCE on both GET and POST; missing or empty `code_challenge` is rejected with `invalid_request` while preserving `state`.
  * Added support for global PKCE enforcement that applies to all applications.
* **Bug Fixes**
  * Updated authorization endpoint handling to ensure the PKCE-enforcing implementation is used.
* **Tests**
  * Added coverage for application create/update defaults, PKCE-required vs not-required behavior, and global override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->