### PR TITLE
[AAP-82668] Add deferred_activity_stream context manager for batched audit logging

### DIFF
--- a/ansible_base/activitystream/__init__.py
+++ b/ansible_base/activitystream/__init__.py
@@ -1,3 +1,3 @@
-from ansible_base.activitystream.signals import no_activity_stream
+from ansible_base.activitystream.signals import deferred_activity_stream, no_activity_stream
 
-__all__ = ['no_activity_stream']
+__all__ = ['deferred_activity_stream', 'no_activity_stream']

--- a/ansible_base/activitystream/signals.py
+++ b/ansible_base/activitystream/signals.py
@@ -25,6 +25,16 @@ class ActivityStreamEnabled(threading.local):
 activitystream_enabled = ActivityStreamEnabled()
 
 
+class _DeferredActivityStream(threading.local):
+    def __init__(self) -> None:
+        self.active: bool = False
+        self.entries: list = []
+        self.audit_lines: list[str] = []
+
+
+_deferred_activity_stream = _DeferredActivityStream()
+
+
 @contextmanager
 def no_activity_stream() -> Generator[None, None, None]:
     previous_value = activitystream_enabled.enabled
@@ -35,12 +45,108 @@ def no_activity_stream() -> Generator[None, None, None]:
         activitystream_enabled.enabled = previous_value
 
 
+def _flush_deferred_activity_stream(entries: list, audit_lines: list[str]) -> None:
+    """Flush accumulated activity stream entries and audit log lines.
+
+    Bulk-creates Entry objects (filling in created_by where missing) and
+    schedules audit lines for emission via transaction.on_commit so they
+    only fire after the enclosing transaction commits.
+    """
+    if entries:
+        from ansible_base.activitystream.models import Entry
+        from ansible_base.lib.utils.models import current_user_or_system_user
+
+        user = current_user_or_system_user()
+        for entry in entries:
+            if entry.created_by is None:
+                entry.created_by = user
+
+        Entry.objects.bulk_create(entries)
+        logger.debug('Bulk-created %d deferred activity stream entries', len(entries))
+
+    if audit_lines:
+        from django.db import connection
+
+        def _emit_audit_lines(lines=audit_lines):
+            for line in lines:
+                log_auth_event(line)
+
+        connection.on_commit(_emit_audit_lines)
+
+
+@contextmanager
+def deferred_activity_stream() -> Generator[None, None, None]:
+    """Defer activity stream entries and audit log lines during bulk operations.
+
+    While active, _store_activitystream_entry accumulates Entry objects and
+    audit log lines in thread-local lists instead of writing them immediately.
+    On successful exit, Entry objects are bulk-created and audit lines are
+    emitted via transaction.on_commit (so they only fire after the enclosing
+    transaction commits — a rollback silently discards them).
+    Re-entrant: inner calls are no-ops (outermost caller owns the flush).
+    """
+    if _deferred_activity_stream.active:
+        yield
+        return
+    _deferred_activity_stream.active = True
+    try:
+        yield
+    except BaseException:
+        _deferred_activity_stream.active = False
+        _deferred_activity_stream.entries = []
+        _deferred_activity_stream.audit_lines = []
+        raise
+    else:
+        entries = _deferred_activity_stream.entries
+        audit_lines = _deferred_activity_stream.audit_lines
+        _deferred_activity_stream.active = False
+        _deferred_activity_stream.entries = []
+        _deferred_activity_stream.audit_lines = []
+        _flush_deferred_activity_stream(entries, audit_lines)
+
+
 def _get_actor_user_and_username() -> Tuple[Optional[AbstractUser], str]:
     """Return (current user, username) or (None, 'unknown') if outside request."""
     from ansible_base.lib.utils.models import current_user_or_system_user
 
     user = current_user_or_system_user()
     return (user, user.username if user else "unknown")
+
+
+def _format_audit_lines(
+    prefix: str,
+    operation: str,
+    model_name: str,
+    obj_str: str,
+    changes: Union[Dict[str, Any], str],
+) -> list[str]:
+    """Build audit log line(s) for a single object change.
+
+    For m2m associate/disassociate, *changes* is a plain string appended to the
+    line.  For create/delete it is a dict collapsed into a single summary line.
+    For update it is a dict expanded into one line per field.
+    """
+    if isinstance(changes, str):
+        return [f"{prefix}{operation} {model_name} {obj_str} {changes}"]
+
+    if operation in ('create', 'delete'):
+        all_fields: Dict[str, Any] = {}
+        if operation == 'create':
+            all_fields.update(changes.get('added_fields', {}))
+        else:
+            all_fields.update(changes.get('removed_fields', {}))
+        changed = changes.get('changed_fields', {})
+        all_fields.update({k: v[1] if operation == 'create' else v[0] for k, v in changed.items()})
+        return [f"{prefix}{operation} {model_name} {obj_str} {all_fields}"]
+
+    lines = []
+    for field_name, value in changes.get('added_fields', {}).items():
+        lines.append(f"{prefix}{operation} {model_name} {obj_str} added {field_name}='{value}'")
+    for field_name, value in changes.get('removed_fields', {}).items():
+        lines.append(f"{prefix}{operation} {model_name} {obj_str} removed {field_name} (was '{value}')")
+    for field_name, (old_val, new_val) in changes.get('changed_fields', {}).items():
+        lines.append(f"{prefix}{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
+    return lines
 
 
 def _log_audit_entry(
@@ -50,34 +156,27 @@ def _log_audit_entry(
     changes: Union[Dict[str, Any], str],
 ) -> None:
     """Emit audit log lines if content_object has audit_log_enabled.
-    For create/update/delete, changes is a dict (added_fields, removed_fields, changed_fields).
-    For m2m associate/disassociate, changes is the rest of the line as a string (e.g. 'with Team Parent (2)')."""
+
+    For create/update/delete, *changes* is a dict (added_fields,
+    removed_fields, changed_fields).  For m2m associate/disassociate,
+    *changes* is the rest of the line as a string
+    (e.g. ``'with Team Parent (2)'``).
+    """
     if not getattr(content_object, 'audit_log_enabled', False):
         return
+
     model_name = content_object.__class__.__name__
     obj_str = f"{content_object} ({content_object.pk})"
     _, actor_username = _get_actor_user_and_username()
     prefix = f"User: {actor_username} "
-    if isinstance(changes, str):
-        log_auth_event(f"{prefix}{operation} {model_name} {obj_str} {changes}")
-        return
-    if operation in ('create', 'delete'):
-        # For create/delete, dump the whole object state as a dict
-        all_fields = {}
-        if operation == 'create':
-            all_fields.update(changes.get('added_fields', {}))
-        else:
-            all_fields.update(changes.get('removed_fields', {}))
-        all_fields.update({k: v[1] if operation == 'create' else v[0] for k, v in changes.get('changed_fields', {}).items()})
-        log_auth_event(f"{prefix}{operation} {model_name} {obj_str} {all_fields}")
+
+    lines = _format_audit_lines(prefix, operation, model_name, obj_str, changes)
+
+    if _deferred_activity_stream.active:
+        _deferred_activity_stream.audit_lines.extend(lines)
     else:
-        # For update, emit one line per change
-        for field_name, value in changes.get('added_fields', {}).items():
-            log_auth_event(f"{prefix}{operation} {model_name} {obj_str} added {field_name}='{value}'")
-        for field_name, value in changes.get('removed_fields', {}).items():
-            log_auth_event(f"{prefix}{operation} {model_name} {obj_str} removed {field_name} (was '{value}')")
-        for field_name, (old_val, new_val) in changes.get('changed_fields', {}).items():
-            log_auth_event(f"{prefix}{operation} {model_name} {obj_str} changed {field_name} from '{old_val}' to '{new_val}'")
+        for line in lines:
+            log_auth_event(line)
 
 
 def _get_limit(
@@ -147,11 +246,18 @@ def _store_activitystream_entry(
     )
 
     if getattr(content_object, 'activity_stream_enabled', True):
-        return Entry.objects.create(
-            content_object=content_object,
-            operation=operation,
-            changes=delta.dict(),
-        )
+        from django.contrib.contenttypes.models import ContentType
+
+        entry_kwargs = {
+            'content_type': ContentType.objects.get_for_model(content_object),
+            'object_id': str(content_object.pk),
+            'operation': operation,
+            'changes': delta.dict(),
+        }
+        if _deferred_activity_stream.active:
+            _deferred_activity_stream.entries.append(Entry(**entry_kwargs))
+            return None
+        return Entry.objects.create(**entry_kwargs)
     return None
 
 

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -299,7 +299,11 @@ def diff(
                 continue
 
             if all_values_as_strings:
-                if getattr(obj, field) is None:
+                # Use attname (e.g. owner_id) for FK fields to avoid
+                # triggering a lazy-load SELECT for the related object.
+                # value_to_string() only needs the raw PK anyway.
+                check_attr = field_obj.attname if hasattr(field_obj, 'attname') else field
+                if getattr(obj, check_attr) is None:
                     value = None
                 else:
                     value = field_obj.value_to_string(obj)

--- a/test_app/tests/activitystream/test_signals.py
+++ b/test_app/tests/activitystream/test_signals.py
@@ -2,6 +2,7 @@ import re
 from unittest import mock
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 
 import ansible_base.activitystream.signals as signals
 from ansible_base.activitystream import no_activity_stream
@@ -865,6 +866,122 @@ def test_audit_log_message_content(expected_content):
 # =============================================================================
 
 
+class TestFormatAuditLines:
+    """Unit tests for _format_audit_lines helper."""
+
+    PREFIX = "User: admin "
+
+    @pytest.mark.parametrize(
+        'operation,changes,expected_substring',
+        [
+            (
+                'create',
+                {'added_fields': {'name': 'foo', 'email': 'a@b.com'}, 'removed_fields': {}, 'changed_fields': {}},
+                "create MyModel obj (1) {'name': 'foo', 'email': 'a@b.com'}",
+            ),
+            (
+                'delete',
+                {'added_fields': {}, 'removed_fields': {'name': 'foo'}, 'changed_fields': {}},
+                "delete MyModel obj (1) {'name': 'foo'}",
+            ),
+        ],
+        ids=['create_formats_added_fields', 'delete_formats_removed_fields'],
+    )
+    def test_create_and_delete_operations(self, operation, changes, expected_substring):
+        """Create and delete operations produce a single summary line."""
+        lines = signals._format_audit_lines(self.PREFIX, operation, 'MyModel', 'obj (1)', changes)
+        assert len(lines) == 1
+        assert expected_substring in lines[0]
+        assert lines[0].startswith(self.PREFIX)
+
+    @pytest.mark.parametrize(
+        'changes,expected_fragments',
+        [
+            (
+                {'added_fields': {'role': 'admin'}, 'removed_fields': {}, 'changed_fields': {}},
+                ["added role='admin'"],
+            ),
+            (
+                {'added_fields': {}, 'removed_fields': {'role': 'admin'}, 'changed_fields': {}},
+                ["removed role (was 'admin')"],
+            ),
+            (
+                {'added_fields': {}, 'removed_fields': {}, 'changed_fields': {'name': ('old', 'new')}},
+                ["changed name from 'old' to 'new'"],
+            ),
+            (
+                {
+                    'added_fields': {'email': 'a@b.com'},
+                    'removed_fields': {'phone': '555'},
+                    'changed_fields': {'name': ('old', 'new')},
+                },
+                ["added email='a@b.com'", "removed phone (was '555')", "changed name from 'old' to 'new'"],
+            ),
+        ],
+        ids=[
+            'update_added_field',
+            'update_removed_field',
+            'update_changed_field',
+            'update_all_field_types',
+        ],
+    )
+    def test_update_operation(self, changes, expected_fragments):
+        """Update operations produce one line per field change."""
+        lines = signals._format_audit_lines(self.PREFIX, 'update', 'MyModel', 'obj (1)', changes)
+        assert len(lines) == len(expected_fragments)
+        for fragment in expected_fragments:
+            assert any(fragment in line for line in lines), f"Expected '{fragment}' in {lines}"
+
+    def test_string_changes_m2m(self):
+        """M2M associate/disassociate passes changes as a plain string."""
+        lines = signals._format_audit_lines(self.PREFIX, 'associate', 'MyModel', 'obj (1)', 'with Team Parent (2)')
+        assert len(lines) == 1
+        assert lines[0] == f"{self.PREFIX}associate MyModel obj (1) with Team Parent (2)"
+
+    @pytest.mark.parametrize(
+        'operation,preposition',
+        [
+            ('associate', 'with'),
+            ('disassociate', 'from'),
+        ],
+        ids=['associate_with', 'disassociate_from'],
+    )
+    def test_m2m_prepositions(self, operation, preposition):
+        """Both associate and disassociate string changes format correctly."""
+        change_str = f"{preposition} Team Foo (99)"
+        lines = signals._format_audit_lines(self.PREFIX, operation, 'Widget', 'w (5)', change_str)
+        assert len(lines) == 1
+        assert f"{operation} Widget w (5) {preposition} Team Foo (99)" in lines[0]
+
+    def test_create_with_changed_fields_uses_new_value(self):
+        """For create, changed_fields should use the new value (index 1)."""
+        changes = {
+            'added_fields': {},
+            'removed_fields': {},
+            'changed_fields': {'status': ('draft', 'published')},
+        }
+        lines = signals._format_audit_lines(self.PREFIX, 'create', 'Post', 'p (3)', changes)
+        assert len(lines) == 1
+        assert 'published' in lines[0]
+
+    def test_delete_with_changed_fields_uses_old_value(self):
+        """For delete, changed_fields should use the old value (index 0)."""
+        changes = {
+            'added_fields': {},
+            'removed_fields': {},
+            'changed_fields': {'status': ('published', 'archived')},
+        }
+        lines = signals._format_audit_lines(self.PREFIX, 'delete', 'Post', 'p (3)', changes)
+        assert len(lines) == 1
+        assert 'published' in lines[0]
+
+    def test_empty_update_changes(self):
+        """Update with no fields in any category returns empty list."""
+        changes = {'added_fields': {}, 'removed_fields': {}, 'changed_fields': {}}
+        lines = signals._format_audit_lines(self.PREFIX, 'update', 'MyModel', 'obj (1)', changes)
+        assert lines == []
+
+
 @pytest.mark.django_db
 def test_audit_log_m2m_associate(user):
     """
@@ -942,3 +1059,200 @@ def test_audit_log_m2m_preposition(user, operation, method_name, expected_prepos
         call_args = mock_log.call_args[0][0]
         assert expected_preposition in call_args
         assert operation in call_args
+
+
+# =============================================================================
+# Tests for _flush_deferred_activity_stream helper
+# =============================================================================
+
+
+class TestFlushDeferredActivityStream:
+    """Tests for the extracted _flush_deferred_activity_stream helper."""
+
+    @pytest.mark.django_db
+    def test_empty_entries_and_lines_is_noop(self):
+        """Calling with empty entries and empty audit_lines does nothing."""
+        signals._flush_deferred_activity_stream([], [])
+        # No error, no entries created
+
+    @pytest.mark.django_db
+    def test_bulk_creates_entries_with_user(self, system_user):
+        """Entries with created_by=None get the current user filled in and are bulk-created."""
+
+        animal = Animal.objects.create(name='flush-test')
+        ct = ContentType.objects.get_for_model(animal)
+        entry = Entry(
+            content_type=ct,
+            object_id=str(animal.pk),
+            operation='create',
+            changes={'added_fields': {'name': 'flush-test'}, 'changed_fields': {}, 'removed_fields': {}},
+            created_by=None,
+        )
+
+        signals._flush_deferred_activity_stream([entry], [])
+
+        saved = Entry.objects.filter(content_type=ct, object_id=str(animal.pk), operation='create').last()
+        assert saved is not None
+        assert saved.created_by == system_user
+
+    @pytest.mark.django_db
+    def test_schedules_audit_lines_on_commit(self):
+        """Audit lines are scheduled via connection.on_commit."""
+        with mock.patch('ansible_base.activitystream.signals.log_auth_event') as mock_log:
+            from django.db import connection
+
+            with mock.patch.object(connection, 'on_commit') as mock_on_commit:
+                signals._flush_deferred_activity_stream([], ['line1', 'line2'])
+
+            mock_on_commit.assert_called_once()
+            # Call the scheduled function to verify it emits the lines
+            scheduled_fn = mock_on_commit.call_args[0][0]
+            scheduled_fn()
+            assert mock_log.call_count == 2
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        'entries_count,lines_count',
+        [(0, 2), (1, 0), (2, 3)],
+        ids=['only_lines', 'only_entries', 'both'],
+    )
+    def test_handles_entries_and_lines_independently(self, system_user, entries_count, lines_count):
+        """Each path (entries and audit_lines) operates independently."""
+
+        animal = Animal.objects.create(name='independent-test')
+        ct = ContentType.objects.get_for_model(animal)
+        entries = [
+            Entry(
+                content_type=ct,
+                object_id=str(animal.pk),
+                operation='create',
+                changes={'added_fields': {}, 'changed_fields': {}, 'removed_fields': {}},
+            )
+            for _ in range(entries_count)
+        ]
+        lines = [f'audit line {i}' for i in range(lines_count)]
+
+        initial_count = Entry.objects.filter(content_type=ct, object_id=str(animal.pk)).count()
+
+        with mock.patch('django.db.connection.on_commit') as mock_on_commit:
+            signals._flush_deferred_activity_stream(entries, lines)
+
+        assert Entry.objects.filter(content_type=ct, object_id=str(animal.pk)).count() == initial_count + entries_count
+        if lines_count > 0:
+            mock_on_commit.assert_called_once()
+        else:
+            mock_on_commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for deferred_activity_stream context manager (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredActivityStream:
+    """Integration tests for the deferred_activity_stream context manager."""
+
+    @pytest.mark.django_db
+    def test_entries_are_deferred_and_bulk_created(self, system_user):
+        """Activity stream entries created inside deferred_activity_stream
+        are accumulated and bulk-created on exit, not saved individually."""
+        from ansible_base.activitystream.signals import deferred_activity_stream
+
+        Animal.objects.create(name='deferred-1')
+        initial_count = Entry.objects.count()
+
+        with deferred_activity_stream():
+            animal_2 = Animal.objects.create(name='deferred-2')
+            animal_3 = Animal.objects.create(name='deferred-3')
+            # While deferred, new entries should not yet be in the DB
+            assert Entry.objects.count() == initial_count
+
+        # After exit, all entries should be flushed
+        assert Entry.objects.count() > initial_count
+        assert Entry.objects.filter(operation='create', object_id=str(animal_2.pk)).exists()
+        assert Entry.objects.filter(operation='create', object_id=str(animal_3.pk)).exists()
+
+    @pytest.mark.django_db
+    def test_entries_discarded_on_exception(self, system_user):
+        """Accumulated entries are discarded when the body raises."""
+        from ansible_base.activitystream.signals import deferred_activity_stream
+
+        initial_count = Entry.objects.count()
+
+        def _create_and_raise():
+            with deferred_activity_stream():
+                Animal.objects.create(name='discard-me')
+                raise RuntimeError('test discard')
+
+        with pytest.raises(RuntimeError, match='test discard'):
+            _create_and_raise()
+
+        # No new entries should have been created
+        assert Entry.objects.count() == initial_count
+
+    @pytest.mark.django_db
+    def test_reentrant_inner_is_noop(self, system_user):
+        """Inner deferred_activity_stream calls are no-ops; outermost flushes."""
+        from ansible_base.activitystream.signals import deferred_activity_stream
+
+        initial_count = Entry.objects.count()
+
+        with deferred_activity_stream():
+            Animal.objects.create(name='outer')
+            with deferred_activity_stream():
+                Animal.objects.create(name='inner')
+                # Still deferred — nothing flushed yet
+                assert Entry.objects.count() == initial_count
+            # Inner exited but outer still active — still deferred
+            assert Entry.objects.count() == initial_count
+
+        # Outermost exit flushes all
+        assert Entry.objects.count() > initial_count
+        assert Entry.objects.filter(operation='create', changes__added_fields__name='outer').exists()
+        assert Entry.objects.filter(operation='create', changes__added_fields__name='inner').exists()
+
+    @pytest.mark.django_db
+    def test_delete_entries_are_deferred(self, system_user):
+        """Delete activity stream entries are also deferred."""
+        from ansible_base.activitystream.signals import deferred_activity_stream
+
+        animal = Animal.objects.create(name='will-delete')
+        animal_pk = animal.pk
+        delete_count_before = Entry.objects.filter(operation='delete').count()
+
+        with deferred_activity_stream():
+            animal.delete()
+            # Delete entry should be deferred — no new delete entries yet
+            assert Entry.objects.filter(operation='delete').count() == delete_count_before
+
+        # After flush, delete entry should exist
+        assert Entry.objects.filter(operation='delete', object_id=str(animal_pk)).exists()
+
+    @pytest.mark.django_db
+    def test_deferred_delete_query_scaling(self, system_user):
+        """deferred_activity_stream should not scale queries with FK field count.
+
+        The diff() utility used by _store_activitystream_entry should use
+        attname (e.g. owner_id) for FK fields instead of the descriptor
+        (e.g. owner) to avoid triggering lazy-load SELECTs for related objects.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from ansible_base.activitystream.signals import deferred_activity_stream, no_activity_stream
+
+        N = 20
+        with no_activity_stream():
+            for i in range(N):
+                Animal.objects.create(name=f'scale-{i}', owner=system_user)
+
+        with CaptureQueriesContext(connection) as ctx:
+            with deferred_activity_stream():
+                Animal.objects.filter(name__startswith='scale-').delete()
+
+        selects = sum(1 for q in ctx if q['sql'].strip().upper().startswith('SELECT'))
+        assert selects < N, (
+            f"Expected fewer than {N} SELECTs for {N} deletes, got {selects}. "
+            f"diff() is likely lazy-loading FK fields via getattr(obj, field) "
+            f"instead of getattr(obj, field_obj.attname)."
+        )


### PR DESCRIPTION
## Summary

- Adds `deferred_activity_stream()` context manager that accumulates `Entry` objects and audit log lines during bulk operations
- On successful exit, entries are `bulk_create`d and audit lines emitted via `transaction.on_commit`
- On exception, accumulated state is discarded (no false audit trail for rolled-back transactions)
- Re-entrant: inner calls are no-ops (outermost caller owns the flush)
- Populates `created_by` on deferred entries before `bulk_create` since `save()` is bypassed
- Extracts `_flush_deferred_activity_stream` and `_format_audit_lines` helpers to reduce cognitive complexity

## Context

Organization deletion at scale triggers per-object activity stream signals during the Django cascade. This context manager enables callers to batch that work:

```python
with deferred_activity_stream():
    org.delete()  # entries accumulate instead of individual INSERTs
# flush: bulk_create + on_commit for audit lines
```

Used by both PR #1050 (raw SQL RBAC cascade optimization) and PR #1053 (batch RBAC rebuilding) to defer activity stream work during org deletion.

Companion AWX PR: https://github.com/ansible/awx/pull/16553

## Test plan

- [x] 71 activity stream tests pass (existing + new)
- [x] `TestFlushDeferredActivityStream` — bulk create, user fill-in, on_commit scheduling
- [x] `TestFormatAuditLines` — create/delete/update formatting, M2M, edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public context manager to defer activity stream side effects, batching entry persistence and emitting related audit events after the surrounding transaction commits.
  - Exposed the deferred activity stream capability for external use.

- **Bug Fixes**
  - Improved audit-log message formatting across create, update, delete, and many-to-many activity changes, including clearer per-field update details and consistent “with/from” wording.

- **Tests**
  - Expanded unit and integration coverage for audit formatting, deferred flushing via commit, independence of buffered entries vs audit lines, nested behavior, and discard-on-error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->