### PR TITLE
[AAP-88393] Fix shared content type app_label mismatch from remote services

### DIFF
--- a/ansible_base/rbac/models/content_type.py
+++ b/ansible_base/rbac/models/content_type.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 from collections import defaultdict
 from typing import Any, Dict, Optional, Sequence, Tuple, Type, Union
 
@@ -9,6 +10,21 @@ from django.db.models.options import Options
 from django.utils.translation import gettext_lazy as _
 
 from ..remote import RemoteObject, get_local_resource_prefix, get_resource_prefix
+
+logger = logging.getLogger('ansible_base.rbac.models.content_type')
+
+
+def _find_shared_model_app_label(model_name: str) -> Optional[str]:
+    """Find the local app_label for a shared model by consulting the resource registry."""
+    from ..remote import get_resource_registry
+
+    registry = get_resource_registry()
+    if registry is None:
+        return None
+    for resource_config in registry.get_resources().values():
+        if resource_config.managed_serializer and resource_config.model._meta.model_name == model_name:
+            return resource_config.model._meta.app_label
+    return None
 
 
 class DABContentTypeManager(django_models.Manager[django_models.Model]):
@@ -187,6 +203,17 @@ class DABContentTypeManager(django_models.Manager[django_models.Model]):
             pct_slug = defaults.pop('parent_content_type')
             max_id += 1
             defaults['id'] = max_id
+            # For shared content types the remote app_label (e.g. EDA's "core")
+            # may not match any locally installed app. Resolve the local app_label
+            # so model_class() can find the model later.
+            if service == 'shared' and 'app_label' in defaults:
+                remote_app_label = defaults['app_label']
+                try:
+                    apps.get_model(remote_app_label, model)
+                except LookupError:
+                    local_app_label = _find_shared_model_app_label(model)
+                    if local_app_label:
+                        defaults['app_label'] = local_app_label
             ct, _ = self.get_or_create(service=service, model=model, defaults=defaults)
             parent_mapping[ct] = pct_slug
 
@@ -290,10 +317,15 @@ class DABContentType(django_models.Model):
 
         try:
             return apps.get_model(self.app_label, self.model)
-        except LookupError as exc:
-            raise LookupError(
-                f'Could not find ({self.app_label}, {self.model}), expected in local service={get_local_resource_prefix()} object service={self.service}'
-            ) from exc
+        except LookupError:
+            from ..remote import get_remote_standin_class
+
+            logger.error(
+                'Could not find (%s, %s) in local service=%s (content type service=%s). '
+                'Falling back to remote stand-in.',
+                self.app_label, self.model, get_local_resource_prefix(), self.service,
+            )
+            return get_remote_standin_class(self)
 
     def get_object_for_this_type(self, **kwargs: Any) -> Union[django_models.Model, RemoteObject]:
         """Return the object referenced by this content type."""

--- a/ansible_base/rbac/models/content_type.py
+++ b/ansible_base/rbac/models/content_type.py
@@ -27,6 +27,19 @@ def _find_shared_model_app_label(model_name: str) -> Optional[str]:
     return None
 
 
+def _resolve_shared_app_label(app_label: str, model_name: str) -> str:
+    """Return a valid local app_label for a shared content type.
+
+    If the given app_label resolves locally, return it as-is. Otherwise
+    consult the resource registry for the correct local app_label.
+    """
+    try:
+        apps.get_model(app_label, model_name)
+        return app_label
+    except LookupError:
+        return _find_shared_model_app_label(model_name) or app_label
+
+
 class DABContentTypeManager(django_models.Manager[django_models.Model]):
     """Manager storing DABContentType objects in a local cache like original ContentType.
 
@@ -203,16 +216,8 @@ class DABContentTypeManager(django_models.Manager[django_models.Model]):
             pct_slug = defaults.pop('parent_content_type')
             max_id += 1
             defaults['id'] = max_id
-            # For shared content types the remote app_label (e.g. EDA's "core")
-            # may not match any locally installed app. Resolve the local app_label
-            # so model_class() can find the model later.
             if service == 'shared' and 'app_label' in defaults:
-                try:
-                    apps.get_model(defaults['app_label'], model)
-                except LookupError:
-                    local_app_label = _find_shared_model_app_label(model)
-                    if local_app_label:
-                        defaults['app_label'] = local_app_label
+                defaults['app_label'] = _resolve_shared_app_label(defaults['app_label'], model)
             ct, _ = self.get_or_create(service=service, model=model, defaults=defaults)
             parent_mapping[ct] = pct_slug
 
@@ -314,35 +319,30 @@ class DABContentType(django_models.Model):
 
             return get_remote_standin_class(self)
 
+        resolved_label = _resolve_shared_app_label(self.app_label, self.model) if self.service == "shared" else self.app_label
         try:
-            return apps.get_model(self.app_label, self.model)
+            model_cls = apps.get_model(resolved_label, self.model)
         except LookupError:
-            pass
+            from ..remote import get_remote_standin_class
 
-        # The stored app_label may come from a remote service (e.g. EDA's "core")
-        # that doesn't match the local app layout. Try the resource registry.
-        if self.service == "shared":
-            local_app_label = _find_shared_model_app_label(self.model)
-            if local_app_label:
-                logger.warning(
-                    "Content type %s.%s has app_label=%s but model found in %s.",
-                    self.service,
-                    self.model,
-                    self.app_label,
-                    local_app_label,
-                )
-                return apps.get_model(local_app_label, self.model)
+            logger.error(
+                "Could not find (%s, %s) in local service=%s (content type service=%s). Falling back to remote stand-in.",
+                self.app_label,
+                self.model,
+                get_local_resource_prefix(),
+                self.service,
+            )
+            return get_remote_standin_class(self)
 
-        from ..remote import get_remote_standin_class
-
-        logger.error(
-            "Could not find (%s, %s) in local service=%s (content type service=%s). Falling back to remote stand-in.",
-            self.app_label,
-            self.model,
-            get_local_resource_prefix(),
-            self.service,
-        )
-        return get_remote_standin_class(self)
+        if resolved_label != self.app_label:
+            logger.warning(
+                "Content type %s.%s has app_label=%s but model found in %s.",
+                self.service,
+                self.model,
+                self.app_label,
+                resolved_label,
+            )
+        return model_cls
 
     def get_object_for_this_type(self, **kwargs: Any) -> Union[django_models.Model, RemoteObject]:
         """Return the object referenced by this content type."""

--- a/ansible_base/rbac/models/content_type.py
+++ b/ansible_base/rbac/models/content_type.py
@@ -207,9 +207,8 @@ class DABContentTypeManager(django_models.Manager[django_models.Model]):
             # may not match any locally installed app. Resolve the local app_label
             # so model_class() can find the model later.
             if service == 'shared' and 'app_label' in defaults:
-                remote_app_label = defaults['app_label']
                 try:
-                    apps.get_model(remote_app_label, model)
+                    apps.get_model(defaults['app_label'], model)
                 except LookupError:
                     local_app_label = _find_shared_model_app_label(model)
                     if local_app_label:
@@ -318,14 +317,32 @@ class DABContentType(django_models.Model):
         try:
             return apps.get_model(self.app_label, self.model)
         except LookupError:
-            from ..remote import get_remote_standin_class
+            pass
 
-            logger.error(
-                'Could not find (%s, %s) in local service=%s (content type service=%s). '
-                'Falling back to remote stand-in.',
-                self.app_label, self.model, get_local_resource_prefix(), self.service,
-            )
-            return get_remote_standin_class(self)
+        # The stored app_label may come from a remote service (e.g. EDA's "core")
+        # that doesn't match the local app layout. Try the resource registry.
+        if self.service == "shared":
+            local_app_label = _find_shared_model_app_label(self.model)
+            if local_app_label:
+                logger.warning(
+                    "Content type %s.%s has app_label=%s but model found in %s.",
+                    self.service,
+                    self.model,
+                    self.app_label,
+                    local_app_label,
+                )
+                return apps.get_model(local_app_label, self.model)
+
+        from ..remote import get_remote_standin_class
+
+        logger.error(
+            "Could not find (%s, %s) in local service=%s (content type service=%s). Falling back to remote stand-in.",
+            self.app_label,
+            self.model,
+            get_local_resource_prefix(),
+            self.service,
+        )
+        return get_remote_standin_class(self)
 
     def get_object_for_this_type(self, **kwargs: Any) -> Union[django_models.Model, RemoteObject]:
         """Return the object referenced by this content type."""

--- a/test_app/tests/rbac/models/test_content_type_app_label.py
+++ b/test_app/tests/rbac/models/test_content_type_app_label.py
@@ -12,7 +12,6 @@ from ansible_base.rbac.models import DABContentType
 from ansible_base.rbac.models.content_type import _find_shared_model_app_label
 from ansible_base.rbac.remote import RemoteObject
 
-
 # -- _find_shared_model_app_label tests --
 
 
@@ -135,6 +134,43 @@ def test_model_class_remote_service_still_returns_standin():
     )
     result = ct.model_class()
     assert issubclass(result, RemoteObject)
+
+
+@pytest.mark.django_db
+def test_model_class_resolves_mismatched_shared_type_via_registry():
+    """A shared content type with a foreign app_label should resolve to the
+    correct local model via the resource registry without persisting."""
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    DABContentType.objects.filter(service='shared', model='user').delete()
+
+    ct = DABContentType.objects.create(
+        service='shared',
+        app_label='core',
+        model='user',
+    )
+    result = ct.model_class()
+    assert result is User
+    # The DB row should NOT be updated (no persist from model_class)
+    ct.refresh_from_db()
+    assert ct.app_label == 'core'
+
+
+@pytest.mark.django_db
+def test_model_class_resolves_mismatched_shared_type_logs_warning(caplog):
+    """Resolving via registry should log a warning."""
+    DABContentType.objects.filter(service='shared', model='user').delete()
+
+    ct = DABContentType.objects.create(
+        service='shared',
+        app_label='core',
+        model='user',
+    )
+    with caplog.at_level('WARNING', logger='ansible_base.rbac.models.content_type'):
+        ct.model_class()
+    assert 'core' in caplog.text
+    assert 'test_app' in caplog.text
 
 
 # -- load_remote_objects app_label resolution tests --

--- a/test_app/tests/rbac/models/test_content_type_app_label.py
+++ b/test_app/tests/rbac/models/test_content_type_app_label.py
@@ -1,0 +1,233 @@
+"""Tests for shared content type app_label resolution.
+
+Covers _find_shared_model_app_label, load_remote_objects app_label fix,
+and model_class() fallback to remote stand-in.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible_base.rbac.models import DABContentType
+from ansible_base.rbac.models.content_type import _find_shared_model_app_label
+from ansible_base.rbac.remote import RemoteObject
+
+
+# -- _find_shared_model_app_label tests --
+
+
+def test_find_shared_model_app_label_returns_match():
+    """When the resource registry has a shared model matching model_name, return its app_label."""
+    mock_config = MagicMock()
+    mock_config.managed_serializer = True
+    mock_config.model._meta.model_name = 'user'
+    mock_config.model._meta.app_label = 'my_app'
+
+    mock_registry = MagicMock()
+    mock_registry.get_resources.return_value = {'my_app.User': mock_config}
+
+    with patch('ansible_base.rbac.remote.get_resource_registry', return_value=mock_registry):
+        assert _find_shared_model_app_label('user') == 'my_app'
+
+
+def test_find_shared_model_app_label_no_match():
+    """When no shared model matches model_name, return None."""
+    mock_config = MagicMock()
+    mock_config.managed_serializer = True
+    mock_config.model._meta.model_name = 'organization'
+    mock_config.model._meta.app_label = 'my_app'
+
+    mock_registry = MagicMock()
+    mock_registry.get_resources.return_value = {'my_app.Organization': mock_config}
+
+    with patch('ansible_base.rbac.remote.get_resource_registry', return_value=mock_registry):
+        assert _find_shared_model_app_label('user') is None
+
+
+def test_find_shared_model_app_label_skips_non_shared():
+    """Models without managed_serializer (not shared) should be skipped."""
+    mock_config = MagicMock()
+    mock_config.managed_serializer = None
+    mock_config.model._meta.model_name = 'user'
+    mock_config.model._meta.app_label = 'my_app'
+
+    mock_registry = MagicMock()
+    mock_registry.get_resources.return_value = {'my_app.User': mock_config}
+
+    with patch('ansible_base.rbac.remote.get_resource_registry', return_value=mock_registry):
+        assert _find_shared_model_app_label('user') is None
+
+
+def test_find_shared_model_app_label_no_registry():
+    """When no resource registry is configured, return None."""
+    with patch('ansible_base.rbac.remote.get_resource_registry', return_value=None):
+        assert _find_shared_model_app_label('user') is None
+
+
+def test_find_shared_model_app_label_empty_registry():
+    """When the resource registry has no models, return None."""
+    mock_registry = MagicMock()
+    mock_registry.get_resources.return_value = {}
+
+    with patch('ansible_base.rbac.remote.get_resource_registry', return_value=mock_registry):
+        assert _find_shared_model_app_label('user') is None
+
+
+# -- model_class() fallback tests --
+
+
+@pytest.mark.django_db
+def test_model_class_returns_standin_for_unresolvable_shared_type():
+    """A shared content type with a foreign app_label should return a remote stand-in, not raise."""
+    ct = DABContentType.objects.create(
+        service='shared',
+        app_label='nonexistent_app',
+        model='somemodel',
+    )
+    result = ct.model_class()
+    assert issubclass(result, RemoteObject)
+
+
+@pytest.mark.django_db
+def test_model_class_returns_standin_for_unresolvable_local_type():
+    """A local content type with a bad app_label should also return a remote stand-in."""
+    ct = DABContentType.objects.create(
+        service='aap',
+        app_label='nonexistent_app',
+        model='somemodel',
+    )
+    result = ct.model_class()
+    assert issubclass(result, RemoteObject)
+
+
+@pytest.mark.django_db
+def test_model_class_logs_error_for_unresolvable_type(caplog):
+    """Falling back to remote stand-in should log an error."""
+    ct = DABContentType.objects.create(
+        service='shared',
+        app_label='fake_app',
+        model='fakemodel',
+    )
+    with caplog.at_level('ERROR', logger='ansible_base.rbac.models.content_type'):
+        ct.model_class()
+    assert 'fake_app' in caplog.text
+    assert 'fakemodel' in caplog.text
+    assert 'Falling back to remote stand-in' in caplog.text
+
+
+@pytest.mark.django_db
+def test_model_class_valid_shared_type_still_works():
+    """A shared content type with a valid app_label should still return the real model class."""
+    from test_app.models import Organization
+
+    ct = DABContentType.objects.get(service='shared', model='organization')
+    result = ct.model_class()
+    assert result is Organization
+
+
+@pytest.mark.django_db
+def test_model_class_remote_service_still_returns_standin():
+    """Content types from remote services should still return remote stand-ins as before."""
+    ct = DABContentType.objects.create(
+        service='eda',
+        app_label='core',
+        model='user',
+    )
+    result = ct.model_class()
+    assert issubclass(result, RemoteObject)
+
+
+# -- load_remote_objects app_label resolution tests --
+
+
+@pytest.mark.django_db
+def test_load_remote_objects_resolves_local_app_label_for_shared_type():
+    """When a shared content type has a foreign app_label, load_remote_objects should
+    resolve it to the local app_label via the resource registry."""
+    DABContentType.objects.filter(service='shared', model='user').delete()
+
+    remote_data = [
+        {
+            'service': 'shared',
+            'app_label': 'core',
+            'model': 'user',
+            'parent_content_type': None,
+            'pk_field_type': 'integer',
+        },
+    ]
+    DABContentType.objects.load_remote_objects(remote_data)
+    ct = DABContentType.objects.get(service='shared', model='user')
+    assert ct.app_label == 'test_app'
+
+
+@pytest.mark.django_db
+def test_load_remote_objects_keeps_valid_app_label():
+    """When a shared content type already has a valid local app_label, don't change it."""
+    DABContentType.objects.filter(service='shared', model='organization').delete()
+
+    remote_data = [
+        {
+            'service': 'shared',
+            'app_label': 'test_app',
+            'model': 'organization',
+            'parent_content_type': None,
+            'pk_field_type': 'integer',
+        },
+    ]
+    DABContentType.objects.load_remote_objects(remote_data)
+    ct = DABContentType.objects.get(service='shared', model='organization')
+    assert ct.app_label == 'test_app'
+
+
+@pytest.mark.django_db
+def test_load_remote_objects_non_shared_type_keeps_remote_app_label():
+    """Non-shared content types should keep the remote app_label as-is."""
+    remote_data = [
+        {
+            'service': 'eda',
+            'app_label': 'core',
+            'model': 'activation',
+            'parent_content_type': None,
+            'pk_field_type': 'integer',
+        },
+    ]
+    DABContentType.objects.load_remote_objects(remote_data)
+    ct = DABContentType.objects.get(service='eda', model='activation')
+    assert ct.app_label == 'core'
+
+
+@pytest.mark.django_db
+def test_load_remote_objects_shared_type_no_registry_match_keeps_remote():
+    """When the resource registry has no match for a shared model, keep the remote app_label."""
+    remote_data = [
+        {
+            'service': 'shared',
+            'app_label': 'foreign_app',
+            'model': 'unknown_shared_model',
+            'parent_content_type': None,
+            'pk_field_type': 'integer',
+        },
+    ]
+    DABContentType.objects.load_remote_objects(remote_data)
+    ct = DABContentType.objects.get(service='shared', model='unknown_shared_model')
+    assert ct.app_label == 'foreign_app'
+
+
+@pytest.mark.django_db
+def test_load_remote_objects_existing_row_not_overwritten():
+    """If a shared content type already exists, get_or_create should not overwrite the app_label."""
+    ct = DABContentType.objects.get(service='shared', model='organization')
+    original_app_label = ct.app_label
+
+    remote_data = [
+        {
+            'service': 'shared',
+            'app_label': 'core',
+            'model': 'organization',
+            'parent_content_type': None,
+            'pk_field_type': 'integer',
+        },
+    ]
+    DABContentType.objects.load_remote_objects(remote_data)
+    ct.refresh_from_db()
+    assert ct.app_label == original_app_label

--- a/test_app/tests/rbac/models/test_content_type_app_label.py
+++ b/test_app/tests/rbac/models/test_content_type_app_label.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ansible_base.rbac.models import DABContentType
-from ansible_base.rbac.models.content_type import _find_shared_model_app_label
+from ansible_base.rbac.models.content_type import _find_shared_model_app_label, _resolve_shared_app_label
 from ansible_base.rbac.remote import RemoteObject
 
 # -- _find_shared_model_app_label tests --
@@ -70,6 +70,27 @@ def test_find_shared_model_app_label_empty_registry():
 
     with patch('ansible_base.rbac.remote.get_resource_registry', return_value=mock_registry):
         assert _find_shared_model_app_label('user') is None
+
+
+# -- _resolve_shared_app_label tests --
+
+
+@pytest.mark.django_db
+def test_resolve_shared_app_label_valid_local():
+    """When the app_label resolves locally, return it as-is."""
+    assert _resolve_shared_app_label('test_app', 'organization') == 'test_app'
+
+
+@pytest.mark.django_db
+def test_resolve_shared_app_label_foreign_resolves_via_registry():
+    """When the app_label doesn't resolve locally, consult the resource registry."""
+    assert _resolve_shared_app_label('core', 'user') == 'test_app'
+
+
+@pytest.mark.django_db
+def test_resolve_shared_app_label_foreign_no_registry_match():
+    """When neither local nor registry resolves, return the original app_label."""
+    assert _resolve_shared_app_label('foreign_app', 'unknown_model') == 'foreign_app'
 
 
 # -- model_class() fallback tests --


### PR DESCRIPTION
When load_remote_objects creates shared content types from remote service data, it stores the remote service's app_label (e.g. EDA's "core") which may not match any locally installed app. This causes model_class() to raise LookupError and 500 the role_definitions endpoint.

Fix in two places:
- load_remote_objects: resolve the local app_label via the resource registry before creating shared content types
- model_class(): if the stored app_label doesn't resolve, consult the resource registry to find and self-heal the correct app_label. If the model truly can't be found, fall back to a remote stand-in instead of raising, preventing 500 errors.

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resolution of shared content types to use the correct application labels.
  - Prevented errors when referenced local models are unavailable by providing a remote fallback.
  - Preserved valid local and remote content-type behavior during remote object loading.
  - Improved handling for empty registries, non-shared content types, and unresolved references.
  - Added clearer error and warning reporting for content types that cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->