### PR TITLE
AAP-83963 — Skip RBAC recompute in post_migrate when no migrations were applied

### DIFF
--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -448,6 +448,11 @@ def post_migration_rbac_setup(sender, *args, **kwargs):
 
     dab_post_migrate.send(sender=sender)
 
+    plan = kwargs.get('plan', None)
+    if plan is not None and len(plan) == 0:
+        logger.info('Skipping RBAC recompute — no migrations were applied')
+        return
+
     compute_team_member_roles()
     compute_object_role_permissions()
 

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -21,6 +21,35 @@ def test_post_migrate_signals():
 
 
 @pytest.mark.django_db
+def test_post_migrate_skips_recompute_when_no_migrations_applied():
+    """post_migration_rbac_setup should skip compute_team_member_roles and
+    compute_object_role_permissions when the plan kwarg is an empty list,
+    meaning no migrations were actually applied."""
+    with (
+        patch('ansible_base.rbac.triggers.compute_team_member_roles') as mock_team,
+        patch('ansible_base.rbac.triggers.compute_object_role_permissions') as mock_obj,
+    ):
+        post_migration_rbac_setup(apps.get_app_config('dab_rbac'), plan=[])
+
+    mock_team.assert_not_called()
+    mock_obj.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_post_migrate_runs_recompute_when_plan_has_entries():
+    """post_migration_rbac_setup should call recompute functions when the
+    plan kwarg contains migration entries."""
+    with (
+        patch('ansible_base.rbac.triggers.compute_team_member_roles') as mock_team,
+        patch('ansible_base.rbac.triggers.compute_object_role_permissions') as mock_obj,
+    ):
+        post_migration_rbac_setup(apps.get_app_config('dab_rbac'), plan=[('fake_migration',)])
+
+    mock_team.assert_called_once()
+    mock_obj.assert_called_once()
+
+
+@pytest.mark.django_db
 def test_change_parent_field(team, rando, inventory, org_inv_rd, member_rd):
     member_rd.give_permission(rando, team)
     org_inv_rd.give_permission(team, inventory.organization)


### PR DESCRIPTION
## Summary
Skip `compute_team_member_roles()` and `compute_object_role_permissions()` when no migrations were actually applied.

**Measured on ScaleLab** (42K ObjectRoles, 418K RoleEvaluations):
- `compute_team_member_roles()`: 1.2s
- `compute_object_role_permissions()`: **1,128s (18.8 minutes)**
- Per pod: ~19 minutes in init container
- 3 replicas rolling sequentially: **~57 minutes per rollout**

Checks the `plan` kwarg from Django's `post_migrate` signal — empty list means no migrations ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-migration access-control setup by skipping unnecessary permission recomputation when no migrations are applied.
  * Preserved existing role and permission updates when migrations require recomputation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->