### PR TITLE
[AAP-86325] Pin pytest-django<4.13 in django4 tox environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ legacy_tox_ini = """
     deps =
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
+        pytest-django<4.13
     commands_pre =
         python -m pip install --upgrade "Django>=4.2.21,<4.3.0"
     docker = db


### PR DESCRIPTION
## Description

- **What is being changed?**
  Add `pytest-django<4.13` as a dep in the `[testenv:py311-django4,py312-django4]` section of `pyproject.toml`.

- **Why is this change needed?**
  pytest-django 4.13.0 introduced `_pre_setup_ran_eagerly` which relies on Django 5.x internals. The django4 tox environment downgrades to Django 4.2.x after installing the latest pytest-django, causing `AttributeError` at test runtime.

- **How does this change address the issue?**
  Pinning `pytest-django<4.13` only in the django4 environment ensures a compatible version is resolved, while Django 5.x environments remain unconstrained.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

JIRA: AAP-86325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment dependencies to support compatibility with Django 4 testing setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->