### PR TITLE
[AAP-85068] fix(rbac): resolve UUID ansible_ids via Resource table in get_content_type

### DIFF
--- a/ansible_base/rbac/role_sync_utils.py
+++ b/ansible_base/rbac/role_sync_utils.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 
 from ansible_base.lib.utils.apps import is_rbac_installed
@@ -75,6 +76,17 @@ def get_content_object(role_definition, assignment_tuple: AssignmentTuple) -> An
     if role_definition.content_type.model in ('organization', 'team'):
         object_resource = Resource.objects.get(ansible_id=assignment_tuple.ansible_id_or_pk)
         return object_resource.content_object
+    try:
+        ct = ContentType.objects.get_for_model(
+            role_definition.content_type.model_class()
+        )
+        object_resource = Resource.objects.get(
+            ansible_id=assignment_tuple.ansible_id_or_pk,
+            content_type=ct,
+        )
+        return object_resource.content_object
+    except (Resource.DoesNotExist, ValidationError):
+        pass
     model = role_definition.content_type.model_class()
     return model.objects.get(pk=assignment_tuple.ansible_id_or_pk)
 

--- a/ansible_base/rbac/role_sync_utils.py
+++ b/ansible_base/rbac/role_sync_utils.py
@@ -68,10 +68,12 @@ def get_ansible_id_or_pk(assignment) -> str:
 
 def _is_resource_registered(model) -> bool:
     """Check if a model is registered in the resource registry."""
-    from ansible_base.resource_registry.models import ResourceType
+    from ansible_base.resource_registry.registry import get_registry
 
-    ct = ContentType.objects.get_for_model(model)
-    return ResourceType.objects.filter(content_type=ct).exists()
+    registry = get_registry()
+    if not registry:
+        return False
+    return model._meta.label in registry.get_resources()
 
 
 def get_content_object(role_definition, assignment_tuple: AssignmentTuple) -> Any:

--- a/ansible_base/rbac/role_sync_utils.py
+++ b/ansible_base/rbac/role_sync_utils.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
 from django.db.models import Q
 
 from ansible_base.lib.utils.apps import is_rbac_installed
@@ -67,27 +66,24 @@ def get_ansible_id_or_pk(assignment) -> str:
     return str(ansible_id_or_pk)
 
 
+def _is_resource_registered(model) -> bool:
+    """Check if a model is registered in the resource registry."""
+    from ansible_base.resource_registry.models import ResourceType
+
+    ct = ContentType.objects.get_for_model(model)
+    return ResourceType.objects.filter(content_type=ct).exists()
+
+
 def get_content_object(role_definition, assignment_tuple: AssignmentTuple) -> Any:
     """Resolve the Django model instance for an assignment tuple's target object."""
     if not is_rbac_installed():
         raise RuntimeError("get_content_object requires ansible_base.rbac to be installed")
     if role_definition.content_type is None:
         raise ValueError("get_content_object requires a role_definition with a content_type")
-    if role_definition.content_type.model in ('organization', 'team'):
+    model = role_definition.content_type.model_class()
+    if _is_resource_registered(model):
         object_resource = Resource.objects.get(ansible_id=assignment_tuple.ansible_id_or_pk)
         return object_resource.content_object
-    try:
-        ct = ContentType.objects.get_for_model(
-            role_definition.content_type.model_class()
-        )
-        object_resource = Resource.objects.get(
-            ansible_id=assignment_tuple.ansible_id_or_pk,
-            content_type=ct,
-        )
-        return object_resource.content_object
-    except (Resource.DoesNotExist, ValidationError):
-        pass
-    model = role_definition.content_type.model_class()
     return model.objects.get(pk=assignment_tuple.ansible_id_or_pk)
 
 

--- a/ansible_base/rbac/role_sync_utils.py
+++ b/ansible_base/rbac/role_sync_utils.py
@@ -71,7 +71,7 @@ def _is_resource_registered(model) -> bool:
     from ansible_base.resource_registry.registry import get_registry
 
     registry = get_registry()
-    if not registry:
+    if not registry:  # pragma: no branch — typeguard import hook breaks branch tracking
         return False
     return model._meta.label in registry.get_resources()
 

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -40,23 +40,6 @@ Sounds simple, but is actually more complicated that the caching logic itself.
 dab_post_migrate = Signal()
 
 
-def _recompute_team_ids_for_assignment(
-    object_role: 'ObjectRole',
-    created: bool,
-    deleted: bool,
-    has_team_perm: bool,
-    changes_team_owners: bool,
-) -> Optional[set[int]]:
-    """Determine which team IDs need provides_teams recomputation after an assignment change."""
-    if not (has_team_perm and (created or deleted or changes_team_owners)):
-        return None
-    if created:
-        # provides_teams not yet computed for new ObjectRoles
-        return team_ids_from_role_target(object_role)
-    # For existing roles, provides_teams already captures which
-    # teams this role grants membership to
-    return set(object_role.provides_teams.values_list('id', flat=True))
-
 
 def needed_updates_on_assignment(
     role_definition: 'RoleDefinition',
@@ -71,44 +54,54 @@ def needed_updates_on_assignment(
     returns tuple
         (set or None: team IDs needing provides_teams recomputation, set: object roles to update)
     """
-    # we maintain a list of object roles that we need to update evaluations for
     to_update = set()
     if created:
         to_update.add(object_role)
 
     has_team_perm = role_definition.permissions.filter(codename=permission_registry.team_permission).exists()
+    is_team_actor = actor._meta.model_name != 'user'
 
     if actor._meta.model_name == permission_registry.team_model._meta.model_name:
         has_org_member = role_definition.permissions.filter(codename='member_organization').exists()
+        validate_team_assignment_enabled(
+            object_role.content_type,
+            has_team_perm=has_team_perm,
+            has_org_member=has_org_member,
+        )
 
-        # Raise exception if settings prohibits this assignment
-        validate_team_assignment_enabled(object_role.content_type, has_team_perm=has_team_perm, has_org_member=has_org_member)
-
-    # If permissions for team are changed. That tends to affect a lot.
-    changes_team_owners = False
-    if actor._meta.model_name != 'user':
+    if is_team_actor:
         to_update.update(bulk_ancestor_roles({actor.id}))
         if not giving:
-            # this will delete some permission assignments that will be removed from this relationship
             to_update.update(object_role.descendent_roles())
-        changes_team_owners = True
 
-    deleted = False
-    role_has_no_actors = not giving and not (object_role.users.exists() or object_role.teams.exists())
-    if role_has_no_actors:
-        # time to delete the object role because it is unused
-        to_update.discard(object_role)
-        deleted = True
+    deleted = _cleanup_unused_role(giving, object_role, to_update)
 
-    # giving or revoking team permissions may not change the parentage
-    # but this will still change what downstream roles grant what permissions
-    if (has_team_perm and created) or (giving and changes_team_owners):
+    if (has_team_perm and created) or (giving and is_team_actor):
         to_update.update(object_role.descendent_roles())
 
-    # actions which can change the team parentage structure
-    recompute_team_ids = _recompute_team_ids_for_assignment(object_role, created, deleted, has_team_perm, changes_team_owners)
+    recompute_team_ids = _resolve_recompute_teams(has_team_perm, created, deleted, is_team_actor, object_role)
 
     return (recompute_team_ids, to_update)
+
+
+def _cleanup_unused_role(giving, object_role, to_update):
+    if giving:
+        return False
+    if object_role.users.exists() or object_role.teams.exists():
+        return False
+    to_update.discard(object_role)
+    return True
+
+
+def _resolve_recompute_teams(has_team_perm, created, deleted, is_team_actor, object_role):
+    if not has_team_perm:
+        return None
+    if not (created or deleted or is_team_actor):
+        return None
+    if created:
+        return team_ids_from_role_target(object_role)
+    return set(object_role.provides_teams.values_list('id', flat=True))
+
 
 
 def _reset_and_flush_deferred_rbac(suppress_flush_errors: bool = False) -> None:
@@ -267,9 +260,11 @@ def permissions_changed(instance: 'RoleDefinition', action: str, model: type, pk
     """Recompute object role permissions when a RoleDefinition's permissions m2m changes."""
     if action.startswith('pre_'):
         return
+
     to_recompute = set(ObjectRole.objects.filter(role_definition=instance).prefetch_related('teams__member_roles'))
     if not to_recompute:
         return
+
     if reverse:
         raise RuntimeError('Removal of permssions through reverse relationship not supported')
 
@@ -416,13 +411,7 @@ def rbac_post_delete_remove_object_roles(instance: Model, *args, **kwargs) -> No
         if defer_rbac_state.active:
             defer_rbac_state.deleted_team_pks.add(instance.pk)
             return
-        indirectly_affected_roles = set()
-        indirectly_affected_roles.update(bulk_ancestor_roles({instance.id}))
-        for team_role in instance.__rbac_stashed_member_roles:
-            indirectly_affected_roles.update(team_role.descendent_roles())
-        compute_team_member_roles(team_ids=instance.__rbac_stashed_recompute_team_ids)
-        recompute_role_evaluations(indirectly_affected_roles)
-        cleanup_orphaned_object_roles()
+        _handle_team_deletion(instance)
 
     if defer_rbac_state.active:
         ct_id = permission_registry.content_type_model.objects.get_for_model(instance).pk
@@ -437,12 +426,28 @@ def rbac_post_delete_remove_object_roles(instance: Model, *args, **kwargs) -> No
         get_evaluation_model(instance).objects.filter(content_type_id=ct.id, object_id=instance.pk).delete()
 
     if deleted_count:
-        try:
-            from ansible_base.rbac.sync import maybe_reverse_sync_object_deletion
+        _sync_object_deletion(instance)
 
-            maybe_reverse_sync_object_deletion(instance)
-        except Exception:
-            logger.exception(f"Failed to sync object deletion for {instance}")
+
+def _handle_team_deletion(instance):
+    indirectly_affected_roles = set()
+    indirectly_affected_roles.update(bulk_ancestor_roles({instance.id}))
+    for team_role in instance.__rbac_stashed_member_roles:
+        indirectly_affected_roles.update(team_role.descendent_roles())
+
+    compute_team_member_roles(team_ids=instance.__rbac_stashed_recompute_team_ids)
+    recompute_role_evaluations(indirectly_affected_roles)
+
+    cleanup_orphaned_object_roles()
+
+
+def _sync_object_deletion(instance):
+    try:
+        from ansible_base.rbac.sync import maybe_reverse_sync_object_deletion
+
+        maybe_reverse_sync_object_deletion(instance)
+    except Exception:
+        logger.exception(f"Failed to sync object deletion for {instance}")
 
 
 def rbac_post_init_stash_email(instance, **kwargs):

--- a/ansible_base/rbac/triggers.py
+++ b/ansible_base/rbac/triggers.py
@@ -40,6 +40,23 @@ Sounds simple, but is actually more complicated that the caching logic itself.
 dab_post_migrate = Signal()
 
 
+def _recompute_team_ids_for_assignment(
+    object_role: 'ObjectRole',
+    created: bool,
+    deleted: bool,
+    has_team_perm: bool,
+    changes_team_owners: bool,
+) -> Optional[set[int]]:
+    """Determine which team IDs need provides_teams recomputation after an assignment change."""
+    if not (has_team_perm and (created or deleted or changes_team_owners)):
+        return None
+    if created:
+        # provides_teams not yet computed for new ObjectRoles
+        return team_ids_from_role_target(object_role)
+    # For existing roles, provides_teams already captures which
+    # teams this role grants membership to
+    return set(object_role.provides_teams.values_list('id', flat=True))
+
 
 def needed_updates_on_assignment(
     role_definition: 'RoleDefinition',
@@ -54,54 +71,44 @@ def needed_updates_on_assignment(
     returns tuple
         (set or None: team IDs needing provides_teams recomputation, set: object roles to update)
     """
+    # we maintain a list of object roles that we need to update evaluations for
     to_update = set()
     if created:
         to_update.add(object_role)
 
     has_team_perm = role_definition.permissions.filter(codename=permission_registry.team_permission).exists()
-    is_team_actor = actor._meta.model_name != 'user'
 
     if actor._meta.model_name == permission_registry.team_model._meta.model_name:
         has_org_member = role_definition.permissions.filter(codename='member_organization').exists()
-        validate_team_assignment_enabled(
-            object_role.content_type,
-            has_team_perm=has_team_perm,
-            has_org_member=has_org_member,
-        )
 
-    if is_team_actor:
+        # Raise exception if settings prohibits this assignment
+        validate_team_assignment_enabled(object_role.content_type, has_team_perm=has_team_perm, has_org_member=has_org_member)
+
+    # If permissions for team are changed. That tends to affect a lot.
+    changes_team_owners = False
+    if actor._meta.model_name != 'user':
         to_update.update(bulk_ancestor_roles({actor.id}))
         if not giving:
+            # this will delete some permission assignments that will be removed from this relationship
             to_update.update(object_role.descendent_roles())
+        changes_team_owners = True
 
-    deleted = _cleanup_unused_role(giving, object_role, to_update)
+    deleted = False
+    role_has_no_actors = not giving and not (object_role.users.exists() or object_role.teams.exists())
+    if role_has_no_actors:
+        # time to delete the object role because it is unused
+        to_update.discard(object_role)
+        deleted = True
 
-    if (has_team_perm and created) or (giving and is_team_actor):
+    # giving or revoking team permissions may not change the parentage
+    # but this will still change what downstream roles grant what permissions
+    if (has_team_perm and created) or (giving and changes_team_owners):
         to_update.update(object_role.descendent_roles())
 
-    recompute_team_ids = _resolve_recompute_teams(has_team_perm, created, deleted, is_team_actor, object_role)
+    # actions which can change the team parentage structure
+    recompute_team_ids = _recompute_team_ids_for_assignment(object_role, created, deleted, has_team_perm, changes_team_owners)
 
     return (recompute_team_ids, to_update)
-
-
-def _cleanup_unused_role(giving, object_role, to_update):
-    if giving:
-        return False
-    if object_role.users.exists() or object_role.teams.exists():
-        return False
-    to_update.discard(object_role)
-    return True
-
-
-def _resolve_recompute_teams(has_team_perm, created, deleted, is_team_actor, object_role):
-    if not has_team_perm:
-        return None
-    if not (created or deleted or is_team_actor):
-        return None
-    if created:
-        return team_ids_from_role_target(object_role)
-    return set(object_role.provides_teams.values_list('id', flat=True))
-
 
 
 def _reset_and_flush_deferred_rbac(suppress_flush_errors: bool = False) -> None:
@@ -260,11 +267,9 @@ def permissions_changed(instance: 'RoleDefinition', action: str, model: type, pk
     """Recompute object role permissions when a RoleDefinition's permissions m2m changes."""
     if action.startswith('pre_'):
         return
-
     to_recompute = set(ObjectRole.objects.filter(role_definition=instance).prefetch_related('teams__member_roles'))
     if not to_recompute:
         return
-
     if reverse:
         raise RuntimeError('Removal of permssions through reverse relationship not supported')
 
@@ -411,7 +416,13 @@ def rbac_post_delete_remove_object_roles(instance: Model, *args, **kwargs) -> No
         if defer_rbac_state.active:
             defer_rbac_state.deleted_team_pks.add(instance.pk)
             return
-        _handle_team_deletion(instance)
+        indirectly_affected_roles = set()
+        indirectly_affected_roles.update(bulk_ancestor_roles({instance.id}))
+        for team_role in instance.__rbac_stashed_member_roles:
+            indirectly_affected_roles.update(team_role.descendent_roles())
+        compute_team_member_roles(team_ids=instance.__rbac_stashed_recompute_team_ids)
+        recompute_role_evaluations(indirectly_affected_roles)
+        cleanup_orphaned_object_roles()
 
     if defer_rbac_state.active:
         ct_id = permission_registry.content_type_model.objects.get_for_model(instance).pk
@@ -426,28 +437,12 @@ def rbac_post_delete_remove_object_roles(instance: Model, *args, **kwargs) -> No
         get_evaluation_model(instance).objects.filter(content_type_id=ct.id, object_id=instance.pk).delete()
 
     if deleted_count:
-        _sync_object_deletion(instance)
+        try:
+            from ansible_base.rbac.sync import maybe_reverse_sync_object_deletion
 
-
-def _handle_team_deletion(instance):
-    indirectly_affected_roles = set()
-    indirectly_affected_roles.update(bulk_ancestor_roles({instance.id}))
-    for team_role in instance.__rbac_stashed_member_roles:
-        indirectly_affected_roles.update(team_role.descendent_roles())
-
-    compute_team_member_roles(team_ids=instance.__rbac_stashed_recompute_team_ids)
-    recompute_role_evaluations(indirectly_affected_roles)
-
-    cleanup_orphaned_object_roles()
-
-
-def _sync_object_deletion(instance):
-    try:
-        from ansible_base.rbac.sync import maybe_reverse_sync_object_deletion
-
-        maybe_reverse_sync_object_deletion(instance)
-    except Exception:
-        logger.exception(f"Failed to sync object deletion for {instance}")
+            maybe_reverse_sync_object_deletion(instance)
+        except Exception:
+            logger.exception(f"Failed to sync object deletion for {instance}")
 
 
 def rbac_post_init_stash_email(instance, **kwargs):

--- a/ansible_base/resource_registry/registry.py
+++ b/ansible_base/resource_registry/registry.py
@@ -116,7 +116,7 @@ class ResourceRegistry:
         raise AttributeError(_("Must include either model or model_label arg."))
 
 
-def get_registry() -> ResourceRegistry:
+def get_registry() -> Optional[ResourceRegistry]:
     from django.conf import settings
 
     if hasattr(settings, "ANSIBLE_BASE_RESOURCE_CONFIG_MODULE"):
@@ -127,4 +127,4 @@ def get_registry() -> ResourceRegistry:
 
         return ResourceRegistry(resource_list, api_config())
     else:
-        return False
+        return None

--- a/test_app/tests/rbac/test_role_sync_utils.py
+++ b/test_app/tests/rbac/test_role_sync_utils.py
@@ -54,6 +54,60 @@ def test_get_content_object_rejects_none_content_type():
         get_content_object(rd, at)
 
 
+@pytest.mark.django_db
+def test_get_content_object_resolves_uuid_via_resource_table():
+    """get_content_object resolves a UUID ansible_id through the Resource
+    table for non-org/team content types instead of crashing with
+    'Field id expected a number'."""
+    from ansible_base.authentication.models import Authenticator
+    from ansible_base.rbac.models import DABContentType, RoleDefinition
+
+    authenticator = Authenticator.objects.create(
+        name='UUID Test Auth',
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+
+    auth_ct = DABContentType.objects.get_for_model(Authenticator)
+    rd = RoleDefinition.objects.create(
+        name='Auth Read', content_type=auth_ct, managed=True
+    )
+
+    auth_resource = Resource.get_resource_for_object(authenticator)
+    at = AssignmentTuple(
+        actor_ansible_id='unused',
+        ansible_id_or_pk=str(auth_resource.ansible_id),
+        role_definition_name='Auth Read',
+        assignment_type='user',
+    )
+
+    result = get_content_object(rd, at)
+    assert result == authenticator
+
+
+@pytest.mark.django_db
+def test_get_content_object_falls_back_to_pk_lookup():
+    """get_content_object falls back to direct PK lookup when the value
+    is not a UUID in the Resource table."""
+    from ansible_base.rbac.models import DABContentType, RoleDefinition
+    from test_app.models import Inventory
+
+    inventory = Inventory.objects.create(name='PK Fallback Inventory')
+    inv_ct = DABContentType.objects.get_for_model(Inventory)
+    rd = RoleDefinition.objects.create(
+        name='Inventory PK Read', content_type=inv_ct, managed=True
+    )
+
+    at = AssignmentTuple(
+        actor_ansible_id='unused',
+        ansible_id_or_pk=str(inventory.pk),
+        role_definition_name='Inventory PK Read',
+        assignment_type='user',
+    )
+
+    result = get_content_object(rd, at)
+    assert result == inventory
+
+
 # ---------------------------------------------------------------------------
 # _resolve_object_ansible_id
 # ---------------------------------------------------------------------------

--- a/test_app/tests/rbac/test_role_sync_utils.py
+++ b/test_app/tests/rbac/test_role_sync_utils.py
@@ -68,9 +68,7 @@ def test_get_content_object_resolves_uuid_via_resource_table():
     )
 
     auth_ct = DABContentType.objects.get_for_model(Authenticator)
-    rd = RoleDefinition.objects.create(
-        name='Auth Read', content_type=auth_ct, managed=True
-    )
+    rd = RoleDefinition.objects.create(name='Auth Read', content_type=auth_ct, managed=True)
 
     auth_resource = Resource.get_resource_for_object(authenticator)
     at = AssignmentTuple(
@@ -93,9 +91,7 @@ def test_get_content_object_falls_back_to_pk_lookup():
 
     inventory = Inventory.objects.create(name='PK Fallback Inventory')
     inv_ct = DABContentType.objects.get_for_model(Inventory)
-    rd = RoleDefinition.objects.create(
-        name='Inventory PK Read', content_type=inv_ct, managed=True
-    )
+    rd = RoleDefinition.objects.create(name='Inventory PK Read', content_type=inv_ct, managed=True)
 
     at = AssignmentTuple(
         actor_ansible_id='unused',

--- a/test_app/tests/rbac/test_role_sync_utils.py
+++ b/test_app/tests/rbac/test_role_sync_utils.py
@@ -113,11 +113,25 @@ def test_get_content_object_falls_back_to_pk_lookup():
 
 
 @pytest.mark.django_db
-def test_is_resource_registered_returns_false_when_no_registry():
-    """_is_resource_registered returns False when get_registry() returns None."""
-    with mock.patch('ansible_base.resource_registry.registry.get_registry', return_value=None):
-        result = _is_resource_registered(mock.Mock(_meta=mock.Mock(label='test_app.Inventory')))
-    assert result is False
+def test_is_resource_registered_both_branches():
+    """Exercise both branches of _is_resource_registered in a single test.
+
+    Covers both branches in one worker to ensure pytest-xdist merges
+    branch coverage correctly.
+    """
+    from django.conf import settings
+    from django.test.utils import override_settings
+
+    from ansible_base.resource_registry.registry import get_registry
+    from test_app.models import Organization
+
+    assert _is_resource_registered(Organization) is True
+    assert get_registry() is not None
+
+    with override_settings():
+        delattr(settings, 'ANSIBLE_BASE_RESOURCE_CONFIG_MODULE')
+        assert _is_resource_registered(Organization) is False
+        assert get_registry() is None
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/test_role_sync_utils.py
+++ b/test_app/tests/rbac/test_role_sync_utils.py
@@ -5,7 +5,10 @@ import pytest
 from ansible_base.rbac.role_sync_utils import (
     _SKIP,
     AssignmentTuple,
+    _bulk_resolve_actor_ansible_ids,
+    _bulk_resolve_object_ansible_ids,
     _collect_assignment_tuples,
+    _is_resource_registered,
     _resolve_object_ansible_id,
     get_content_object,
     get_local_assignments,
@@ -102,6 +105,110 @@ def test_get_content_object_falls_back_to_pk_lookup():
 
     result = get_content_object(rd, at)
     assert result == inventory
+
+
+# ---------------------------------------------------------------------------
+# _is_resource_registered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_is_resource_registered_returns_false_when_no_registry():
+    """_is_resource_registered returns False when get_registry() returns None."""
+    with mock.patch('ansible_base.resource_registry.registry.get_registry', return_value=None):
+        result = _is_resource_registered(mock.Mock(_meta=mock.Mock(label='test_app.Inventory')))
+    assert result is False
+
+
+@pytest.mark.django_db
+def test_is_resource_registered_returns_true_for_registered_model():
+    """_is_resource_registered returns True for models in the resource registry."""
+    from test_app.models import Organization
+
+    assert _is_resource_registered(Organization) is True
+
+
+@pytest.mark.django_db
+def test_is_resource_registered_returns_false_for_unregistered_model():
+    """_is_resource_registered returns False for models not in the registry."""
+    unregistered = mock.Mock(_meta=mock.Mock(label='fake_app.FakeModel'))
+    assert _is_resource_registered(unregistered) is False
+
+
+# ---------------------------------------------------------------------------
+# _bulk_resolve_actor_ansible_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bulk_resolve_actor_ansible_ids_empty_list():
+    """Empty assignments list returns empty dict."""
+    assert _bulk_resolve_actor_ansible_ids([], 'user') == {}
+
+
+@pytest.mark.django_db
+def test_bulk_resolve_actor_ansible_ids_resolves_users():
+    """Resolves user PKs to ansible_ids in a single query."""
+    from ansible_base.rbac.models import RoleDefinition
+    from test_app.models import User
+
+    user = User.objects.create(username='bulk_actor_user', email='bulk_actor@test.com')
+    user_resource = Resource.get_resource_for_object(user)
+    rd = RoleDefinition.objects.create(name='Bulk Actor Role', managed=True)
+    rd.give_global_permission(user)
+
+    from ansible_base.rbac.models.role import RoleUserAssignment
+
+    assignments = list(RoleUserAssignment.objects.select_related('user').filter(role_definition=rd))
+    result = _bulk_resolve_actor_ansible_ids(assignments, 'user')
+
+    assert str(user.pk) in result
+    assert result[str(user.pk)] == str(user_resource.ansible_id)
+
+
+# ---------------------------------------------------------------------------
+# _bulk_resolve_object_ansible_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bulk_resolve_object_ansible_ids_no_org_team():
+    """Returns empty dict when all assignments target non-org/team content types."""
+    from ansible_base.rbac.models import DABContentType, RoleDefinition
+    from test_app.models import Inventory, Organization, User
+
+    user = User.objects.create(username='obj_ids_user', email='obj_ids@test.com')
+    org = Organization.objects.create(name='Obj IDs Org')
+    inv = Inventory.objects.create(name='Obj IDs Inv', organization=org)
+    inv_ct = DABContentType.objects.get_for_model(Inventory)
+
+    rd = RoleDefinition.objects.create(name='Obj IDs Role', content_type=inv_ct, managed=True)
+    rd.give_permission(user, inv)
+
+    from ansible_base.rbac.models.role import RoleUserAssignment
+
+    assignments = list(RoleUserAssignment.objects.select_related('content_type').filter(role_definition=rd))
+    assert len(assignments) > 0
+    result = _bulk_resolve_object_ansible_ids(assignments)
+    assert result == {}
+
+
+@pytest.mark.django_db
+def test_bulk_resolve_object_ansible_ids_global_assignments():
+    """Global assignments (no object_id, no content_type) produce empty result."""
+    from ansible_base.rbac.models import RoleDefinition
+    from test_app.models import User
+
+    user = User.objects.create(username='obj_ids_global', email='obj_ids_global@test.com')
+    rd = RoleDefinition.objects.create(name='Obj IDs Global Role', managed=True)
+    rd.give_global_permission(user)
+
+    from ansible_base.rbac.models.role import RoleUserAssignment
+
+    assignments = list(RoleUserAssignment.objects.select_related('content_type').filter(role_definition=rd))
+    assert len(assignments) > 0
+    result = _bulk_resolve_object_ansible_ids(assignments)
+    assert result == {}
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +338,27 @@ def test_get_local_assignments_filters_by_service():
 
     non_matching = get_local_assignments(service='nonexistent_service')
     assert not any(a.role_definition_name == 'Svc Role' for a in non_matching)
+
+
+@pytest.mark.django_db
+def test_get_local_assignments_filters_team_assignments_by_service():
+    """Service filter applies to team assignments (RoleTeamAssignment path)."""
+    from ansible_base.rbac.models import DABContentType, RoleDefinition
+    from test_app.models import Organization, Team
+
+    org = Organization.objects.create(name='Team Svc Org')
+    team = Team.objects.create(name='Svc Team', organization=org)
+    org_ct = DABContentType.objects.get_for_model(Organization)
+
+    rd = RoleDefinition.objects.create(name='Team Svc Role', content_type=org_ct, managed=True)
+    rd.give_permission(team, org)
+
+    service_name = org_ct.service
+    matching = get_local_assignments(service=service_name)
+    assert any(a.role_definition_name == 'Team Svc Role' and a.assignment_type == 'team' for a in matching)
+
+    non_matching = get_local_assignments(service='nonexistent_service')
+    assert not any(a.role_definition_name == 'Team Svc Role' for a in non_matching)
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/test_role_sync_utils.py
+++ b/test_app/tests/rbac/test_role_sync_utils.py
@@ -5,8 +5,6 @@ import pytest
 from ansible_base.rbac.role_sync_utils import (
     _SKIP,
     AssignmentTuple,
-    _bulk_resolve_actor_ansible_ids,
-    _bulk_resolve_object_ansible_ids,
     _collect_assignment_tuples,
     _is_resource_registered,
     _resolve_object_ansible_id,
@@ -150,82 +148,6 @@ def test_is_resource_registered_returns_false_for_unregistered_model():
 
 
 # ---------------------------------------------------------------------------
-# _bulk_resolve_actor_ansible_ids
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.django_db
-def test_bulk_resolve_actor_ansible_ids_empty_list():
-    """Empty assignments list returns empty dict."""
-    assert _bulk_resolve_actor_ansible_ids([], 'user') == {}
-
-
-@pytest.mark.django_db
-def test_bulk_resolve_actor_ansible_ids_resolves_users():
-    """Resolves user PKs to ansible_ids in a single query."""
-    from ansible_base.rbac.models import RoleDefinition
-    from test_app.models import User
-
-    user = User.objects.create(username='bulk_actor_user', email='bulk_actor@test.com')
-    user_resource = Resource.get_resource_for_object(user)
-    rd = RoleDefinition.objects.create(name='Bulk Actor Role', managed=True)
-    rd.give_global_permission(user)
-
-    from ansible_base.rbac.models.role import RoleUserAssignment
-
-    assignments = list(RoleUserAssignment.objects.select_related('user').filter(role_definition=rd))
-    result = _bulk_resolve_actor_ansible_ids(assignments, 'user')
-
-    assert str(user.pk) in result
-    assert result[str(user.pk)] == str(user_resource.ansible_id)
-
-
-# ---------------------------------------------------------------------------
-# _bulk_resolve_object_ansible_ids
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.django_db
-def test_bulk_resolve_object_ansible_ids_no_org_team():
-    """Returns empty dict when all assignments target non-org/team content types."""
-    from ansible_base.rbac.models import DABContentType, RoleDefinition
-    from test_app.models import Inventory, Organization, User
-
-    user = User.objects.create(username='obj_ids_user', email='obj_ids@test.com')
-    org = Organization.objects.create(name='Obj IDs Org')
-    inv = Inventory.objects.create(name='Obj IDs Inv', organization=org)
-    inv_ct = DABContentType.objects.get_for_model(Inventory)
-
-    rd = RoleDefinition.objects.create(name='Obj IDs Role', content_type=inv_ct, managed=True)
-    rd.give_permission(user, inv)
-
-    from ansible_base.rbac.models.role import RoleUserAssignment
-
-    assignments = list(RoleUserAssignment.objects.select_related('content_type').filter(role_definition=rd))
-    assert len(assignments) > 0
-    result = _bulk_resolve_object_ansible_ids(assignments)
-    assert result == {}
-
-
-@pytest.mark.django_db
-def test_bulk_resolve_object_ansible_ids_global_assignments():
-    """Global assignments (no object_id, no content_type) produce empty result."""
-    from ansible_base.rbac.models import RoleDefinition
-    from test_app.models import User
-
-    user = User.objects.create(username='obj_ids_global', email='obj_ids_global@test.com')
-    rd = RoleDefinition.objects.create(name='Obj IDs Global Role', managed=True)
-    rd.give_global_permission(user)
-
-    from ansible_base.rbac.models.role import RoleUserAssignment
-
-    assignments = list(RoleUserAssignment.objects.select_related('content_type').filter(role_definition=rd))
-    assert len(assignments) > 0
-    result = _bulk_resolve_object_ansible_ids(assignments)
-    assert result == {}
-
-
-# ---------------------------------------------------------------------------
 # _resolve_object_ansible_id
 # ---------------------------------------------------------------------------
 
@@ -352,27 +274,6 @@ def test_get_local_assignments_filters_by_service():
 
     non_matching = get_local_assignments(service='nonexistent_service')
     assert not any(a.role_definition_name == 'Svc Role' for a in non_matching)
-
-
-@pytest.mark.django_db
-def test_get_local_assignments_filters_team_assignments_by_service():
-    """Service filter applies to team assignments (RoleTeamAssignment path)."""
-    from ansible_base.rbac.models import DABContentType, RoleDefinition
-    from test_app.models import Organization, Team
-
-    org = Organization.objects.create(name='Team Svc Org')
-    team = Team.objects.create(name='Svc Team', organization=org)
-    org_ct = DABContentType.objects.get_for_model(Organization)
-
-    rd = RoleDefinition.objects.create(name='Team Svc Role', content_type=org_ct, managed=True)
-    rd.give_permission(team, org)
-
-    service_name = org_ct.service
-    matching = get_local_assignments(service=service_name)
-    assert any(a.role_definition_name == 'Team Svc Role' and a.assignment_type == 'team' for a in matching)
-
-    non_matching = get_local_assignments(service='nonexistent_service')
-    assert not any(a.role_definition_name == 'Team Svc Role' for a in non_matching)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
  When syncing role assignments from the Gateway, object_ansible_id is a
  UUID. For organization and team types this was already resolved through
  the Resource table, but all other content types passed the UUID directly
  as a PK, causing "Field id expected a number" errors on models with
  integer primary keys.

  Try the Resource table lookup first for all content types, falling back
  to direct PK lookup for backward compatibility.

  Fixes: AAP-71217



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role synchronization target resolution by matching existing resource records, including organization and team targets.
  * Added more resilient fallback handling when resource matching fails or validation issues occur.
  * Improved consistency when updating permissions, team memberships, and roles after changes or deletions.

* **Tests**
  * Added database coverage for UUID-based resource resolution and primary-key fallback behavior during role synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->