### PR TITLE
AAP-85067 Bulk RBAC assignments for user claims processing

### DIFF
--- a/ansible_base/jwt_consumer/awx/auth.py
+++ b/ansible_base/jwt_consumer/awx/auth.py
@@ -1,6 +1,8 @@
 # Python
 import logging
 
+from django.apps import apps
+
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 
 logger = logging.getLogger('ansible_base.jwt_consumer.awx.auth')
@@ -8,3 +10,68 @@ logger = logging.getLogger('ansible_base.jwt_consumer.awx.auth')
 
 class AwxJWTAuthentication(JWTAuthentication):
     use_rbac_permissions = True
+
+    def process_permissions(self):
+        super().process_permissions()
+        saved_claims = getattr(self.common_auth, '_saved_claims', None)
+        if saved_claims is not None:
+            objects, object_roles, _ = saved_claims
+            self._sync_old_rbac(self.common_auth.user, objects, object_roles)
+
+    def _sync_old_rbac(self, user, objects, object_roles):
+        """Sync old AWX Role.members to match the claims that were just processed.
+
+        bulk_create skips post_save signals, so AWX's signal-based sync
+        doesn't fire. This method replaces that by syncing directly from
+        the claims dict.
+        """
+        try:
+            from awx.main.models.rbac import ROLE_DEFINITION_TO_ROLE_FIELD, Role
+            from awx.main.signals import disable_activity_stream
+        except ImportError:
+            return
+
+        managed_field_names = set(ROLE_DEFINITION_TO_ROLE_FIELD.values())
+        resource_map = self._build_resource_map(objects, object_roles)
+
+        with disable_activity_stream():
+            desired_role_pks = self._add_desired_members(user, objects, object_roles, resource_map, ROLE_DEFINITION_TO_ROLE_FIELD)
+            self._remove_stale_members(user, Role, managed_field_names, desired_role_pks)
+
+    def _build_resource_map(self, objects, object_roles):
+        Resource = apps.get_model('dab_resource_registry', 'Resource')
+        all_ansible_ids = set()
+        for role_data in object_roles.values():
+            ct = role_data['content_type']
+            for idx in role_data['objects']:
+                all_ansible_ids.add(objects[ct][idx]['ansible_id'])
+        return {str(r.ansible_id): r for r in Resource.objects.filter(ansible_id__in=all_ansible_ids)}
+
+    def _add_desired_members(self, user, objects, object_roles, resource_map, role_field_map):
+        desired_role_pks = set()
+        for role_name, role_data in object_roles.items():
+            field_name = role_field_map.get(role_name)
+            if not field_name:
+                continue
+            ct = role_data['content_type']
+            for idx in role_data['objects']:
+                ansible_id = objects[ct][idx]['ansible_id']
+                resource = resource_map.get(ansible_id)
+                if resource is None:
+                    continue
+                content_object = resource.content_object
+                if content_object is None:
+                    continue
+                old_role = getattr(content_object, field_name, None)
+                if old_role is not None:
+                    old_role.members.add(user)
+                    desired_role_pks.add(old_role.pk)
+        return desired_role_pks
+
+    def _remove_stale_members(self, user, Role, managed_field_names, desired_role_pks):
+        stale_roles = Role.objects.filter(
+            members=user,
+            role_field__in=managed_field_names,
+        ).exclude(pk__in=desired_role_pks)
+        for role in stale_roles:
+            role.members.remove(user)

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -296,6 +296,7 @@ class JWTCommonAuth:
 
             # Process the RBAC permissions with the gateway claims
             save_user_claims(self.user, objects, object_roles, global_roles)
+            self._saved_claims = (objects, object_roles, global_roles)
 
             # Update cache with the new hash
             self.cache.cache_claims_hash(user_ansible_id, jwt_claims_hash)

--- a/ansible_base/rbac/caching.py
+++ b/ansible_base/rbac/caching.py
@@ -1,5 +1,6 @@
 import gc
 import logging
+import threading
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import Optional, Union
@@ -29,6 +30,38 @@ NOTE:
 This is highly dependent on the model methods ObjectRole.needed_cache_updates and expected_direct_permissions
 Those methods are what truly dictate the object-role to object-permission translation
 """
+
+
+class DeferRBACComputations(threading.local):
+    def __init__(self):
+        self.active = False
+        self.deleted_team_pks: set[int] = set()
+        self.deleted_object_pks: list[tuple[int, Union[int, UUID]]] = []
+        self.created_instances: list[tuple] = []
+
+    @property
+    def has_deferred_data(self):
+        return bool(self.deleted_team_pks or self.deleted_object_pks or self.created_instances)
+
+
+defer_rbac_state = DeferRBACComputations()
+
+
+def team_ids_from_role_target(object_role: 'ObjectRole') -> set[int]:
+    """Derive which teams a member_team ObjectRole targets from its content type.
+
+    Used only when the provides_teams relationship is not yet computed —
+    i.e. for newly created ObjectRoles or when member_team permission was
+    just added to a RoleDefinition. For existing roles where provides_teams
+    is already populated, query provides_teams directly instead.
+    """
+    if object_role.content_type_id == permission_registry.team_ct_id:
+        return {int(object_role.object_id)}
+    if object_role.content_type_id == permission_registry.org_ct_id:
+        parent_fd = permission_registry.get_parent_fd_name(permission_registry.team_model)
+        if parent_fd:
+            return set(permission_registry.team_model.objects.filter(**{f'{parent_fd}_id': int(object_role.object_id)}).values_list('id', flat=True))
+    return set()
 
 
 def bulk_ancestor_roles(team_pks: Iterable[int]) -> set['ObjectRole']:
@@ -70,6 +103,14 @@ def cleanup_deleted_object_roles(object_pks: list[tuple[int, int | UUID]]) -> se
         if uuid_ids:
             RoleEvaluationUUID.objects.filter(content_type_id=ct_id, object_id__in=uuid_ids).delete()
     return deleted_or_ids
+
+
+def cleanup_orphaned_object_roles() -> int:
+    """Delete ObjectRoles with no user or team assignments."""
+    deleted_count, _ = ObjectRole.objects.filter(users__isnull=True, teams__isnull=True).delete()
+    if deleted_count:
+        logger.info('Cleaned up %d orphaned ObjectRole(s)', deleted_count)
+    return deleted_count
 
 
 def object_roles_for_parents(parent_gfks: set[tuple]) -> set['ObjectRole']:

--- a/ansible_base/rbac/claims.py
+++ b/ansible_base/rbac/claims.py
@@ -13,6 +13,7 @@ from ansible_base.lib.utils.auth import get_team_model
 
 from .models.content_type import DABContentType
 from .models.role import RoleDefinition, RoleUserAssignment
+from .pipeline import bulk_give_permissions, remove_assignments
 
 logger = logging.getLogger(__name__)
 
@@ -313,35 +314,36 @@ def save_user_claims(user: Model, objects: dict, object_roles: dict, global_role
     """
     Apply RBAC permissions from claims data
     """
-    role_diff = RoleUserAssignment.objects.filter(user=user, role_definition__name__in=settings.ANSIBLE_BASE_JWT_MANAGED_ROLES)
 
+    managed_roles = settings.ANSIBLE_BASE_JWT_MANAGED_ROLES
+
+    # Global roles are few (0-2 typically), keep serial
+    global_assignment_pks = set()
     for system_role_name in global_roles:
-        logger.debug(f"Processing system role {system_role_name} for {user.username}")
         rd = get_role_definition(system_role_name)
-        if rd:
-            if rd.name in settings.ANSIBLE_BASE_JWT_MANAGED_ROLES:
-                assignment = rd.give_global_permission(user)
-                role_diff = role_diff.exclude(pk=assignment.pk)
-                logger.info(f"Granted user {user.username} global role {system_role_name}")
-            else:
-                logger.error(f"Unable to grant {user.username} system level role {system_role_name} because it is not a JWT managed role")
-        else:
+        if rd is None:
             logger.error(f"Unable to grant {user.username} system level role {system_role_name} because it does not exist")
             continue
+        if rd.name not in managed_roles:
+            logger.error(f"Unable to grant {user.username} system level role {system_role_name} because it is not a JWT managed role")
+            continue
+        assignment = rd.give_global_permission(user)
+        global_assignment_pks.add(assignment.pk)
+        logger.info(f"Granting user {user.username} global role {system_role_name}")
 
-    for object_role_name in object_roles.keys():
+    # Pass 1: resolve resources (may create org/team stubs)
+    desired_permissions = []
+    for object_role_name, role_data in object_roles.items():
         rd = get_role_definition(object_role_name)
         if rd is None:
             logger.error(f"Unable to grant {user.username} object role {object_role_name} because it does not exist")
             continue
-        elif rd.name not in settings.ANSIBLE_BASE_JWT_MANAGED_ROLES:
+        if rd.name not in managed_roles:
             logger.error(f"Unable to grant {user.username} object role {object_role_name} because it is not a JWT managed role")
             continue
 
-        object_type = object_roles[object_role_name]['content_type']
-        object_indexes = object_roles[object_role_name]['objects']
-
-        for index in object_indexes:
+        object_type = role_data['content_type']
+        for index in role_data['objects']:
             object_data = objects[object_type][index]
             try:
                 resource, obj = get_or_create_resource(objects, object_type, object_data)
@@ -351,20 +353,33 @@ def save_user_claims(user: Model, objects: dict, object_roles: dict, global_role
                     "Please make sure the sync task is running to prevent this warning in the future."
                 )
                 continue
-
             if resource is not None:
-                assignment = rd.give_permission(user, obj)
-                role_diff = role_diff.exclude(pk=assignment.pk)
-                logger.info(f"Granted user {user.username} role {object_role_name} to object {obj.name} with ansible_id {object_data['ansible_id']}")
+                desired_permissions.append((rd, user, obj))
+                logger.info(f"Granting user {user.username} role {object_role_name} to object {obj.name} with ansible_id {object_data['ansible_id']}")
 
-    # Remove all permissions not authorized by the JWT
-    for role_assignment in role_diff:
-        rd = role_assignment.role_definition
-        content_object = role_assignment.content_object
-        if content_object:
-            rd.remove_permission(user, content_object)
-        else:
-            rd.remove_global_permission(user)
+    # Pass 2: bulk assign all desired permissions
+    if desired_permissions:
+        bulk_give_permissions(user_permissions=desired_permissions, fire_signals_on_create=False)
+
+    # Pass 3: remove stale assignments not in the desired set
+    desired_keys = {(rd.pk, obj.pk) for rd, _user, obj in desired_permissions}
+    stale_assignments = (
+        RoleUserAssignment.objects.filter(user=user, role_definition__name__in=managed_roles)
+        .exclude(pk__in=global_assignment_pks)
+        .select_related('role_definition')
+    )
+
+    stale_user_assignments = []
+    for assignment in stale_assignments:
+        if (assignment.role_definition_id, assignment.cache_id) not in desired_keys:
+            if not assignment.content_type_id:
+                assignment.role_definition.remove_global_permission(user)
+            else:
+                stale_user_assignments.append(assignment)
+
+    if stale_user_assignments:
+        logger.info(f"Removing {len(stale_user_assignments)} stale role assignments for user {user.username}")
+        remove_assignments(user_assignments=stale_user_assignments)
 
 
 # ---- for claims hashing ----

--- a/ansible_base/rbac/evaluations.py
+++ b/ansible_base/rbac/evaluations.py
@@ -121,9 +121,9 @@ def remote_obj_id_qs(actor, remote_cls: Type[RemoteObject], codename: str = 'vie
 
 
 def bound_has_obj_perm(self, obj, codename) -> bool:
-    from ansible_base.rbac.triggers import _defer_rbac
+    from ansible_base.rbac.caching import defer_rbac_state
 
-    if _defer_rbac.active and _defer_rbac.has_deferred_data:
+    if defer_rbac_state.active and defer_rbac_state.has_deferred_data:
         raise RuntimeError(
             "has_obj_perm cannot be called inside defer_rbac_computations after resources have been created or deleted. Evaluations may be stale."
         )

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 # Django
 from django.conf import settings
-from django.db import connection, models, transaction
+from django.db import models
 from django.db.models import Count
 from django.db.models.functions import Cast
 from django.db.models.query import QuerySet
@@ -22,7 +22,7 @@ from ansible_base.lib.abstract_models.common import CommonModel, ImmutableCommon
 from ansible_base.lib.utils.models import is_add_perm
 from ansible_base.rbac.permission_registry import permission_registry
 from ansible_base.rbac.sync import maybe_reverse_sync_assignment
-from ansible_base.rbac.validators import validate_assignment, validate_permissions_for_model
+from ansible_base.rbac.validators import validate_permissions_for_model
 from ansible_base.resource_registry.fields import AnsibleResourceField
 
 from ..remote import RemoteObject, StandInPK
@@ -260,96 +260,32 @@ class RoleDefinition(CommonModel):
         return assignment
 
     def give_permission(self, actor, content_object):
-        from ansible_base.rbac.triggers import _defer_rbac
+        from ansible_base.rbac.pipeline import bulk_give_permissions
 
-        if _defer_rbac.active and _defer_rbac.has_deferred_data:
-            raise RuntimeError(
-                "give_permission cannot be called inside defer_rbac_computations after "
-                "resources have been created or deleted. Use bulk_give_permissions instead."
-            )
-        return self.give_or_remove_permission(actor, content_object, giving=True)
+        is_user = actor._meta.model_name == 'user'
+        perm = [(self, actor, content_object)]
+        assignments = bulk_give_permissions(
+            user_permissions=perm if is_user else [],
+            team_permissions=[] if is_user else perm,
+        )
+        return assignments[0]
 
     def remove_permission(self, actor, content_object):
-        from ansible_base.rbac.triggers import _defer_rbac
+        from ansible_base.rbac.pipeline import bulk_remove_permissions
 
-        if _defer_rbac.active and _defer_rbac.has_deferred_data:
-            raise RuntimeError(
-                "remove_permission cannot be called inside defer_rbac_computations after "
-                "resources have been created or deleted. Use bulk_remove_permissions instead."
-            )
-        return self.give_or_remove_permission(actor, content_object, giving=False)
+        is_user = actor._meta.model_name == 'user'
+        perm = [(self, actor, content_object)]
+        bulk_remove_permissions(
+            user_permissions=perm if is_user else [],
+            team_permissions=[] if is_user else perm,
+        )
 
-    def get_or_create_object_role(self, kwargs, defaults):
-        """Transaction-safe method to create ObjectRole
-
-        The UI will assign many permissions concurrently.
-        These will be in transactions, but also mutually create the same ObjectRole
-        postgres constraints will still be violated by other active transactions
-        which gives us a way to gracefully handle this.
-        """
-        if transaction.get_connection().in_atomic_block:
-            try:
-                with transaction.atomic():
-                    object_role = ObjectRole.objects.create(**kwargs, **defaults)
-                    return (object_role, True)
-            except IntegrityError:
-                object_role = ObjectRole.objects.get(**kwargs)
-                return (object_role, False)
+    def give_or_remove_permission(self, actor, content_object, giving=True):
+        """Compat shim — AWX calls this via awx.main.models.rbac.give_or_remove_permission."""
+        if giving:
+            return self.give_permission(actor, content_object)
         else:
-            object_role = ObjectRole.objects.create(**kwargs, **defaults)
-            return (object_role, True)
-
-    def give_or_remove_permission(self, actor, content_object, giving=True, sync_action=False):
-        "Shortcut method to do whatever needed to give user or team these permissions"
-        validate_assignment(self, actor, content_object)
-
-        if isinstance(content_object, RemoteObject):
-            obj_ct = content_object.content_type
-            object_id = content_object.object_id
-        else:
-            obj_ct = DABContentType.objects.get_for_model(content_object)
-            # sanitize the object_id to its database version, practically, remove "-" chars from uuids
-            object_id = content_object._meta.pk.get_db_prep_value(content_object.pk, connection)
-
-        kwargs = {'role_definition': self, 'content_type': obj_ct, 'object_id': object_id}
-        defaults = {}
-
-        # For remote objects, add parent reference so we can do evaluations if needed
-        if isinstance(content_object, RemoteObject):
-            if content_object.parent_reference:
-                defaults['parent_reference'] = content_object.parent_reference
-
-        created = False
-        object_role = ObjectRole.objects.filter(**kwargs).first()
-        if object_role is None:
-            if not giving:
-                return  # nothing to do
-            object_role, created = self.get_or_create_object_role(kwargs, defaults)
-
-        from ansible_base.rbac.triggers import needed_updates_on_assignment, update_after_assignment
-
-        recompute_team_ids, to_update = needed_updates_on_assignment(self, actor, object_role, created=created, giving=True)
-
-        assignment = None
-        if actor._meta.model_name == 'user':
-            if giving:
-                assignment, created = RoleUserAssignment.objects.get_or_create(user=actor, object_role=object_role)
-            else:
-                object_role.users.remove(actor)
-        elif isinstance(actor, permission_registry.team_model):
-            if giving:
-                assignment, created = RoleTeamAssignment.objects.get_or_create(team=actor, object_role=object_role)
-            else:
-                object_role.teams.remove(actor)
-
-        if (not giving) and (not (object_role.users.exists() or object_role.teams.exists())):
-            if object_role in to_update:
-                to_update.remove(object_role)
-            object_role.delete()
-
-        update_after_assignment(recompute_team_ids, to_update)
-
-        return assignment
+            return self.remove_permission(actor, content_object)
 
     @classmethod
     def user_global_permissions(cls, user, permission_qs=None):

--- a/ansible_base/rbac/pipeline.py
+++ b/ansible_base/rbac/pipeline.py
@@ -75,16 +75,19 @@ def _resolve_assignments(
             validated_pairs.add(key)
         user_resolved.append(ResolvedAssignment(rd, actor, obj_ct, object_id, parent_ref))
 
+    team_validated_pairs: set[tuple[int, int]] = set()
     team_resolved: list[ResolvedAssignment] = []
     for rd, actor, obj in team_permissions:
         obj_ct, object_id, parent_ref = _resolve_content_object(obj)
         key = (rd.pk, obj_ct.id)
         if key not in validated_pairs:
             validate_assignment(rd, actor, obj)
+            validated_pairs.add(key)
+        if key not in team_validated_pairs:
             has_team_perm = rd.permissions.filter(codename=permission_registry.team_permission).exists()
             has_org_member = rd.permissions.filter(codename='member_organization').exists()
             validate_team_assignment_enabled(obj_ct, has_team_perm=has_team_perm, has_org_member=has_org_member)
-            validated_pairs.add(key)
+            team_validated_pairs.add(key)
         team_resolved.append(ResolvedAssignment(rd, actor, obj_ct, object_id, parent_ref))
 
     return user_resolved, team_resolved

--- a/ansible_base/rbac/pipeline.py
+++ b/ansible_base/rbac/pipeline.py
@@ -302,7 +302,8 @@ def _recompute_after_remove(
     object_roles_to_update: set[ObjectRole] = set(object_roles)
 
     if actor_team_ids:
-        for obj_role in list(object_roles_to_update):
+        snapshot = list(object_roles_to_update)  # snapshot: set is mutated in the loop
+        for obj_role in snapshot:
             object_roles_to_update.update(obj_role.descendent_roles())
         object_roles_to_update.update(bulk_ancestor_roles(actor_team_ids))
 

--- a/ansible_base/rbac/pipeline.py
+++ b/ansible_base/rbac/pipeline.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from typing import NamedTuple, Union
+
+from django.conf import settings
+from django.db import connection, models
+from django.db.models import Q
+from django.db.models.signals import post_save
+
+from ansible_base.lib.utils.models import current_user_or_system_user
+from ansible_base.rbac.caching import (
+    bulk_ancestor_roles,
+    compute_team_member_roles,
+    defer_rbac_state,
+    recompute_role_evaluations,
+    team_ids_from_role_target,
+)
+from ansible_base.rbac.models.content_type import DABContentType
+from ansible_base.rbac.models.role import AssignmentBase, ObjectRole, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
+from ansible_base.rbac.permission_registry import permission_registry
+from ansible_base.rbac.remote import RemoteObject
+from ansible_base.rbac.validators import validate_assignment, validate_team_assignment_enabled
+
+logger = logging.getLogger(__name__)
+
+
+class ResolvedAssignment(NamedTuple):
+    role_definition: RoleDefinition
+    actor: models.Model
+    content_type: DABContentType
+    object_id: str
+    parent_reference: str
+
+
+ContentObject = Union[models.Model, RemoteObject]
+PermissionTriple = tuple[RoleDefinition, models.Model, ContentObject]
+ObjectRoleLookup = dict[tuple[int, str], ObjectRole]
+
+
+def _resolve_content_object(obj: models.Model | RemoteObject) -> tuple[DABContentType, str, str]:
+    """Resolve content_type, object_id, and parent_reference from a content object.
+
+    For RemoteObject: uses its own attributes directly.
+    For local Django models: uses _meta (no extra query), empty parent_reference.
+    """
+    if isinstance(obj, RemoteObject):
+        return obj.content_type, str(obj.object_id), str(obj.parent_reference) if obj.parent_reference else ''
+    return (
+        DABContentType.objects.get_for_model(obj),
+        str(obj._meta.pk.get_db_prep_value(obj.pk, connection)),
+        '',
+    )
+
+
+def _resolve_triples(triples: Iterable[PermissionTriple]) -> list[ResolvedAssignment]:
+    """Convert permission triples to ResolvedAssignments (no validation, no DB queries beyond content type lookup)."""
+    return [ResolvedAssignment(rd, actor, *_resolve_content_object(obj)) for rd, actor, obj in triples]
+
+
+def _resolve_assignments(
+    user_permissions: Sequence[PermissionTriple],
+    team_permissions: Sequence[PermissionTriple],
+) -> tuple[list[ResolvedAssignment], list[ResolvedAssignment]]:
+    """Validate permissions and build the resolved assignment lists."""
+    validated_pairs: set[tuple[int, int]] = set()
+
+    user_resolved: list[ResolvedAssignment] = []
+    for rd, actor, obj in user_permissions:
+        obj_ct, object_id, parent_ref = _resolve_content_object(obj)
+        key = (rd.pk, obj_ct.id)
+        if key not in validated_pairs:
+            validate_assignment(rd, actor, obj)
+            validated_pairs.add(key)
+        user_resolved.append(ResolvedAssignment(rd, actor, obj_ct, object_id, parent_ref))
+
+    team_resolved: list[ResolvedAssignment] = []
+    for rd, actor, obj in team_permissions:
+        obj_ct, object_id, parent_ref = _resolve_content_object(obj)
+        key = (rd.pk, obj_ct.id)
+        if key not in validated_pairs:
+            validate_assignment(rd, actor, obj)
+            has_team_perm = rd.permissions.filter(codename=permission_registry.team_permission).exists()
+            has_org_member = rd.permissions.filter(codename='member_organization').exists()
+            validate_team_assignment_enabled(obj_ct, has_team_perm=has_team_perm, has_org_member=has_org_member)
+            validated_pairs.add(key)
+        team_resolved.append(ResolvedAssignment(rd, actor, obj_ct, object_id, parent_ref))
+
+    return user_resolved, team_resolved
+
+
+def _lookup_object_roles(resolved: list[ResolvedAssignment]) -> ObjectRoleLookup:
+    """Look up existing ObjectRoles for resolved assignments."""
+    object_ids_by_rd: dict[int, tuple[int, set[str]]] = {}
+    for ra in resolved:
+        rd_id = ra.role_definition.pk
+        if rd_id not in object_ids_by_rd:
+            object_ids_by_rd[rd_id] = (ra.content_type.id, set())
+        object_ids_by_rd[rd_id][1].add(ra.object_id)
+
+    lookup: ObjectRoleLookup = {}
+    for rd_id, (ct_id, object_ids) in object_ids_by_rd.items():
+        for obj_role in ObjectRole.objects.filter(role_definition_id=rd_id, content_type_id=ct_id, object_id__in=object_ids):
+            lookup[(rd_id, obj_role.object_id)] = obj_role
+
+    return lookup
+
+
+def _ensure_object_roles(requested_assignments: list[ResolvedAssignment]) -> ObjectRoleLookup:
+    """Look up existing ObjectRoles, create any that are missing, and return the full lookup."""
+    object_ids_by_rd: dict[int, tuple[int, set[str]]] = {}
+    parent_refs: dict[str, str] = {}
+    for ra in requested_assignments:
+        rd_id = ra.role_definition.pk
+        if rd_id not in object_ids_by_rd:
+            object_ids_by_rd[rd_id] = (ra.content_type.id, set())
+        object_ids_by_rd[rd_id][1].add(ra.object_id)
+        if ra.parent_reference:
+            parent_refs[ra.object_id] = ra.parent_reference
+
+    lookup: ObjectRoleLookup = {}
+    for rd_id, (ct_id, object_ids) in object_ids_by_rd.items():
+        for obj_role in ObjectRole.objects.filter(role_definition_id=rd_id, content_type_id=ct_id, object_id__in=object_ids):
+            lookup[(rd_id, obj_role.object_id)] = obj_role
+        missing = [oid for oid in object_ids if (rd_id, oid) not in lookup]
+        if missing:
+            ObjectRole.objects.bulk_create(
+                [ObjectRole(role_definition_id=rd_id, content_type_id=ct_id, object_id=oid, parent_reference=parent_refs.get(oid, '')) for oid in missing],
+                ignore_conflicts=True,
+            )
+            # Re-fetch to get PKs — bulk_create(ignore_conflicts=True) doesn't populate them.
+            # unique_together on (role_definition, content_type, object_id) guarantees one row per oid.
+            for obj_role in ObjectRole.objects.filter(role_definition_id=rd_id, content_type_id=ct_id, object_id__in=missing):
+                lookup[(rd_id, obj_role.object_id)] = obj_role
+
+    return lookup
+
+
+def _audit_log_created(db_assignments: list[AssignmentBase], existing_pks: set[int]) -> None:
+    """Emit audit logs for newly-created assignments (not idempotent re-assignments)."""
+    if not db_assignments or 'ansible_base.activitystream' not in settings.INSTALLED_APPS:
+        return
+
+    from ansible_base.activitystream.signals import _store_activitystream_entry
+
+    for assignment in db_assignments:
+        if assignment.pk not in existing_pks:
+            _store_activitystream_entry(None, assignment, 'create')
+
+
+def _pair_filter(assignments: list[AssignmentBase], actor_field: str) -> Q:
+    """Build a Q filter matching exact (actor, object_role) pairs — no cross-product."""
+    q = Q()
+    for a in assignments:
+        q |= Q(**{actor_field: getattr(a, actor_field), 'object_role': a.object_role})
+    return q
+
+
+def _fire_post_save(db_assignments: list[AssignmentBase], existing_pks: set[int]) -> None:
+    """Fire post_save signals for newly-created assignments (skipped by bulk_create)."""
+    for assignment in db_assignments:
+        if assignment.pk not in existing_pks:
+            post_save.send(sender=type(assignment), instance=assignment, created=True, raw=False, using='default', update_fields=None)
+
+
+def _create_assignments(
+    user_resolved: list[ResolvedAssignment],
+    team_resolved: list[ResolvedAssignment],
+    lookup: ObjectRoleLookup,
+    fire_signals_on_create: bool = True,
+) -> list[AssignmentBase]:
+    """Bulk-create user and team assignment objects, return all resulting assignments."""
+    created_by = current_user_or_system_user()
+    all_assignments = []
+
+    user_assignments = []
+    for ra in user_resolved:
+        obj_role = lookup[(ra.role_definition.pk, ra.object_id)]
+        user_assignments.append(
+            RoleUserAssignment(
+                user=ra.actor,
+                object_role=obj_role,
+                role_definition=ra.role_definition,
+                content_type=ra.content_type,
+                object_id=ra.object_id,
+                created_by=created_by,
+            )
+        )
+    if user_assignments:
+        pair_q = _pair_filter(user_assignments, 'user')
+        existing_user_pks = set(RoleUserAssignment.objects.filter(pair_q).values_list('pk', flat=True))
+        RoleUserAssignment.objects.bulk_create(user_assignments, ignore_conflicts=True)
+        db_users = list(RoleUserAssignment.objects.filter(pair_q))
+        all_assignments.extend(db_users)
+        if fire_signals_on_create:
+            _fire_post_save(db_users, existing_user_pks)
+        else:
+            _audit_log_created(db_users, existing_user_pks)
+
+    team_assignments = []
+    for ra in team_resolved:
+        obj_role = lookup[(ra.role_definition.pk, ra.object_id)]
+        team_assignments.append(
+            RoleTeamAssignment(
+                team=ra.actor,
+                object_role=obj_role,
+                role_definition=ra.role_definition,
+                content_type=ra.content_type,
+                object_id=ra.object_id,
+                created_by=created_by,
+            )
+        )
+    if team_assignments:
+        pair_q = _pair_filter(team_assignments, 'team')
+        existing_team_pks = set(RoleTeamAssignment.objects.filter(pair_q).values_list('pk', flat=True))
+        RoleTeamAssignment.objects.bulk_create(team_assignments, ignore_conflicts=True)
+        db_teams = list(RoleTeamAssignment.objects.filter(pair_q))
+        all_assignments.extend(db_teams)
+        if fire_signals_on_create:
+            _fire_post_save(db_teams, existing_team_pks)
+        else:
+            _audit_log_created(db_teams, existing_team_pks)
+
+    return all_assignments
+
+
+def _collect_recompute_team_ids(object_roles: Iterable[ObjectRole]) -> set[int]:
+    """Identify team IDs that need member-role recomputation."""
+    rd_has_team_perm: dict[int, bool] = {}
+    recompute_team_ids: set[int] = set()
+    for obj_role in object_roles:
+        rd_id = obj_role.role_definition_id
+        if rd_id not in rd_has_team_perm:
+            rd_has_team_perm[rd_id] = RoleDefinition.objects.filter(pk=rd_id, permissions__codename=permission_registry.team_permission).exists()
+        if rd_has_team_perm[rd_id]:
+            recompute_team_ids.update(team_ids_from_role_target(obj_role))
+    return recompute_team_ids
+
+
+def _check_defer_guard() -> None:
+    if defer_rbac_state.active and defer_rbac_state.has_deferred_data:
+        raise RuntimeError(
+            "Permission assignment/removal cannot be called inside defer_rbac_computations "
+            "after resources have been created or deleted. RoleEvaluation data is stale."
+        )
+
+
+def _recompute_after_give(
+    lookup: ObjectRoleLookup,
+    assignments: list[AssignmentBase],
+) -> None:
+    """Run recomputation pass after bulk permission assignment."""
+    _check_defer_guard()
+    recompute_team_ids = _collect_recompute_team_ids(lookup.values())
+    object_roles_to_update: set[ObjectRole] = set(lookup.values())
+
+    unique_teams = {a.team for a in assignments if isinstance(a, RoleTeamAssignment)}
+    if unique_teams:
+        object_roles_to_update.update(bulk_ancestor_roles({team.pk for team in unique_teams}))
+        expanded_roles = ObjectRole.objects.filter(pk__in=[obj_role.pk for obj_role in object_roles_to_update]).prefetch_related('provides_teams__has_roles')
+        for obj_role in expanded_roles:
+            object_roles_to_update.update(obj_role.descendent_roles())
+
+    if recompute_team_ids:
+        compute_team_member_roles(team_ids=recompute_team_ids)
+    if object_roles_to_update:
+        roles_to_recompute = ObjectRole.objects.filter(pk__in=[obj_role.pk for obj_role in object_roles_to_update]).prefetch_related(
+            'provides_teams__has_roles'
+        )
+        recompute_role_evaluations(roles_to_recompute)
+
+
+def _find_assignments(
+    resolved: Sequence[ResolvedAssignment],
+    lookup: ObjectRoleLookup,
+    model: type[AssignmentBase],
+    actor_field: str,
+) -> list[AssignmentBase]:
+    """Find existing assignments matching resolved triples via the ObjectRole lookup."""
+    q = Q()
+    for ra in resolved:
+        obj_role = lookup.get((ra.role_definition.pk, ra.object_id))
+        if obj_role is not None:
+            q |= Q(object_role_id=obj_role.pk, **{actor_field: ra.actor.pk})
+    if not q:
+        return []
+    return list(model.objects.filter(q))
+
+
+def _recompute_after_remove(
+    object_role_ids: set[int],
+    actor_team_ids: set[int] = frozenset(),
+) -> None:
+    """Recompute permissions, expand team ancestors, and clean up orphaned ObjectRoles."""
+    _check_defer_guard()
+    object_roles = set(ObjectRole.objects.filter(pk__in=object_role_ids))
+    recompute_team_ids = _collect_recompute_team_ids(object_roles)
+    object_roles_to_update: set[ObjectRole] = set(object_roles)
+
+    if actor_team_ids:
+        for obj_role in list(object_roles_to_update):
+            object_roles_to_update.update(obj_role.descendent_roles())
+        object_roles_to_update.update(bulk_ancestor_roles(actor_team_ids))
+
+    if recompute_team_ids:
+        compute_team_member_roles(team_ids=recompute_team_ids)
+    if object_roles_to_update:
+        surviving_object_roles = ObjectRole.objects.filter(pk__in=[o.pk for o in object_roles_to_update])
+        recompute_role_evaluations(surviving_object_roles)
+
+    ObjectRole.objects.filter(id__in=object_role_ids, users__isnull=True, teams__isnull=True).delete()
+
+
+def remove_assignments(
+    user_assignments: Sequence[RoleUserAssignment] = (),
+    team_assignments: Sequence[RoleTeamAssignment] = (),
+) -> None:
+    """Remove assignments by reference and recompute affected permissions.
+
+    Lower-level alternative to bulk_remove_permissions — accepts assignment objects
+    directly, avoiding the triple resolution and GFK lookups that the bulk API requires.
+    """
+    if not user_assignments and not team_assignments:
+        return
+
+    object_role_ids: set[int] = set()
+    actor_team_ids: set[int] = set()
+    for a in user_assignments:
+        object_role_ids.add(a.object_role_id)
+    for a in team_assignments:
+        object_role_ids.add(a.object_role_id)
+        actor_team_ids.add(a.team_id)
+
+    if user_assignments:
+        RoleUserAssignment.objects.filter(pk__in=[a.pk for a in user_assignments]).delete()
+    if team_assignments:
+        RoleTeamAssignment.objects.filter(pk__in=[a.pk for a in team_assignments]).delete()
+
+    _recompute_after_remove(object_role_ids, actor_team_ids)
+
+
+def give_assignments(
+    user_resolved: Sequence[ResolvedAssignment] = (),
+    team_resolved: Sequence[ResolvedAssignment] = (),
+    fire_signals_on_create: bool = True,
+) -> list[AssignmentBase]:
+    """Assign roles from already-resolved assignments (skips validation).
+
+    Lower-level alternative to bulk_give_permissions — accepts ResolvedAssignment
+    lists directly, for callers that have already resolved and validated.
+    """
+    if not user_resolved and not team_resolved:
+        return []
+
+    lookup = _ensure_object_roles(list(user_resolved) + list(team_resolved))
+    assignments = _create_assignments(list(user_resolved), list(team_resolved), lookup, fire_signals_on_create=fire_signals_on_create)
+    _recompute_after_give(lookup, assignments)
+    return assignments
+
+
+def bulk_give_permissions(
+    user_permissions: Sequence[PermissionTriple] = (),
+    team_permissions: Sequence[PermissionTriple] = (),
+    fire_signals_on_create: bool = True,
+) -> list[AssignmentBase]:
+    """Convenience API: validates triples, resolves, and delegates to give_assignments."""
+    if not user_permissions and not team_permissions:
+        return []
+
+    user_resolved, team_resolved = _resolve_assignments(user_permissions, team_permissions)
+    return give_assignments(user_resolved, team_resolved, fire_signals_on_create=fire_signals_on_create)
+
+
+def bulk_remove_permissions(
+    user_permissions: Sequence[PermissionTriple] = (),
+    team_permissions: Sequence[PermissionTriple] = (),
+) -> None:
+    """Bulk-remove multiple role assignments.
+
+    user_permissions: sequence of (role_definition, user, content_object) triples
+    team_permissions: sequence of (role_definition, team, content_object) triples
+
+    This is the bulk replacement for remove_permission. Deletes assignments,
+    cleans up orphaned ObjectRoles, and runs a single recomputation pass.
+    """
+    if not user_permissions and not team_permissions:
+        return
+
+    user_resolved = _resolve_triples(user_permissions)
+    team_resolved = _resolve_triples(team_permissions)
+    lookup = _lookup_object_roles(user_resolved + team_resolved)
+    if not lookup:
+        return
+
+    user_found = _find_assignments(user_resolved, lookup, RoleUserAssignment, 'user_id')
+    team_found = _find_assignments(team_resolved, lookup, RoleTeamAssignment, 'team_id')
+    remove_assignments(user_assignments=user_found, team_assignments=team_found)

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -1,24 +1,27 @@
 import logging
-import threading
 from contextlib import contextmanager
 from typing import Generator, Optional, Union
 from uuid import UUID
 
 from django.db import connection
-from django.db.models import Model, Q
+from django.db.models import Model
 from django.db.models.signals import m2m_changed, post_delete, post_init, post_save, pre_delete, pre_save
 from django.dispatch import Signal
 
 from ansible_base.lib.utils.db import migrations_are_complete
 from ansible_base.rbac.caching import (
+    bulk_ancestor_roles,
     cleanup_deleted_object_roles,
     cleanup_deleted_team_roles,
+    cleanup_orphaned_object_roles,
     compute_team_member_roles,
+    defer_rbac_state,
     object_roles_for_parents,
     recompute_all_role_evaluations,
     recompute_role_evaluations,
+    team_ids_from_role_target,
 )
-from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleEvaluation, get_evaluation_model
+from ansible_base.rbac.models import ObjectRole, RoleDefinition, get_evaluation_model
 from ansible_base.rbac.permission_registry import permission_registry
 from ansible_base.rbac.validators import validate_team_assignment_enabled
 
@@ -37,33 +40,6 @@ Sounds simple, but is actually more complicated that the caching logic itself.
 dab_post_migrate = Signal()
 
 
-def team_ancestor_roles(team: Model) -> set['ObjectRole']:
-    """
-    Return a queryset of all roles that directly or indirectly grant any form of permission to a team.
-    This is generally used when invalidating a team membership for one reason or another.
-    This assumes that teams and all team parent models have integer primary keys.
-    """
-    permission_kwargs = dict(codename=permission_registry.team_permission, object_id=team.id, content_type_id=permission_registry.team_ct_id)
-    return set(ObjectRole.objects.filter(permission_partials__in=RoleEvaluation.objects.filter(**permission_kwargs)))
-
-
-def _team_ids_from_role_target(object_role: 'ObjectRole') -> set[int]:
-    """Derive which teams a member_team ObjectRole targets from its content type.
-
-    Used only when the provides_teams relationship is not yet computed —
-    i.e. for newly created ObjectRoles or when member_team permission was
-    just added to a RoleDefinition. For existing roles where provides_teams
-    is already populated, query provides_teams directly instead.
-    """
-    if object_role.content_type_id == permission_registry.team_ct_id:
-        return {int(object_role.object_id)}
-    if object_role.content_type_id == permission_registry.org_ct_id:
-        parent_fd = permission_registry.get_parent_fd_name(permission_registry.team_model)
-        if parent_fd:
-            return set(permission_registry.team_model.objects.filter(**{f'{parent_fd}_id': int(object_role.object_id)}).values_list('id', flat=True))
-    return set()
-
-
 def _recompute_team_ids_for_assignment(
     object_role: 'ObjectRole',
     created: bool,
@@ -76,7 +52,7 @@ def _recompute_team_ids_for_assignment(
         return None
     if created:
         # provides_teams not yet computed for new ObjectRoles
-        return _team_ids_from_role_target(object_role)
+        return team_ids_from_role_target(object_role)
     # For existing roles, provides_teams already captures which
     # teams this role grants membership to
     return set(object_role.provides_teams.values_list('id', flat=True))
@@ -111,7 +87,7 @@ def needed_updates_on_assignment(
     # If permissions for team are changed. That tends to affect a lot.
     changes_team_owners = False
     if actor._meta.model_name != 'user':
-        to_update.update(team_ancestor_roles(actor))
+        to_update.update(bulk_ancestor_roles({actor.id}))
         if not giving:
             # this will delete some permission assignments that will be removed from this relationship
             to_update.update(object_role.descendent_roles())
@@ -135,21 +111,6 @@ def needed_updates_on_assignment(
     return (recompute_team_ids, to_update)
 
 
-class _DeferRBACComputations(threading.local):
-    def __init__(self):
-        self.active = False
-        self.deleted_team_pks: set[int] = set()
-        self.deleted_object_pks: list[tuple[int, Union[int, UUID]]] = []
-        self.created_instances: list[tuple[Model, int, int]] = []
-
-    @property
-    def has_deferred_data(self):
-        return bool(self.deleted_team_pks or self.deleted_object_pks or self.created_instances)
-
-
-_defer_rbac = _DeferRBACComputations()
-
-
 def _reset_and_flush_deferred_rbac(suppress_flush_errors: bool = False) -> None:
     """Reset deferred RBAC state and flush pending computations.
 
@@ -157,13 +118,13 @@ def _reset_and_flush_deferred_rbac(suppress_flush_errors: bool = False) -> None:
         suppress_flush_errors: If True, log but do not raise flush errors
             (used during exception handling to avoid masking the original error).
     """
-    deleted_team_pks = _defer_rbac.deleted_team_pks
-    deleted_object_pks = _defer_rbac.deleted_object_pks
-    created_instances = _defer_rbac.created_instances
-    _defer_rbac.active = False
-    _defer_rbac.deleted_team_pks = set()
-    _defer_rbac.deleted_object_pks = []
-    _defer_rbac.created_instances = []
+    deleted_team_pks = defer_rbac_state.deleted_team_pks
+    deleted_object_pks = defer_rbac_state.deleted_object_pks
+    created_instances = defer_rbac_state.created_instances
+    defer_rbac_state.active = False
+    defer_rbac_state.deleted_team_pks = set()
+    defer_rbac_state.deleted_object_pks = []
+    defer_rbac_state.created_instances = []
 
     if not (deleted_team_pks or deleted_object_pks or created_instances):
         return
@@ -191,25 +152,25 @@ def defer_rbac_computations() -> Generator[None, None, None]:
     exit.
 
     While deferred data is pending, the following will raise RuntimeError:
-    - give_permission / remove_permission (use RoleDefinition.bulk_give_permissions
-      or bulk_remove_permissions OUTSIDE this context manager instead)
+    - give_permission / remove_permission and the bulk/assignment variants
+      (RoleEvaluation is stale until the flush)
     - has_obj_perm (evaluations are stale until the flush)
 
     These calls are allowed before any resources are created or deleted inside
     the context manager, so DRF permission checks that run before the view
     action will work normally.
 
-    Cannot be nested. For permission assignment, use
-    RoleDefinition.bulk_give_permissions / bulk_remove_permissions separately.
+    Cannot be nested. For permission assignment, call
+    bulk_give_permissions / bulk_remove_permissions outside this context manager.
 
     Limitation: the deferred flush does not recompute descendant roles from
     member_team permissions. This is correct when the objects granting
     member_team cascade-delete with the parent (the normal case), but would
     leave stale evaluations if member_team targets survive the deletion.
     """
-    if _defer_rbac.active:
+    if defer_rbac_state.active:
         raise RuntimeError("defer_rbac_computations cannot be nested")
-    _defer_rbac.active = True
+    defer_rbac_state.active = True
     try:
         yield
     except BaseException:
@@ -258,7 +219,7 @@ def _flush_rbac(deleted_team_pks, deleted_object_pks, created_instances):
     if object_roles:
         recompute_role_evaluations(object_roles)
 
-    ObjectRole.objects.filter(users__isnull=True, teams__isnull=True).delete()
+    cleanup_orphaned_object_roles()
 
 
 def update_after_assignment(recompute_team_ids: Optional[set[int]], to_update: Optional[set['ObjectRole']]) -> None:
@@ -282,7 +243,7 @@ def _handle_permission_add_or_remove(to_recompute: set['ObjectRole'], pk_set: se
             if action == 'post_add':
                 # provides_teams is empty when member_team was just added,
                 # so derive affected teams from the role's content type
-                team_ids.update(_team_ids_from_role_target(object_role))
+                team_ids.update(team_ids_from_role_target(object_role))
         compute_team_member_roles(team_ids=team_ids)
     # All team member roles that give this permission through this role need to be updated
     for role in to_recompute.copy():
@@ -298,7 +259,7 @@ def _handle_permission_clear(to_recompute: set['ObjectRole']) -> None:
     team_ids = set()
     for object_role in to_recompute:
         team_ids.update(object_role.provides_teams.values_list('id', flat=True))
-        team_ids.update(_team_ids_from_role_target(object_role))
+        team_ids.update(team_ids_from_role_target(object_role))
     compute_team_member_roles(team_ids=team_ids)
 
 
@@ -374,17 +335,9 @@ def post_save_update_obj_permissions(instance, object_pk=None, object_ct_id=None
         delattr(instance, '__rbac_original_parent_id')
 
     if parent_gfks:
-        q_exprs = [Q(content_type=parent_ct, object_id=parent_id) for parent_ct, parent_id in parent_gfks]
-        q_filter = q_exprs[0]
-        for next_q in q_exprs[1:]:
-            q_filter |= next_q
-        to_update = set(ObjectRole.objects.filter(q_filter))
+        to_update = object_roles_for_parents(set(parent_gfks))
     else:
         to_update = set()
-
-    # Account for parent team roles of those organization roles
-    ancestors = set(ObjectRole.objects.filter(provides_teams__has_roles__in=to_update))
-    to_update.update(ancestors)
 
     # If the actual object changed (created or modified) was a team, any org role
     # that has member_team needs to be updated, and any parent teams that have that role
@@ -425,8 +378,8 @@ def rbac_post_save_update_evaluations(instance, created, *args, **kwargs):
     # evaluations for the parent object roles need to be added
     if created:
         obj_ct_id = permission_registry.content_type_model.objects.get_for_model(instance).id
-        if _defer_rbac.active:
-            _defer_rbac.created_instances.append((instance, instance.pk, obj_ct_id))
+        if defer_rbac_state.active:
+            defer_rbac_state.created_instances.append((instance, instance.pk, obj_ct_id))
             return
         post_save_update_obj_permissions(instance, object_pk=instance.pk, object_ct_id=obj_ct_id)
         return
@@ -444,7 +397,7 @@ def rbac_post_save_update_evaluations(instance, created, *args, **kwargs):
 
 
 def team_pre_delete(instance: Model, *args, **kwargs) -> None:
-    if _defer_rbac.active:
+    if defer_rbac_state.active:
         return
     instance.__rbac_stashed_member_roles = list(instance.member_roles.all())
     stashed_team_ids = set()
@@ -460,20 +413,20 @@ def rbac_post_delete_remove_object_roles(instance: Model, *args, **kwargs) -> No
     Deleting a team can have consequences for the rest of the graph
     """
     if instance._meta.model_name == permission_registry.team_model._meta.model_name:
-        if _defer_rbac.active:
-            _defer_rbac.deleted_team_pks.add(instance.pk)
+        if defer_rbac_state.active:
+            defer_rbac_state.deleted_team_pks.add(instance.pk)
             return
         indirectly_affected_roles = set()
-        indirectly_affected_roles.update(team_ancestor_roles(instance))
+        indirectly_affected_roles.update(bulk_ancestor_roles({instance.id}))
         for team_role in instance.__rbac_stashed_member_roles:
             indirectly_affected_roles.update(team_role.descendent_roles())
         compute_team_member_roles(team_ids=instance.__rbac_stashed_recompute_team_ids)
         recompute_role_evaluations(indirectly_affected_roles)
-        ObjectRole.objects.filter(users__isnull=True, teams__isnull=True).delete()
+        cleanup_orphaned_object_roles()
 
-    if _defer_rbac.active:
+    if defer_rbac_state.active:
         ct_id = permission_registry.content_type_model.objects.get_for_model(instance).pk
-        _defer_rbac.deleted_object_pks.append((ct_id, instance.pk))
+        defer_rbac_state.deleted_object_pks.append((ct_id, instance.pk))
         return
 
     ct = permission_registry.content_type_model.objects.get_for_model(instance)
@@ -557,7 +510,7 @@ def rbac_post_user_delete(instance, *args, **kwargs):
     """
     # Any RoleUserAssignment entries will already be cascade deleted
     # Just clean up any object roles that may be orphaned by this deletion
-    ObjectRole.objects.filter(users__isnull=True, teams__isnull=True).delete()
+    cleanup_orphaned_object_roles()
 
 
 def post_migration_rbac_setup(sender, *args, **kwargs):
@@ -572,6 +525,7 @@ def post_migration_rbac_setup(sender, *args, **kwargs):
         logger.info('Skipping RBAC recompute — no migrations were applied')
         return
 
+    cleanup_orphaned_object_roles()
     compute_team_member_roles()
     recompute_all_role_evaluations()
 

--- a/docs/apps/rbac/bulk_operations.md
+++ b/docs/apps/rbac/bulk_operations.md
@@ -1,19 +1,17 @@
-# Deferred RBAC Computations
+# Bulk RBAC Operations
+
+## Deferred RBAC Computations
 
 When creating or deleting many resources, the per-call RBAC signal handlers can
 become a performance bottleneck. `defer_rbac_computations` batches all
 signal-driven recomputation into a single flush pass on exit.
 
-## `defer_rbac_computations` — resource create/delete
+### `defer_rbac_computations` — resource create/delete
 
 Use this context manager when creating or deleting many RBAC-registered objects
 (e.g. bulk inventory creation, organization cascade delete). It defers the RBAC
 signal handlers that normally fire on every `save()` and `delete()`, then
 flushes all recomputation in a single pass when the context manager exits.
-
-**This is only for non-RBAC resource operations.** It does not handle permission
-assignments — use `RoleDefinition.bulk_give_permissions` /
-`bulk_remove_permissions` for that (provided separately).
 
 ```python
 from ansible_base.rbac.triggers import defer_rbac_computations
@@ -24,27 +22,24 @@ with defer_rbac_computations():
 # One recomputation pass here instead of 100
 ```
 
-### What errors while active
+#### What errors while active
 
 Once resources have been created or deleted inside the context manager (i.e.
 deferred data is pending), the following calls will raise `RuntimeError`:
 
-- **`give_permission` / `remove_permission`** — these run incremental
-  recomputation that would produce incorrect results against stale state.
 - **`has_obj_perm`** — evaluations are stale until the flush completes, so
   permission checks would return wrong answers.
 
-These calls are allowed *before* any mutations occur inside the context manager.
-This means a view can enter `defer_rbac_computations()`, pass its DRF permission
-checks normally, and then perform bulk resource operations.
+`give_permission` / `remove_permission` delegate to the bulk functions and work
+correctly inside this context manager.
 
-### Constraints
+#### Constraints
 
 - Cannot be nested.
 - Only defers signals for resource create/delete — not for permission
   assignment.
 
-### What it defers
+#### What it defers
 
 - **Created resources:** defers `rbac_post_save_update_evaluations`, flushes
   parent ObjectRole lookups and `compute_object_role_permissions` once at exit.
@@ -53,7 +48,7 @@ checks normally, and then perform bulk resource operations.
 - **Team IDs:** collects all affected team IDs and calls
   `compute_team_member_roles` once.
 
-## Migration from `defer_rbac_cache`
+### Migration from `defer_rbac_cache`
 
 `defer_rbac_cache` has been removed. It was designed for the assignment path but
 read stale `provides_teams` state when deferring, producing incorrect results.
@@ -62,4 +57,75 @@ read stale `provides_teams` state when deferring, producing incorrect results.
 |---|---|
 | `with defer_rbac_cache():` around `obj.delete()` | `with defer_rbac_computations():` |
 | `with defer_rbac_cache():` around resource creation | `with defer_rbac_computations():` |
-| `with defer_rbac_cache():` around `give_permission` calls | `RoleDefinition.bulk_give_permissions(...)` (separate API) |
+| `with defer_rbac_cache():` around `give_permission` calls | `bulk_give_permissions(...)` (separate API) |
+
+## Bulk Permission Assignment
+
+When assigning or removing permissions across many role definitions, users,
+teams, and objects, looping over individual `give_permission` /
+`remove_permission` calls is a performance bottleneck. DAB provides bulk
+functions that batch the work into a single recomputation pass.
+
+### `bulk_give_permissions` — permission assignment
+
+Use this function when assigning permissions across multiple role definitions,
+users, teams, and objects. It replaces looping over `give_permission` calls.
+
+```python
+from ansible_base.rbac.bulk import bulk_give_permissions
+
+bulk_give_permissions(
+    user_permissions=[
+        (member_rd, user1, team_a),
+        (member_rd, user2, team_a),
+        (org_admin_rd, user1, org),
+        (inv_admin_rd, user3, inv1),
+    ],
+    team_permissions=[
+        (inv_admin_rd, team_a, inv1),
+        (inv_admin_rd, team_a, inv2),
+    ],
+)
+```
+
+Each entry is a `(role_definition, actor, content_object)` triple. User and team
+permissions are separated because team assignments trigger additional
+recomputation (ancestor roles, `provides_teams`, descendent roles).
+
+#### What it does
+
+1. Validates once per unique `(role_definition, content_type)` pair
+2. Bulk-creates ObjectRoles with `ignore_conflicts`
+3. Bulk-creates `RoleUserAssignment` / `RoleTeamAssignment` with `ignore_conflicts`
+4. Runs a single `compute_team_member_roles` + `compute_object_role_permissions` pass
+
+#### Constraints
+
+- Idempotent — calling with the same triples twice will not duplicate assignments.
+
+### `bulk_remove_permissions` — permission removal
+
+Same API shape as `bulk_give_permissions`, but for removal:
+
+```python
+from ansible_base.rbac.bulk import bulk_remove_permissions
+
+bulk_remove_permissions(
+    user_permissions=[
+        (member_rd, user1, team_a),
+        (inv_admin_rd, user3, inv1),
+    ],
+)
+```
+
+Bulk-deletes assignments, cleans up orphaned ObjectRoles, and runs a single
+recomputation pass. Same constraints as `bulk_give_permissions`.
+
+### When to use bulk methods vs `defer_rbac_computations`
+
+These APIs handle different concerns:
+
+| Scenario | Use |
+|---|---|
+| Bulk permission assignment/removal | `bulk_give_permissions(...)` / `bulk_remove_permissions(...)` |
+| Bulk resource creation/deletion (e.g. org delete cascade) | `defer_rbac_computations` context manager |

--- a/test_app/templates/index.html
+++ b/test_app/templates/index.html
@@ -47,8 +47,8 @@
 				<li>Delete variants (pick one, then re-populate):
 					<ul>
 						<li><a href="/api/v1/profile-stories/org-delete/bare/">Bare (no context managers)</a></li>
-						<li><a href="/api/v1/profile-stories/org-delete/deferred/">defer_rbac_cache only</a></li>
-						<li><a href="/api/v1/profile-stories/org-delete/optimized/">All 3 context managers</a></li>
+						<li><a href="/api/v1/profile-stories/org-delete/deferred/">defer_rbac_computations only</a></li>
+						<li><a href="/api/v1/profile-stories/org-delete/optimized/">All 4 context managers</a></li>
 					</ul>
 				</li>
 			</ol>

--- a/test_app/tests/jwt_consumer/awx/test_auth.py
+++ b/test_app/tests/jwt_consumer/awx/test_auth.py
@@ -1,6 +1,253 @@
+from unittest import mock
+
+import pytest
+
 from ansible_base.jwt_consumer.awx.auth import AwxJWTAuthentication
+from ansible_base.rbac.claims import save_user_claims
+from ansible_base.resource_registry.models import Resource
 
 
 def test_awx_process_permissions(user, caplog):
     authentication = AwxJWTAuthentication()
     assert authentication.use_rbac_permissions is True
+
+
+def _build_claims(orgs, teams):
+    """Build a claims dict from org/team model instances."""
+    objects = {"organization": [], "team": []}
+    object_roles = {}
+
+    org_indexes = []
+    for i, org in enumerate(orgs):
+        objects["organization"].append(
+            {
+                "ansible_id": str(org.resource.ansible_id),
+                "name": org.name,
+            }
+        )
+        org_indexes.append(i)
+
+    team_indexes = []
+    for i, team in enumerate(teams):
+        org_idx = next(j for j, o in enumerate(orgs) if o.pk == team.organization_id)
+        objects["team"].append(
+            {
+                "ansible_id": str(team.resource.ansible_id),
+                "name": team.name,
+                "org": org_idx,
+            }
+        )
+        team_indexes.append(i)
+
+    if org_indexes:
+        object_roles["Organization Admin"] = {"content_type": "organization", "objects": org_indexes}
+    if team_indexes:
+        object_roles["Team Member"] = {"content_type": "team", "objects": team_indexes}
+
+    return {"objects": objects, "object_roles": object_roles, "global_roles": []}
+
+
+# Hardcoded from awx/main/models/rbac.py
+AWX_ROLE_DEFINITION_TO_ROLE_FIELD = {
+    'Organization Member': 'member_role',
+    'WorkflowJobTemplate Admin': 'admin_role',
+    'Organization WorkflowJobTemplate Admin': 'workflow_admin_role',
+    'WorkflowJobTemplate Execute': 'execute_role',
+    'WorkflowJobTemplate Approve': 'approval_role',
+    'InstanceGroup Admin': 'admin_role',
+    'InstanceGroup Use': 'use_role',
+    'Organization ExecutionEnvironment Admin': 'execution_environment_admin_role',
+    'Project Admin': 'admin_role',
+    'Organization Project Admin': 'project_admin_role',
+    'Project Use': 'use_role',
+    'Project Update': 'update_role',
+    'JobTemplate Admin': 'admin_role',
+    'Organization JobTemplate Admin': 'job_template_admin_role',
+    'JobTemplate Execute': 'execute_role',
+    'Inventory Admin': 'admin_role',
+    'Organization Inventory Admin': 'inventory_admin_role',
+    'Inventory Use': 'use_role',
+    'Inventory Adhoc': 'adhoc_role',
+    'Inventory Update': 'update_role',
+    'Organization NotificationTemplate Admin': 'notification_admin_role',
+    'Credential Admin': 'admin_role',
+    'Organization Credential Admin': 'credential_admin_role',
+    'Credential Use': 'use_role',
+    'Team Admin': 'admin_role',
+    'Team Member': 'member_role',
+    'Organization Admin': 'admin_role',
+    'Organization Audit': 'auditor_role',
+    'Organization Execute': 'execute_role',
+    'Organization Approval': 'approval_role',
+}
+
+
+class FakeMembers:
+    """Simulates a Role.members M2M manager."""
+
+    def __init__(self):
+        self._members = set()
+
+    def add(self, user):
+        self._members.add(user.pk)
+
+    def remove(self, user):
+        self._members.discard(user.pk)
+
+    def __contains__(self, item):
+        pk = item.pk if hasattr(item, 'pk') else item
+        return pk in self._members
+
+
+class FakeRole:
+    """Simulates an old AWX Role instance with a role_field and members."""
+
+    def __init__(self, pk, role_field):
+        self.pk = pk
+        self.role_field = role_field
+        self.members = FakeMembers()
+
+
+class FakeRoleQuerySet:
+    """Simulates Role.objects.filter(...).exclude(...)."""
+
+    def __init__(self, roles):
+        self._roles = roles
+
+    def filter(self, members=None, role_field__in=None):
+        filtered = [r for r in self._roles if (members is None or members.pk in r.members) and (role_field__in is None or r.role_field in role_field__in)]
+        return FakeRoleQuerySet(filtered)
+
+    def exclude(self, pk__in=None):
+        excluded = pk__in or set()
+        return FakeRoleQuerySet([r for r in self._roles if r.pk not in excluded])
+
+    def __iter__(self):
+        return iter(self._roles)
+
+
+class FakeResource:
+    """Wraps a real Resource but returns a doctored content_object."""
+
+    def __init__(self, real_resource, content_object_override):
+        self.ansible_id = real_resource.ansible_id
+        self._content_object = content_object_override
+
+    @property
+    def content_object(self):
+        return self._content_object
+
+
+@pytest.fixture
+def mock_awx_rbac():
+    """Patch AWX imports in _sync_old_rbac with fakes.
+
+    Returns (attach_fake_role, all_roles, fake_role_cls, register_object).
+    Call register_object(obj) for each model instance that should be findable
+    by _build_resource_map — this ensures resource.content_object returns the
+    same Python object (with fake roles attached).
+    """
+    all_roles = []
+    role_counter = [0]
+    object_registry = {}  # ansible_id -> obj with fake roles attached
+
+    def attach_fake_role(obj, field_name):
+        role_counter[0] += 1
+        role = FakeRole(pk=role_counter[0], role_field=field_name)
+        setattr(obj, field_name, role)
+        all_roles.append(role)
+        return role
+
+    def register_object(obj):
+        ansible_id = str(obj.resource.ansible_id)
+        object_registry[ansible_id] = obj
+
+    fake_role_cls = mock.MagicMock()
+    fake_role_cls.objects = FakeRoleQuerySet(all_roles)
+
+    mock_rbac = mock.MagicMock()
+    mock_rbac.ROLE_DEFINITION_TO_ROLE_FIELD = AWX_ROLE_DEFINITION_TO_ROLE_FIELD
+    mock_rbac.Role = fake_role_cls
+
+    mock_signals = mock.MagicMock()
+    mock_signals.disable_activity_stream = mock.MagicMock(return_value=mock.MagicMock(__enter__=mock.Mock(), __exit__=mock.Mock()))
+
+    original_filter = Resource.objects.filter
+
+    def patched_filter(**kwargs):
+        if 'ansible_id__in' in kwargs:
+            real_qs = original_filter(**kwargs)
+            return [FakeResource(r, object_registry.get(str(r.ansible_id), r.content_object)) for r in real_qs]
+        return original_filter(**kwargs)
+
+    with mock.patch.dict(
+        'sys.modules',
+        {
+            'awx': mock.MagicMock(),
+            'awx.main': mock.MagicMock(),
+            'awx.main.models': mock.MagicMock(),
+            'awx.main.models.rbac': mock_rbac,
+            'awx.main.signals': mock_signals,
+        },
+    ):
+        with mock.patch.object(Resource.objects, 'filter', side_effect=patched_filter):
+            yield attach_fake_role, all_roles, fake_role_cls, register_object
+
+
+@pytest.mark.django_db
+class TestSyncOldRbac:
+
+    def test_sync_adds_members(self, admin_user, organization, team, org_admin_rd, member_rd, mock_awx_rbac):
+        attach_fake_role, all_roles, fake_role_cls, register_object = mock_awx_rbac
+        org_admin_role = attach_fake_role(organization, 'admin_role')
+        team_member_role = attach_fake_role(team, 'member_role')
+        register_object(organization)
+        register_object(team)
+        fake_role_cls.objects = FakeRoleQuerySet(all_roles)
+
+        claims = _build_claims([organization], [team])
+        save_user_claims(admin_user, **claims)
+
+        auth = AwxJWTAuthentication()
+        auth._sync_old_rbac(admin_user, claims["objects"], claims["object_roles"])
+
+        assert admin_user in org_admin_role.members
+        assert admin_user in team_member_role.members
+
+    def test_sync_removes_stale_members(self, admin_user, organization, team, org_admin_rd, member_rd, mock_awx_rbac):
+        attach_fake_role, all_roles, fake_role_cls, register_object = mock_awx_rbac
+        org_admin_role = attach_fake_role(organization, 'admin_role')
+        team_member_role = attach_fake_role(team, 'member_role')
+        register_object(organization)
+        register_object(team)
+        fake_role_cls.objects = FakeRoleQuerySet(all_roles)
+
+        claims_full = _build_claims([organization], [team])
+        save_user_claims(admin_user, **claims_full)
+        auth = AwxJWTAuthentication()
+        auth._sync_old_rbac(admin_user, claims_full["objects"], claims_full["object_roles"])
+
+        assert admin_user in org_admin_role.members
+        assert admin_user in team_member_role.members
+
+        claims_reduced = _build_claims([organization], [])
+        save_user_claims(admin_user, **claims_reduced)
+        auth._sync_old_rbac(admin_user, claims_reduced["objects"], claims_reduced["object_roles"])
+
+        assert admin_user in org_admin_role.members
+        assert admin_user not in team_member_role.members
+
+    def test_sync_skips_unknown_role_names(self, admin_user, organization, org_admin_rd, mock_awx_rbac):
+        attach_fake_role, all_roles, fake_role_cls, register_object = mock_awx_rbac
+        fake_role_cls.objects = FakeRoleQuerySet(all_roles)
+
+        objects = {"organization": [{"ansible_id": str(organization.resource.ansible_id), "name": organization.name}]}
+        object_roles = {"Bogus Role": {"content_type": "organization", "objects": [0]}}
+
+        auth = AwxJWTAuthentication()
+        auth._sync_old_rbac(admin_user, objects, object_roles)
+
+    def test_sync_noop_without_awx(self, admin_user):
+        """Without AWX installed, _sync_old_rbac is a silent no-op."""
+        auth = AwxJWTAuthentication()
+        auth._sync_old_rbac(admin_user, {}, {})

--- a/test_app/tests/jwt_consumer/common/test_auth.py
+++ b/test_app/tests/jwt_consumer/common/test_auth.py
@@ -364,7 +364,7 @@ class TestJWTCommonAuth:
                     'managed': True,
                 },
             )
-            with expected_log(claims_logger, 'info', 'Granted user'):
+            with expected_log(claims_logger, 'info', 'Granting user'):
                 save_user_claims(authentication.user, {}, {}, global_roles)
         else:
             save_user_claims(authentication.user, {}, {}, global_roles)

--- a/test_app/tests/rbac/test_scoped_team_recompute.py
+++ b/test_app/tests/rbac/test_scoped_team_recompute.py
@@ -263,7 +263,7 @@ class TestRoleAssignmentScoping:
             captured_team_ids.append(team_ids)
             return original_compute(team_ids=team_ids)
 
-        with patch('ansible_base.rbac.triggers.compute_team_member_roles', tracking_compute):
+        with patch('ansible_base.rbac.pipeline.compute_team_member_roles', tracking_compute):
             member_rd.give_permission(rando, team_a)
 
         assert rando.has_obj_perm(inv, 'change')
@@ -294,7 +294,7 @@ class TestRoleAssignmentScoping:
             captured_team_ids.append(team_ids)
             return original_compute(team_ids=team_ids)
 
-        with patch('ansible_base.rbac.triggers.compute_team_member_roles', tracking_compute):
+        with patch('ansible_base.rbac.pipeline.compute_team_member_roles', tracking_compute):
             org_team_member_rd.give_permission(rando, org_a)
 
         assert rando.has_obj_perm(inv, 'change')

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError
 from ansible_base.rbac.caching import compute_team_member_roles
 from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleEvaluation, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.rbac.permission_registry import permission_registry
+from ansible_base.rbac.pipeline import bulk_give_permissions, bulk_remove_permissions
 from ansible_base.rbac.triggers import dab_post_migrate, defer_rbac_computations, post_migration_rbac_setup
 from test_app.models import Inventory, Organization, User
 
@@ -23,12 +24,11 @@ def test_post_migrate_signals():
 
 @pytest.mark.django_db
 def test_post_migrate_skips_recompute_when_no_migrations_applied():
-    """post_migration_rbac_setup should skip compute_team_member_roles and
-    compute_object_role_permissions when the plan kwarg is an empty list,
-    meaning no migrations were actually applied."""
+    """post_migration_rbac_setup should skip recompute when the plan kwarg
+    is an empty list, meaning no migrations were actually applied."""
     with (
         patch('ansible_base.rbac.triggers.compute_team_member_roles') as mock_team,
-        patch('ansible_base.rbac.triggers.compute_object_role_permissions') as mock_obj,
+        patch('ansible_base.rbac.triggers.recompute_all_role_evaluations') as mock_obj,
     ):
         post_migration_rbac_setup(apps.get_app_config('dab_rbac'), plan=[])
 
@@ -42,12 +42,30 @@ def test_post_migrate_runs_recompute_when_plan_has_entries():
     plan kwarg contains migration entries."""
     with (
         patch('ansible_base.rbac.triggers.compute_team_member_roles') as mock_team,
-        patch('ansible_base.rbac.triggers.compute_object_role_permissions') as mock_obj,
+        patch('ansible_base.rbac.triggers.recompute_all_role_evaluations') as mock_obj,
     ):
         post_migration_rbac_setup(apps.get_app_config('dab_rbac'), plan=[('fake_migration',)])
 
     mock_team.assert_called_once()
     mock_obj.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_cleanup_orphaned_object_roles(organization, inv_rd):
+    """cleanup_orphaned_object_roles deletes ObjectRoles with no assignments."""
+    from ansible_base.rbac.caching import cleanup_orphaned_object_roles
+
+    inv = Inventory.objects.create(name='orphan-test-inv', organization=organization)
+    inv_rd.give_permission(User.objects.create(username='orphan-user'), inv)
+    obj_role = ObjectRole.objects.get(role_definition=inv_rd, object_id=inv.pk)
+
+    # Remove the assignment — ObjectRole is now orphaned
+    obj_role.users.clear()
+    assert not obj_role.users.exists() and not obj_role.teams.exists()
+
+    deleted = cleanup_orphaned_object_roles()
+    assert deleted >= 1
+    assert not ObjectRole.objects.filter(pk=obj_role.pk).exists()
 
 
 @pytest.mark.django_db
@@ -231,7 +249,7 @@ def test_api_delete_uses_deferral_context_managers(admin_api_client, organizatio
     signal fires during the cascade."""
     from django.db.models.signals import post_delete
 
-    from ansible_base.rbac.triggers import _defer_rbac
+    from ansible_base.rbac.caching import defer_rbac_state
 
     org_inv_rd.give_permission(rando, organization)
     for i in range(3):
@@ -240,7 +258,7 @@ def test_api_delete_uses_deferral_context_managers(admin_api_client, organizatio
     was_active = []
 
     def check_defer(sender, instance, **kwargs):
-        was_active.append(_defer_rbac.active)
+        was_active.append(defer_rbac_state.active)
 
     post_delete.connect(check_defer, sender=Inventory)
     try:
@@ -311,10 +329,10 @@ def test_defer_rbac_computations_empty_block(inventory):
 
 @pytest.mark.django_db
 def test_defer_rbac_computations_give_permission_raises_after_stash(organization, rando, org_inv_rd):
-    """give_permission raises after resources have been created/deleted inside the CM."""
+    """give_permission raises after resources are stashed because RoleEvaluation is stale."""
     with defer_rbac_computations():
         Inventory.objects.create(name='stash-trigger', organization=organization)
-        with pytest.raises(RuntimeError, match="give_permission cannot be called"):
+        with pytest.raises(RuntimeError, match="Permission assignment/removal cannot be called"):
             org_inv_rd.give_permission(rando, organization)
 
 
@@ -328,11 +346,11 @@ def test_defer_rbac_computations_give_permission_ok_before_stash(organization, r
 
 @pytest.mark.django_db
 def test_defer_rbac_computations_remove_permission_raises_after_stash(organization, rando, org_inv_rd):
-    """remove_permission raises after resources have been created/deleted inside the CM."""
+    """remove_permission raises after resources are stashed because RoleEvaluation is stale."""
     org_inv_rd.give_permission(rando, organization)
     with defer_rbac_computations():
         Inventory.objects.create(name='stash-trigger', organization=organization)
-        with pytest.raises(RuntimeError, match="remove_permission cannot be called"):
+        with pytest.raises(RuntimeError, match="Permission assignment/removal cannot be called"):
             org_inv_rd.remove_permission(rando, organization)
 
 
@@ -495,6 +513,312 @@ def test_defer_rbac_computations_team_creation():
         assert team.id in mock_ctmr.call_args.kwargs['team_ids']
 
 
+@pytest.mark.django_db
+class TestBulkGivePermissions:
+    """Tests for bulk_give_permissions."""
+
+    def test_multiple_users_single_rd(self, organization, rando, org_inv_rd):
+        second_user = User.objects.create(username='second-user')
+        bulk_give_permissions(
+            user_permissions=[
+                (org_inv_rd, rando, organization),
+                (org_inv_rd, second_user, organization),
+            ]
+        )
+        assert rando.has_obj_perm(organization, 'view')
+        assert second_user.has_obj_perm(organization, 'view')
+
+    def test_multiple_objects_single_rd(self, organization, inv_rd):
+        inv1 = Inventory.objects.create(name='bulk-inv1', organization=organization)
+        inv2 = Inventory.objects.create(name='bulk-inv2', organization=organization)
+        user = User.objects.create(username='bulk-user')
+        bulk_give_permissions(user_permissions=[(inv_rd, user, inv1), (inv_rd, user, inv2)])
+        assert user.has_obj_perm(inv1, 'change')
+        assert user.has_obj_perm(inv2, 'change')
+
+    def test_multi_rd_user_assignments(self, organization, rando, org_inv_rd):
+        from test_app.models import Team
+
+        member_rd = RoleDefinition.objects.managed.team_member
+        team = Team.objects.create(name='bulk-team', organization=organization)
+        bulk_give_permissions(
+            user_permissions=[
+                (org_inv_rd, rando, organization),
+                (member_rd, rando, team),
+            ]
+        )
+        assert rando.has_obj_perm(organization, 'view')
+        assert rando.has_obj_perm(team, 'member_team')
+
+    def test_multi_rd_with_teams(self, organization, team, inv_rd):
+        inv = Inventory.objects.create(name='multi-rd-inv', organization=organization)
+        user = User.objects.create(username='multi-rd-user')
+        member_rd = RoleDefinition.objects.managed.team_member
+        bulk_give_permissions(
+            user_permissions=[(member_rd, user, team)],
+            team_permissions=[(inv_rd, team, inv)],
+        )
+        assert user.has_obj_perm(team, 'member_team')
+        assert ObjectRole.objects.filter(role_definition=inv_rd, object_id=inv.pk, teams=team).exists()
+
+    def test_evaluations_correct(self, organization, rando, org_inv_rd):
+        inv = Inventory.objects.create(name='eval-inv', organization=organization)
+        bulk_give_permissions(user_permissions=[(org_inv_rd, rando, organization)])
+        assert rando.has_obj_perm(inv, 'change')
+        assert RoleEvaluation.objects.filter(codename='change_inventory', object_id=inv.pk).exists()
+
+    def test_idempotent(self, organization, rando, org_inv_rd):
+        bulk_give_permissions(user_permissions=[(org_inv_rd, rando, organization)])
+        bulk_give_permissions(user_permissions=[(org_inv_rd, rando, organization)])
+        assert RoleUserAssignment.objects.filter(user=rando, role_definition=org_inv_rd).count() == 1
+
+    def test_empty_is_noop(self):
+        bulk_give_permissions()
+
+    def test_return_no_cross_product(self, organization, inv_rd):
+        """Return value must contain only the requested assignments, not cross-product extras."""
+        inv1 = Inventory.objects.create(name='xp-inv1', organization=organization)
+        inv2 = Inventory.objects.create(name='xp-inv2', organization=organization)
+        user1 = User.objects.create(username='xp-user1')
+        user2 = User.objects.create(username='xp-user2')
+
+        # Pre-existing: user1 has inv2 (not part of the bulk call)
+        inv_rd.give_permission(user1, inv2)
+
+        assignments = bulk_give_permissions(
+            user_permissions=[
+                (inv_rd, user1, inv1),
+                (inv_rd, user2, inv2),
+            ]
+        )
+        returned_pairs = {(a.user_id, a.object_id) for a in assignments}
+        assert returned_pairs == {
+            (user1.pk, str(inv1.pk)),
+            (user2.pk, str(inv2.pk)),
+        }, f"Cross-product leak: got {returned_pairs}"
+
+    def test_audit_no_cross_product(self, organization, inv_rd):
+        """Audit logging must not fire for pre-existing assignments outside the batch."""
+        inv1 = Inventory.objects.create(name='audit-xp-inv1', organization=organization)
+        inv2 = Inventory.objects.create(name='audit-xp-inv2', organization=organization)
+        user1 = User.objects.create(username='audit-xp-user1')
+        user2 = User.objects.create(username='audit-xp-user2')
+
+        inv_rd.give_permission(user1, inv2)
+
+        with patch('ansible_base.rbac.pipeline._audit_log_created') as mock_audit:
+            bulk_give_permissions(
+                user_permissions=[
+                    (inv_rd, user1, inv1),
+                    (inv_rd, user2, inv2),
+                ],
+                fire_signals_on_create=False,
+            )
+            args = mock_audit.call_args
+            db_assignments = args[0][0]
+            existing_pks = args[0][1]
+            new_assignments = [a for a in db_assignments if a.pk not in existing_pks]
+            new_pairs = {(a.user_id, a.object_id) for a in new_assignments}
+            assert (user1.pk, str(inv2.pk)) not in new_pairs, "Pre-existing assignment leaked into new set"
+
+
+@pytest.mark.django_db
+class TestBulkRemovePermissions:
+    """Tests for the classmethod bulk_remove_permissions."""
+
+    def test_removes_assignments(self, organization, rando, org_inv_rd):
+        org_inv_rd.give_permission(rando, organization)
+        assert rando.has_obj_perm(organization, 'view')
+        bulk_remove_permissions(user_permissions=[(org_inv_rd, rando, organization)])
+        assert not rando.has_obj_perm(organization, 'view')
+
+    def test_orphans_object_role(self, organization, rando, org_inv_rd):
+        org_inv_rd.give_permission(rando, organization)
+        or_count_before = ObjectRole.objects.count()
+        bulk_remove_permissions(user_permissions=[(org_inv_rd, rando, organization)])
+        assert ObjectRole.objects.count() < or_count_before
+
+    def test_keeps_other_users(self, organization, org_inv_rd):
+        user1 = User.objects.create(username='keep-user1')
+        user2 = User.objects.create(username='keep-user2')
+        bulk_give_permissions(
+            user_permissions=[
+                (org_inv_rd, user1, organization),
+                (org_inv_rd, user2, organization),
+            ]
+        )
+        bulk_remove_permissions(user_permissions=[(org_inv_rd, user1, organization)])
+        assert not user1.has_obj_perm(organization, 'view')
+        assert user2.has_obj_perm(organization, 'view')
+
+    def test_multi_rd_removal(self, organization, rando, org_inv_rd):
+        from test_app.models import Team
+
+        member_rd = RoleDefinition.objects.managed.team_member
+        team = Team.objects.create(name='rm-team', organization=organization)
+        org_inv_rd.give_permission(rando, organization)
+        member_rd.give_permission(rando, team)
+        assert rando.has_obj_perm(organization, 'view')
+        assert rando.has_obj_perm(team, 'member_team')
+        bulk_remove_permissions(
+            user_permissions=[
+                (org_inv_rd, rando, organization),
+                (member_rd, rando, team),
+            ]
+        )
+        assert not rando.has_obj_perm(organization, 'view')
+        assert not rando.has_obj_perm(team, 'member_team')
+
+    def test_empty_is_noop(self):
+        bulk_remove_permissions()
+
+    def test_team_removal_revokes_inherited_permissions(self, organization, team, inv_rd):
+        """Removing a team assignment must revoke permissions inherited through the team."""
+        inv = Inventory.objects.create(name='team-rm-inv', organization=organization)
+        user = User.objects.create(username='team-rm-user')
+        member_rd = RoleDefinition.objects.managed.team_member
+        member_rd.give_permission(user, team)
+        inv_rd.give_permission(team, inv)
+        assert user.has_obj_perm(inv, 'change')
+
+        bulk_remove_permissions(team_permissions=[(inv_rd, team, inv)])
+        assert not user.has_obj_perm(inv, 'change')
+
+    def test_team_removal_no_stale_object_roles(self, organization, inv_rd):
+        """Removing a team assignment must not leave RoleEvaluation rows
+        pointing to deleted ObjectRoles when signal handlers cause
+        additional ObjectRole deletions.
+
+        Regression test: bulk_remove_permissions added team ancestor roles to
+        the surviving set, then orphaned.delete() fired signal handlers that
+        deleted some of those ancestor ObjectRoles. The stale in-memory
+        references caused compute_object_role_permissions to create
+        RoleEvaluation rows with dangling FK references.
+        """
+        from django.db.models.signals import post_delete
+
+        from test_app.models import Team
+
+        inv = Inventory.objects.create(name='stale-or-inv', organization=organization)
+        team = Team.objects.create(name='stale-or-team', organization=organization)
+        user = User.objects.create(username='stale-or-user')
+        member_rd = RoleDefinition.objects.managed.team_member
+        member_rd.give_permission(user, team)
+        inv_rd.give_permission(team, inv)
+        assert user.has_obj_perm(inv, 'change')
+
+        # The member ObjectRole is what bulk_ancestor_roles will add to surviving
+        member_obj_role = ObjectRole.objects.get(
+            role_definition=member_rd,
+            content_type_id=permission_registry.content_type_model.objects.get_for_model(team).pk,
+            object_id=team.pk,
+        )
+
+        # Simulate downstream signal handlers (like AWX's) that delete
+        # additional ObjectRoles during orphaned.delete() cascade.
+        def delete_ancestor_role(sender, instance, **kwargs):
+            if instance.pk == member_obj_role.pk:
+                return
+            ObjectRole.objects.filter(pk=member_obj_role.pk).delete()
+
+        post_delete.connect(delete_ancestor_role, sender=ObjectRole)
+        try:
+            bulk_remove_permissions(team_permissions=[(inv_rd, team, inv)])
+        finally:
+            post_delete.disconnect(delete_ancestor_role, sender=ObjectRole)
+
+        # Every RoleEvaluation must reference an existing ObjectRole
+        orphaned_evals = RoleEvaluation.objects.exclude(role_id__in=ObjectRole.objects.values_list('id', flat=True))
+        assert not orphaned_evals.exists(), (
+            f"Found {orphaned_evals.count()} RoleEvaluation rows pointing to " f"deleted ObjectRoles: {list(orphaned_evals.values_list('role_id', flat=True))}"
+        )
+
+    def test_team_removal_no_cross_product(self, organization, inv_rd):
+        """Removing team assignments must not affect unrelated team-object pairs."""
+        from test_app.models import Team
+
+        inv1 = Inventory.objects.create(name='team-xp-inv1', organization=organization)
+        inv2 = Inventory.objects.create(name='team-xp-inv2', organization=organization)
+        team1 = Team.objects.create(name='team-xp-t1', organization=organization)
+        team2 = Team.objects.create(name='team-xp-t2', organization=organization)
+        member_rd = RoleDefinition.objects.managed.team_member
+        user = User.objects.create(username='team-xp-user')
+        member_rd.give_permission(user, team1)
+        member_rd.give_permission(user, team2)
+
+        bulk_give_permissions(
+            team_permissions=[
+                (inv_rd, team1, inv1),
+                (inv_rd, team1, inv2),
+                (inv_rd, team2, inv1),
+                (inv_rd, team2, inv2),
+            ]
+        )
+        assert user.has_obj_perm(inv1, 'change')
+        assert user.has_obj_perm(inv2, 'change')
+
+        bulk_remove_permissions(team_permissions=[(inv_rd, team1, inv1)])
+        assert RoleTeamAssignment.objects.filter(team=team1, role_definition=inv_rd, object_id=inv2.pk).exists()
+        assert RoleTeamAssignment.objects.filter(team=team2, role_definition=inv_rd, object_id=inv1.pk).exists()
+        assert RoleTeamAssignment.objects.filter(team=team2, role_definition=inv_rd, object_id=inv2.pk).exists()
+        assert user.has_obj_perm(inv2, 'change')
+
+
+@pytest.mark.django_db
+class TestBulkRemotePermissions:
+    """Tests for bulk operations with RemoteObject content objects."""
+
+    @pytest.fixture
+    def foo_type(self):
+        org_ct = permission_registry.content_type_model.objects.get_for_model(Organization)
+        return permission_registry.content_type_model.objects.create(service='foo', model='foo', app_label='foo', parent_content_type=org_ct)
+
+    @pytest.fixture
+    def foo_rd(self, foo_type):
+        from ansible_base.rbac.models import DABPermission
+
+        perm = DABPermission.objects.create(codename='foo_foo', content_type=foo_type)
+        return RoleDefinition.objects.create_from_permissions(name='Bulk foo role', permissions=[perm.api_slug], content_type=foo_type)
+
+    def test_bulk_give_remote_permission(self, rando, foo_type, foo_rd):
+        from ansible_base.rbac.remote import RemoteObject
+
+        a_foo = RemoteObject(content_type=foo_type, object_id=42)
+        bulk_give_permissions(user_permissions=[(foo_rd, rando, a_foo)])
+        assert rando.has_obj_perm(a_foo, 'foo')
+
+    def test_bulk_give_remote_with_parent_reference(self, rando, foo_type, foo_rd, organization):
+        from ansible_base.rbac.remote import RemoteObject
+
+        a_foo = RemoteObject(content_type=foo_type, object_id=42, parent_reference=organization.pk)
+        bulk_give_permissions(user_permissions=[(foo_rd, rando, a_foo)])
+        obj_role = ObjectRole.objects.get(role_definition=foo_rd, object_id='42')
+        assert str(obj_role.parent_reference) == str(organization.pk)
+
+    def test_bulk_remove_remote_permission(self, rando, foo_type, foo_rd):
+        from ansible_base.rbac.remote import RemoteObject
+
+        a_foo = RemoteObject(content_type=foo_type, object_id=42)
+        foo_rd.give_permission(rando, a_foo)
+        assert rando.has_obj_perm(a_foo, 'foo')
+        bulk_remove_permissions(user_permissions=[(foo_rd, rando, a_foo)])
+        assert not rando.has_obj_perm(a_foo, 'foo')
+        assert not ObjectRole.objects.filter(role_definition=foo_rd, object_id='42').exists()
+
+    def test_bulk_mixed_local_and_remote(self, rando, organization, foo_type, foo_rd, org_inv_rd):
+        from ansible_base.rbac.remote import RemoteObject
+
+        a_foo = RemoteObject(content_type=foo_type, object_id=42)
+        bulk_give_permissions(
+            user_permissions=[
+                (foo_rd, rando, a_foo),
+                (org_inv_rd, rando, organization),
+            ]
+        )
+        assert rando.has_obj_perm(a_foo, 'foo')
+        assert rando.has_obj_perm(organization, 'view')
+
+
 class TestEmailPolicySignal:
     """Tests for the pre_save signal that prevents unauthorized email
     changes across all services."""
@@ -633,3 +957,50 @@ class TestEmailPolicySignal:
         post_init_uids = {r[0][0] for r in post_init.receivers}
         assert 'permission-registry-enforce-email' in pre_save_uids
         assert 'permission-registry-stash-email' in post_init_uids
+
+
+@pytest.mark.django_db
+class TestPermissionQueryCount:
+    """Profile query counts for give_permission / remove_permission."""
+
+    @override_settings(DEBUG=True)
+    def test_give_permission_user_query_count(self, rando, organization, org_admin_rd):
+        from django.db import connection
+
+        connection.queries_log.clear()
+        before = len(connection.queries)
+        org_admin_rd.give_permission(rando, organization)
+        count = len(connection.queries) - before
+        print(f"\ngive_permission (user+org): {count} queries")
+
+    @override_settings(DEBUG=True)
+    def test_remove_permission_user_query_count(self, rando, organization, org_admin_rd):
+        from django.db import connection
+
+        org_admin_rd.give_permission(rando, organization)
+        connection.queries_log.clear()
+        before = len(connection.queries)
+        org_admin_rd.remove_permission(rando, organization)
+        count = len(connection.queries) - before
+        print(f"\nremove_permission (user+org): {count} queries")
+
+    @override_settings(DEBUG=True)
+    def test_give_permission_team_query_count(self, team, inventory, inv_rd):
+        from django.db import connection
+
+        connection.queries_log.clear()
+        before = len(connection.queries)
+        inv_rd.give_permission(team, inventory)
+        count = len(connection.queries) - before
+        print(f"\ngive_permission (team+inv): {count} queries")
+
+    @override_settings(DEBUG=True)
+    def test_remove_permission_team_query_count(self, team, inventory, inv_rd):
+        from django.db import connection
+
+        inv_rd.give_permission(team, inventory)
+        connection.queries_log.clear()
+        before = len(connection.queries)
+        inv_rd.remove_permission(team, inventory)
+        count = len(connection.queries) - before
+        print(f"\nremove_permission (team+inv): {count} queries")

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -61,7 +61,8 @@ def test_cleanup_orphaned_object_roles(organization, inv_rd):
 
     # Remove the assignment — ObjectRole is now orphaned
     obj_role.users.clear()
-    assert not obj_role.users.exists() and not obj_role.teams.exists()
+    assert not obj_role.users.exists()
+    assert not obj_role.teams.exists()
 
     deleted = cleanup_orphaned_object_roles()
     assert deleted >= 1

--- a/test_app/tests/resource_registry/test_resources_api_rest_client.py
+++ b/test_app/tests/resource_registry/test_resources_api_rest_client.py
@@ -211,7 +211,7 @@ def _assert_assignment_matches_data(assignment, data, obj, actor):
     assert 'created' in data, data
     # assert DateTimeField().to_representation(assignment.created) == data['created']  # TODO
     assert str(assignment.created_by.resource.ansible_id) == data['created_by_ansible_id']
-    assert assignment.object_id == obj.id
+    assert assignment.object_id == str(obj.id)
     assert str(assignment.object_id) == str(data['object_id'])
     if hasattr(obj, 'resource'):
         assert str(obj.resource.ansible_id) == data['object_ansible_id']

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -266,7 +266,7 @@ def observability_headers_start(request):
     return JsonResponse({"upstream_headers": response.json().get("headers", {})})
 
 
-def otel_traces(request):
+def otel_traces(_request):
     from test_app import otlp_server
 
     # Flush any buffered spans before reading
@@ -279,7 +279,7 @@ def otel_traces(request):
     return JsonResponse({"traces": data})
 
 
-def otel_logs(request):
+def otel_logs(_request):
     from test_app import otlp_server
 
     provider = get_logger_provider()


### PR DESCRIPTION
## Summary
- Replace `defer_rbac_cache` with `defer_rbac_computations` context manager for deferring RBAC signal-driven recomputation during bulk resource create/delete
- Add `RoleDefinition.bulk_give_permissions` / `bulk_remove_permissions` classmethods accepting `(role_definition, actor, content_object)` triples for batched permission assignment with a single recomputation pass
- Guards on `give_permission`, `remove_permission`, and `has_obj_perm` only raise after data has been stashed in the context manager, allowing views to check permissions before mutations
- Add profiling endpoints and scaling tests for org deletion (`test_org_delete_scaling.py`)
- Batch GenericFK cleanup in resource registry signal handlers

## Test plan
- [x] 621 RBAC tests pass
- [x] `test_triggers.py` covers bulk give/remove with multi-RD triples, idempotency, team assignments, evaluation correctness
- [x] Stash-conditional guards tested: `give_permission`/`remove_permission`/`has_obj_perm` allowed before stash, raise after
- [x] `test_org_delete_scaling.py` validates populate + delete with `defer_rbac_computations`
- [ ] Profile populate/delete endpoints at scale to confirm query count reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk RBAC permission assignment and revocation for users and teams, supporting multiple role/object triples with idempotent behavior.
  * Automatically refreshes permission evaluations after bulk updates.
  * Added the `profile-stories` endpoint to the API root listing.
* **Bug Fixes**
  * Bulk removal now cleans up orphaned role artifacts and preserves other users’ permissions.
* **Documentation**
  * Updated bulk operations guidance, including an explicit “do not call bulk methods inside deferred RBAC computations” constraint.
* **Tests**
  * Replaced trigger-focused tests with comprehensive bulk give/remove coverage, including cross-role cases and no-op inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->