### PR TITLE
AAP-85255 Fix Fernet256 compatibility with cryptography 50.0.0

### DIFF
--- a/ansible_base/lib/utils/encryption.py
+++ b/ansible_base/lib/utils/encryption.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Tuple
 
 from cryptography.fernet import Fernet
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import algorithms
 from django.conf import settings
 from django.utils.encoding import smart_bytes, smart_str
 from django.utils.functional import SimpleLazyObject
@@ -73,6 +74,7 @@ class Fernet256(Fernet):
 
         self._signing_key = self.key[:32]
         self._encryption_key = self.key[32:]
+        self._aes = algorithms.AES(self._encryption_key)
         self._backend = default_backend()
 
     def is_encrypted_string(self, value: Any) -> Tuple[bool, Optional[str], Optional[str]]:


### PR DESCRIPTION
## Summary
- Cache `self._aes = algorithms.AES(self._encryption_key)` in `Fernet256.__init__` to match the attribute that `cryptography` 50.0.0's `Fernet.encrypt()`/`decrypt()` now reference instead of constructing inline.
- Backwards-compatible: `_aes` is simply unused on older versions.

## Test plan
- [x] All 31 `test_app/tests/lib/utils/test_encryption.py` tests pass
- [ ] Verify in-files CI (unpinned cryptography) no longer fails with `AttributeError` on `_aes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption initialization for more reliable data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->