### PR TITLE
[AAP-82668] Wrap DELETE dispatch in ensure_transaction for flush consistency

### DIFF
--- a/ansible_base/lib/utils/views/ansible_base.py
+++ b/ansible_base/lib/utils/views/ansible_base.py
@@ -84,6 +84,9 @@ class AnsibleBaseView(APIView):
         if request.method != 'DELETE':
             return super().dispatch(request, *args, **kwargs)
         with ExitStack() as stack:
+            from ansible_base.lib.utils.db import ensure_transaction
+
+            stack.enter_context(ensure_transaction())
             if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
                 from ansible_base.activitystream import deferred_activity_stream
 


### PR DESCRIPTION
## Summary

The deferred RBAC flush in `defer_rbac_computations` runs after the consumer's `perform_destroy()` has committed its `@transaction.atomic`. If the flush raises, the delete is already committed and cannot be rolled back — leaving orphaned RBAC data.

## Fix

Add `ensure_transaction()` (from `ansible_base.lib.utils.db`) as the outermost context in `AnsibleBaseView.dispatch()` for DELETE requests. This wraps the deferral contexts and the delete in a single transaction, so the flush is part of the same atomic block.

`ensure_transaction()` is a no-op if a transaction is already active — no unexpected savepoints, no conflict with consumer transaction management. It only opens a transaction if one doesn't already exist.

## Why at the view level, not in defer_rbac_computations

`defer_rbac_computations` is an ORM-level library utility. It shouldn't own transaction management — that's the consumer's responsibility. The view layer (`dispatch`) is the right place to ensure transactional consistency because it knows the full scope of the request.

## Evidence

A gateway test (`test_flush_failure_rolls_back_delete` in jewel PR ansible/jewel#160) mocks `compute_team_member_roles` to raise, then asserts the org still exists. Without this fix, the assertion fails. With this fix, both tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of DELETE requests by ensuring related activity, access-control, and cleanup operations are processed within a transaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->