### PR TITLE
AAP-86117 Replace correlated EXISTS with collect-IDs in UserAccessViewSet

### DIFF
--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -5,7 +5,7 @@ from typing import Type
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
-from django.db.models import Exists, Model, OuterRef, Q
+from django.db.models import Model, Q
 from django.utils.translation import gettext_lazy as _
 from rest_framework import permissions
 from rest_framework.exceptions import NotFound, ValidationError
@@ -397,36 +397,34 @@ class UserAccessViewSet(
         evaluation_cls = get_evaluation_model(obj)
         reverse_name = evaluation_cls._meta.get_field('role').remote_field.name
         assignment_cls = actor_cls._meta.get_field('role_assignments').related_model
+        actor_field = 'user_id' if actor_cls._meta.model_name == 'user' else 'team_id'
 
         if permission:
             obj_eval_qs = evaluation_cls.objects.filter(codename=permission.codename, object_id=obj.pk, content_type_id=ct.id)
         else:
             obj_eval_qs = evaluation_cls.objects.filter(object_id=obj.pk, content_type_id=ct.id)
 
-        # Use EXISTS subqueries instead of filter(role_assignments__in=...).distinct()
-        # to avoid a Cartesian product explosion in the RBAC join chain.
-        # At scale (100K+ role assignments, 485K+ role evaluations), the IN pattern
-        # produces 500M+ intermediate rows; EXISTS short-circuits per actor.
-        actor_field = 'user_id' if actor_cls._meta.model_name == 'user' else 'team_id'
-
-        obj_exists = assignment_cls.objects.filter(
-            **{actor_field: OuterRef('pk'), f'object_role__{reverse_name}__in': obj_eval_qs},
-        )
+        # Collect actor IDs from the assignment side rather than correlating
+        # per actor row. The set of matching roles/assignments is small relative
+        # to the actor table, so querying from that direction avoids an EXISTS
+        # subquery that must be evaluated for every actor.
+        role_ids = obj_eval_qs.values_list('role_id', flat=True)
+        obj_actor_ids = assignment_cls.objects.filter(
+            object_role_id__in=role_ids,
+        ).values_list(actor_field, flat=True)
 
         if permission:
-            global_exists = assignment_cls.objects.filter(
-                **{actor_field: OuterRef('pk')},
+            global_actor_ids = assignment_cls.objects.filter(
                 content_type=None,
                 role_definition__permissions=permission,
-            )
+            ).values_list(actor_field, flat=True)
         else:
-            global_exists = assignment_cls.objects.filter(
-                **{actor_field: OuterRef('pk')},
+            global_actor_ids = assignment_cls.objects.filter(
                 content_type=None,
                 role_definition__permissions__content_type=ct,
-            )
+            ).values_list(actor_field, flat=True)
 
-        filters = Exists(obj_exists) | Exists(global_exists)
+        filters = Q(pk__in=obj_actor_ids) | Q(pk__in=global_actor_ids)
         if actor_cls._meta.model_name == 'user':
             filters = filters | Q(is_superuser=True)
 

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -395,7 +395,6 @@ class UserAccessViewSet(
         permission, ct, obj = self.get_data_from_url()
 
         evaluation_cls = get_evaluation_model(obj)
-        reverse_name = evaluation_cls._meta.get_field('role').remote_field.name
         assignment_cls = actor_cls._meta.get_field('role_assignments').related_model
         actor_field = 'user_id' if actor_cls._meta.model_name == 'user' else 'team_id'
 


### PR DESCRIPTION
## Summary

- Replace `Exists(OuterRef)` subqueries with `pk__in` subqueries in `UserAccessViewSet.get_queryset()`
- Fixes `GET /api/v1/role_user_access/<model>/<pk>/` and `GET /api/v1/role_team_access/<model>/<pk>/` harakiri (503) at `page_size=100` with large organizations

## Problem

The `UserAccessViewSet.get_queryset()` built correlated `Exists()` subqueries that PostgreSQL evaluated **per actor row** in `auth_user`. Each EXISTS check joined through `roleuserassignment → objectrole → roleevaluation`. At Kyndryl scale (5,371 users, 772K+ role evaluations), this caused:

- `GET /api/v1/role_user_access/shared.organization/15/?page_size=100` → uwsgi harakiri → **503**
- `page_size=50` worked but took **5+ seconds**
- Scale lab devel: **p50 = 8.3s, 22% fail rate**

The root cause is that `Exists(OuterRef('pk'))` correlates the subquery to the outer user table — PostgreSQL must evaluate the 3-table join (assignment → objectrole → evaluation) once per user row. With 4000+ users and 772K evaluations, this is O(users × join_cost).

## Fix

Collect actor IDs from the assignment side via `pk__in` subqueries instead of correlating per user:

```python
# Before: correlated EXISTS per user row
obj_exists = assignment_cls.objects.filter(
    user_id=OuterRef('pk'), object_role__permission_partials__in=obj_eval_qs)
filters = Exists(obj_exists) | Exists(global_exists)

# After: collect IDs from assignment side
role_ids = obj_eval_qs.values_list('role_id', flat=True)
obj_actor_ids = assignment_cls.objects.filter(
    object_role_id__in=role_ids).values_list('user_id', flat=True)
filters = Q(pk__in=obj_actor_ids) | Q(pk__in=global_actor_ids)
```

PostgreSQL materializes the `pk__in` subqueries into a **hashed SubPlan** (executed once, loops=1), then probes each user row against the hash — O(assignments + users) instead of O(users × join_cost).

## Benchmark (PostgreSQL, 4007 users, 8023 assignments, 151 evaluations)

Query: `GET /api/v1/role_user_access/shared.organization/<pk>/`

| Variant | page=100 | full eval (4001 users) | EXPLAIN execution |
|---------|----------|----------------------|-------------------|
| **Before** (EXISTS) | 8.0ms | 74.8ms | 3.1ms |
| **After** (collect IDs) | 4.9ms | 66.0ms | 2.5ms |

At this test scale (151 evaluations) the improvement is modest. The fix targets Kyndryl-class environments (772K evaluations, 5371 users) where the EXISTS join cost per user row compounds severely — the per-row join through 772K evaluations runs 5371 times vs materializing once.

Data generation for reproduction:

```bash
# Generate 4000 users, 50 teams, org memberships, team memberships
DJANGO_SETTINGS_MODULE=test_app.settings pytest ~/planning/bench_access_list_perf.py -s -q -k generate
# Run benchmarks
DJANGO_SETTINGS_MODULE=test_app.settings pytest ~/planning/bench_access_list_perf.py -s -q -k bench
```

Result sets verified identical between old and new querysets.

## Test plan

- [x] All 7 access list tests pass (`test_app/tests/rbac/api/test_access_lists.py`)
- [x] All 106 RBAC API tests pass (`test_app/tests/rbac/api/`)
- [x] All 652 RBAC tests pass (`test_app/tests/rbac/`)
- [x] Result set equivalence verified (4001 users match exactly)

Fixes: https://redhat.atlassian.net/browse/AAP-86117

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access filtering for permission-specific and content-type-wide role assignments.
  * Preserved global assignment handling while ensuring actors are matched consistently against applicable roles and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->