### PR TITLE
fix: check permissions before removing role assignment in service-index API

### DIFF
--- a/ansible_base/rbac/service_api/views.py
+++ b/ansible_base/rbac/service_api/views.py
@@ -14,6 +14,7 @@ from ansible_base.rest_filters.rest_framework import ansible_id_backend
 from ansible_base.rest_filters.rest_framework.ansible_id_backend import ServiceFilterBackend
 
 from ..models import DABContentType, DABPermission, RoleTeamAssignment, RoleUserAssignment
+from ..policies import check_can_remove_assignment
 from . import serializers as service_serializers
 
 
@@ -95,6 +96,11 @@ class BaseSerivceRoleAssignmentViewSet(
         if not existing:
             output_serializer = self.get_serializer(existing)
             return Response(output_serializer.data, status=status.HTTP_200_OK)
+
+        # check permissions before removing a role assignment. Previously it was possible
+        # to remove a role assignment for a remote object in Gateway with neither side (Gateway
+        # and the remote side, e.g. Controller) checking if this was allowed.
+        check_can_remove_assignment(request.user, existing)
 
         # Save properties for sync after it is done locally (at which point assignment will not exist)
         role_definition = existing.role_definition


### PR DESCRIPTION
## Description

We were not enforcing permissions when the service API synced back a role removal from Gateway to Controller. This PR adds the required check.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test

  As admin:
  1. Create two teams (team1, team2) in the Default organization
  2. Create two users (team1_user, team2_user) and add each to their respective team
  3. Navigate to a Job Template → Access tab → Add roles
  4. Give both teams the "JobTemplate Execute" role on that Job Template

  As team1_user:
  5. Navigate to the same Job Template → Access tab
  6. Try to remove team2's "JobTemplate Execute" role
  7. Before fix: role is removed successfully
  8. After fix: operation is denied (403)

  As admin (verify no regression):
  9. Remove team2's role from the same Access tab
  10. Should succeed normally
