### PR TITLE
[AAP-85471] Handle reverse-sync errors in role assignment/unassignment

### DIFF
--- a/ansible_base/rbac/sync.py
+++ b/ansible_base/rbac/sync.py
@@ -16,6 +16,8 @@ This module handles RBAC-specific reverse-sync scenarios:
 
 import logging
 
+from ansible_base.resource_registry.utils.sync_to_resource_server import get_current_user_resource_client
+
 logger = logging.getLogger('ansible_base.rbac.sync')
 
 
@@ -47,13 +49,10 @@ def maybe_reverse_sync_assignment(assignment):
         return
 
     try:
-        from ansible_base.resource_registry.utils.sync_to_resource_server import get_current_user_resource_client
-
         client = get_current_user_resource_client()
         client.sync_assignment(assignment)
     except Exception as e:
         logger.warning(f"Failed to reverse-sync assignment {assignment}: {e}")
-        return
 
 
 def maybe_reverse_sync_unassignment(role_definition, actor, content_object):
@@ -61,13 +60,10 @@ def maybe_reverse_sync_unassignment(role_definition, actor, content_object):
         return
 
     try:
-        from ansible_base.resource_registry.utils.sync_to_resource_server import get_current_user_resource_client
-
         client = get_current_user_resource_client()
         client.sync_unassignment(role_definition, actor, content_object)
     except Exception as e:
         logger.warning(f"Failed to reverse-sync unassignment for {role_definition}: {e}")
-        return
 
 
 def maybe_reverse_sync_object_deletion(content_object):

--- a/ansible_base/rbac/sync.py
+++ b/ansible_base/rbac/sync.py
@@ -46,20 +46,28 @@ def maybe_reverse_sync_assignment(assignment):
     if not reverse_sync_enabled_all_conditions(assignment):
         return
 
-    from ansible_base.resource_registry.utils.sync_to_resource_server import get_current_user_resource_client
+    try:
+        from ansible_base.resource_registry.utils.sync_to_resource_server import get_current_user_resource_client
 
-    client = get_current_user_resource_client()
-    client.sync_assignment(assignment)
+        client = get_current_user_resource_client()
+        client.sync_assignment(assignment)
+    except Exception as e:
+        logger.warning(f"Failed to reverse-sync assignment {assignment}: {e}")
+        return
 
 
 def maybe_reverse_sync_unassignment(role_definition, actor, content_object):
     if not reverse_sync_enabled_all_conditions(role_definition):
         return
 
-    from ansible_base.resource_registry.utils.sync_to_resource_server import get_current_user_resource_client
+    try:
+        from ansible_base.resource_registry.utils.sync_to_resource_server import get_current_user_resource_client
 
-    client = get_current_user_resource_client()
-    client.sync_unassignment(role_definition, actor, content_object)
+        client = get_current_user_resource_client()
+        client.sync_unassignment(role_definition, actor, content_object)
+    except Exception as e:
+        logger.warning(f"Failed to reverse-sync unassignment for {role_definition}: {e}")
+        return
 
 
 def maybe_reverse_sync_object_deletion(content_object):

--- a/test_app/tests/rbac/test_rbac_cross_service_sync.py
+++ b/test_app/tests/rbac/test_rbac_cross_service_sync.py
@@ -275,7 +275,7 @@ def test_sync_url_construction(inventory, enable_reverse_sync):  # noqa: F811
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('exception_cls', [Exception, ConnectionError])
-def test_sync_assignment_handles_errors_gracefully(rando, inventory, inv_rd, enable_reverse_sync, exception_cls):  # noqa: F811
+def test_sync_assignment_handles_sync_error(rando, inventory, inv_rd, enable_reverse_sync, exception_cls):  # noqa: F811
     with enable_reverse_sync():
         with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
             assignment = inv_rd.give_permission(rando, inventory)
@@ -286,10 +286,28 @@ def test_sync_assignment_handles_errors_gracefully(rando, inventory, inv_rd, ena
 
                 maybe_reverse_sync_assignment(assignment)
 
+                mock_get_client.assert_called_once()
+                mock_get_client.return_value.sync_assignment.assert_called_once_with(assignment)
+
+
+@pytest.mark.django_db
+def test_sync_assignment_handles_client_acquisition_error(rando, inventory, inv_rd, enable_reverse_sync):  # noqa: F811
+    with enable_reverse_sync():
+        with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
+            assignment = inv_rd.give_permission(rando, inventory)
+            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+                mock_get_client.side_effect = Exception("client acquisition failed")
+
+                from ansible_base.rbac.sync import maybe_reverse_sync_assignment
+
+                maybe_reverse_sync_assignment(assignment)
+
+                mock_get_client.assert_called_once()
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('exception_cls', [Exception, ConnectionError])
-def test_sync_unassignment_handles_errors_gracefully(rando, inventory, inv_rd, enable_reverse_sync, exception_cls):  # noqa: F811
+def test_sync_unassignment_handles_sync_error(rando, inventory, inv_rd, enable_reverse_sync, exception_cls):  # noqa: F811
     with enable_reverse_sync():
         with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
             with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
@@ -298,3 +316,20 @@ def test_sync_unassignment_handles_errors_gracefully(rando, inventory, inv_rd, e
                 from ansible_base.rbac.sync import maybe_reverse_sync_unassignment
 
                 maybe_reverse_sync_unassignment(inv_rd, rando, inventory)
+
+                mock_get_client.assert_called_once()
+                mock_get_client.return_value.sync_unassignment.assert_called_once_with(inv_rd, rando, inventory)
+
+
+@pytest.mark.django_db
+def test_sync_unassignment_handles_client_acquisition_error(rando, inventory, inv_rd, enable_reverse_sync):  # noqa: F811
+    with enable_reverse_sync():
+        with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
+            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+                mock_get_client.side_effect = Exception("client acquisition failed")
+
+                from ansible_base.rbac.sync import maybe_reverse_sync_unassignment
+
+                maybe_reverse_sync_unassignment(inv_rd, rando, inventory)
+
+                mock_get_client.assert_called_once()

--- a/test_app/tests/rbac/test_rbac_cross_service_sync.py
+++ b/test_app/tests/rbac/test_rbac_cross_service_sync.py
@@ -279,7 +279,7 @@ def test_sync_assignment_handles_sync_error(rando, inventory, inv_rd, enable_rev
     with enable_reverse_sync():
         with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
             assignment = inv_rd.give_permission(rando, inventory)
-            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+            with patch('ansible_base.rbac.sync.get_current_user_resource_client') as mock_get_client:
                 mock_get_client.return_value.sync_assignment.side_effect = exception_cls("sync failed")
 
                 from ansible_base.rbac.sync import maybe_reverse_sync_assignment
@@ -295,7 +295,7 @@ def test_sync_assignment_handles_client_acquisition_error(rando, inventory, inv_
     with enable_reverse_sync():
         with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
             assignment = inv_rd.give_permission(rando, inventory)
-            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+            with patch('ansible_base.rbac.sync.get_current_user_resource_client') as mock_get_client:
                 mock_get_client.side_effect = Exception("client acquisition failed")
 
                 from ansible_base.rbac.sync import maybe_reverse_sync_assignment
@@ -310,7 +310,7 @@ def test_sync_assignment_handles_client_acquisition_error(rando, inventory, inv_
 def test_sync_unassignment_handles_sync_error(rando, inventory, inv_rd, enable_reverse_sync, exception_cls):  # noqa: F811
     with enable_reverse_sync():
         with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
-            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+            with patch('ansible_base.rbac.sync.get_current_user_resource_client') as mock_get_client:
                 mock_get_client.return_value.sync_unassignment.side_effect = exception_cls("sync failed")
 
                 from ansible_base.rbac.sync import maybe_reverse_sync_unassignment
@@ -325,7 +325,7 @@ def test_sync_unassignment_handles_sync_error(rando, inventory, inv_rd, enable_r
 def test_sync_unassignment_handles_client_acquisition_error(rando, inventory, inv_rd, enable_reverse_sync):  # noqa: F811
     with enable_reverse_sync():
         with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
-            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+            with patch('ansible_base.rbac.sync.get_current_user_resource_client') as mock_get_client:
                 mock_get_client.side_effect = Exception("client acquisition failed")
 
                 from ansible_base.rbac.sync import maybe_reverse_sync_unassignment

--- a/test_app/tests/rbac/test_rbac_cross_service_sync.py
+++ b/test_app/tests/rbac/test_rbac_cross_service_sync.py
@@ -1,8 +1,8 @@
 """
-Unit tests for sync_object_deletion method - AAP-51985 cross-service sync integration
+Unit tests for cross-service reverse-sync in ansible_base.rbac.sync
 
-Tests the new DABResourceAPIClient.sync_object_deletion method that handles
-the HTTP communication between Controller and Gateway for role cleanup.
+Covers sync_object_deletion (AAP-51985), and error handling for
+sync_assignment / sync_unassignment (AAP-85471).
 """
 
 from unittest.mock import MagicMock, patch
@@ -271,3 +271,30 @@ def test_sync_url_construction(inventory, enable_reverse_sync):  # noqa: F811
 
                 # Should include object-delete endpoint
                 assert 'object-delete' in call_positional[1]  # path
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('exception_cls', [Exception, ConnectionError])
+def test_sync_assignment_handles_errors_gracefully(rando, inventory, inv_rd, enable_reverse_sync, exception_cls):  # noqa: F811
+    with enable_reverse_sync():
+        with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
+            assignment = inv_rd.give_permission(rando, inventory)
+            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+                mock_get_client.return_value.sync_assignment.side_effect = exception_cls("sync failed")
+
+                from ansible_base.rbac.sync import maybe_reverse_sync_assignment
+
+                maybe_reverse_sync_assignment(assignment)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('exception_cls', [Exception, ConnectionError])
+def test_sync_unassignment_handles_errors_gracefully(rando, inventory, inv_rd, enable_reverse_sync, exception_cls):  # noqa: F811
+    with enable_reverse_sync():
+        with override_settings(RESOURCE_SERVER={'URL': 'http://gateway.example.com', 'SECRET_KEY': 'test-secret'}):
+            with patch('ansible_base.resource_registry.utils.sync_to_resource_server.get_current_user_resource_client') as mock_get_client:
+                mock_get_client.return_value.sync_unassignment.side_effect = exception_cls("sync failed")
+
+                from ansible_base.rbac.sync import maybe_reverse_sync_unassignment
+
+                maybe_reverse_sync_unassignment(inv_rd, rando, inventory)


### PR DESCRIPTION
## Summary
- `maybe_reverse_sync_assignment` and `maybe_reverse_sync_unassignment` let exceptions propagate unhandled, causing the caller's API to return a raw HTML 500 page.
- This wraps both functions in try/except to log a warning instead, matching the pattern already used by `maybe_reverse_sync_object_deletion` in the same file.
- The root cause (a settings mismatch between Controller and Gateway for `ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER`) is addressed in a companion Gateway PR — this is the defensive fix ensuring reverse-sync failures never produce unhandled 500s.

Reolves https://redhat.atlassian.net/browse/AAP-85471 (together with https://github.com/ansible/jewel/pull/193)

## Test plan
- [ ] Verify that a reverse-sync failure (e.g., Gateway rejects with 400) results in a logged warning, not an unhandled 500
- [ ] Verify existing `test_creator_permission_does_reverse_sync` still passes
- [ ] Verify role assignment and unassignment still work when reverse sync succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience during assignment and unassignment synchronization by handling client and synchronization failures gracefully.
  * Added warning logging when synchronization cannot be completed, preventing these errors from interrupting other operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->