### PR TITLE
[AAP-86982] Move plan=[] skip after ResourceType creation in initialize_resources

### DIFF
--- a/ansible_base/resource_registry/apps.py
+++ b/ansible_base/resource_registry/apps.py
@@ -36,11 +36,6 @@ def initialize_resources(sender, **kwargs):
         logger.info('Not running resource_registry post_migrate because migrations are incomplete')
         return
 
-    plan = kwargs.get('plan', None)
-    if plan is not None and len(plan) == 0:
-        logger.info('Skipping resource initialization — no migrations were applied')
-        return
-
     apps = kwargs.get("apps")
     if apps is None:
         from django.apps import apps
@@ -78,6 +73,14 @@ def initialize_resources(sender, **kwargs):
                 for k, v in defaults.items():
                     setattr(rt, k, v)
                 rt.save()
+
+        # Skip the expensive missing-resource scan when no migrations were applied.
+        # ResourceType creation above must still run because post_save signal
+        # handlers depend on ResourceType records existing.
+        plan = kwargs.get('plan', None)
+        if plan is not None and len(plan) == 0:
+            logger.info('Skipping missing-resource scan — no migrations were applied')
+            return
 
         # Create resources
         for r_type in ResourceType.objects.all():

--- a/test_app/tests/resource_registry/test_migration.py
+++ b/test_app/tests/resource_registry/test_migration.py
@@ -27,11 +27,10 @@ def test_initialize_resources_skips_scan_but_creates_types_when_no_migrations_ap
     the expensive missing-resource scan."""
     from ansible_base.resource_registry.models import ResourceType
 
-    rt_count_before = ResourceType.objects.count()
+    ResourceType.objects.all().delete()
     with patch('ansible_base.resource_registry.models.init_resource_from_object') as mock_init:
         initialize_resources(apps.get_app_config('dab_resource_registry'), plan=[])
     mock_init.assert_not_called()
-    assert ResourceType.objects.count() >= rt_count_before
     assert ResourceType.objects.count() > 0
 
 

--- a/test_app/tests/resource_registry/test_migration.py
+++ b/test_app/tests/resource_registry/test_migration.py
@@ -21,12 +21,18 @@ def test_existing_resources_created_in_post_migration():
 
 
 @pytest.mark.django_db
-def test_initialize_resources_skips_when_no_migrations_applied():
-    """initialize_resources should skip resource scanning when the plan kwarg
-    is an empty list, meaning no migrations were actually applied."""
-    with patch('ansible_base.resource_registry.registry.get_registry') as mock_registry:
+def test_initialize_resources_skips_scan_but_creates_types_when_no_migrations_applied():
+    """When plan=[] (no migrations applied), initialize_resources should still
+    create ResourceType records (needed by post_save signal handlers) but skip
+    the expensive missing-resource scan."""
+    from ansible_base.resource_registry.models import ResourceType
+
+    rt_count_before = ResourceType.objects.count()
+    with patch('ansible_base.resource_registry.models.init_resource_from_object') as mock_init:
         initialize_resources(apps.get_app_config('dab_resource_registry'), plan=[])
-    mock_registry.assert_not_called()
+    mock_init.assert_not_called()
+    assert ResourceType.objects.count() >= rt_count_before
+    assert ResourceType.objects.count() > 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- PR #1094 added a `plan=[]` early-return at the top of `initialize_resources()` to skip expensive work when no migrations were applied. The early-return fired **before** the `ResourceType.objects.update_or_create()` loop, so ResourceType records were never created when `plan=[]`.
- This breaks AWX CI (2432 test errors) because AWX uses pytest-django's `--nomigrations` flag, which creates tables via syncdb and emits `post_migrate` with `plan=[]` as the **only** invocation. Without ResourceType records, the `post_save` signal handler raises `ContentType.resource_type.RelatedObjectDoesNotExist` on every model save.
- Fix: move the `plan=[]` check to **after** ResourceType creation but **before** the expensive missing-resource scan. ResourceTypes are always created (~76ms for 5 `update_or_create` calls) while the costly `NOT EXISTS` query is still skipped on no-op `post_migrate`.

## Root cause detail

The `plan=[]` pattern was modeled after the RBAC handler (PR #1064), but that handler only skips derived recomputation (`compute_team_member_roles` / `compute_object_role_permissions`). No live signal handlers depend on those. In contrast, `initialize_resources` was skipping foundational ResourceType creation that `post_save` signal handlers depend on for every model save.

With `--nomigrations`, pytest-django's `DisableMigrations` class makes Django see no migration modules for any app. Django's `migrate` command runs syncdb to create tables, then calls `emit_post_migrate_signal(plan=[])` — there is no earlier "real migration" phase where ResourceTypes would be created.

## Verified locally

Patched the installed DAB in the AWX Docker container and ran the full AWX test suite:

- **Without fix (PR #1094 as-is):** `ContentType has no resource_type` — 2432 errors
- **With fix:** 3824 passed, 5 skipped, 2 xfailed, 1 xpassed, 0 failures (570s)

## Test plan

- [ ] DAB's own `test_initialize_resources_skips_scan_but_creates_types_when_no_migrations_applied` — verifies ResourceTypes are created but `init_resource_from_object` is not called when `plan=[]`
- [ ] DAB's existing `test_initialize_resources_runs_when_plan_has_entries` and `test_initialize_resources_runs_when_plan_not_provided` — verify normal paths still work
- [ ] AWX CI api-test passes (the 2432 errors are resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resource types are now updated correctly during initialization, even when no migrations are applied.
  - Missing-resource scanning is skipped when appropriate, with a clear log message.

- **Tests**
  - Added coverage confirming resource type records are created while the missing-resource scan is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->