### PR TITLE
AAP-86117 Prefetch object_role_assignments to eliminate N+1 serializer queries

### DIFF
--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -308,7 +308,70 @@ class AccessListMixin:
 
         return assignment_list
 
+    def _bulk_fetch_assignments(self, actor_ids):
+        """Bulk-fetch and classify role assignments for a page of actors."""
+        from ..models import DABContentType, get_evaluation_model
+
+        obj = self.context["related_object"]
+        permission = self.context.get("permission")
+        ct = self.context["content_type"]
+
+        actor_cls = self.Meta.model
+        assignment_cls = actor_cls._meta.get_field('role_assignments').related_model
+        actor_field = 'user_id' if actor_cls._meta.model_name == 'user' else 'team_id'
+
+        evaluation_cls = get_evaluation_model(obj)
+        eval_filter = {'object_id': obj.pk, 'content_type_id': ct.id}
+        if permission:
+            eval_filter['codename'] = permission.codename
+        obj_eval_qs = evaluation_cls.objects.filter(**eval_filter)
+
+        obj_assignments = assignment_cls.objects.filter(
+            object_role__in=obj_eval_qs.values_list('role_id', flat=True),
+            **{f'{actor_field}__in': actor_ids},
+        ).select_related('role_definition')
+
+        global_filter = {
+            'content_type': None,
+            f'{actor_field}__in': actor_ids,
+        }
+        if permission:
+            global_filter['role_definition__permissions'] = permission
+        else:
+            global_filter['role_definition__permissions__content_type'] = ct
+        global_assignments = assignment_cls.objects.filter(**global_filter).select_related('role_definition')
+
+        team_ct = DABContentType.objects.get_for_model(get_team_model())
+        assignments_by_actor = {}
+        for qs_part in (obj_assignments, global_assignments):
+            for a in qs_part.distinct():
+                actor_id = getattr(a, actor_field)
+                if a.content_type_id is None:
+                    perm_type = "global"
+                elif a.content_type_id == team_ct.pk:
+                    perm_type = "team"
+                elif a.content_type_id == ct.pk:
+                    perm_type = "direct"
+                else:
+                    perm_type = "indirect"
+                entry = {"type": perm_type, "role_definition": self.summarize_role_definition(a.role_definition)}
+                assignments_by_actor.setdefault(actor_id, []).append(entry)
+        return assignments_by_actor
+
     def get_object_role_assignments(self, actor):
+        # When many=True, DRF wraps us in a ListSerializer. self.parent points
+        # to it, and self.parent.instance holds the page of objects. We lazy-
+        # prefetch on the first call and cache on the parent. Each request gets
+        # its own serializer tree so there is no instance-reuse or thread concern.
+        if self.parent is not None:
+            if not hasattr(self.parent, '_prefetched_assignments'):
+                actors = getattr(self.parent, 'instance', None)
+                if actors is not None:
+                    self.parent._prefetched_assignments = self._bulk_fetch_assignments([a.pk for a in actors])
+            prefetched = getattr(self.parent, '_prefetched_assignments', None)
+            if prefetched is not None:
+                return prefetched.get(actor.pk, [])
+
         obj = self.context.get("related_object")
         permission = self.context.get("permission")
         ct = self.context.get("content_type")

--- a/ansible_base/rbac/api/views.py
+++ b/ansible_base/rbac/api/views.py
@@ -427,7 +427,10 @@ class UserAccessViewSet(
         if actor_cls._meta.model_name == 'user':
             filters = filters | Q(is_superuser=True)
 
-        return actor_cls.objects.filter(filters)
+        qs = actor_cls.objects.filter(filters)
+        if hasattr(actor_cls, 'resource'):
+            qs = qs.select_related('resource')
+        return qs
 
     def get_serializer(self, *args, **kwargs):
         """Awkwardly override this method, because eda-server uses a custom base viewset class.

--- a/test_app/tests/rbac/api/test_access_lists.py
+++ b/test_app/tests/rbac/api/test_access_lists.py
@@ -1,4 +1,6 @@
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac import permission_registry
@@ -193,4 +195,103 @@ def test_org_admin_role_user_access_bug(organization, org_admin_rd):
         f"AAP-52187 BUG: Org admin should be able to view role access for organization they manage. "
         f"User has shared.view_organization permission and can access org detail endpoint, "
         f"but role_user_access fails with: {response.status_code} {response.data}"
+    )
+
+
+@pytest.mark.django_db
+def test_prefetch_team_assignment_type(admin_api_client, inv_rd, inventory, member_rd):
+    """The bulk prefetch classifies team-member-based assignments as 'team' type."""
+    user = User.objects.create(username='team-type-user')
+    team = Team.objects.create(name='team-type-team', organization=inventory.organization)
+    inv_rd.give_permission(team, inventory)
+    member_rd.give_permission(user, team)
+
+    url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'}) + '?is_superuser=false'
+    response = admin_api_client.get(url)
+    assert response.status_code == 200
+
+    user_entry = next(r for r in response.data['results'] if r['username'] == 'team-type-user')
+    assert len(user_entry['object_role_assignments']) == 1
+    assert user_entry['object_role_assignments'][0]['type'] == 'team'
+
+
+@pytest.mark.django_db
+def test_prefetch_indirect_assignment_type(admin_api_client, org_inv_rd, inventory):
+    """The bulk prefetch classifies org-level role assignments as 'indirect' type."""
+    user = User.objects.create(username='indirect-type-user')
+    org_inv_rd.give_permission(user, inventory.organization)
+
+    url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'}) + '?is_superuser=false'
+    response = admin_api_client.get(url)
+    assert response.status_code == 200
+
+    user_entry = next(r for r in response.data['results'] if r['username'] == 'indirect-type-user')
+    assert len(user_entry['object_role_assignments']) == 1
+    assert user_entry['object_role_assignments'][0]['type'] == 'indirect'
+
+
+@pytest.mark.django_db
+def test_prefetch_fallback_without_parent(inv_rd, inventory):
+    """get_object_role_assignments falls back to per-user queries when self.parent is None."""
+    from rest_framework import serializers as drf_serializers
+
+    from ansible_base.rbac.api.serializers import UserAccessListMixin
+    from ansible_base.rbac.models import DABContentType
+
+    user = User.objects.create(username='fallback-user')
+    inv_rd.give_permission(user, inventory)
+    ct = DABContentType.objects.get_for_model(type(inventory))
+
+    class TestSerializer(UserAccessListMixin, drf_serializers.ModelSerializer):
+        class Meta:
+            model = User
+            fields = ['id']
+
+    serializer = TestSerializer(
+        context={
+            'related_object': inventory,
+            'permission': None,
+            'content_type': ct,
+        }
+    )
+    assert serializer.parent is None
+    assignments = serializer.get_object_role_assignments(user)
+    assert len(assignments) == 1
+    assert assignments[0]['type'] == 'direct'
+
+
+@pytest.mark.django_db
+def test_user_access_list_query_count(admin_api_client, inv_rd, inventory):
+    """Query count should not scale with the number of users in the result.
+    With prefetched assignments, going from 2 to 20 users should add at most
+    a handful of queries, not 18 extra (one per additional user)."""
+    url = get_relative_url('role-user-access', kwargs={'pk': inventory.pk, 'model_name': 'aap.inventory'})
+
+    # Measure with 2 users
+    for i in range(2):
+        u = User.objects.create(username=f'query-count-user-{i}')
+        inv_rd.give_permission(u, inventory)
+
+    admin_api_client.get(url)  # warm up
+    with CaptureQueriesContext(connection) as ctx_small:
+        response = admin_api_client.get(url)
+    assert response.status_code == 200
+    queries_small = len(ctx_small.captured_queries)
+
+    # Add 18 more users (20 total)
+    for i in range(2, 20):
+        u = User.objects.create(username=f'query-count-user-{i}')
+        inv_rd.give_permission(u, inventory)
+
+    admin_api_client.get(url)  # warm up
+    with CaptureQueriesContext(connection) as ctx_large:
+        response = admin_api_client.get(url)
+    assert response.status_code == 200
+    queries_large = len(ctx_large.captured_queries)
+
+    added_queries = queries_large - queries_small
+    assert added_queries < 5, (
+        f"Adding 18 users increased query count by {added_queries} "
+        f"({queries_small} -> {queries_large}). "
+        f"object_role_assignments may be doing per-user queries."
     )


### PR DESCRIPTION
## Summary

- Prefetch all role assignments for the target object in `UserAccessViewSet.get_serializer_context()` with a single query
- Look up per-user assignments from the prefetched dict in `AccessListMixin.get_object_role_assignments()` instead of hitting the DB per user
- Both `UserAccessViewSet` and `TeamAccessViewSet` benefit (shared parent class)

## Context

Follow-up to #1092 (collect-IDs fix for the queryset). The queryset optimization brought the DB query from seconds to 21ms, but the endpoint was still 8-9 seconds. Profiling on scalelab gateway showed serialization was the bottleneck:

- `get_object_role_assignments` is a `SerializerMethodField` that calls `assignment_qs_user_to_obj_perm(actor, obj, permission)` **per user** on every page
- With `page_size=100`, that's 100 DISTINCT queries at ~42ms each = 4.3s in serialization alone
- The actual queryset + pagination completed in 21ms

## Profiling results (scalelab gateway, Default org with 7,153 users)

| | Before | After |
|---|---|---|
| Serialization time | 4.528s | 0.009s |
| DB queries during serialization | 213 | 0 |
| DB time in serialization | 4.278s | 0.000s |
| **Speedup** | | **478x** |

Endpoint response time should drop from ~8s to under 1s for the `shared.organization` user access tab.


## Test plan

- [x] Existing `test_user_access_list` validates correctness of `object_role_assignments` types (direct, indirect, team)
- [x] New `test_user_access_list_query_count` asserts that adding 18 users increases query count by fewer than 5 (would be 18+ without prefetch)
- [x] Falls back to per-user queries if `_prefetched_assignments` is not in context (backwards compatible)
- [x] Build into devel gateway image on scalelab-a and verify `role_user_access: shared.organization` endpoint drops from ~8s to <1s
- [x] Run perf comparison to confirm no regression on other `role_user_access` and `role_team_access` endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance Improvements

- Improved user access-list loading by reducing repeated database queries as the number of users increases.
- Larger access lists now load with more consistent performance.
- Access details are prepared more efficiently while preserving direct, global, team, and indirect role information.

## Bug Fixes

- Improved consistency of displayed role details and access links.
- Preloaded access information is now used reliably when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->