### PR TITLE
AAP-82668 Revert dispatch-level deferral CM wrapping from AnsibleBaseView

### DIFF
--- a/ansible_base/lib/utils/views/ansible_base.py
+++ b/ansible_base/lib/utils/views/ansible_base.py
@@ -1,8 +1,6 @@
 import logging
 import time
-from contextlib import ExitStack
 
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework.views import APIView
 
@@ -64,39 +62,6 @@ class AnsibleBaseView(APIView):
             response['Warning'] = _('This resource has been deprecated and will be removed in a future release.')
 
         return response
-
-    def dispatch(self, request, *args, **kwargs):
-        # We wrap DELETE requests with deferral context managers so that
-        # cascade deletes of large resources (e.g. organizations with many
-        # teams/users) batch all signal-driven RBAC recomputation, activity
-        # stream logging, and resource cleanup into a single pass instead
-        # of firing per-object.
-        #
-        # We use dispatch() because DestroyModelMixin appears earlier in the
-        # MRO than AnsibleBaseView (typical inheritance is
-        # SomeViewSet(ModelViewSet, AnsibleBaseView)), so overriding
-        # destroy() or perform_destroy() here would never be reached.
-        # dispatch() is not defined by ViewSetMixin or DestroyModelMixin,
-        # only by APIView, which AnsibleBaseView precedes in the MRO.
-        #
-        # The installed-app guards ensure this is safe when optional DAB
-        # apps (rbac, activitystream, resource_registry) are not enabled.
-        if request.method != 'DELETE':
-            return super().dispatch(request, *args, **kwargs)
-        with ExitStack() as stack:
-            if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
-                from ansible_base.activitystream import deferred_activity_stream
-
-                stack.enter_context(deferred_activity_stream())
-            if 'ansible_base.rbac' in settings.INSTALLED_APPS:
-                from ansible_base.rbac.triggers import defer_rbac_computations
-
-                stack.enter_context(defer_rbac_computations())
-            if 'ansible_base.resource_registry' in settings.INSTALLED_APPS:
-                from ansible_base.resource_registry.signals.handlers import defer_resource_cleanup
-
-                stack.enter_context(defer_resource_cleanup())
-            return super().dispatch(request, *args, **kwargs)
 
     def extra_related_fields(self, obj):
         """

--- a/ansible_base/resource_registry/models/resource.py
+++ b/ansible_base/resource_registry/models/resource.py
@@ -1,7 +1,9 @@
 import uuid
+from contextlib import ExitStack
 from functools import lru_cache
 from typing import TYPE_CHECKING, Union
 
+from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
@@ -139,7 +141,16 @@ class Resource(models.Model):
             raise ValidationError({"resource_type": _(f"Resource type: {self.content_type.resource_type.name} cannot be managed by Resources.")})
 
         with transaction.atomic():
-            with no_reverse_sync():
+            with ExitStack() as stack:
+                if 'ansible_base.activitystream' in settings.INSTALLED_APPS:
+                    from ansible_base.activitystream import deferred_activity_stream
+
+                    stack.enter_context(deferred_activity_stream())
+                if 'ansible_base.rbac' in settings.INSTALLED_APPS:
+                    from ansible_base.rbac.triggers import defer_rbac_computations
+
+                    stack.enter_context(defer_rbac_computations())
+                stack.enter_context(no_reverse_sync())
                 self.content_object.delete()
             self.delete()
 

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -225,6 +225,37 @@ def test_defer_rbac_computations_flushes_on_exception(organization, rando, org_i
 
 
 @pytest.mark.django_db
+def test_service_index_delete_uses_deferral_context_managers(organization, rando, org_inv_rd):
+    """Resource.delete_resource (used by service-index DELETE) should use
+    defer_rbac_computations, verified by checking that the context manager
+    is active when the post_delete signal fires during the cascade."""
+    from django.db.models.signals import post_delete
+
+    from ansible_base.rbac.triggers import _defer_rbac
+    from ansible_base.resource_registry.models import Resource
+
+    org_inv_rd.give_permission(rando, organization)
+    for i in range(3):
+        Inventory.objects.create(name=f'defer-svc-inv-{i}', organization=organization)
+
+    was_active = []
+
+    def check_defer(sender, instance, **kwargs):
+        was_active.append(_defer_rbac.active)
+
+    post_delete.connect(check_defer, sender=Inventory)
+    try:
+        resource = Resource.get_resource_for_object(organization)
+        resource.delete_resource()
+    finally:
+        post_delete.disconnect(check_defer, sender=Inventory)
+
+    assert len(was_active) == 3
+    assert all(was_active), "defer_rbac_computations should have been active during delete_resource cascade"
+    assert not Organization.objects.filter(pk=organization.pk).exists()
+
+
+@pytest.mark.django_db
 def test_defer_rbac_computations_defers_resource_creation(organization, rando, org_inv_rd):
     """Creating a child resource inside defer_rbac_computations should defer
     RoleEvaluation updates until the context manager exits."""

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -24,16 +24,16 @@ def test_post_migrate_signals():
 @pytest.mark.django_db
 def test_post_migrate_skips_recompute_when_no_migrations_applied():
     """post_migration_rbac_setup should skip compute_team_member_roles and
-    compute_object_role_permissions when the plan kwarg is an empty list,
+    recompute_all_role_evaluations when the plan kwarg is an empty list,
     meaning no migrations were actually applied."""
     with (
         patch('ansible_base.rbac.triggers.compute_team_member_roles') as mock_team,
-        patch('ansible_base.rbac.triggers.compute_object_role_permissions') as mock_obj,
+        patch('ansible_base.rbac.triggers.recompute_all_role_evaluations') as mock_recompute,
     ):
         post_migration_rbac_setup(apps.get_app_config('dab_rbac'), plan=[])
 
     mock_team.assert_not_called()
-    mock_obj.assert_not_called()
+    mock_recompute.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -42,12 +42,12 @@ def test_post_migrate_runs_recompute_when_plan_has_entries():
     plan kwarg contains migration entries."""
     with (
         patch('ansible_base.rbac.triggers.compute_team_member_roles') as mock_team,
-        patch('ansible_base.rbac.triggers.compute_object_role_permissions') as mock_obj,
+        patch('ansible_base.rbac.triggers.recompute_all_role_evaluations') as mock_recompute,
     ):
         post_migration_rbac_setup(apps.get_app_config('dab_rbac'), plan=[('fake_migration',)])
 
     mock_team.assert_called_once()
-    mock_obj.assert_called_once()
+    mock_recompute.assert_called_once()
 
 
 @pytest.mark.django_db
@@ -222,36 +222,6 @@ def test_defer_rbac_computations_flushes_on_exception(organization, rando, org_i
 
     inv = Inventory.objects.get(name='error-inv')
     assert rando.has_obj_perm(inv, 'change')
-
-
-@pytest.mark.django_db
-def test_api_delete_uses_deferral_context_managers(admin_api_client, organization, rando, org_inv_rd):
-    """DELETE via the API should use defer_rbac_computations, verified by
-    checking that the context manager is active when the post_delete
-    signal fires during the cascade."""
-    from django.db.models.signals import post_delete
-
-    from ansible_base.rbac.triggers import _defer_rbac
-
-    org_inv_rd.give_permission(rando, organization)
-    for i in range(3):
-        Inventory.objects.create(name=f'defer-api-inv-{i}', organization=organization)
-
-    was_active = []
-
-    def check_defer(sender, instance, **kwargs):
-        was_active.append(_defer_rbac.active)
-
-    post_delete.connect(check_defer, sender=Inventory)
-    try:
-        response = admin_api_client.delete(f'/api/v1/organizations/{organization.pk}/')
-    finally:
-        post_delete.disconnect(check_defer, sender=Inventory)
-
-    assert response.status_code == 204
-    assert len(was_active) == 3
-    assert all(was_active), "defer_rbac_computations should have been active during delete"
-    assert not Organization.objects.filter(pk=organization.pk).exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Removes the `dispatch()` override from `AnsibleBaseView` that wrapped all DELETE requests with `defer_rbac_computations`, `deferred_activity_stream`, and `defer_resource_cleanup`
- The dispatch-level wrapping ran OUTSIDE any app-level `@transaction.atomic`, so flush failures could not roll back the delete — apps should apply deferral CMs inside their own transaction boundaries (e.g. in `perform_destroy`)
- Fixes tests that mocked the non-existent `triggers.compute_object_role_permissions` (should be `triggers.recompute_all_role_evaluations`)

## Background
Commit 886ef9d (PR #1059) added the dispatch override. In jewel/gateway, `ResourceAPIUpdateMixin.perform_destroy` is decorated with `@transaction.atomic`, but the deferral flush ran after `perform_destroy` returned (at dispatch exit), so flush failures couldn't roll back the delete. The companion jewel PR moves the deferral CMs inside `perform_destroy` where they belong.

## Test plan
- [x] RBAC tests pass (621 passed)
- [x] Activitystream tests pass (102 passed)
- [x] Resource registry tests pass (36 passed, 1 pre-existing deadlock flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined request processing by removing obsolete handling paths.
  - Improved consistency in permission evaluation workflows following data migrations.
- **Tests**
  - Updated coverage to validate current role-evaluation behavior.
  - Removed outdated checks for deferred organization-deletion processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->