### PR TITLE
[AAP-84893] Remove stale redis<8.0.0 version cap

### DIFF
--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -15,7 +15,7 @@ channels==4.3.2
     # via -r requirements/requirements_channels.in
 charset-normalizer==3.4.4
     # via requests
-cryptography==46.0.5  # Components should use this or later for CVE-2026-26007
+cryptography==46.0.5
     # via
     #   -r requirements/requirements.in
     #   jwcrypto
@@ -83,10 +83,6 @@ lxml==5.3.0
     #   -r requirements/requirements_authentication.in
     #   python3-saml
     #   xmlsec
-markdown-it-py==4.0.0
-    # via rich
-mdurl==0.1.2
-    # via markdown-it-py
 netaddr==1.3.0
     # via pyrad
 oauthlib==3.3.1
@@ -177,8 +173,6 @@ pyasn1-modules==0.4.2
     # via python-ldap
 pycparser==2.23
     # via cffi
-pygments==2.20.0
-    # via rich
 pyjwt==2.10.1
     # via
     #   -r requirements/requirements_jwt_consumer.in

--- a/requirements/requirements_redis_client.in
+++ b/requirements/requirements_redis_client.in
@@ -1,2 +1,2 @@
 django-redis
-redis>=7.4.0,<8.0.0  # 8.0.0 breaks Unix socket connections (https://github.com/redis/redis-py/issues/4086)
+redis>=7.4.0  # 8.0.0 broke Unix socket connections (redis/redis-py#4086), fixed in 8.0.1


### PR DESCRIPTION
## Description

- **What is being changed?**
  Remove the `<8.0.0` upper bound from the `redis` pin in `requirements/requirements_redis_client.in`, changing `redis>=7.4.0,<8.0.0` to `redis>=7.4.0`.

- **Why is this change needed?**
  The cap was added because redis-py 8.0.0 broke Unix socket connections (redis/redis-py#4086). This was fixed in redis-py 8.0.1 (released 2026-06-23). The cap is now stale and prevents downstream consumers from using redis-py 8.x.

- **How does this change address the issue?**
  Removing the upper bound allows pip-compile to resolve redis-py 8.x when downstream projects pin `redis>=8.0.1`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
None.

### Steps to Test
1. Review `requirements/requirements_redis_client.in` — verify the constraint is `redis>=7.4.0`
2. Run `cd requirements && ./updater.sh run` — verify `requirements_all.txt` regenerates successfully
3. Verify `redis` version in `requirements_all.txt` stays at 7.4.0 (run mode keeps existing pins)

### Expected Results
- `requirements_all.txt` regenerates without errors
- `redis==7.4.0` is preserved (satisfies `>=7.4.0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Redis client dependency constraint to support version 8.0.1 and later.
  * Removed unused documentation-related dependencies from the locked requirements.
  * Cleaned up an outdated security note in the dependency lockfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->