### PR TITLE
[AAP-82668] Replace Redis cache with thread-local for get_system_user()

### DIFF
--- a/ansible_base/lib/abstract_models/user.py
+++ b/ansible_base/lib/abstract_models/user.py
@@ -21,16 +21,3 @@ class AbstractDABUser(AbstractUser):
 
     all_objects = UserManager()
     objects = UserManager()
-
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        from ansible_base.lib.utils.models import clear_system_user_cache
-
-        clear_system_user_cache()
-
-    def delete(self, *args, **kwargs):
-        result = super().delete(*args, **kwargs)
-        from ansible_base.lib.utils.models import clear_system_user_cache
-
-        clear_system_user_cache()
-        return result

--- a/ansible_base/lib/abstract_models/user.py
+++ b/ansible_base/lib/abstract_models/user.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.models import AbstractUser, UserManager
 
+from ansible_base.lib.utils.create_system_user import get_system_username
+
 
 class AbstractDABUser(AbstractUser):
     class Meta(AbstractUser.Meta):
@@ -21,3 +23,12 @@ class AbstractDABUser(AbstractUser):
 
     all_objects = UserManager()
     objects = UserManager()
+
+    def delete(self, *args, **kwargs):
+        was_system_user = self.username == get_system_username()[0]
+        result = super().delete(*args, **kwargs)
+        if was_system_user:
+            from ansible_base.lib.utils.models import clear_system_user_cache
+
+            clear_system_user_cache()
+        return result

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -101,47 +101,11 @@ class NotARealException(Exception):
     pass
 
 
-SYSTEM_USER_CACHE_KEY = "dab:system_user"
-SYSTEM_USER_CACHE_TTL = 300
-
-
-def _has_shared_cache() -> bool:
-    """Return True if the default cache backend is a shared store (Redis, memcached).
-
-    DummyCache and LocMemCache are not suitable for cross-process caching,
-    so we only cache the system user when a real shared backend is configured.
-    """
-    from django.core.cache import cache
-
-    backend_module = type(cache).__module__
-    return 'dummy' not in backend_module and 'locmem' not in backend_module
-
-
-def clear_system_user_cache():
-    """Clear the cached system user.
-
-    Call this between tests or whenever the system user may have been
-    deleted/recreated (e.g. after a database flush).
-    """
-    if _has_shared_cache():
-        from django.core.cache import cache
-
-        cache.delete(SYSTEM_USER_CACHE_KEY)
-
-
 def get_system_user() -> Optional[AbstractUser]:
 
     from ansible_base.lib.abstract_models.user import AbstractDABUser
 
     system_username, setting_name = get_system_username()
-
-    use_cache = _has_shared_cache()
-    if use_cache:
-        from django.core.cache import cache
-
-        cached = cache.get(SYSTEM_USER_CACHE_KEY)
-        if cached is not None and cached.username == system_username:
-            return cached
     user_model = get_user_model()
 
     # If we use subclass of AbstractDABUser ensure we use manager for unfiltered queryset
@@ -170,10 +134,6 @@ def get_system_user() -> Optional[AbstractUser]:
             system_user = create_system_user(user_model=get_user_model())
         except caught_exception:
             system_user = None
-
-    if use_cache and system_user is not None:
-        # Cache the full User instance (~1 kB serialized) to avoid a DB round-trip on hit.
-        cache.set(SYSTEM_USER_CACHE_KEY, system_user, timeout=SYSTEM_USER_CACHE_TTL)
 
     return system_user
 

--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import asdict, dataclass
 from itertools import chain
 from typing import TYPE_CHECKING, Optional
@@ -8,6 +9,7 @@ from typing import TYPE_CHECKING, Optional
 from crum import get_current_user
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.signals import request_started
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from inflection import underscore
@@ -101,18 +103,34 @@ class NotARealException(Exception):
     pass
 
 
-def get_system_user() -> Optional[AbstractUser]:
+_system_user_local = threading.local()
 
+
+def _clear_system_user_cache_on_request(**kwargs):
+    _system_user_local.cached = None
+
+
+def clear_system_user_cache():
+    _system_user_local.cached = None
+
+
+def get_system_user() -> Optional[AbstractUser]:
     from ansible_base.lib.abstract_models.user import AbstractDABUser
 
     system_username, setting_name = get_system_username()
+
+    cached = getattr(_system_user_local, 'cached', None)
+    if cached is not None:
+        cached_username, cached_user = cached
+        if cached_username == system_username:
+            return cached_user
+
     user_model = get_user_model()
 
     # If we use subclass of AbstractDABUser ensure we use manager for unfiltered queryset
     user_manager = user_model.all_objects if issubclass(user_model, AbstractDABUser) else user_model.objects
 
     system_user = user_manager.filter(username=system_username).first()
-    # We are using a global variable to try and track if this thread has already spit out the message, if so ignore
     if system_username is not None and system_user is None:
         logger.error(
             _(
@@ -126,16 +144,18 @@ def get_system_user() -> Optional[AbstractUser]:
             from ansible_base.resource_registry.models import ResourceType
 
             caught_exception = ResourceType.DoesNotExist
-            # If resource registry is installed we hit issues here during test tear downs
-            # For an unidentified reason, during teardown, the tests are calling the post_migration signals from resource_registry
-            # These eventually call get_or_create on models which then try and call current_or_system_user which eventually leads here
-            # But the system is in a weird state here because its being torn down, so the creation of system_user fails
         try:
             system_user = create_system_user(user_model=get_user_model())
         except caught_exception:
             system_user = None
 
+    if system_user is not None:
+        _system_user_local.cached = (system_username, system_user)
+
     return system_user
+
+
+request_started.connect(_clear_system_user_cache_on_request)
 
 
 def current_user_or_system_user() -> Optional[AbstractUser]:

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -99,6 +99,21 @@ def clear_content_type_cache():
     ContentType.objects.clear_cache()
 
 
+@pytest.fixture(autouse=True)
+def clear_system_user_thread_local_cache():
+    """Clear the cached system user between tests.
+
+    Tests run inside a transaction that is rolled back after each test. Without
+    this fixture a cached User object from a previous test would survive the
+    rollback, pointing at a pk that no longer exists in the DB.
+    """
+    from ansible_base.lib.utils.models import clear_system_user_cache
+
+    clear_system_user_cache()
+    yield
+    clear_system_user_cache()
+
+
 @pytest.fixture
 def azuread_configuration():
     return {

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -99,21 +99,6 @@ def clear_content_type_cache():
     ContentType.objects.clear_cache()
 
 
-@pytest.fixture(autouse=True)
-def _clear_system_user_cache():
-    """Clear the cached system user between tests.
-
-    Tests run inside a transaction that is rolled back after each test. Without
-    this fixture a cached User object from a previous test would survive the
-    rollback, pointing at a pk that no longer exists in the DB.
-    """
-    from ansible_base.lib.utils.models import clear_system_user_cache
-
-    clear_system_user_cache()
-    yield
-    clear_system_user_cache()
-
-
 @pytest.fixture
 def azuread_configuration():
     return {

--- a/test_app/tests/lib/utils/test_create_system_user.py
+++ b/test_app/tests/lib/utils/test_create_system_user.py
@@ -1,12 +1,9 @@
-from unittest.mock import patch
-
 import pytest
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 
 from ansible_base.lib.utils.create_system_user import create_system_user, get_system_username
-from ansible_base.lib.utils.models import get_system_user
 from test_app.models import ManagedUser, User
 
 
@@ -76,112 +73,8 @@ class TestGetSystemUser:
 
     @pytest.mark.django_db
     def test_get_system_user_from_managed_model(self):
-        User.all_objects.get(username=get_system_username()[0]).delete()
+        User.all_objects.filter(username=get_system_username()[0]).delete()
         create_system_user(user_model=ManagedUser)
 
         assert ManagedUser.objects.filter(username=get_system_username()[0]).count() == 0
         assert ManagedUser.all_objects.filter(username=get_system_username()[0]).count() == 1
-
-
-class TestGetSystemUserCache:
-    """Tests for the get_system_user() Redis caching behavior."""
-
-    @pytest.fixture(autouse=True)
-    def _isolated_cache(self, request):
-        """Patch SYSTEM_USER_CACHE_KEY to a per-test value so parallel workers can't race."""
-        isolated_key = f'dab:system_user:test:{request.node.name}'
-        with (
-            patch('ansible_base.lib.utils.models._has_shared_cache', return_value=True),
-            patch('ansible_base.lib.utils.models.SYSTEM_USER_CACHE_KEY', isolated_key),
-        ):
-            from django.core.cache import cache
-
-            cache.delete(isolated_key)
-            self.cache = cache
-            self.cache_key = isolated_key
-            yield
-            cache.delete(isolated_key)
-
-    @pytest.mark.django_db
-    def test_second_call_returns_cached_result(self, system_user):
-        """Second call to get_system_user() should return from cache when a shared backend is configured."""
-        user1 = get_system_user()
-        assert user1 is not None
-        cached = self.cache.get(self.cache_key)
-        assert cached.pk == user1.pk
-
-        user2 = get_system_user()
-        assert user2.pk == user1.pk
-
-    @pytest.mark.django_db
-    def test_no_caching_without_shared_backend(self, system_user):
-        """When no shared cache backend is available, every call queries the DB."""
-        with patch('ansible_base.lib.utils.models._has_shared_cache', return_value=False):
-            self.cache.delete(self.cache_key)
-            get_system_user()
-            assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_cache_not_set_for_none_result(self):
-        """If system user creation returns None, the result is not cached."""
-        with patch('ansible_base.lib.utils.models.create_system_user', return_value=None):
-            with override_settings(SYSTEM_USERNAME='nonexistent_cache_test_user'):
-                result = get_system_user()
-
-        assert result is None
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_clear_system_user_cache(self, system_user):
-        """clear_system_user_cache() removes the cached entry from the shared backend."""
-        from ansible_base.lib.utils.models import clear_system_user_cache
-
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        clear_system_user_cache()
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_save_invalidates_cache(self, system_user):
-        """Saving the system user should clear the cache."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        system_user.save()
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_delete_invalidates_cache(self, system_user):
-        """Deleting the system user should clear the cache."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        system_user.delete()
-        assert self.cache.get(self.cache_key) is None
-
-    @pytest.mark.django_db
-    def test_rename_system_user_invalidates_cache(self, system_user):
-        """Renaming the system user should invalidate and repopulate correctly."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-        assert user1.username == system_user.username
-
-        system_user.username = 'renamed_user'
-        system_user.save()
-        assert self.cache.get(self.cache_key) is None
-
-        user2 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user2.pk
-        assert user2.username == get_system_username()[0]
-        assert user2.pk != system_user.pk
-
-    @pytest.mark.django_db
-    def test_setting_change_bypasses_cache(self, system_user):
-        """Changing SYSTEM_USERNAME should not return the old cached user."""
-        user1 = get_system_user()
-        assert self.cache.get(self.cache_key).pk == user1.pk
-
-        with override_settings(SYSTEM_USERNAME='different_username'):
-            user2 = get_system_user()
-            assert user2 is not user1

--- a/test_app/tests/lib/utils/test_create_system_user.py
+++ b/test_app/tests/lib/utils/test_create_system_user.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 
 from ansible_base.lib.utils.create_system_user import create_system_user, get_system_username
+from ansible_base.lib.utils.models import clear_system_user_cache, get_system_user
 from test_app.models import ManagedUser, User
 
 
@@ -74,7 +77,70 @@ class TestGetSystemUser:
     @pytest.mark.django_db
     def test_get_system_user_from_managed_model(self):
         User.all_objects.filter(username=get_system_username()[0]).delete()
+        clear_system_user_cache()
         create_system_user(user_model=ManagedUser)
 
         assert ManagedUser.objects.filter(username=get_system_username()[0]).count() == 0
         assert ManagedUser.all_objects.filter(username=get_system_username()[0]).count() == 1
+
+
+class TestGetSystemUserCache:
+    """Tests for the thread-local get_system_user() cache."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        clear_system_user_cache()
+        yield
+        clear_system_user_cache()
+
+    @pytest.mark.django_db
+    def test_second_call_returns_cached_result(self, system_user, django_assert_num_queries):
+        user1 = get_system_user()
+        assert user1 is not None
+
+        with django_assert_num_queries(0):
+            user2 = get_system_user()
+
+        assert user2 is user1
+
+    @pytest.mark.django_db
+    def test_cache_invalidated_when_username_changes(self, system_user):
+        user1 = get_system_user()
+        assert user1 is not None
+
+        with override_settings(SYSTEM_USERNAME='nonexistent_user'):
+            user2 = get_system_user()
+            assert user2 is not user1
+
+    @pytest.mark.django_db
+    def test_cache_not_set_for_none_result(self):
+        import ansible_base.lib.utils.models as models_mod
+
+        with patch('ansible_base.lib.utils.models.create_system_user', return_value=None):
+            with override_settings(SYSTEM_USERNAME='nonexistent_cache_test_user'):
+                result = get_system_user()
+
+        assert result is None
+        assert getattr(models_mod._system_user_local, 'cached', None) is None
+
+    @pytest.mark.django_db
+    def test_clear_system_user_cache(self, system_user):
+        import ansible_base.lib.utils.models as models_mod
+
+        get_system_user()
+        assert getattr(models_mod._system_user_local, 'cached', None) is not None
+
+        clear_system_user_cache()
+        assert getattr(models_mod._system_user_local, 'cached', None) is None
+
+    @pytest.mark.django_db
+    def test_request_started_clears_cache(self, system_user):
+        from django.core.signals import request_started
+
+        import ansible_base.lib.utils.models as models_mod
+
+        get_system_user()
+        assert getattr(models_mod._system_user_local, 'cached', None) is not None
+
+        request_started.send(sender=self.__class__)
+        assert getattr(models_mod._system_user_local, 'cached', None) is None


### PR DESCRIPTION
## Summary

Replaces the Redis-based `get_system_user()` cache (#1056) with a
thread-local in-memory cache, and clears it at the start of each HTTP
request via `request_started` signal.

## Why

Profiling at 50K scale showed `get_system_user()` called ~49,800 times
during org deletion cascade. The Redis cache from #1056 eliminates the
DB query but **49,800 Redis round-trips (~0.35ms each) still account
for 17 seconds** of the 41-second delete time.

Thread-local cache eliminates all network round-trips. The cache is:
- **Thread-safe** — `threading.local()` isolates per-thread
- **Per-request fresh** — `request_started` signal clears at the start of each HTTP request
- **Management-command safe** — cache lives for the command's duration (no `request_started` fires)
- **Invalidated on username change** — cache is keyed on `system_username`
- **Invalidated on delete** — `AbstractDABUser.delete()` clears the cache when the system user is deleted

## Cache invalidation

| Scenario | Mechanism |
|----------|-----------|
| New HTTP request | `request_started` signal clears thread-local |
| System username setting changes | Cache key mismatch → automatic miss |
| System user deleted via `user.delete()` | `AbstractDABUser.delete()` override clears cache |
| System user deleted via queryset `.filter().delete()` | Not caught by model `delete()` — next `request_started` clears it |
| Management command | Cache lives for command duration, cleared on next request |

Depends on #1065 (revert of #1056).

## Test plan

- [x] `test_second_call_returns_cached_result` — zero DB queries on second call
- [x] `test_cache_invalidated_when_username_changes` — cache miss on setting change
- [x] `test_cache_not_set_for_none_result` — None results not cached
- [x] `test_clear_system_user_cache` — explicit clear works
- [x] `test_request_started_clears_cache` — signal clears thread-local

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale system-user data by moving to request-scoped caching that resets at the start of each request.
  - Cache is now cleared only when deleting the system user, not on every user save.
- **Refactor**
  - Updated system-user caching to use per-thread local storage instead of shared caching.
- **Tests**
  - Expanded/updated coverage to validate thread-local reuse, cache invalidation on system-username changes, and cache clearing on request start and explicit clears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->