### PR TITLE
[AAP-79673] Add view_team to Organization Member managed role

### DIFF
--- a/ansible_base/rbac/managed.py
+++ b/ansible_base/rbac/managed.py
@@ -180,6 +180,12 @@ class OrganizationMember(OrganizationMixin, ManagedActionBase):
     description = gettext_noop("Has member permission to a single organization")
     action = 'member_organization'
 
+    def get_permissions(self, apps) -> set[str]:
+        perms = super().get_permissions(apps)
+        team_model = apps.get_model(settings.ANSIBLE_BASE_TEAM_MODEL)
+        perms.add(f'view_{team_model._meta.model_name}')
+        return perms
+
 
 class TeamAdmin(TeamMixin, ManagedAdminBase):
     name = gettext_noop("Team Admin")

--- a/test_app/tests/rbac/test_managed.py
+++ b/test_app/tests/rbac/test_managed.py
@@ -2,8 +2,8 @@ import pytest
 from django.apps import apps
 
 from ansible_base.rbac import permission_registry
-from ansible_base.rbac.managed import managed_role_templates
-from ansible_base.rbac.models import DABPermission, RoleDefinition
+from ansible_base.rbac.managed import OrganizationMember, managed_role_templates
+from ansible_base.rbac.models import DABPermission, RoleDefinition, RoleEvaluation
 from ansible_base.rbac.validators import validate_permissions_for_model
 
 
@@ -48,3 +48,136 @@ def test_create_all_managed_roles():
     "This is a method that may be called in migrations, etc."
     assert not RoleDefinition.objects.filter(name='Cow Mooer').exists()
     permission_registry.create_managed_roles(apps)
+
+
+@pytest.mark.django_db
+def test_org_member_includes_view_team():
+    """Organization Member role definition should include view_team permission"""
+    rd = RoleDefinition.objects.managed.org_member
+    perm_codenames = set(rd.permissions.values_list('codename', flat=True))
+    assert 'view_team' in perm_codenames
+    assert 'view_organization' in perm_codenames
+    assert 'member_organization' in perm_codenames
+
+
+@pytest.mark.django_db
+def test_org_member_can_see_teams_in_org(rando, organization, team, org_member_rd):
+    """Organization members should be able to view teams within that organization."""
+    Team = permission_registry.team_model
+    assert set(RoleEvaluation.accessible_objects(Team, rando, 'view_team')) == set()
+
+    org_member_rd.give_permission(rando, organization)
+
+    assert set(RoleEvaluation.accessible_objects(Team, rando, 'view_team')) == {team}
+
+
+@pytest.mark.django_db
+def test_org_member_cannot_see_teams_in_other_org(rando, organization, team, org_member_rd):
+    """Organization members should not see teams from other organizations."""
+    from test_app.models import Organization as OrgModel
+
+    Team = permission_registry.team_model
+    other_org = OrgModel.objects.create(name='other-org')
+    other_team = Team.objects.create(name='other-team', organization=other_org)
+
+    org_member_rd.give_permission(rando, organization)
+
+    visible = set(RoleEvaluation.accessible_objects(Team, rando, 'view_team'))
+    assert team in visible
+    assert other_team not in visible
+
+
+@pytest.mark.django_db
+def test_org_member_sees_multiple_teams_in_org(rando, organization, org_member_rd):
+    """Organization members see all teams in their org, not just one."""
+    Team = permission_registry.team_model
+    team_a = Team.objects.create(name='team-a', organization=organization)
+    team_b = Team.objects.create(name='team-b', organization=organization)
+    team_c = Team.objects.create(name='team-c', organization=organization)
+
+    org_member_rd.give_permission(rando, organization)
+
+    visible = set(RoleEvaluation.accessible_objects(Team, rando, 'view_team'))
+    assert visible == {team_a, team_b, team_c}
+
+
+@pytest.mark.django_db
+def test_org_member_sees_teams_via_access_qs(rando, organization, team, org_member_rd):
+    """Verify the higher-level access_qs API also returns org teams for members."""
+    Team = permission_registry.team_model
+    assert Team.access_qs(rando).count() == 0
+
+    org_member_rd.give_permission(rando, organization)
+
+    assert team in Team.access_qs(rando)
+
+
+@pytest.mark.django_db
+def test_org_member_new_team_becomes_visible(rando, organization, org_member_rd):
+    """Teams created after org membership is granted should also be visible."""
+    Team = permission_registry.team_model
+    org_member_rd.give_permission(rando, organization)
+
+    new_team = Team.objects.create(name='new-team', organization=organization)
+
+    assert new_team in set(RoleEvaluation.accessible_objects(Team, rando, 'view_team'))
+
+
+@pytest.mark.django_db
+def test_update_perms_adds_view_team_to_existing_role():
+    """When create_managed_roles runs with update_perms=True,
+    an existing Organization Member role gets view_team added."""
+    org_member_rd = RoleDefinition.objects.managed.org_member
+    view_team_perm = DABPermission.objects.get(codename='view_team')
+
+    # Simulate a stale role missing view_team
+    org_member_rd.permissions.remove(view_team_perm)
+    assert 'view_team' not in set(org_member_rd.permissions.values_list('codename', flat=True))
+
+    permission_registry.create_managed_roles(apps, update_perms=True)
+    org_member_rd.refresh_from_db()
+
+    assert 'view_team' in set(org_member_rd.permissions.values_list('codename', flat=True))
+
+    RoleDefinition.objects.managed.clear()
+
+
+@pytest.mark.django_db
+def test_org_member_revoke_removes_view_team(rando, organization, team, org_member_rd):
+    """Granting then removing org membership should make teams invisible again."""
+    Team = permission_registry.team_model
+    org_member_rd.give_permission(rando, organization)
+    assert team in set(RoleEvaluation.accessible_objects(Team, rando, 'view_team'))
+
+    org_member_rd.remove_permission(rando, organization)
+    assert set(RoleEvaluation.accessible_objects(Team, rando, 'view_team')) == set()
+
+
+@pytest.mark.django_db
+def test_update_perms_false_does_not_add_view_team():
+    """create_managed_roles with default update_perms=False should not
+    add view_team to an existing role that is missing it."""
+    org_member_rd = RoleDefinition.objects.managed.org_member
+    view_team_perm = DABPermission.objects.get(codename='view_team')
+
+    org_member_rd.permissions.remove(view_team_perm)
+    assert 'view_team' not in set(org_member_rd.permissions.values_list('codename', flat=True))
+
+    permission_registry.create_managed_roles(apps)
+    org_member_rd.refresh_from_db()
+
+    assert 'view_team' not in set(org_member_rd.permissions.values_list('codename', flat=True))
+
+    # Restore for other tests
+    org_member_rd.permissions.add(view_team_perm)
+    RoleDefinition.objects.managed.clear()
+
+
+@pytest.mark.django_db
+def test_org_member_constructor_permissions():
+    """OrganizationMember.get_permissions returns view_team alongside the base permissions."""
+    constructor = OrganizationMember()
+    perms = constructor.get_permissions(apps)
+    assert 'view_team' in perms
+    assert 'view_organization' in perms
+    assert 'member_organization' in perms


### PR DESCRIPTION
## Type of Change

Bug fix — restores org-scoped team discoverability for organization members.

## Summary

Organization members cannot discover teams within their organization. The `OrganizationMember` managed role only grants `view_organization` + `member_organization`, but not `view_team`. This means users with org membership cannot see teams in their org through `Team.access_qs()` or `RoleEvaluation.accessible_objects()`.

Previously (Tower 4.6), `access.py` had a special case where org members could see all teams in their org. This was never modeled as proper role inheritance, so it was lost when DAB RBAC replaced the legacy access control.

**Fix**: Override `OrganizationMember.get_permissions()` to include `view_{team_model_name}`. The resource tree (`org → team` via `parent_field_name='organization'`) then automatically expands this permission to all teams in the organization through the `RoleEvaluation` cache. This respects the intended directionality of DAB RBAC — permissions flow down the resource tree, not sideways between siblings.

### What this enables

- A user with `Organization Member` role can now **see teams in their organization** via `Team.access_qs()` and `RoleEvaluation.accessible_objects()`
- Scoped to the org boundary — teams in other organizations remain invisible
- `OrganizationAdmin` already had this implicitly via `ManagedAdminBase` (all child permissions) — this fix brings `OrganizationMember` to parity for the `view_team` permission specifically

### Upgrade path

Consuming applications that already have `Organization Member` role definitions created need to call `create_managed_roles(apps, update_perms=True)` to sync the new permission onto existing roles.

## Prior art

Builds on the approach from draft PR #1029 by @AlanCoding. This is a fresh implementation on current `devel` with expanded test coverage.

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Steps to Test

1. Run `test_app/tests/rbac/test_managed.py` — all 12 tests should pass
2. Key tests:
   - `test_org_member_can_see_teams_in_org` — org member sees teams in their org
   - `test_org_member_cannot_see_teams_in_other_org` — org member does NOT see teams in other orgs
   - `test_org_member_sees_multiple_teams_in_org` — all teams in the org are visible
   - `test_org_member_sees_teams_via_access_qs` — works through the `Model.access_qs()` API
   - `test_org_member_new_team_becomes_visible` — dynamically created teams are visible
   - `test_update_perms_adds_view_team_to_existing_role` — upgrade path for existing deployments

### Expected Results

Organization members can view teams within their organization. Teams in other organizations remain hidden. The `update_perms=True` path correctly syncs existing roles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Organization members can now view all teams within their organization.
  - Team visibility remains restricted to the member’s organization and updates automatically as teams are added or permissions change.

- **Bug Fixes**
  - Corrected organization member permissions to include team visibility consistently.

- **Tests**
  - Added coverage for team access, cross-organization restrictions, permission updates, and revocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->