### PR TITLE
AAP-84431 Prevent single orphan deletion failure from crashing periodic_resource_sync

### DIFF
--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -543,9 +543,10 @@ class SyncExecutor:
             resource_type,
             manifest_list,
         )
-        self.deleted_count = resources_to_cleanup.count()
-        if self.deleted_count:
-            self.write(f"Deleting {self.deleted_count} orphaned resources")
+        orphan_count = resources_to_cleanup.count()
+        deleted_before = len(self.results["deleted"])
+        if orphan_count:
+            self.write(f"Deleting {orphan_count} orphaned resources")
             for orphan in resources_to_cleanup:
                 try:
                     _sc = orphan.content_type.resource_type.serializer_class
@@ -553,10 +554,11 @@ class SyncExecutor:
                     data.update(orphan.summary_fields())
                     with transaction.atomic():
                         delete_resource(orphan)
-                except ResourceDeletionError as exc:
-                    self.write(f"Error deleting orphaned resources {str(exc)}")
+                except Exception as exc:
+                    self.write(f"Error deleting orphaned resource {orphan.ansible_id}: {type(exc).__name__}: {exc}")
                 else:  # persist in the report
                     self.results["deleted"].append(data)
+        self.deleted_count = len(self.results["deleted"]) - deleted_before  # actual successes for this resource type
 
     def _handle_retries(self):  # pragma: no cover
         """Check if there are unavailable resources to re-try."""

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -3,7 +3,7 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
-from django.db.utils import Error
+from django.db.utils import Error, IntegrityError
 from django.test import override_settings
 
 from ansible_base.lib.testing.util import StaticResourceAPIClient
@@ -25,6 +25,7 @@ from ansible_base.resource_registry.tasks.sync import (
     create_api_client,
     get_remote_assignments,
 )
+from test_app.models import User
 
 
 @pytest.fixture(scope="function")
@@ -865,7 +866,6 @@ def test_attempt_update_resource_error_exception(static_api_client, resource_to_
 def test_delete_resource_exception_handling():
     """Test that delete_resource logs exceptions with logger.exception."""
     from ansible_base.resource_registry.tasks.sync import ResourceDeletionError, delete_resource
-    from test_app.models import User
 
     # Create a user (which will auto-create a Resource via signals)
     user = User.objects.create(username='testuser', email='test@example.com')
@@ -1025,7 +1025,6 @@ def test_get_local_assignments_skips_users_without_resources():
     """Test get_local_assignments skips user assignments when user has no Resource."""
     from ansible_base.rbac.models import RoleDefinition
     from ansible_base.resource_registry.tasks.sync import get_local_assignments
-    from test_app.models import User
 
     # Create a user with resource
     user = User.objects.create(username='testuser', email='test@example.com')
@@ -1185,7 +1184,6 @@ def test_get_ansible_id_or_pk_for_non_org_team():
 
     # Create role and assignment
     role_def = RoleDefinition.objects.create(name='Inventory Admin', content_type=inv_dab_ct, managed=True)
-    from test_app.models import User
 
     user = User.objects.create(username='testuser', email='test@example.com')
     assignment = role_def.give_permission(user, inventory)
@@ -1277,7 +1275,6 @@ def test_create_local_assignment_global():
     """Test create_local_assignment creates global assignment."""
     from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
     from ansible_base.resource_registry.tasks.sync import AssignmentTuple, create_local_assignment
-    from test_app.models import User
 
     # Create user with resource
     user = User.objects.create(username='testuser', email='test@example.com')
@@ -1377,7 +1374,6 @@ def test_delete_local_assignment_global():
     """Test delete_local_assignment removes global assignment"""
     from ansible_base.rbac.models import RoleDefinition
     from ansible_base.resource_registry.tasks.sync import AssignmentTuple, delete_local_assignment
-    from test_app.models import User
 
     # Create user with resource
     user = User.objects.create(username='testuser', email='test@example.com')
@@ -1403,3 +1399,29 @@ def test_delete_local_assignment_global():
     from ansible_base.rbac.models import RoleUserAssignment
 
     assert not RoleUserAssignment.objects.filter(user=user, role_definition=role_def, object_id__isnull=True).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_orphans_continues_after_deletion_error(admin_api_client, static_api_client, stdout):
+    """Test that _cleanup_orphans skips a failing orphan, logs it and continues deleting the rest."""
+    url = get_relative_url("resource-list")
+    for username in ("orphan_one", "orphan_two"):
+        response = admin_api_client.post(
+            url,
+            {
+                "service_id": "57592fbc-7ecb-405f-9f5f-ebad20932d38",
+                "resource_type": "shared.user",
+                "resource_data": {"username": username, "last_name": "Test", "email": f"{username}@example.com"},
+            },
+            format="json",
+        )
+        assert response.status_code == 201
+
+    with mock.patch("ansible_base.resource_registry.tasks.sync.delete_resource", side_effect=IntegrityError("FK constraint")):
+        executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
+        executor.run()
+
+    error_lines = [line for line in stdout.lines if "IntegrityError" in line]
+    assert len(error_lines) == 2
+    assert User.objects.filter(username__in=["orphan_one", "orphan_two"]).count() == 2
+    assert executor.deleted_count == 0


### PR DESCRIPTION
## Description
The `_cleanup_orphans` method in `SyncExecutor` only caught `ResourceDeletionError`. Any other exception (e.g., IntegrityError from a FK constraint) propagated up and crashed the entire `periodic_resource_sync task`,  preventing all subsequent sync operations from running. A single un-deletable orphan resource blocked the entire sync cycle.

## Solution
- Widened the except clause from `ResourceDeletionError` to `Exception` so any failure is caught, logged, and skipped.
- Improved the error log message to include the orphan's `ansible_id`, exception type, and exception details for easier debugging
- Fixed `deleted_count` to report actual successful deletions per resource type rather than the number of orphans found (pre-existing bug now more visible with errors being caught)

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Test Plan
- [x] test_cleanup_orphans_continues_after_deletion_error — creates two orphan resources, mocks delete_resource to raise IntegrityError on both, asserts:
     - Two error lines are logged (loop hit both orphans, didn't stop at the first)
     - Both users still exist in the database (neither was deleted)
     - deleted_count == 0 (reports actual successes, not attempts)
- [x] All 63 existing tests in test_resource_sync.py pass with no regressions
- [x] Linters pass (black, flake8, isort)

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
