### PR TITLE
fix: enforce permissions for changing role assignments

### DIFF
--- a/ansible_base/rbac/policies.py
+++ b/ansible_base/rbac/policies.py
@@ -5,9 +5,9 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser
 from django.db.models import Model
 from django.db.models.query import QuerySet
-from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import PermissionDenied
 
+from ansible_base.lib.utils.models import is_add_perm
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.rbac.evaluations import has_super_permission
 from ansible_base.rbac.models import DABPermission, ObjectRole
@@ -84,31 +84,35 @@ def can_change_user(request_user: Optional[AbstractBaseUser], target_user: Optio
 def check_content_obj_permission(request_user, obj) -> None:
     """Permission policy rules for giving or removing obj permission
 
-    Right now we are not supporting a separate permission to manage permission
-    on objects, so we firstly look to a simple matter of having change permission
-    If that is not available, then we check all object-level permissions.
+    User must hold all object-level permissions for the model to manage
+    role assignments on that object. This prevents privilege escalation
+    where a user with partial permissions (e.g. change but not execute)
+    could assign themselves a role containing permissions they lack.
     """
     if isinstance(obj, RemoteObject):
+        # we retain this check: Gateway uses this to skip enforcing permissions on objects
+        # it considers remote like JobTemplates, Inventories etc.
         if not get_setting('ANSIBLE_BASE_ENFORCE_REMOTE_OBJECT_PERMISSIONS', True):
             return
-        permissions = DABPermission.objects.filter(content_type=obj.content_type)
-        for permission in permissions:
-            if permission.codename.startswith('change'):
-                if not request_user.has_obj_perm(obj, 'change'):
-                    raise PermissionDenied
-                return
-        for permission in permissions:
+        for permission in DABPermission.objects.filter(content_type=obj.content_type):
+            # we need to skip checking add permissions: they are not meant for remote objects but
+            # are evaluated at a higher level (organization). Checking here would raise a RuntimeError.
+            if is_add_perm(permission.codename):
+                continue
+
+            # to add or remove role assignments to remote objects, the user is required to hold
+            # *every* permission that exists for this model (except add). This prevents users
+            # with insufficient permission from assigning themselves a role containing permissions they lack.
             if not request_user.has_obj_perm(obj, permission.codename):
                 raise PermissionDenied
-    elif 'change' in obj._meta.default_permissions:
-        # Model has no change permission, so user must have all permissions for the applicable model
-        if not request_user.has_obj_perm(obj, 'change'):
+        return
+
+    # Non-remote objects: again, the user must hold *every* (non-add) permission in order to change
+    # role assignments
+    cls = type(obj)
+    for codename in permissions_allowed_for_role(cls)[cls]:
+        if not request_user.has_obj_perm(obj, codename):
             raise PermissionDenied
-    else:
-        cls = type(obj)
-        for codename in permissions_allowed_for_role(cls)[cls]:
-            if not request_user.has_obj_perm(obj, codename):
-                raise PermissionDenied({'detail': _('You do not have {codename} permission the object').format(codename=codename)})
 
 
 def check_can_remove_assignment(request_user: Model, assignment: Model):

--- a/ansible_base/rbac/service_api/views.py
+++ b/ansible_base/rbac/service_api/views.py
@@ -14,6 +14,7 @@ from ansible_base.rest_filters.rest_framework import ansible_id_backend
 from ansible_base.rest_filters.rest_framework.ansible_id_backend import ServiceFilterBackend
 
 from ..models import DABContentType, DABPermission, RoleTeamAssignment, RoleUserAssignment
+from ..policies import check_can_remove_assignment
 from . import serializers as service_serializers
 
 
@@ -95,6 +96,11 @@ class BaseSerivceRoleAssignmentViewSet(
         if not existing:
             output_serializer = self.get_serializer(existing)
             return Response(output_serializer.data, status=status.HTTP_200_OK)
+
+        # check permissions before removing a role assignment. Previously it was possible
+        # to remove a role assignment for a remote object in Gateway with neither side (Gateway
+        # and the remote side, e.g. Controller) checking if this was allowed.
+        check_can_remove_assignment(request.user, existing)
 
         # Save properties for sync after it is done locally (at which point assignment will not exist)
         role_definition = existing.role_definition

--- a/test_app/tests/rbac/api/test_assignment_permissions.py
+++ b/test_app/tests/rbac/api/test_assignment_permissions.py
@@ -38,8 +38,6 @@ def test_create_user_assignment_immutable(user_api_client, user, rando, task_adm
     task_view_rd.give_permission(user, task)
     response = user_api_client.post(url, data=request_data)
     assert response.status_code == 403, response.data
-    # Test custom error message
-    assert 'You do not have cancel_immutabletask permission' in str(response.data)
 
     task_admin_rd.give_permission(user, task)
     response = user_api_client.post(url, data=request_data)
@@ -58,8 +56,6 @@ def test_remove_user_assignment_immutable(user_api_client, user, rando, task_adm
     task_view_rd.give_permission(user, task)
     response = user_api_client.delete(url)
     assert response.status_code == 403, response.data
-    # Test custom error message
-    assert 'You do not have cancel_immutabletask permission' in str(response.data)
 
     task_admin_rd.give_permission(user, task)
     response = user_api_client.delete(url)
@@ -69,13 +65,18 @@ def test_remove_user_assignment_immutable(user_api_client, user, rando, task_adm
 
 
 @pytest.mark.django_db
-def test_remove_user_assignment_with_global_role(user_api_client, user, inv_rd, global_inv_rd, rando, inventory):
+def test_remove_user_assignment_with_global_role(user_api_client, user, inv_rd, rando, inventory):
     assignment = inv_rd.give_permission(rando, inventory)
     url = get_relative_url('roleuserassignment-detail', kwargs={'pk': assignment.pk})
     response = user_api_client.delete(url)
     assert response.status_code == 404, response.data
 
-    global_inv_rd.give_global_permission(user)
+    global_admin_rd = RoleDefinition.objects.create_from_permissions(
+        permissions=['change_inventory', 'delete_inventory', 'view_inventory', 'update_inventory'],
+        name='global-inv-admin',
+        content_type=None,
+    )
+    global_admin_rd.give_global_permission(user)
     response = user_api_client.delete(url)
     assert response.status_code == 204, response.data
 

--- a/test_app/tests/rbac/api/test_rbac_serializers.py
+++ b/test_app/tests/rbac/api/test_rbac_serializers.py
@@ -2,6 +2,8 @@ import pytest
 from django.test.utils import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac import permission_registry
+from ansible_base.rbac.models import RoleDefinition
 from test_app.models import Inventory, User
 
 
@@ -76,8 +78,13 @@ class TestAssignmentPermission:
         assert response.status_code == 403
         assert not rando.has_obj_perm(inventory_2, 'change')
 
-        # After giving user admin to inventory, user can delegate that permission to others
-        inv_rd.give_permission(org_admin, inventory_2)
+        # After giving user all permissions on inventory, user can delegate that permission to others
+        inv_admin_rd = RoleDefinition.objects.create_from_permissions(
+            permissions=['change_inventory', 'delete_inventory', 'view_inventory', 'update_inventory'],
+            name='inv-admin',
+            content_type=permission_registry.content_type_model.objects.get_for_model(Inventory),
+        )
+        inv_admin_rd.give_permission(org_admin, inventory_2)
         response = user_api_client.post(url, data=create_data)
         assert response.status_code == 201
         assert rando.has_obj_perm(inventory_2, 'change')

--- a/test_app/tests/rbac/api/test_rbac_views.py
+++ b/test_app/tests/rbac/api/test_rbac_views.py
@@ -2,7 +2,9 @@ import pytest
 from django.test.utils import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
+from test_app.models import Inventory
 
 
 @pytest.mark.django_db
@@ -117,7 +119,12 @@ def test_remove_user_assignment(user_api_client, user, inv_rd, rando, inventory)
     response = user_api_client.delete(url)
     assert response.status_code == 404, response.data
 
-    inv_rd.give_permission(user, inventory)
+    inv_admin_rd = RoleDefinition.objects.create_from_permissions(
+        permissions=['change_inventory', 'delete_inventory', 'view_inventory', 'update_inventory'],
+        name='inv-admin',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Inventory),
+    )
+    inv_admin_rd.give_permission(user, inventory)
     response = user_api_client.delete(url)
     assert response.status_code == 204, response.data
 
@@ -149,7 +156,12 @@ def test_remove_team_assignment(user_api_client, user, inv_rd, team, inventory):
     response = user_api_client.delete(url)
     assert response.status_code == 404, response.data
 
-    inv_rd.give_permission(user, inventory)
+    inv_admin_rd = RoleDefinition.objects.create_from_permissions(
+        permissions=['change_inventory', 'delete_inventory', 'view_inventory', 'update_inventory'],
+        name='inv-admin',
+        content_type=permission_registry.content_type_model.objects.get_for_model(Inventory),
+    )
+    inv_admin_rd.give_permission(user, inventory)
     response = user_api_client.delete(url)
     assert response.status_code == 204, response.data
 

--- a/test_app/tests/rbac/test_policies.py
+++ b/test_app/tests/rbac/test_policies.py
@@ -1,9 +1,12 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
+from rest_framework.exceptions import PermissionDenied
 
-from ansible_base.rbac.policies import can_change_user, visible_users
-from test_app.models import User
+from ansible_base.rbac.models import RoleDefinition
+from ansible_base.rbac.permission_registry import permission_registry
+from ansible_base.rbac.policies import can_change_user, check_content_obj_permission, visible_users
+from test_app.models import Inventory, Organization, User
 
 
 @pytest.mark.django_db
@@ -196,3 +199,49 @@ def test_visible_users_anonymous_user():
 
     qs = visible_users(AnonymousUser())
     assert not qs.exists()
+
+
+@pytest.mark.django_db
+class TestCheckContentObjPermission:
+    """Tests for check_content_obj_permission privilege escalation fix (AAP-78640)."""
+
+    def test_user_with_all_permissions_passes(self):
+        """User holding all permissions on an object can manage role assignments."""
+        org = Organization.objects.create(name='test-org')
+        inv = Inventory.objects.create(name='test-inv', organization=org)
+        user = User.objects.create(username='full-perm-user')
+
+        ct = permission_registry.content_type_model.objects.get_for_model(Inventory)
+        admin_rd = RoleDefinition.objects.create_from_permissions(
+            permissions=['change_inventory', 'delete_inventory', 'view_inventory', 'update_inventory'],
+            name='inv-full-admin',
+            content_type=ct,
+        )
+        admin_rd.give_permission(user, inv)
+
+        check_content_obj_permission(user, inv)
+
+    def test_user_with_only_change_cannot_manage_roles(self):
+        """User with only change permission cannot manage role assignments (AAP-78640)."""
+        org = Organization.objects.create(name='test-org')
+        inv = Inventory.objects.create(name='test-inv', organization=org)
+        user = User.objects.create(username='change-only-user')
+
+        ct = permission_registry.content_type_model.objects.get_for_model(Inventory)
+        change_rd = RoleDefinition.objects.create_from_permissions(
+            permissions=['change_inventory', 'view_inventory'],
+            name='inv-change-only',
+            content_type=ct,
+        )
+        change_rd.give_permission(user, inv)
+
+        with pytest.raises(PermissionDenied):
+            check_content_obj_permission(user, inv)
+
+    def test_superuser_bypasses_check(self):
+        """Superusers have all permissions and should always pass."""
+        org = Organization.objects.create(name='test-org')
+        inv = Inventory.objects.create(name='test-inv', organization=org)
+        admin = User.objects.create(username='admin-user', is_superuser=True)
+
+        check_content_obj_permission(admin, inv)


### PR DESCRIPTION
## Description

Currently there are two problems with assigning and removing role assignments. 

**First**, check_content_obj_permission only required change permission to assign or remove any role on an object, regardless of what permissions that role contained.

**Second**, the service API's _unassign had no permission check at all.

With this change, we fix both: deletions are now permission-checked, and assigning or removing roles requires the user to hold every object-level permission (change, delete, view, plus any model-specific ones like execute) except add (add must be enforced at an organization level).

For example, a user with only change permissions on a Job Template (but no execute) can assign themselves JT Admin, gaining execute rights they never had.

The test needed to be updated, because the old behavior 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization checks for managing remote objects, requiring all applicable permissions except “add.”
  * Validated removal permissions before deleting role assignments or synchronizing remote unassignments.
  * Ensured users with only change or view access cannot manage roles.
  * Preserved superuser access while improving permission-denied handling.

* **Tests**
  * Expanded coverage for object-management permissions and role-assignment removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->