### PR TITLE
AAP-87982 Fix descendant over-expansion in team assignment recomputation

### DIFF
--- a/ansible_base/rbac/pipeline.py
+++ b/ansible_base/rbac/pipeline.py
@@ -260,10 +260,10 @@ def _recompute_after_give(
 
     unique_teams = {a.team for a in assignments if isinstance(a, RoleTeamAssignment)}
     if unique_teams:
-        object_roles_to_update.update(bulk_ancestor_roles({team.pk for team in unique_teams}))
-        expanded_roles = ObjectRole.objects.filter(pk__in=[obj_role.pk for obj_role in object_roles_to_update]).prefetch_related('provides_teams__has_roles')
-        for obj_role in expanded_roles:
+        direct_roles = ObjectRole.objects.filter(pk__in=[obj_role.pk for obj_role in object_roles_to_update]).prefetch_related('provides_teams__has_roles')
+        for obj_role in direct_roles:
             object_roles_to_update.update(obj_role.descendent_roles())
+        object_roles_to_update.update(bulk_ancestor_roles({team.pk for team in unique_teams}))
 
     if recompute_team_ids:
         compute_team_member_roles(team_ids=recompute_team_ids)

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -1036,7 +1036,10 @@ class TestTeamAssignmentRecomputeScope:
         with mock_patch.object(ObjectRole, 'descendent_roles', tracking_descendent):
             inv_rd.give_permission(team, inventory)
 
+        direct_role = ObjectRole.objects.get(role_definition=inv_rd, object_id=inventory.pk)
+        assert direct_role.pk in called_on_pks, "descendent_roles() must be called on the directly affected ObjectRole"
+
         for pk in called_on_pks:
             assert pk not in ancestor_pks, (
-                f"descendent_roles() was called on ancestor ObjectRole pk={pk}; " f"this causes O(ancestors × descendants) recomputation"
+                f"descendent_roles() was called on ancestor ObjectRole pk={pk}; " f"this causes O(ancestors x descendants) recomputation"
             )

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -1005,3 +1005,38 @@ class TestPermissionQueryCount:
         inv_rd.remove_permission(team, inventory)
         count = len(connection.queries) - before
         print(f"\nremove_permission (team+inv): {count} queries")
+
+
+@pytest.mark.django_db
+class TestTeamAssignmentRecomputeScope:
+    """Verify that give_permission for teams only expands descendants
+    of directly affected ObjectRoles, not of ancestor roles."""
+
+    def test_descendent_expansion_excludes_ancestors(self, team, inventory, inv_rd, org_team_member_rd, organization):
+        """When assigning a team to an inventory role, descendent_roles should
+        only be called on the directly affected ObjectRole, not on the ancestor
+        ObjectRoles returned by bulk_ancestor_roles."""
+        from unittest.mock import patch as mock_patch
+
+        from ansible_base.rbac.caching import bulk_ancestor_roles
+
+        org_team_member_rd.give_permission(team, organization)
+
+        ancestor_roles = bulk_ancestor_roles({team.pk})
+        assert len(ancestor_roles) > 0, "Test requires ancestor roles to exist"
+
+        ancestor_pks = {r.pk for r in ancestor_roles}
+        called_on_pks = []
+        original_descendent = ObjectRole.descendent_roles
+
+        def tracking_descendent(self):
+            called_on_pks.append(self.pk)
+            return original_descendent(self)
+
+        with mock_patch.object(ObjectRole, 'descendent_roles', tracking_descendent):
+            inv_rd.give_permission(team, inventory)
+
+        for pk in called_on_pks:
+            assert pk not in ancestor_pks, (
+                f"descendent_roles() was called on ancestor ObjectRole pk={pk}; " f"this causes O(ancestors × descendants) recomputation"
+            )


### PR DESCRIPTION
## Summary

- Fix `_recompute_after_give()` in `pipeline.py` to only expand `descendent_roles()` on directly affected ObjectRoles, not on ancestor roles returned by `bulk_ancestor_roles()`
- The buggy ordering (ancestors first, then expand all) caused O(ancestors × descendants) RoleEvaluation recomputations per team assignment instead of O(direct_descendants + ancestors)
- This matches `_recompute_after_remove()`'s correct pattern and the pre-AAP-85067 behavior in `needed_updates_on_assignment()`

### Root Cause

AAP-85067 refactored `give_permission` into `pipeline.py`. The new `_recompute_after_give()` added ancestor roles to the update set **before** the descendant expansion loop, so `descendent_roles()` was called on every ancestor ObjectRole — not just the directly affected ones.

At scale (131 orgs, 2,969 teams), an org-level role granting team membership to 20+ teams produces dozens of descendant roles per ancestor. A single `POST /role_team_assignments/` would trigger hundreds of unnecessary `recompute_role_evaluations()` calls.

### Scale Lab Numbers (from ticket)

| Environment | Avg latency | vs stable |
|-------------|------------|-----------|
| stable (pre-AAP-85067) | 305ms | baseline |
| next (with bug) | 653ms | **2.1×** |
| devel (with bug) | 2,907ms | **9.5×** |
| under load (next) | 4,300ms avg, 10.3s max | — |

### Fix

Swap the order in `_recompute_after_give()`: expand descendants of direct roles first, **then** add ancestors (without further expansion). This is a 3-line change matching `_recompute_after_remove()`'s existing pattern.

## Test plan

- [x] New test `TestTeamAssignmentRecomputeScope::test_descendent_expansion_excludes_ancestors` — verifies `descendent_roles()` is never called on ancestor ObjectRoles. Fails on the old code, passes on the fix.
- [x] All 662 RBAC tests pass (661 existing + 1 new)
- [ ] Scale Lab validation: re-run Elijah's reproducer script on patched build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved role assignment recalculation to apply descendant roles only to directly affected roles.
  - Prevented ancestor roles from being incorrectly included during descendant-role processing.

- **Tests**
  - Added coverage confirming team assignments to inventory roles use the correct recalculation scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->