### PR TITLE
AAP-85842 Disable reverse RBAC sync during JWT claims old Role sync

### DIFF
--- a/ansible_base/jwt_consumer/awx/auth.py
+++ b/ansible_base/jwt_consumer/awx/auth.py
@@ -26,7 +26,7 @@ class AwxJWTAuthentication(JWTAuthentication):
         the claims dict.
         """
         try:
-            from awx.main.models.rbac import ROLE_DEFINITION_TO_ROLE_FIELD, Role
+            from awx.main.models.rbac import ROLE_DEFINITION_TO_ROLE_FIELD, Role, disable_rbac_sync
             from awx.main.signals import disable_activity_stream
         except ImportError:
             return
@@ -34,7 +34,7 @@ class AwxJWTAuthentication(JWTAuthentication):
         managed_field_names = set(ROLE_DEFINITION_TO_ROLE_FIELD.values())
         resource_map = self._build_resource_map(objects, object_roles)
 
-        with disable_activity_stream():
+        with disable_activity_stream(), disable_rbac_sync():
             desired_role_pks = self._add_desired_members(user, objects, object_roles, resource_map, ROLE_DEFINITION_TO_ROLE_FIELD)
             self._remove_stale_members(user, Role, managed_field_names, desired_role_pks)
 


### PR DESCRIPTION
## Summary

- Wraps `_sync_old_rbac` in `disable_rbac_sync()` alongside the existing `disable_activity_stream()`
- Each `members.add()` was firing `m2m_changed` → `sync_members_to_new_rbac` → serial `give_permission` with full RBAC recompute, negating the bulk speedup from AAP-85067
- This is safe because `save_user_claims` already created all DAB assignments via `bulk_give_permissions`; `members.add()` only needs to populate the old `Role.members` M2M table

**Benchmark (550 grants, AWX sqlite):**

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total time | 19.16s | 2.17s | 8.8x |
| Old RBAC sync | 17.76s | 0.75s | 23.7x |

## Test plan

- [ ] Existing `test_app/tests/rbac/` suite passes
- [ ] AWX JWT consumer tests pass
- [ ] Perfscale verification with 500+ grants shows acceptable timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role membership synchronization by temporarily disabling related RBAC and activity-stream processing.
  * Preserved safe behavior when required synchronization components cannot be imported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->