### PR TITLE
Replace deprecated sonarcloud-github-action with sonarqube-scan-action

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -125,7 +125,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@e44258b109568baa0df60ed515909fc6c72cba92
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f  # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
@@ -186,7 +186,7 @@ jobs:
           echo "└── Result: ✅ Running SonarCloud branch analysis"
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@e44258b109568baa0df60ed515909fc6c72cba92
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f  # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}


### PR DESCRIPTION
## Summary
- The `SonarSource/sonarcloud-github-action` was archived in Oct 2025 and is deprecated in favor of `SonarSource/sonarqube-scan-action`
- SonarCloud now requires Java 21+; the deprecated action runs the scanner under Java 17, causing analysis failures
- Migrates both SonarCloud scan steps (PR analysis and branch analysis) to `SonarSource/sonarqube-scan-action` v8.2.1
- The new action is a drop-in replacement — `args`, `SONAR_TOKEN`, and `GITHUB_TOKEN` env vars are fully compatible

## Test plan
- [ ] Verify SonarCloud PR analysis job passes on this PR
- [ ] Verify SonarCloud branch analysis runs successfully after merge to devel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code-quality scanning workflows to use the latest SonarQube scanning action.
  * Preserved existing scan settings for pull requests and long-lived branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->