### PR TITLE
Fix namespace-scoped role assignment sync failing with UUID as integer PK

### DIFF
--- a/ansible_base/rbac/role_sync_utils.py
+++ b/ansible_base/rbac/role_sync_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import uuid as _uuid_module
 from dataclasses import dataclass
 from typing import Any
 
@@ -48,22 +49,25 @@ class AssignmentTuple:
 def get_ansible_id_or_pk(assignment) -> str:
     """Resolve the ansible_id or raw PK for an assignment's target object.
 
-    For organization/team content types the object's ``ansible_id`` is
-    looked up via the Resource table.  For all other types the raw
-    ``object_id`` is returned directly.
+    Looks up the object's ``ansible_id`` via the Resource table for all
+    content types that have a registry entry, so local tuples carry the same
+    UUID that Gateway sends in ``object_ansible_id``.  Falls back to the raw
+    ``object_id`` for types without a Resource entry.  Raises for
+    organization/team objects that are missing a Resource entry, as those
+    must always be registered.
     """
     if not is_rbac_installed():
         raise RuntimeError("get_ansible_id_or_pk requires ansible_base.rbac to be installed")
+    object_resource = Resource.objects.filter(
+        object_id=assignment.object_id,
+        content_type__app_label=assignment.content_type.app_label,
+        content_type__model=assignment.content_type.model,
+    ).first()
+    if object_resource:
+        return str(object_resource.ansible_id)
     if assignment.content_type.model in ('organization', 'team'):
-        object_resource = Resource.objects.filter(object_id=assignment.object_id, content_type__model=assignment.content_type.model).first()
-        if object_resource:
-            ansible_id_or_pk = object_resource.ansible_id
-        else:
-            raise RuntimeError(f"Error: {assignment.content_type.model} {assignment.object_id} was found without an associated Resource.")
-    else:
-        ansible_id_or_pk = assignment.object_id
-
-    return str(ansible_id_or_pk)
+        raise RuntimeError(f"Error: {assignment.content_type.model} {assignment.object_id} was found without an associated Resource.")
+    return str(assignment.object_id)
 
 
 def get_content_object(role_definition, assignment_tuple: AssignmentTuple) -> Any:
@@ -72,9 +76,16 @@ def get_content_object(role_definition, assignment_tuple: AssignmentTuple) -> An
         raise RuntimeError("get_content_object requires ansible_base.rbac to be installed")
     if role_definition.content_type is None:
         raise ValueError("get_content_object requires a role_definition with a content_type")
-    if role_definition.content_type.model in ('organization', 'team'):
-        object_resource = Resource.objects.get(ansible_id=assignment_tuple.ansible_id_or_pk)
-        return object_resource.content_object
+    # Try Resource registry first — handles UUID ansible_ids from Gateway for all content types,
+    # not only organization and team.  Only attempt when the value is a valid UUID; integer PKs
+    # would cause a UUIDField ValidationError in the filter.
+    try:
+        _uuid_module.UUID(str(assignment_tuple.ansible_id_or_pk))
+        resource = Resource.objects.filter(ansible_id=assignment_tuple.ansible_id_or_pk).first()
+        if resource is not None:
+            return resource.content_object
+    except (ValueError, AttributeError):
+        pass
     model = role_definition.content_type.model_class()
     return model.objects.get(pk=assignment_tuple.ansible_id_or_pk)
 
@@ -101,52 +112,64 @@ def _bulk_resolve_actor_ansible_ids(assignments: list, actor_attr: str) -> dict[
     }
 
 
-def _bulk_resolve_object_ansible_ids(assignments: list) -> dict[tuple[str, str], str]:
-    """Build a ``{(str(object_id), model_name): str(ansible_id)}`` map for org/team objects.
+def _bulk_resolve_object_ansible_ids(assignments: list) -> dict[tuple[str, str, str], str]:
+    """Build a ``{(str(object_id), app_label, model): str(ansible_id)}`` map for all resource-registered objects.
 
-    Only organization and team content types need Resource lookups — all
-    other types use the raw ``object_id`` directly.
+    Resolves ansible_ids for every content type that has a Resource entry,
+    not only organization and team.  The caller falls back to the raw
+    ``object_id`` for types with no entry in the result map.
+
+    Keys on ``(object_id, app_label, model)`` rather than ``(object_id, model)``
+    to avoid collisions when two DABContentType services share a model name.
     """
-    org_team_ids = set()
+    object_ids: set[str] = set()
+    app_labels: set[str] = set()
+    model_names: set[str] = set()
     for a in assignments:
-        if a.object_id and a.content_type and a.content_type.model in ('organization', 'team'):
-            org_team_ids.add(str(a.object_id))
+        if a.object_id and a.content_type:
+            object_ids.add(str(a.object_id))
+            app_labels.add(a.content_type.app_label)
+            model_names.add(a.content_type.model)
 
-    if not org_team_ids:
+    if not object_ids:
         return {}
 
     return {
-        (str(obj_id), model): str(ansible_id)
-        for obj_id, model, ansible_id in Resource.objects.filter(
-            object_id__in=org_team_ids,
-            content_type__model__in=['organization', 'team'],
-        ).values_list('object_id', 'content_type__model', 'ansible_id')
+        (str(obj_id), app_label, model): str(ansible_id)
+        for obj_id, app_label, model, ansible_id in Resource.objects.filter(
+            object_id__in=object_ids,
+            content_type__app_label__in=app_labels,
+            content_type__model__in=model_names,
+        ).values_list('object_id', 'content_type__app_label', 'content_type__model', 'ansible_id')
     }
 
 
 _SKIP = object()
 
 
-def _resolve_object_ansible_id(assignment, object_map: dict[tuple[str, str], str]):
+def _resolve_object_ansible_id(assignment, object_map: dict[tuple[str, str, str], str]):
     """Resolve the ansible_id or pk for an assignment's target object.
 
-    Returns ``None`` for global assignments, the resolved ansible_id for
-    org/team objects, the raw ``object_id`` for other types, or the
-    sentinel ``_SKIP`` if an org/team resource is missing.
+    Returns ``None`` for global assignments, the resolved ansible_id if one
+    exists in the Resource registry, the raw ``object_id`` for types without
+    a registry entry, or the sentinel ``_SKIP`` if an org/team object is
+    missing a Resource entry (those must always be registered).
     """
     if not assignment.object_id or not assignment.content_type:
         return None
 
     model_name = assignment.content_type.model
-    if model_name not in ('organization', 'team'):
-        return str(assignment.object_id)
-
-    key = (str(assignment.object_id), model_name)
+    key = (str(assignment.object_id), assignment.content_type.app_label, model_name)
     resolved = object_map.get(key)
-    if resolved is None:
+    if resolved is not None:
+        return resolved
+
+    if model_name in ('organization', 'team'):
         logger.error(f"{model_name} {assignment.object_id} found without an associated Resource, skipping assignment.")
         return _SKIP
-    return resolved
+
+    # For types without a Resource registry entry, fall back to the raw integer PK.
+    return str(assignment.object_id)
 
 
 def _collect_assignment_tuples(

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -4,6 +4,7 @@ import asyncio
 import csv
 import logging
 import time
+import uuid as _uuid_mod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -131,6 +132,56 @@ class RemoteAssignmentFetcher:
         teams_ok = self._paginate(self.api_client.list_team_assignments, 'team_ansible_id', 'team')
         return RemoteAssignmentResult(assignments=self.assignments, is_complete=teams_ok)
 
+    @staticmethod
+    def _collect_known_uuids(results: list) -> set:
+        """Return the Resource ansible_ids Hub recognises from a page of assignments.
+
+        Only values that parse as valid UUIDs are queried — non-UUID strings
+        (e.g. plain integers) would raise a UUIDField ValidationError in the DB.
+        """
+        candidate_uuids = set()
+        for item in results:
+            val = item.get('object_ansible_id')
+            if val:
+                try:
+                    _uuid_mod.UUID(str(val))
+                    candidate_uuids.add(str(val))
+                except (ValueError, AttributeError):
+                    pass
+        if not candidate_uuids:
+            return set()
+        return {str(u) for u in Resource.objects.filter(ansible_id__in=candidate_uuids).values_list('ansible_id', flat=True)}
+
+    @staticmethod
+    def _resolve_ansible_id_or_pk(assignment: dict, known_uuids: set) -> str | None:
+        """Return the identifier to use for an assignment's target object.
+
+        Prefers object_ansible_id when Hub has a matching Resource row so both
+        sides of the set comparison carry the same UUID (AAP-77392). Falls back
+        to integer object_id for types without a Resource registry entry.
+        """
+        uuid_val = assignment.get('object_ansible_id')
+        if uuid_val and str(uuid_val) in known_uuids:
+            return str(uuid_val)
+        return assignment.get('object_id')
+
+    def _process_page(self, results: list, actor_id_key: str, assignment_type: str) -> None:
+        """Add valid assignments from a single response page to ``self.assignments``."""
+        known_uuids = self._collect_known_uuids(results)
+        for assignment in results:
+            role_name = assignment['role_definition']
+            if role_name not in self.local_role_names:
+                logger.debug(f"Skipping remote {assignment_type} assignment with unknown local role: {role_name}")
+                continue
+            self.assignments.add(
+                AssignmentTuple(
+                    actor_ansible_id=assignment[actor_id_key],
+                    ansible_id_or_pk=self._resolve_ansible_id_or_pk(assignment, known_uuids),
+                    role_definition_name=role_name,
+                    assignment_type=assignment_type,
+                )
+            )
+
     def _paginate(self, list_fn, actor_id_key: str, assignment_type: str) -> bool:
         """Paginate a single assignment endpoint, adding results to ``self.assignments``.
 
@@ -148,20 +199,7 @@ class RemoteAssignmentFetcher:
                     return False
 
                 data = resp.json()
-                for assignment in data.get('results') or []:
-                    role_name = assignment['role_definition']
-                    if role_name not in self.local_role_names:
-                        logger.debug(f"Skipping remote {assignment_type} assignment with unknown local role: {role_name}")
-                        continue
-                    ansible_id_or_pk = assignment.get('object_ansible_id') or assignment.get('object_id')
-                    self.assignments.add(
-                        AssignmentTuple(
-                            actor_ansible_id=assignment[actor_id_key],
-                            ansible_id_or_pk=ansible_id_or_pk,
-                            role_definition_name=role_name,
-                            assignment_type=assignment_type,
-                        )
-                    )
+                self._process_page(data.get('results') or [], actor_id_key, assignment_type)
 
                 if not data.get('next'):
                     return True

--- a/test_app/tests/rbac/test_role_sync_utils.py
+++ b/test_app/tests/rbac/test_role_sync_utils.py
@@ -5,8 +5,10 @@ import pytest
 from ansible_base.rbac.role_sync_utils import (
     _SKIP,
     AssignmentTuple,
+    _bulk_resolve_object_ansible_ids,
     _collect_assignment_tuples,
     _resolve_object_ansible_id,
+    get_ansible_id_or_pk,
     get_content_object,
     get_local_assignments,
 )
@@ -66,23 +68,23 @@ def test_resolve_object_ansible_id_global_assignment():
 
 
 def test_resolve_object_ansible_id_non_org_team():
-    """Non-org/team types return the raw object_id."""
-    ct = mock.Mock(model='inventory')
+    """Non-org/team types return the raw object_id when no map entry."""
+    ct = mock.Mock(model='inventory', app_label='test_app')
     assignment = mock.Mock(object_id='42', content_type=ct)
     assert _resolve_object_ansible_id(assignment, {}) == '42'
 
 
 def test_resolve_object_ansible_id_org_resolved():
     """Org/team types return the resolved ansible_id from the map."""
-    ct = mock.Mock(model='organization')
+    ct = mock.Mock(model='organization', app_label='test_app')
     assignment = mock.Mock(object_id='7', content_type=ct)
-    object_map = {('7', 'organization'): 'resolved-uuid'}
+    object_map = {('7', 'test_app', 'organization'): 'resolved-uuid'}
     assert _resolve_object_ansible_id(assignment, object_map) == 'resolved-uuid'
 
 
 def test_resolve_object_ansible_id_org_missing():
     """Missing org/team resource returns _SKIP sentinel."""
-    ct = mock.Mock(model='organization')
+    ct = mock.Mock(model='organization', app_label='test_app')
     assignment = mock.Mock(object_id='999', content_type=ct)
     assert _resolve_object_ansible_id(assignment, {}) is _SKIP
 
@@ -325,3 +327,187 @@ def test_backward_compat_imports():
         get_local_assignments,
         get_remote_assignments,
     )
+
+
+# ---------------------------------------------------------------------------
+# AAP-77392 — namespace-scoped role sync: UUID resolution for all content types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_content_object_resolves_uuid_for_non_org_team_type():
+    """get_content_object resolves a UUID ansible_id via Resource for any content type.
+
+    Regression test for AAP-77392: previously only org/team used Resource lookup,
+    so namespace-scoped UUIDs caused "Field 'id' expected a number" ValueError.
+    """
+    from ansible_base.authentication.models import Authenticator
+    from ansible_base.rbac.models import DABContentType
+
+    auth = Authenticator.objects.create(
+        name='test-auth-uuid',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    auth_resource = Resource.get_resource_for_object(auth)
+    auth_ct = DABContentType.objects.get_for_model(Authenticator)
+
+    rd = mock.Mock()
+    rd.content_type = auth_ct
+
+    at = AssignmentTuple('actor-uuid', str(auth_resource.ansible_id), 'Some Role', 'user')
+    result = get_content_object(rd, at)
+    assert result == auth
+
+
+@pytest.mark.django_db
+def test_get_content_object_falls_back_to_pk_when_no_resource_entry():
+    """get_content_object falls back to integer PK lookup when no Resource entry exists."""
+    from django.contrib.contenttypes.models import ContentType
+
+    from ansible_base.authentication.models import Authenticator
+    from ansible_base.rbac.models import DABContentType
+
+    auth = Authenticator.objects.create(
+        name='test-auth-pk',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    auth_ct = DABContentType.objects.get_for_model(Authenticator)
+    base_ct = ContentType.objects.get_for_model(Authenticator)
+
+    Resource.objects.filter(object_id=auth.pk, content_type=base_ct).delete()
+
+    rd = mock.Mock()
+    rd.content_type = auth_ct
+
+    at = AssignmentTuple('actor-uuid', str(auth.pk), 'Some Role', 'user')
+    result = get_content_object(rd, at)
+    assert result == auth
+
+
+@pytest.mark.django_db
+def test_get_ansible_id_or_pk_returns_uuid_for_registered_non_org_team():
+    """get_ansible_id_or_pk returns the Resource ansible_id for non-org/team registered types.
+
+    Regression test for AAP-77392: previously returned raw integer PK for all
+    non-org/team types, causing local tuples to not match remote UUID-keyed tuples.
+    """
+    from ansible_base.authentication.models import Authenticator
+
+    auth = Authenticator.objects.create(
+        name='test-auth-ansid',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    auth_resource = Resource.get_resource_for_object(auth)
+
+    assignment = mock.Mock()
+    assignment.object_id = auth.pk
+    assignment.content_type.model = 'authenticator'
+    assignment.content_type.pk = auth_resource.content_type_id
+    # Use real content_type so filter(content_type=...) works
+    from ansible_base.rbac.models import DABContentType
+
+    assignment.content_type = DABContentType.objects.get_for_model(Authenticator)
+
+    result = get_ansible_id_or_pk(assignment)
+    assert result == str(auth_resource.ansible_id)
+
+
+@pytest.mark.django_db
+def test_get_ansible_id_or_pk_falls_back_to_pk_when_no_resource():
+    """get_ansible_id_or_pk falls back to integer PK for types with no Resource entry."""
+    from django.contrib.contenttypes.models import ContentType
+
+    from ansible_base.authentication.models import Authenticator
+    from ansible_base.rbac.models import DABContentType
+
+    auth = Authenticator.objects.create(
+        name='test-auth-pkfallback',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    auth_ct = DABContentType.objects.get_for_model(Authenticator)
+    base_ct = ContentType.objects.get_for_model(Authenticator)
+    Resource.objects.filter(object_id=auth.pk, content_type=base_ct).delete()
+
+    assignment = mock.Mock()
+    assignment.object_id = auth.pk
+    assignment.content_type = auth_ct
+
+    result = get_ansible_id_or_pk(assignment)
+    assert result == str(auth.pk)
+
+
+def test_resolve_object_ansible_id_non_org_team_with_resource_entry():
+    """_resolve_object_ansible_id uses the object_map for non-org/team types when present."""
+    ct = mock.Mock(model='authenticator', app_label='authentication')
+    assignment = mock.Mock(object_id='5', content_type=ct)
+    object_map = {('5', 'authentication', 'authenticator'): 'some-uuid-value'}
+    assert _resolve_object_ansible_id(assignment, object_map) == 'some-uuid-value'
+
+
+def test_resolve_object_ansible_id_non_org_team_without_resource_entry():
+    """_resolve_object_ansible_id falls back to raw PK for non-org/team with no map entry."""
+    ct = mock.Mock(model='authenticator', app_label='authentication')
+    assignment = mock.Mock(object_id='5', content_type=ct)
+    assert _resolve_object_ansible_id(assignment, {}) == '5'
+
+
+@pytest.mark.django_db
+def test_bulk_resolve_object_ansible_ids_includes_non_org_team():
+    """_bulk_resolve_object_ansible_ids resolves UUIDs for all registered content types."""
+    from ansible_base.authentication.models import Authenticator
+    from ansible_base.rbac.models import DABContentType
+
+    auth = Authenticator.objects.create(
+        name='test-auth-bulk',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    auth_ct = DABContentType.objects.get_for_model(Authenticator)
+    auth_resource = Resource.get_resource_for_object(auth)
+
+    assignment = mock.Mock()
+    assignment.object_id = auth.pk
+    assignment.content_type = auth_ct
+
+    result = _bulk_resolve_object_ansible_ids([assignment])
+    key = (str(auth.pk), auth_ct.app_label, 'authenticator')
+    assert key in result
+    assert result[key] == str(auth_resource.ansible_id)
+
+
+@pytest.mark.django_db
+def test_get_local_assignments_uses_uuid_for_registered_non_org_team():
+    """Local assignments for non-org/team registered types carry the ansible_id UUID.
+
+    End-to-end regression test for AAP-77392: ensures set comparison between
+    local and remote assignments matches when both use UUIDs.
+    """
+    from ansible_base.authentication.models import Authenticator
+    from ansible_base.rbac.models import DABContentType, RoleDefinition
+    from test_app.models import User
+
+    user = User.objects.create(username='ns_user_77392', email='ns77392@test.com')
+    user_resource = Resource.get_resource_for_object(user)
+    auth = Authenticator.objects.create(
+        name='test-auth-local-assign',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    auth_resource = Resource.get_resource_for_object(auth)
+    auth_ct = DABContentType.objects.get_for_model(Authenticator)
+
+    rd = RoleDefinition.objects.create(name='Auth Owner 77392', content_type=auth_ct, managed=True)
+    rd.give_permission(user, auth)
+
+    assignments = get_local_assignments()
+    matching = [a for a in assignments if a.role_definition_name == 'Auth Owner 77392']
+
+    assert len(matching) == 1
+    assert matching[0].actor_ansible_id == str(user_resource.ansible_id)
+    # Must be the UUID from the Resource registry, not the integer PK
+    assert matching[0].ansible_id_or_pk == str(auth_resource.ansible_id)
+    assert matching[0].ansible_id_or_pk != str(auth.pk)

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -456,7 +456,7 @@ def test_get_remote_assignments_incomplete_on_failure(failure_mode):
     api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
     page1 = _mock_response(
         body={
-            "results": [{"user_ansible_id": "u1", "object_ansible_id": "o1", "role_definition": "Team Member"}],
+            "results": [{"user_ansible_id": "u1", "object_ansible_id": "o1", "object_id": "o1", "role_definition": "Team Member"}],
             "next": "http://example.com/page2",
         }
     )
@@ -497,6 +497,7 @@ def test_get_remote_assignments_complete_on_success():
 
 
 @pytest.mark.django_db
+@pytest.mark.django_db
 def test_get_remote_assignments_filters_unknown_roles(static_api_client):
     """Assignments for roles that do not exist locally should be filtered out.
 
@@ -512,12 +513,14 @@ def test_get_remote_assignments_filters_unknown_roles(static_api_client):
             {
                 'user_ansible_id': 'aaaaaaaa-1111-2222-3333-444444444444',
                 'object_ansible_id': '1',
+                'object_id': '1',
                 'role_definition': local_role.name,
             },
             # Assignment for a role from another service — should be filtered out
             {
                 'user_ansible_id': 'bbbbbbbb-1111-2222-3333-444444444444',
                 'object_ansible_id': '1',
+                'object_id': '1',
                 'role_definition': 'Credential Admin',
             },
         ],
@@ -529,6 +532,7 @@ def test_get_remote_assignments_filters_unknown_roles(static_api_client):
             {
                 'team_ansible_id': 'cccccccc-1111-2222-3333-444444444444',
                 'object_ansible_id': '1',
+                'object_id': '1',
                 'role_definition': 'Some Other Service Role',
             },
         ],
@@ -719,7 +723,7 @@ def test_remote_assignment_fetcher_multi_page_with_assignments():
     page1 = _mock_response(
         body={
             'results': [
-                {'user_ansible_id': 'u1', 'object_ansible_id': 'obj1', 'role_definition': 'MultiPageRole'},
+                {'user_ansible_id': 'u1', 'object_ansible_id': 'obj1', 'object_id': 'obj1', 'role_definition': 'MultiPageRole'},
             ],
             'next': 'http://example.com/page2',
         }
@@ -727,7 +731,7 @@ def test_remote_assignment_fetcher_multi_page_with_assignments():
     page2 = _mock_response(
         body={
             'results': [
-                {'user_ansible_id': 'u2', 'object_ansible_id': 'obj2', 'role_definition': 'MultiPageRole'},
+                {'user_ansible_id': 'u2', 'object_ansible_id': 'obj2', 'object_id': 'obj2', 'role_definition': 'MultiPageRole'},
             ],
             'next': None,
         }
@@ -793,6 +797,97 @@ def test_remote_assignment_fetcher_uses_object_id_fallback():
     assert len(result.assignments) == 1
     assignment = next(iter(result.assignments))
     assert assignment.ansible_id_or_pk == '42'
+
+
+@pytest.mark.django_db
+def test_collect_known_uuids_returns_uuids_found_in_resource_table():
+    """_collect_known_uuids returns only UUIDs that have a matching Resource row."""
+    from ansible_base.authentication.models import Authenticator
+
+    auth = Authenticator.objects.create(
+        name='test-auth-uuid-known',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    resource = Resource.get_resource_for_object(auth)
+    known_uuid = str(resource.ansible_id)
+    unknown_uuid = str(uuid4())
+
+    results = [
+        {'object_ansible_id': known_uuid},
+        {'object_ansible_id': unknown_uuid},
+        {'object_ansible_id': 'not-a-uuid'},  # invalid — should be skipped
+        {},  # no object_ansible_id — should be skipped
+    ]
+
+    known = RemoteAssignmentFetcher._collect_known_uuids(results)
+
+    assert known_uuid in known
+    assert unknown_uuid not in known
+    assert 'not-a-uuid' not in known
+
+
+def test_collect_known_uuids_empty_results():
+    """_collect_known_uuids returns an empty set when results have no valid UUIDs."""
+    assert RemoteAssignmentFetcher._collect_known_uuids([]) == set()
+    assert RemoteAssignmentFetcher._collect_known_uuids([{'object_ansible_id': 'bad'}]) == set()
+    assert RemoteAssignmentFetcher._collect_known_uuids([{}]) == set()
+
+
+def test_resolve_ansible_id_or_pk_uses_uuid_when_known():
+    """_resolve_ansible_id_or_pk returns the UUID when it is in known_uuids."""
+    uuid = str(uuid4())
+    assignment = {'object_ansible_id': uuid, 'object_id': '10'}
+    result = RemoteAssignmentFetcher._resolve_ansible_id_or_pk(assignment, {uuid})
+    assert result == uuid
+
+
+def test_resolve_ansible_id_or_pk_falls_back_when_uuid_unknown():
+    """_resolve_ansible_id_or_pk falls back to object_id when UUID is not known."""
+    assignment = {'object_ansible_id': str(uuid4()), 'object_id': '10'}
+    result = RemoteAssignmentFetcher._resolve_ansible_id_or_pk(assignment, set())
+    assert result == '10'
+
+
+def test_resolve_ansible_id_or_pk_no_uuid():
+    """_resolve_ansible_id_or_pk returns object_id when object_ansible_id is absent."""
+    assignment = {'object_id': '10'}
+    result = RemoteAssignmentFetcher._resolve_ansible_id_or_pk(assignment, set())
+    assert result == '10'
+
+
+@pytest.mark.django_db
+def test_paginate_uses_uuid_when_resource_row_exists():
+    """_paginate uses object_ansible_id when Hub has a matching Resource row."""
+    from ansible_base.authentication.models import Authenticator
+
+    auth = Authenticator.objects.create(
+        name='test-auth-paginate-uuid',
+        enabled=False,
+        type='ansible_base.authentication.authenticator_plugins.local',
+    )
+    resource = Resource.get_resource_for_object(auth)
+    known_uuid = str(resource.ansible_id)
+
+    RoleDefinition.objects.create(name='UUIDRole', managed=True)
+
+    api_client = mock.Mock(spec=["list_user_assignments", "list_team_assignments"])
+    api_client.list_user_assignments.return_value = _mock_response(
+        body={
+            'results': [
+                {'user_ansible_id': str(uuid4()), 'object_ansible_id': known_uuid, 'object_id': str(auth.pk), 'role_definition': 'UUIDRole'},
+            ],
+            'next': None,
+        }
+    )
+    api_client.list_team_assignments.return_value = _mock_response()
+
+    result = RemoteAssignmentFetcher(api_client).fetch()
+
+    assert result.is_complete is True
+    assert len(result.assignments) == 1
+    assignment = next(iter(result.assignments))
+    assert assignment.ansible_id_or_pk == known_uuid
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description

**What is being changed?**

Three functions in \`role_sync_utils.py\` and the pagination loop in \`sync.py\` are updated to correctly handle \`object_ansible_id\` UUIDs for non-organization/team content types.

**Why is this change needed?**

When Gateway returns \`object_ansible_id\` as a UUID for namespace-scoped role assignments (e.g. \`galaxy.collection_namespace_owner\`), Hub's sync passes it directly to \`model.objects.get(pk=<uuid>)\`. \`Namespace\` uses an integer PK so this raises \`ValueError: Field 'id' expected a number\`, the local \`RoleUserAssignment\` is never created, and the user gets a 403 on collection upload.

A second defect in the same path caused perpetual spurious sync cycles: \`get_ansible_id_or_pk()\` and the bulk resolution helpers only resolved UUIDs via the Resource registry for \`organization\` and \`team\` types, so local tuples carried integer PKs while remote tuples carried UUIDs — the set comparison never matched.

There is also a deeper issue: \`galaxy.Namespace\` is not registered in galaxy_ng's resource registry, so Hub has no Resource rows for namespaces. The Resource registry fixes in \`role_sync_utils.py\` alone are not sufficient — the UUID lookup returns None and we still fall through to the broken path. Confirmed on a live AAP 2.6 environment.

**How does this change address the issue?**

- \`get_content_object()\`: attempt Resource registry lookup for all content types (UUID-validated to avoid UUIDField errors); fall back to integer PK for types with no registry entry
- \`get_ansible_id_or_pk()\`: resolve via Resource for all types, preserving the mandatory-entry guard for org/team
- \`_bulk_resolve_object_ansible_ids()\`: extend to all content types, keyed by \`(object_id, app_label, model)\` to avoid collisions across services sharing a model name
- \`_resolve_object_ansible_id()\`: use the extended map for all types; fall back to raw PK when no registry entry exists
- \`_paginate()\`: batch-resolve which \`object_ansible_id\` UUIDs Hub has Resource rows for per page; fall back to integer \`object_id\` for any UUID Hub doesn't recognise — ensures both sides of the set comparison carry the same identifier regardless of whether the content type is registered

Fixes: [AAP-77392](https://redhat.atlassian.net/browse/AAP-77392)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications (batch UUID lookup per page, not per assignment)
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

A running AAP 2.6 environment with Gateway connected to Hub (\`RESOURCE_SERVER\` configured).

### Steps to Test

1. Create a non-superuser and a namespace in Hub
2. Assign \`galaxy.collection_namespace_owner\` to the user on that namespace via Gateway \`POST /api/gateway/v1/role_user_assignments/\`
3. Trigger Hub resource sync: \`pulpcore-manager shell -c "from galaxy_ng.app.tasks.resource_sync import run; run()"\`
4. Check logs for \`assignment_errors\`
5. Attempt a collection upload as the assigned user

### Expected Results

\`assignments_created: 1\`, \`assignment_errors: 0\`. Collection upload succeeds (200, not 403).

## Additional Context

### Required Actions

- [x] Requires downstream repository changes — a separate galaxy_ng PR is needed to add \`ResourceConfig(models.Namespace)\` to \`resource_api.py\`. Without it Hub has no Resource rows for namespaces so the UUID path in \`get_content_object\` always misses. The \`_paginate\` fallback covers this gap in the meantime.

### Screenshots/Logs

Before fix:
\`\`\`
ERROR: Failed to create assignment ... galaxy.collection_namespace_owner
ValueError: Field 'id' expected a number but got '<uuid>'
assignments_created: 0 | assignment_errors: 1
\`\`\`

After fix (verified on live AAP 2.6):
\`\`\`
assignments_created: 1 | assignment_errors: 0
\`\`\`

[AAP-77392]: https://redhat.atlassian.net/browse/AAP-77392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role assignment synchronization across registered resource types.
  * Prevented conflicts when different services use the same model names.
  * Added reliable fallback handling for unrecognized UUIDs and legacy numeric identifiers.
  * Improved organization and team assignment handling when resources are missing.
  * Ensured remote assignment pagination consistently resolves resource identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->