### PR TITLE
[AAP-86677] Skip resource initialization when no migrations applied and optimize query

### DIFF
--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -2,7 +2,7 @@ import logging
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.db.models import TextField, signals
+from django.db.models import Exists, OuterRef, TextField, signals
 from django.db.models.functions import Cast
 from django.db.utils import IntegrityError
 
@@ -34,6 +34,11 @@ def initialize_resources(sender, **kwargs):
 
     if not migrations_are_complete():
         logger.info('Not running resource_registry post_migrate because migrations are incomplete')
+        return
+
+    plan = kwargs.get('plan', None)
+    if plan is not None and len(plan) == 0:
+        logger.info('Skipping resource initialization — no migrations were applied')
         return
 
     apps = kwargs.get("apps")
@@ -82,7 +87,7 @@ def initialize_resources(sender, **kwargs):
             logger.info(f"adding unmigrated resources for {r_type.name}")
 
             missing_resources_qs = resource_model.objects.annotate(pk_text=Cast('pk', TextField())).exclude(
-                pk_text__in=Resource.objects.filter(content_type=r_type.content_type).values("object_id")
+                Exists(Resource.objects.filter(content_type=r_type.content_type, object_id=OuterRef('pk_text')))
             )
 
             data = []

--- a/test_app/tests/resource_registry/test_migration.py
+++ b/test_app/tests/resource_registry/test_migration.py
@@ -1,6 +1,14 @@
-import pytest
+from unittest.mock import patch
 
+import pytest
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Exists, OuterRef, TextField
+from django.db.models.functions import Cast
+
+from ansible_base.resource_registry.apps import initialize_resources
 from ansible_base.resource_registry.models import Resource
+from test_app.models import Organization
 
 
 @pytest.mark.django_db
@@ -10,3 +18,85 @@ def test_existing_resources_created_in_post_migration():
     created successfully.
     """
     assert Resource.objects.filter(name="migration resource", content_type__resource_type__name="aap.resourcemigrationtestmodel").exists()
+
+
+@pytest.mark.django_db
+def test_initialize_resources_skips_when_no_migrations_applied():
+    """initialize_resources should skip resource scanning when the plan kwarg
+    is an empty list, meaning no migrations were actually applied."""
+    with patch('ansible_base.resource_registry.registry.get_registry') as mock_registry:
+        initialize_resources(apps.get_app_config('dab_resource_registry'), plan=[])
+    mock_registry.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_initialize_resources_runs_when_plan_has_entries():
+    """initialize_resources should proceed with resource scanning when the
+    plan kwarg contains migration entries."""
+    with patch('ansible_base.resource_registry.registry.get_registry') as mock_registry:
+        mock_registry.return_value = None
+        initialize_resources(apps.get_app_config('dab_resource_registry'), plan=[('fake_migration',)])
+    mock_registry.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_initialize_resources_runs_when_plan_not_provided():
+    """initialize_resources should proceed when plan kwarg is not provided
+    (e.g. when called from django-admin flush)."""
+    with patch('ansible_base.resource_registry.registry.get_registry') as mock_registry:
+        mock_registry.return_value = None
+        initialize_resources(apps.get_app_config('dab_resource_registry'))
+    mock_registry.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_missing_resources_queryset_finds_unregistered_objects():
+    """The NOT EXISTS queryset correctly identifies objects that do not yet
+    have a corresponding Resource entry."""
+    ct = ContentType.objects.get_for_model(Organization)
+
+    org_with_resource = Organization.objects.create(name="has-resource")
+    org_without_resource = Organization.objects.create(name="no-resource")
+
+    # post_save signal auto-creates Resource entries; remove one to simulate a gap
+    Resource.objects.filter(content_type=ct, object_id=str(org_without_resource.pk)).delete()
+
+    missing_qs = Organization.objects.annotate(pk_text=Cast('pk', TextField())).exclude(
+        Exists(Resource.objects.filter(content_type=ct, object_id=OuterRef('pk_text')))
+    )
+
+    missing_ids = set(missing_qs.values_list('pk', flat=True))
+    assert org_without_resource.pk in missing_ids
+    assert org_with_resource.pk not in missing_ids
+
+
+@pytest.mark.django_db
+def test_missing_resources_queryset_returns_nothing_when_all_registered():
+    """When every object has a Resource entry, the queryset returns nothing."""
+    ct = ContentType.objects.get_for_model(Organization)
+
+    orgs = [Organization.objects.create(name=f"org-{i}") for i in range(3)]
+    for org in orgs:
+        Resource.objects.get_or_create(content_type=ct, object_id=str(org.pk))
+
+    missing_qs = (
+        Organization.objects.filter(pk__in=[o.pk for o in orgs])
+        .annotate(pk_text=Cast('pk', TextField()))
+        .exclude(Exists(Resource.objects.filter(content_type=ct, object_id=OuterRef('pk_text'))))
+    )
+
+    assert missing_qs.count() == 0
+
+
+@pytest.mark.django_db
+def test_initialize_resources_creates_missing_resources():
+    """initialize_resources creates Resource entries for objects that are missing them."""
+    ct = ContentType.objects.get_for_model(Organization)
+    org = Organization.objects.create(name="needs-resource")
+
+    Resource.objects.filter(content_type=ct, object_id=str(org.pk)).delete()
+    assert not Resource.objects.filter(content_type=ct, object_id=str(org.pk)).exists()
+
+    initialize_resources(apps.get_app_config('dab_resource_registry'), plan=[('fake_migration',)])
+
+    assert Resource.objects.filter(content_type=ct, object_id=str(org.pk)).exists()


### PR DESCRIPTION
## Summary

- **Skip when no migrations applied**: Add `plan` kwarg check to `initialize_resources` post-migrate handler, matching the existing pattern in `post_migration_rbac_setup`. When Django's migrate command reports "No migrations to apply", the `plan` kwarg is `[]` — but `initialize_resources` never checked it, running the full resource scan on every pod restart.

- **Optimize the missing-resources query**: Replace `NOT IN` subquery with `NOT EXISTS` (`Exists` + `OuterRef`). Postgres plans the old query as a materialized nested loop (estimated cost ~836M); the new query uses a Hash Anti Join (estimated cost ~29k).

## Context

On scalelab (83k teams, 527k resource registry entries), the old `NOT IN` query in `initialize_resources` exceeded the 150s `statement_timeout` and crashed the gateway `run-migrations` init container in a `CrashLoopBackOff`. The container log showed:

```
Running migrations:
  No migrations to apply.
Traceback (most recent call last):
  ...
  File ".../ansible_base/resource_registry/apps.py", line 89, in initialize_resources
    for obj in missing_resources_qs:
psycopg.errors.QueryCanceled: canceling statement due to statement timeout
```

## EXPLAIN comparison (scalelab, 83k teams)

**Before (NOT IN)** — estimated cost 836,291,384:
```
Seq Scan on aap_gateway_api_team t  (cost=0.00..836291384.12 rows=41738 width=62)
  Filter: (NOT (SubPlan 1))
  SubPlan 1
    ->  Materialize  (cost=0.00..18721.12 rows=526206 width=6)
          ->  Seq Scan on dab_resource_registry_resource r  (cost=0.00..14034.09 rows=526206 width=6)
                Filter: (content_type_id = 11)
```

**After (NOT EXISTS)** — estimated cost 29,107, actual 1.4s:
```
Hash Anti Join  (cost=22667.66..29106.66 rows=41738 width=62) (actual time=1421.412..1421.416 rows=0 loops=1)
  Hash Cond: ((t.id)::text = r.object_id)
  ->  Seq Scan on aap_gateway_api_team t  (cost=0.00..1790.76 rows=83476 width=62) (actual time=0.016..91.700 rows=83476 loops=1)
  ->  Hash  (cost=14034.09..14034.09 rows=526206 width=6) (actual time=821.213..821.215 rows=527864 loops=1)
        ->  Seq Scan on dab_resource_registry_resource r  (cost=0.00..14034.09 rows=526206 width=6) (actual time=0.067..427.003 rows=527864 loops=1)
              Filter: (content_type_id = 11)
```

## Test plan

- [x] `test_initialize_resources_skips_when_no_migrations_applied` — verifies `plan=[]` skips resource scanning
- [x] `test_initialize_resources_runs_when_plan_has_entries` — verifies `plan=[(...)]` proceeds normally
- [x] `test_initialize_resources_runs_when_plan_not_provided` — verifies no `plan` kwarg (e.g. `django-admin flush`) proceeds normally
- [x] `test_missing_resources_queryset_finds_unregistered_objects` — verifies the NOT EXISTS query correctly identifies objects without Resource entries
- [x] `test_missing_resources_queryset_returns_nothing_when_all_registered` — verifies the query returns empty when all objects are registered
- [x] `test_initialize_resources_creates_missing_resources` — end-to-end: creates an object, deletes its Resource, runs initialize_resources, verifies Resource is recreated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource initialization during migrations to avoid unnecessary processing when no migrations were applied.
  * Improved detection of unregistered resources.
  * Ensured missing resource entries are created correctly.

* **Tests**
  * Added coverage for migration-plan handling, resource detection, and creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->