### PR TITLE
AAP-86116 Replace correlated subquery with JOIN for ansible_id annotation

### DIFF
--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -410,7 +410,7 @@ class AssignmentBase(ImmutableCommonModel, ObjectRoleFields, _AuditableBase):
 
     # object_role is internal, and not shown in serializer
     # content_type does not have a link, and ResourceType will be used in lieu sometime
-    ignore_relations = ['content_type', 'object_role']
+    ignore_relations = ['content_type', 'object_role', 'resource']
 
     class Meta:
         app_label = 'dab_rbac'

--- a/ansible_base/rbac/service_api/views.py
+++ b/ansible_base/rbac/service_api/views.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from django.db.models import OuterRef, Subquery
+from django.db.models import F
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -8,7 +8,6 @@ from rest_framework.viewsets import GenericViewSet, mixins
 from ansible_base.lib.utils.schema import extend_schema_if_available
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 from ansible_base.lib.utils.views.permissions import try_add_oauth2_scope_permission
-from ansible_base.resource_registry.models import Resource
 from ansible_base.resource_registry.views import HasResourceRegistryPermissions
 from ansible_base.rest_filters.rest_framework import ansible_id_backend
 from ansible_base.rest_filters.rest_framework.ansible_id_backend import ServiceFilterBackend
@@ -121,24 +120,13 @@ class BaseSerivceRoleAssignmentViewSet(
                 instance.role_definition.remove_global_permission(instance.actor)
 
 
-def resource_ansible_id_expr(ct_field='content_type_id', oid_field='object_id'):
-    return Subquery(
-        Resource.objects.filter(
-            content_type_id=OuterRef(ct_field),
-            object_id=OuterRef(oid_field),
-        ).values(
-            'ansible_id'
-        )[:1]
-    )
-
-
 class ServiceRoleUserAssignmentViewSet(BaseSerivceRoleAssignmentViewSet):
     """List of user assignments for cross-service communication"""
 
     resource_purpose = "RBAC role assignments for users on resources indexed from connected AAP services"
 
     queryset = RoleUserAssignment.objects.prefetch_related('user__resource__content_type', *prefetch_related).annotate(
-        _object_ansible_id_annotation=resource_ansible_id_expr()
+        _object_ansible_id_annotation=F('resource__ansible_id')
     )
     serializer_class = service_serializers.ServiceRoleUserAssignmentSerializer
     filter_backends = AnsibleBaseDjangoAppApiView.filter_backends + [
@@ -162,7 +150,7 @@ class ServiceRoleTeamAssignmentViewSet(BaseSerivceRoleAssignmentViewSet):
     resource_purpose = "RBAC role assignments for teams on resources indexed from connected AAP services"
 
     queryset = RoleTeamAssignment.objects.prefetch_related('team__resource__content_type', *prefetch_related).annotate(
-        _object_ansible_id_annotation=resource_ansible_id_expr()
+        _object_ansible_id_annotation=F('resource__ansible_id')
     )
     serializer_class = service_serializers.ServiceRoleTeamAssignmentSerializer
     filter_backends = AnsibleBaseDjangoAppApiView.filter_backends + [

--- a/ansible_base/rbac/service_api/views.py
+++ b/ansible_base/rbac/service_api/views.py
@@ -125,15 +125,17 @@ class ServiceRoleUserAssignmentViewSet(BaseSerivceRoleAssignmentViewSet):
 
     resource_purpose = "RBAC role assignments for users on resources indexed from connected AAP services"
 
-    queryset = RoleUserAssignment.objects.prefetch_related('user__resource__content_type', *prefetch_related).annotate(
-        _object_ansible_id_annotation=F('resource__ansible_id')
-    )
     serializer_class = service_serializers.ServiceRoleUserAssignmentSerializer
     filter_backends = AnsibleBaseDjangoAppApiView.filter_backends + [
         ansible_id_backend.UserAnsibleIdAliasFilterBackend,
         ansible_id_backend.RoleAssignmentFilterBackend,
         ServiceFilterBackend,
     ]
+
+    def get_queryset(self):
+        return RoleUserAssignment.objects.prefetch_related('user__resource__content_type', *prefetch_related).annotate(
+            _object_ansible_id_annotation=F('resource__ansible_id')
+        )
 
     @action(detail=False, methods=['post'], url_path='assign')
     def assign(self, request):
@@ -149,15 +151,17 @@ class ServiceRoleTeamAssignmentViewSet(BaseSerivceRoleAssignmentViewSet):
 
     resource_purpose = "RBAC role assignments for teams on resources indexed from connected AAP services"
 
-    queryset = RoleTeamAssignment.objects.prefetch_related('team__resource__content_type', *prefetch_related).annotate(
-        _object_ansible_id_annotation=F('resource__ansible_id')
-    )
     serializer_class = service_serializers.ServiceRoleTeamAssignmentSerializer
     filter_backends = AnsibleBaseDjangoAppApiView.filter_backends + [
         ansible_id_backend.TeamAnsibleIdAliasFilterBackend,
         ansible_id_backend.RoleAssignmentFilterBackend,
         ServiceFilterBackend,
     ]
+
+    def get_queryset(self):
+        return RoleTeamAssignment.objects.prefetch_related('team__resource__content_type', *prefetch_related).annotate(
+            _object_ansible_id_annotation=F('resource__ansible_id')
+        )
 
     @action(detail=False, methods=['post'], url_path='assign')
     def assign(self, request):

--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -179,3 +179,13 @@ class ResourceRegistryConfig(AppConfig):
         signals.pre_migrate.connect(disconnect_resource_signals, sender=self)
         signals.post_migrate.connect(initialize_resources, sender=self)
         signals.post_migrate.connect(connect_resource_signals, sender=self)
+
+        from django.apps import apps
+
+        if apps.is_installed('ansible_base.rbac'):
+            from ansible_base.rbac.models import RoleTeamAssignment, RoleUserAssignment
+            from ansible_base.resource_registry.fields import AssignmentResourceField
+
+            for model in (RoleUserAssignment, RoleTeamAssignment):
+                if not hasattr(model, 'resource'):
+                    AssignmentResourceField().contribute_to_class(model, 'resource')

--- a/ansible_base/resource_registry/fields.py
+++ b/ansible_base/resource_registry/fields.py
@@ -152,3 +152,46 @@ class AnsibleResourceField(models.ForeignObject):
         Return the content type associated with this field's model.
         """
         return ContentType.objects.get_for_model(self.model)
+
+
+class AssignmentResourceField(models.ForeignObject):
+    """
+    ForeignObject joining assignment models to Resource via the row's own
+    (content_type_id, object_id) — both columns are variable per row.
+
+    Unlike AnsibleResourceField which uses a constant content_type and a
+    Cast(pk, TextField), this field joins two columns that already match
+    in type (both TextField, both FK to ContentType).
+
+    Added dynamically via contribute_to_class in ResourceRegistryConfig.ready()
+    so that dab_rbac works standalone without resource_registry.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            Resource,
+            on_delete=models.DO_NOTHING,
+            from_fields=['object_id'],
+            to_fields=['object_id'],
+            null=True,
+            blank=True,
+            editable=False,
+            serialize=False,
+            **kwargs,
+        )
+
+    def contribute_to_class(self, cls, name, private_only=False, **kwargs):
+        super().contribute_to_class(cls, name, private_only=True, **kwargs)
+
+    def get_extra_restriction(self, alias, remote_alias):
+        resource_ct_field = self.remote_field.model._meta.get_field("content_type")
+        local_ct_field = self.model._meta.get_field("content_type")
+
+        ct_lookup = self.get_lookup("exact")(
+            local_ct_field.get_col(remote_alias),
+            resource_ct_field.get_col(alias),
+        )
+        return WhereNode([ct_lookup], connector=AND)
+
+    def get_extra_descriptor_filter(self, instance):
+        return {"content_type_id": instance.content_type_id}

--- a/test_app/tests/resource_registry/models/test_resource_field.py
+++ b/test_app/tests/resource_registry/models/test_resource_field.py
@@ -206,9 +206,7 @@ def test_assignment_resource_field_f_annotation(admin_user, organization):
     )
     rd.give_permission(admin_user, organization)
 
-    qs = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).annotate(
-        _ansible_id=F('resource__ansible_id')
-    )
+    qs = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).annotate(_ansible_id=F('resource__ansible_id'))
     assignment = qs.first()
     assert assignment is not None
     assert str(assignment._ansible_id) == str(org_resource.ansible_id)
@@ -262,6 +260,22 @@ def test_assignment_resource_field_null_object(admin_user):
     assignment = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).select_related('resource').first()
     assert assignment is not None
     assert assignment.resource is None
+
+
+@pytest.mark.django_db
+def test_assignment_resource_excluded_from_summary_fields(admin_user, organization):
+    """Test that resource is excluded from summary_fields via ignore_relations."""
+    rd = RoleDefinition.objects.create_from_permissions(
+        name='test-org-view-sf',
+        permissions=['view_organization'],
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+    rd.give_permission(admin_user, organization)
+
+    assignment = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).first()
+    assert 'resource' in type(assignment).ignore_relations
+    summary = assignment.get_summary_fields()
+    assert 'resource' not in summary
 
 
 @pytest.mark.skipif(VERSION[0] < 5, reason='get_prefetch_querysets() is only valid for Django 5+')

--- a/test_app/tests/resource_registry/models/test_resource_field.py
+++ b/test_app/tests/resource_registry/models/test_resource_field.py
@@ -1,7 +1,10 @@
 import pytest
 from django import VERSION
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import F
 
+from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
+from ansible_base.rbac.permission_registry import permission_registry
 from ansible_base.resource_registry.models import Resource, ResourceType
 from test_app.models import Inventory, Organization
 
@@ -189,6 +192,76 @@ def test_resource_field_prefetch_resource_type_from_organization(organization, o
     expected_resource_type = ResourceType.objects.get(content_type=org_ctype)
     for org_pk, resource_type_pk in resource_type_data.items():
         assert resource_type_pk == expected_resource_type.pk
+
+
+@pytest.mark.django_db
+def test_assignment_resource_field_f_annotation(admin_user, organization):
+    """Test that F('resource__ansible_id') produces a JOIN-based annotation on assignment models."""
+    org_ct = ContentType.objects.get_for_model(Organization)
+    org_resource = Resource.objects.get(object_id=str(organization.pk), content_type=org_ct)
+    rd = RoleDefinition.objects.create_from_permissions(
+        name='test-org-view',
+        permissions=['view_organization'],
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+    rd.give_permission(admin_user, organization)
+
+    qs = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).annotate(
+        _ansible_id=F('resource__ansible_id')
+    )
+    assignment = qs.first()
+    assert assignment is not None
+    assert str(assignment._ansible_id) == str(org_resource.ansible_id)
+
+
+@pytest.mark.django_db
+def test_assignment_resource_field_select_related(admin_user, organization):
+    """Test select_related('resource') on assignment models."""
+    org_ct = ContentType.objects.get_for_model(Organization)
+    org_resource = Resource.objects.get(object_id=str(organization.pk), content_type=org_ct)
+    rd = RoleDefinition.objects.create_from_permissions(
+        name='test-org-view-sr',
+        permissions=['view_organization'],
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+    rd.give_permission(admin_user, organization)
+
+    qs = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).select_related('resource')
+    assignment = qs.first()
+    assert assignment is not None
+    assert assignment.resource is not None
+    assert assignment.resource.ansible_id == org_resource.ansible_id
+
+
+@pytest.mark.django_db
+def test_assignment_resource_field_lazy_access(admin_user, organization):
+    """Test lazy instance access on assignment.resource (exercises get_extra_descriptor_filter)."""
+    org_ct = ContentType.objects.get_for_model(Organization)
+    org_resource = Resource.objects.get(object_id=str(organization.pk), content_type=org_ct)
+    rd = RoleDefinition.objects.create_from_permissions(
+        name='test-org-view-lazy',
+        permissions=['view_organization'],
+        content_type=permission_registry.content_type_model.objects.get_for_model(Organization),
+    )
+    rd.give_permission(admin_user, organization)
+
+    assignment = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).first()
+    assert assignment.resource.ansible_id == org_resource.ansible_id
+
+
+@pytest.mark.django_db
+def test_assignment_resource_field_null_object(admin_user):
+    """Test that system-wide assignments (no content_type/object_id) return None for resource."""
+    rd = RoleDefinition.objects.create_from_permissions(
+        name='test-global-view',
+        permissions=['view_organization'],
+        content_type=None,
+    )
+    rd.give_global_permission(admin_user)
+
+    assignment = RoleUserAssignment.objects.filter(user=admin_user, role_definition=rd).select_related('resource').first()
+    assert assignment is not None
+    assert assignment.resource is None
 
 
 @pytest.mark.skipif(VERSION[0] < 5, reason='get_prefetch_querysets() is only valid for Django 5+')


### PR DESCRIPTION
## Summary

- Adds `AssignmentResourceField` (`ForeignObject`) to `resource_registry/fields.py` that joins assignment models to `Resource` via `(content_type_id, object_id)` — both columns variable per row, no Cast needed
- Dynamically attached to `RoleUserAssignment` and `RoleTeamAssignment` via `contribute_to_class` in `ResourceRegistryConfig.ready()`, so `dab_rbac` works standalone without `resource_registry`
- Replaces `resource_ansible_id_expr()` (correlated `Subquery`) with `F('resource__ansible_id')` (JOIN-based scalar) in both service API viewsets — same annotation attribute name, zero serializer changes

## Problem

The service API annotates each assignment row with `object_ansible_id` using a correlated `Subquery` against the `Resource` table. Although the covering index makes each probe fast (~0.001ms), postgres evaluates the subquery for **every row in the scan**, including rows skipped by OFFSET pagination. This makes the full table walk (gateway sync) cost O(N²) across pages.

## Benchmark results (8K assignments)

| Scenario | Subquery (before) | F() JOIN (after) | Improvement |
|----------|-------------------|------------------|-------------|
| Page 1 (sz=50) | 0.001s | 0.002s | same |
| High offset (7970) | 0.018s | 0.003s | **6x faster** |
| Full table walk (8020 rows) | 0.258s | 0.182s | **30% faster** |

The high-offset case shows the biggest win — exactly where correlated subquery OFFSET amplification hurts most. At production scale (110K+ assignments), the O(N²) effect would be far more pronounced.

### SQL change

Before (correlated subquery, evaluated per row):
```sql
SELECT ..., (SELECT ansible_id FROM resource WHERE content_type_id = assignment.content_type_id AND object_id = assignment.object_id LIMIT 1) AS _object_ansible_id_annotation
FROM dab_rbac_roleuserassignment
```

After (LEFT JOIN, evaluated once):
```sql
SELECT ..., resource.ansible_id AS _object_ansible_id_annotation
FROM dab_rbac_roleuserassignment
LEFT OUTER JOIN dab_resource_registry_resource ON (
    assignment.object_id = resource.object_id
    AND assignment.content_type_id = resource.content_type_id
)
```

## Test plan

- [x] 70 service API tests pass (`pytest -k service`)
- [x] 294 resource_registry tests pass
- [x] No migration generated (`makemigrations --check --dry-run`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved how resource information is associated with user and team assignments.
  - Resource relationships are now available automatically when role-based access control is enabled.
  - Improved efficiency when loading related resources.
  - Resource details are excluded from assignment summaries where appropriate.

- **Bug Fixes**
  - Prevented mismatched resource associations across resource types.
  - Ensured global assignments without a specific resource continue to behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->