### PR TITLE
AAP-85713 Add jewel (aap-gateway) downstream CI tests

### DIFF
--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -177,7 +177,6 @@ jobs:
         working-directory: jewel
         env:
           PYTEST_NUM_PROCESSES: auto
-          GATEWAY_TEST_DIRS: ""
           PYTEST_ADDOPTS: --disable-warnings
         run: tox -e py312 -- -m "not perf"
 

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -117,6 +117,70 @@ jobs:
         env:
           PYTEST_ADDOPTS: --disable-warnings
 
+  jewel:
+    name: jewel
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+    env:
+      TOX_DOCKER_GATEWAY: "0.0.0.0"
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: dab
+          show-progress: false
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ansible/jewel
+          path: jewel
+          persist-credentials: false
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install tox
+        run: pip install tox tox-docker requests
+
+      - name: Place DAB in jewel checkout
+        run: cp -a dab jewel/django-ansible-base
+
+      - name: Create tox environment
+        working-directory: jewel
+        env:
+          GATEWAY_TEST_DIRS: ""
+        run: |
+          tox -e py312 \
+            -x testenv:py312.docker= \
+            -- --collect-only aap_gateway_api/tests/__init__.py
+
+      - name: Rebuild lxml and xmlsec from source
+        working-directory: jewel
+        run: |
+          XMLSEC_VERSION=$(.tox/py312/bin/pip freeze | grep xmlsec | sed 's:^.*=::')
+          LXML_VERSION=$(.tox/py312/bin/pip freeze | grep lxml | sed 's:^.*=::')
+          echo "Rebuilding xmlsec==${XMLSEC_VERSION} and lxml==${LXML_VERSION} from source"
+          .tox/py312/bin/pip install --no-cache-dir --no-binary lxml,xmlsec --force-reinstall \
+            lxml==${LXML_VERSION} xmlsec==${XMLSEC_VERSION}
+
+      - name: Run jewel tests
+        working-directory: jewel
+        env:
+          PYTEST_NUM_PROCESSES: auto
+          GATEWAY_TEST_DIRS: ""
+          PYTEST_ADDOPTS: --disable-warnings
+        run: tox -e py312 -- -m "not perf"
+
   hub:
     name: hub
     runs-on: ubuntu-latest

--- a/.github/workflows/dab-consumers.yml
+++ b/.github/workflows/dab-consumers.yml
@@ -120,6 +120,8 @@ jobs:
   jewel:
     name: jewel
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     env:


### PR DESCRIPTION
## Summary
- Adds a new `jewel` job to the DAB consumers CI workflow that runs the jewel (upstream aap-gateway) test suite against the current DAB branch
- Follows the same pattern as the existing AWX, EDA, and Hub downstream test jobs
- Leverages jewel's built-in local DAB checkout detection (`django-ansible-base/.git`) so no patches to jewel are needed

## Test plan
- [ ] CI runs the new jewel job successfully against `ansible/jewel` devel branch
- [ ] Existing AWX, EDA, and Hub downstream jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated compatibility testing for Jewel on Ubuntu 24.04.
  * Validation now covers the required system and Python environments, integration setup, and non-performance test suites.
  * Expanded coverage to better reflect real-world installation and runtime conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->