### PR TITLE
Bump Django requirement to 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,6 @@ jobs:
             python-version: "3.12"
             sonar: false
             junit-xml-upload: false
-          - env: py311-django4
-            python-version: "3.11"
-            sonar: false
-            junit-xml-upload: false
-          - env: py312-django4
-            python-version: "3.12"
-            sonar: false
-            junit-xml-upload: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,12 +104,10 @@ legacy_tox_ini = """
         py312
         py311-sqlite
         py312-sqlite
-        py311-django4
-        py312-django4
         py311-in-files
         py312-in-files
     labels =
-        test = py311-check, py312-check, py311, py312, py311-sqlite, py312-sqlite, py312-django4, py311-in-files, py312-in-files
+        test = py311-check, py312-check, py311, py312, py311-sqlite, py312-sqlite, py311-in-files, py312-in-files
         lint = flake8, black, isort
 
     [testenv]
@@ -133,15 +131,6 @@ legacy_tox_ini = """
     docker = db
     setenv =
         DJANGO_SETTINGS_MODULE = test_app.sqlite3settings
-
-    [testenv:py311-django4,py312-django4]
-    deps =
-        -r{toxinidir}/requirements/requirements_all.txt
-        -r{toxinidir}/requirements/requirements_dev.txt
-        pytest-django<4.13
-    commands_pre =
-        python -m pip install --upgrade "Django>=4.2.21,<4.3.0"
-    docker = db
 
     [testenv:py311-in-files,py312-in-files]
     deps =

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 # if you are add a new feature which requires dependencies they should be in a separate requirements_<feature>.in file
 #
 cryptography
-Django>=4.2.26,<6.0    # Updating for CVE-2025-64459
+Django>=5,<6.0
 djangorestframework<3.16 # problem with OAuth2Application.organization null handling
 django-crum
 inflection


### PR DESCRIPTION
The minimum needed has been 5 already for few months, and 4 is effectively not used/tested anymore. Hence:
- bump the requirement to 5
- drop the tox jobs for 4

Fixes AAP-86325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dropped support for Django 4 test environments.
  * Updated the supported Django version range to Django 5.x.
  * Removed the outdated security advisory comment from the dependency specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->