### PR TITLE
AAPRFE-2425 Fix per-attribute ANY semantics & empty attribute handling

### DIFF
--- a/ansible_base/authentication/utils/claims.py
+++ b/ansible_base/authentication/utils/claims.py
@@ -525,6 +525,10 @@ def _process_in_operator(
 ) -> Optional[bool]:
     """Fast path for 'in' operator: set intersection instead of per-value loop.
 
+    Uses ANY semantics: if any user value is found in the trigger set,
+    the attribute is considered a match. The result is then joined with
+    has_access using the cross-attribute join_condition.
+
     Trigger values are casefolded defensively here even though the caller
     (_prepare_case_insensitive_data) already lowercases them, so that direct
     callers of _process_user_value also get correct case-insensitive behavior.
@@ -533,16 +537,15 @@ def _process_in_operator(
     user_set = {f"{v}".casefold() for v in user_value}
     matched = user_set & trigger_set
 
-    result = bool(matched) if join_condition == 'or' else user_set.issubset(trigger_set)
-    has_access = has_access_with_join(has_access, result, join_condition)
+    per_attr_match = bool(matched)
 
     if logger.isEnabledFor(logging.DEBUG):
         if matched:
-            _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] matched value(s) {sorted(matched)} in {trigger_value}, {_result_suffix(result)}")
+            _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] matched value(s) {sorted(matched)} in {trigger_value}, {_result_suffix(per_attr_match)}")
         else:
-            _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] has no matching values in {trigger_value}, {_result_suffix(result)}")
+            _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] has no matching values in {trigger_value}, {_result_suffix(per_attr_match)}")
 
-    return has_access
+    return has_access_with_join(has_access, per_attr_match, join_condition)
 
 
 _OPERATOR_DISPATCH = {
@@ -556,25 +559,32 @@ _OPERATOR_DISPATCH = {
 def _process_scalar_operator(
     has_access: Optional[bool], operator: str, trigger_value, user_value: List[str], join_condition: str, attribute: str, map_id: int, tracking_id: str
 ) -> Optional[bool]:
-    """Per-value loop with early exit for equals/matches/contains/ends_with."""
+    """Per-value loop for equals/matches/contains/ends_with.
+
+    Uses ANY semantics within a single attribute: if any user value matches,
+    the attribute is considered a match. The result is then joined with
+    has_access using the cross-attribute join_condition.
+    """
     evaluate_fn = _OPERATOR_DISPATCH[operator]
 
+    per_attr_match = False
     for a_user_value in user_value:
         user_str = f"{a_user_value}".casefold()
         result = evaluate_fn(user_str, trigger_value)
-        has_access = has_access_with_join(has_access, result, join_condition)
 
         if logger.isEnabledFor(logging.DEBUG):
             header = f"Attr [{attribute}] value [{user_str}]"
             message = _get_operator_messages(operator, result)
             _prefixed_debug(map_id, tracking_id, f"{header} {message} [{trigger_value}], {_result_suffix(result)}")
 
-        if result and join_condition == 'or':
-            break
-        if not result and join_condition == 'and':
+        if result:
+            per_attr_match = True
             break
 
-    return has_access
+    if logger.isEnabledFor(logging.DEBUG):
+        _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] final per-attribute result: {_result_suffix(per_attr_match)}")
+
+    return has_access_with_join(has_access, per_attr_match, join_condition)
 
 
 def _process_user_value(
@@ -591,8 +601,12 @@ def _process_user_value(
             trigger_value = condition[op]
             break
 
-    if not operator or not user_value:
+    if not operator:
         return has_access
+
+    if not user_value:
+        _prefixed_debug(map_id, tracking_id, f"Attr [{attribute}] present but empty, treating as no match")
+        return has_access_with_join(has_access, False, join_condition)
 
     if operator == "in":
         return _process_in_operator(has_access, trigger_value, user_value, join_condition, attribute, map_id, tracking_id)

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -719,8 +719,8 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
             {"email": ["bar@example.com", "foo@example.com"]},
-            claims.TriggerResult.SKIP,
-            id="user attribute is list, one match, explicit 'and', negative",
+            claims.TriggerResult.ALLOW,
+            id="user attribute is list, one match, explicit 'and', positive",
         ),
         pytest.param(
             {"email": {"equals": "foo@example.com"}, "join_condition": "and"},
@@ -848,6 +848,32 @@ def test_has_access_with_join(current_access, new_access, condition, expected):
             {"cn": ["ldap_org_admin"], "employeeType": ["manager"]},
             claims.TriggerResult.ALLOW,
             id="all attribute required by 'and' condition should result in allow",
+        ),
+        pytest.param(
+            {
+                "cn": {"contains": "ldap"},
+                "employeeType": {"contains": "manager"},
+                "join_condition": "and",
+            },
+            {"cn": ["ldap_admin"], "employeeType": ["manager", "executor"]},
+            claims.TriggerResult.ALLOW,
+            id="regression_any_semantics_and_across_attrs_positive",
+        ),
+        pytest.param(
+            {
+                "cn": {"contains": "ldap"},
+                "employeeType": {"contains": "manager"},
+                "join_condition": "and",
+            },
+            {"cn": ["ldap_admin"], "employeeType": ["executor"]},
+            claims.TriggerResult.SKIP,
+            id="regression_any_semantics_and_across_attrs_negative",
+        ),
+        pytest.param(
+            {"cn": {"contains": "ldap"}, "employeeType": {"contains": "manager"}, "join_condition": "or"},
+            {"cn": ["zzz"], "employeeType": ["manager", "executor"]},
+            claims.TriggerResult.ALLOW,
+            id="regression_any_semantics_or_across_attrs_positive_one_side",
         ),
     ],
 )
@@ -2927,12 +2953,12 @@ class TestProcessUserValueInOperatorCorrectness:
     def test_in_multi_value_partial_match_and_join(self):
         tc = {'groups': {'in': ['admin']}}
         result = claims._process_user_value(None, tc, ['user', 'admin'], 'and', 'groups', 1, 't')
-        assert result is False
+        assert result is True
 
-    def test_in_empty_user_value_returns_none(self):
+    def test_in_empty_user_value_returns_false(self):
         tc = {'groups': {'in': ['admin']}}
         result = claims._process_user_value(None, tc, [], 'or', 'groups', 1, 't')
-        assert result is None
+        assert result is False
 
     def test_in_case_insensitive(self):
         tc = {'groups': {'in': ['admin']}}
@@ -2968,10 +2994,10 @@ class TestProcessUserValueInOperatorCorrectness:
         assert result is True
 
     def test_in_partial_match_and_join(self):
-        """With 'and' join, partial match (some values in trigger) must return False."""
+        """With ANY semantics, partial match (any value in trigger) returns True."""
         tc = {'groups': {'in': ['admin', 'editor']}}
         result = claims._process_user_value(None, tc, ['admin', 'viewer'], 'and', 'groups', 1, 't')
-        assert result is False
+        assert result is True
 
     def test_in_many_groups_single_trigger_no_match(self):
         """33 user groups, trigger has 1 non-matching value."""
@@ -3002,17 +3028,17 @@ class TestEarlyExitForOtherOperators:
         # Should have logged a, b, target — then stopped (3 not 5)
         assert len(value_logs) == 3, f"Expected early exit after 3 values, got {len(value_logs)} log lines"
 
-    def test_equals_early_exit_and_join(self, caplog):
-        """With 'and' join, first mismatch should stop iteration."""
+    def test_equals_any_semantics_and_join(self, caplog):
+        """With ANY semantics, first match should stop iteration regardless of join_condition."""
         values = ['target', 'wrong', 'target', 'target']
         tc = {'attr': {'equals': 'target'}}
 
         with caplog.at_level(logging.DEBUG, logger='ansible_base.authentication.utils.claims'):
             result = claims._process_user_value(None, tc, values, 'and', 'attr', 1, 'exit-test')
 
-        assert result is False
+        assert result is True
         value_logs = [r for r in caplog.records if 'value [' in r.getMessage() and 'Map [1]' in r.getMessage()]
-        assert len(value_logs) == 2, f"Expected early exit after 2 values, got {len(value_logs)} log lines"
+        assert len(value_logs) == 1, f"Expected early exit after 1 value (first match), got {len(value_logs)} log lines"
 
     def test_contains_early_exit_or_join(self, caplog):
         """With 'or' join, first match should stop iteration."""
@@ -3050,17 +3076,17 @@ class TestEarlyExitForOtherOperators:
         value_logs = [r for r in caplog.records if 'value [' in r.getMessage() and 'Map [1]' in r.getMessage()]
         assert len(value_logs) == 2, f"Expected early exit after 2 values, got {len(value_logs)} log lines"
 
-    def test_matches_early_exit_and_join(self, caplog):
-        """With 'and' join, first regex mismatch should stop iteration."""
+    def test_matches_any_semantics_and_join(self, caplog):
+        """With ANY semantics, first regex match should stop iteration regardless of join_condition."""
         values = ['admin-1', 'not-admin', 'admin-2']
         tc = {'attr': {'matches': r'^admin-.*'}}
 
         with caplog.at_level(logging.DEBUG, logger='ansible_base.authentication.utils.claims'):
             result = claims._process_user_value(None, tc, values, 'and', 'attr', 1, 'exit-test')
 
-        assert result is False
+        assert result is True
         value_logs = [r for r in caplog.records if 'value [' in r.getMessage() and 'Map [1]' in r.getMessage()]
-        assert len(value_logs) == 2, f"Expected early exit after 2 values, got {len(value_logs)} log lines"
+        assert len(value_logs) == 1, f"Expected early exit after 1 value (first match), got {len(value_logs)} log lines"
 
 
 class TestProcessUserValueEdgeCases:


### PR DESCRIPTION
## Description

Replaces #846 (accidentally closed, unable to reopen).

Linked issue: #845

### What is being changed?

- Fix evaluation logic in `_process_scalar_operator and _process_in_operator`:
  - Apply **ANY semantics** (short-circuit on first match) for attributes with multiple values.
  - Treat empty/falsy attributes as no match, log debug message, and join `False`.
- Update upstream early-exit tests (`TestEarlyExitForOtherOperators`) to match ANY semantics.
- Update `test_claims.py` expectations and add regression cases.

### Why is this change needed?

The current implementation folds each value into `has_access_with_join` iteratively, effectively resulting in **AND semantics**, which causes false negatives when only one match should allow access.
Also, empty attributes are not properly handled.

### How does this change address the issue?

- Implements proper **ANY semantics** at the attribute level.
- Handles empty attributes explicitly as no match.
- Expands test coverage to ensure correctness.

### Migration impact

This is an RFE / behavior change, not a non-breaking bug fix. Existing authenticator map
configurations that rely on the previous AND semantics within a single attribute may produce
different authorization results after this change:

- **Before**: When Condition type is "All" and a source returns multiple values for one attribute
  (e.g., `email: ["allowed@example.com", "untrusted@example.net"]`), all values had to match the
  Comparison for the attribute to be considered a match.
- **After**: If **any** single value matches, the attribute is considered a match. The Condition
  type (All / At least one) now applies only across attributes, not within a single attribute's
  values.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Testing Instructions

### Prerequisites

- Set environment variable: `DJANGO_SETTINGS_MODULE=test_app.sqlite3settings`

### Steps to Test

1. Set up the test environment.

2. Run the following tests:

   ```bash
   pytest test_app/tests/authentication/utils/test_claims.py --color=yes -q

3. Verify that all 271 tests pass.

Expected Results

- Attributes with multiple values allow access if any value matches.
- Empty attributes are treated as no match (SKIP).
- Regression cases (cn / employeeType with AND/OR conditions) behave as expected.

---
Additional Context

- Strengthened test coverage to prevent regressions.
- Note: since #846, upstream refactored _process_user_value into _process_scalar_operator and _process_in_operator. This PR applies the same fix to the new code structure.

Required Actions

- [x] Requires documentation updates
  - https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/secure-assembly_gw_mapping
      - In the "Authenticator map triggers" > "Based on attributes" section, the Condition type description states that when the source system returns multiple values for a single attribute and Condition type is set to "All", all values must match the Comparison for the trigger to be True.
    - This description needs to be updated to reflect the new ANY semantics within a single attribute: when a source returns multiple values for one attribute, if any value matches, the attribute is considered a match. The Condition type (All/At least one) applies across attributes, not within a single attribute's values.
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-valued user attributes now evaluate with “any match” behavior, making access checks more consistent across attribute combinations.
  * Empty attribute values now fail the check explicitly instead of being ignored.
  * `in`, `equals`, `matches`, `contains`, and `ends_with` evaluations now return predictable results with clearer join-condition handling.

* **Tests**
  * Updated and expanded access-evaluation tests to cover multi-value matching, empty values, and cross-attribute `and`/`or` cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->