### PR TITLE
[AAP-82668] Revert Redis-based get_system_user() cache

### DIFF
--- a/ansible_base/lib/abstract_models/user.py
+++ b/ansible_base/lib/abstract_models/user.py
@@ -21,16 +21,3 @@ class AbstractDABUser(AbstractUser):
 
     all_objects = UserManager()
     objects = UserManager()
-
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        from ansible_base.lib.utils.models import clear_system_user_cache
-
-        clear_system_user_cache()
-
-    def delete(self, *args, **kwargs):
-        result = super().delete(*args, **kwargs)
-        from ansible_base.lib.utils.models import clear_system_user_cache
-
-        clear_system_user_cache()
-        return result

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -101,47 +101,11 @@ class NotARealException(Exception):
     pass
 
 
-SYSTEM_USER_CACHE_KEY = "dab:system_user"
-SYSTEM_USER_CACHE_TTL = 300
-
-
-def _has_shared_cache() -> bool:
-    """Return True if the default cache backend is a shared store (Redis, memcached).
-
-    DummyCache and LocMemCache are not suitable for cross-process caching,
-    so we only cache the system user when a real shared backend is configured.
-    """
-    from django.core.cache import cache
-
-    backend_module = type(cache).__module__
-    return 'dummy' not in backend_module and 'locmem' not in backend_module
-
-
-def clear_system_user_cache():
-    """Clear the cached system user.
-
-    Call this between tests or whenever the system user may have been
-    deleted/recreated (e.g. after a database flush).
-    """
-    if _has_shared_cache():
-        from django.core.cache import cache
-
-        cache.delete(SYSTEM_USER_CACHE_KEY)
-
-
 def get_system_user() -> Optional[AbstractUser]:
 
     from ansible_base.lib.abstract_models.user import AbstractDABUser
 
     system_username, setting_name = get_system_username()
-
-    use_cache = _has_shared_cache()
-    if use_cache:
-        from django.core.cache import cache
-
-        cached = cache.get(SYSTEM_USER_CACHE_KEY)
-        if cached is not None and cached.username == system_username:
-            return cached
     user_model = get_user_model()
 
     # If we use subclass of AbstractDABUser ensure we use manager for unfiltered queryset
@@ -170,10 +134,6 @@ def get_system_user() -> Optional[AbstractUser]:
             system_user = create_system_user(user_model=get_user_model())
         except caught_exception:
             system_user = None
-
-    if use_cache and system_user is not None:
-        # Cache the full User instance (~1 kB serialized) to avoid a DB round-trip on hit.
-        cache.set(SYSTEM_USER_CACHE_KEY, system_user, timeout=SYSTEM_USER_CACHE_TTL)
 
     return system_user
 

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -99,21 +99,6 @@ def clear_content_type_cache():
     ContentType.objects.clear_cache()
 
 
-@pytest.fixture(autouse=True)
-def _clear_system_user_cache():
-    """Clear the cached system user between tests.
-
-    Tests run inside a transaction that is rolled back after each test. Without
-    this fixture a cached User object from a previous test would survive the
-    rollback, pointing at a pk that no longer exists in the DB.
-    """
-    from ansible_base.lib.utils.models import clear_system_user_cache
-
-    clear_system_user_cache()
-    yield
-    clear_system_user_cache()
-
-
 @pytest.fixture
 def azuread_configuration():
     return {

--- a/test_app/tests/lib/utils/test_create_system_user.py
+++ b/test_app/tests/lib/utils/test_create_system_user.py
@@ -1,12 +1,9 @@
-from unittest.mock import patch
-
 import pytest
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 
 from ansible_base.lib.utils.create_system_user import create_system_user, get_system_username
-from ansible_base.lib.utils.models import get_system_user
 from test_app.models import ManagedUser, User
 
 
@@ -76,112 +73,8 @@ class TestGetSystemUser:
 
     @pytest.mark.django_db
     def test_get_system_user_from_managed_model(self):
-        User.all_objects.get(username=get_system_username()[0]).delete()
+        User.all_objects.filter(username=get_system_username()[0]).delete()
         create_system_user(user_model=ManagedUser)
 
         assert ManagedUser.objects.filter(username=get_system_username()[0]).count() == 0
         assert ManagedUser.all_objects.filter(username=get_system_username()[0]).count() == 1
-
-
-class TestGetSystemUserCache:
-    """Tests for the get_system_user() Redis caching behavior."""
-
-    @pytest.fixture(autouse=True)
-    def _isolated_cache(self, request):
-        """Patch SYSTEM_USER_CACHE_KEY to a per-test value so parallel workers can't race."""
-        isolated_key = f'dab:system_user:test:{request.node.name}'
-        with (
-            patch('ansible_base.lib.utils.models._has_shared_cache', return_value=True),
-            patch('ansible_base.lib.utils.models.SYSTEM_USER_CACHE_KEY', isolated_key),
-        ):
-            from django.core.cache import cache
-
-            cache.delete(isolated_key)
-            self.cache = cache
-            self.cache_key = isolated_key
-            yield
-            cache.delete(isolated_key)
-
-    @pytest.mark.django_db
-    def test_second_call_returns_cached_result(self, system_user):
-        """Second call to get_system_user() should return from cache when a shared backend is configured."""
-        user1 = get_system_user()
-        assert user1 is not None
-        cached = self.cache.get(self.cache_key)
-        assert cached.pk == user1.pk
-
-        user2 = get_system_user()
-        assert user2.pk == user1.pk
-
-    @pytest.mark.django_db
-    def test_no_caching_without_shared_backend(self, system_user):
-        """When no shared cache backend is available, every call queries the DB."""
-        with patch('ansible_base.lib.utils.models._has_shared_cache', return_value=False):
-            self.cache.delete(self.cache_key)
-            get_system_user()
-            assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_cache_not_set_for_none_result(self):
-        """If system user creation returns None, the result is not cached."""
-        with patch('ansible_base.lib.utils.models.create_system_user', return_value=None):
-            with override_settings(SYSTEM_USERNAME='nonexistent_cache_test_user'):
-                result = get_system_user()
-
-        assert result is None
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_clear_system_user_cache(self, system_user):
-        """clear_system_user_cache() removes the cached entry from the shared backend."""
-        from ansible_base.lib.utils.models import clear_system_user_cache
-
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        clear_system_user_cache()
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_save_invalidates_cache(self, system_user):
-        """Saving the system user should clear the cache."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        system_user.save()
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_delete_invalidates_cache(self, system_user):
-        """Deleting the system user should clear the cache."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        system_user.delete()
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_rename_system_user_invalidates_cache(self, system_user):
-        """Renaming the system user should invalidate and repopulate correctly."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-        assert user1.username == system_user.username
-
-        system_user.username = 'renamed_user'
-        system_user.save()
-        assert self.cache.get(self.cache_key) is None
-
-        user2 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user2.pk
-        assert user2.username == get_system_username()[0]
-        assert user2.pk != system_user.pk
-
-    @pytest.mark.django_db
-    def test_setting_change_bypasses_cache(self, system_user):
-        """Changing SYSTEM_USERNAME should not return the old cached user."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        with override_settings(SYSTEM_USERNAME='different_username'):
-            user2 = get_system_user()
-            assert user2 is not user1


### PR DESCRIPTION
## Summary

Reverts #1056 — the Redis-based `get_system_user()` cache.

## Why

Profiling at 50K scale showed `get_system_user()` called ~49,800 times during
org deletion cascade. The Redis cache eliminates the DB query on each call,
but 49,800 Redis round-trips (~0.35ms each) still account for **17 seconds**
of the 41-second delete time.

A follow-up PR will replace this with a thread-local in-memory cache that
eliminates all network round-trips, with `request_started` signal clearing
to ensure freshness per HTTP request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system user resolution by removing stale cross-process caching behavior.
  * System user records are now resolved directly through the configured user manager, providing more consistent results after user changes.
  * Improved cache isolation during automated operations by ensuring content type state is reset between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->