### PR TITLE
[AAP-82668] Add cached_system_user() context manager for bulk operations

### DIFF
--- a/ansible_base/lib/utils/models.py
+++ b/ansible_base/lib/utils/models.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import threading
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from itertools import chain
 from typing import TYPE_CHECKING, Optional
@@ -101,18 +103,53 @@ class NotARealException(Exception):
     pass
 
 
-def get_system_user() -> Optional[AbstractUser]:
+_system_user_local = threading.local()
 
+
+@contextmanager
+def cached_system_user():
+    """Cache the system user for the duration of the context.
+
+    Within this context, get_system_user() returns the cached instance
+    instead of querying the DB or Redis on every call. Use this to avoid
+    redundant lookups during bulk operations like cascade deletes where
+    get_system_user() may be called thousands of times via activity
+    stream signals.
+
+    Re-entrant: nested calls are no-ops.
+    """
+    if getattr(_system_user_local, 'cached', None) is not None:
+        yield
+        return
+    user = get_system_user()
+    _system_user_local.cached = (get_system_username()[0], user)
+    try:
+        yield
+    finally:
+        _system_user_local.cached = None
+
+
+def clear_system_user_cache():
+    _system_user_local.cached = None
+
+
+def get_system_user() -> Optional[AbstractUser]:
     from ansible_base.lib.abstract_models.user import AbstractDABUser
 
     system_username, setting_name = get_system_username()
+
+    cached = getattr(_system_user_local, 'cached', None)
+    if cached is not None:
+        cached_username, cached_user = cached
+        if cached_username == system_username:
+            return cached_user
+
     user_model = get_user_model()
 
     # If we use subclass of AbstractDABUser ensure we use manager for unfiltered queryset
     user_manager = user_model.all_objects if issubclass(user_model, AbstractDABUser) else user_model.objects
 
     system_user = user_manager.filter(username=system_username).first()
-    # We are using a global variable to try and track if this thread has already spit out the message, if so ignore
     if system_username is not None and system_user is None:
         logger.error(
             _(

--- a/test_app/tests/conftest.py
+++ b/test_app/tests/conftest.py
@@ -99,6 +99,21 @@ def clear_content_type_cache():
     ContentType.objects.clear_cache()
 
 
+@pytest.fixture(autouse=True)
+def clear_system_user_thread_local_cache():
+    """Clear the cached system user between tests.
+
+    Tests run inside a transaction that is rolled back after each test. Without
+    this fixture a cached User object from a previous test would survive the
+    rollback, pointing at a pk that no longer exists in the DB.
+    """
+    from ansible_base.lib.utils.models import clear_system_user_cache
+
+    clear_system_user_cache()
+    yield
+    clear_system_user_cache()
+
+
 @pytest.fixture
 def azuread_configuration():
     return {

--- a/test_app/tests/lib/utils/test_create_system_user.py
+++ b/test_app/tests/lib/utils/test_create_system_user.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 
 from ansible_base.lib.utils.create_system_user import create_system_user, get_system_username
+from ansible_base.lib.utils.models import cached_system_user, clear_system_user_cache, get_system_user
 from test_app.models import ManagedUser, User
 
 
@@ -74,7 +77,68 @@ class TestGetSystemUser:
     @pytest.mark.django_db
     def test_get_system_user_from_managed_model(self):
         User.all_objects.filter(username=get_system_username()[0]).delete()
+        clear_system_user_cache()
         create_system_user(user_model=ManagedUser)
 
         assert ManagedUser.objects.filter(username=get_system_username()[0]).count() == 0
         assert ManagedUser.all_objects.filter(username=get_system_username()[0]).count() == 1
+
+
+class TestCachedSystemUser:
+    """Tests for the cached_system_user() context manager."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        clear_system_user_cache()
+        yield
+        clear_system_user_cache()
+
+    @pytest.mark.django_db
+    def test_cached_within_context(self, system_user, django_assert_num_queries):
+        with cached_system_user():
+            user1 = get_system_user()
+            assert user1 is not None
+
+            with django_assert_num_queries(0):
+                user2 = get_system_user()
+
+            assert user2 is user1
+
+    @pytest.mark.django_db
+    def test_cache_cleared_after_context(self, system_user):
+        with cached_system_user():
+            get_system_user()
+
+        import ansible_base.lib.utils.models as models_mod
+
+        assert getattr(models_mod._system_user_local, 'cached', None) is None
+
+    @pytest.mark.django_db
+    def test_uncached_outside_context(self, system_user, django_assert_num_queries):
+        user1 = get_system_user()
+        assert user1 is not None
+
+        with django_assert_num_queries(1):
+            get_system_user()
+
+    @pytest.mark.django_db
+    def test_cache_not_set_for_none_result(self):
+        import ansible_base.lib.utils.models as models_mod
+
+        with patch('ansible_base.lib.utils.models.create_system_user', return_value=None):
+            with override_settings(SYSTEM_USERNAME='nonexistent_cache_test_user'):
+                result = get_system_user()
+
+        assert result is None
+        assert getattr(models_mod._system_user_local, 'cached', None) is None
+
+    @pytest.mark.django_db
+    def test_reentrant(self, system_user, django_assert_num_queries):
+        with cached_system_user():
+            with cached_system_user():
+                user1 = get_system_user()
+
+            with django_assert_num_queries(0):
+                user2 = get_system_user()
+
+            assert user2 is user1


### PR DESCRIPTION
## Summary

Alternative to #1066. Adds a `cached_system_user()` context manager that
caches `get_system_user()` in a thread-local for the duration of the context.
Outside the context, `get_system_user()` queries the DB on every call
(existing behavior).

## Why

Same motivation as #1066 — at 50K scale, `get_system_user()` is called
~49,800 times during cascade delete. But instead of implicit caching via
`request_started` signal, this makes the caching explicit and scoped via
a context manager — consistent with how `deferred_activity_stream` and
`defer_rbac_computations` work.

Designed to be stacked in the view's `dispatch()` ExitStack:

```python
with ExitStack() as stack:
    stack.enter_context(cached_system_user())
    stack.enter_context(deferred_activity_stream())
    stack.enter_context(defer_rbac_computations())
    return super().dispatch(request, *args, **kwargs)
```

## Trade-offs vs #1066 (thread-local + request_started)

| | Context manager (#1067) | Thread-local + signal (#1066) |
|---|---|---|
| Scope | Explicit — you see it in the ExitStack | Implicit — connected via signal |
| Debuggability | Easy to trace | Hard to find why caching is happening |
| Management commands | Must wrap explicitly | Automatic |
| Consistency | Same pattern as other deferrals | Different mechanism |

Depends on #1065 (revert of #1056).

## Test plan

- [x] `test_cached_within_context` — zero DB queries on second call within context
- [x] `test_cache_cleared_after_context` — cache gone after context exits
- [x] `test_uncached_outside_context` — normal DB query without context
- [x] `test_cache_not_set_for_none_result` — None results not cached
- [x] `test_reentrant` — nested contexts work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved system-user lookups by reusing the result within a temporary execution context.
  * Ensured cached data is cleared when the context ends, preventing stale results.
  * Nested contexts now reuse the same cached lookup safely.

* **Bug Fixes**
  * Prevented missing system-user results from being incorrectly cached.
  * Improved isolation between operations and tests to avoid stale user data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->