### PR TITLE
AAP-88824 Drop Python 3.11 from CI and project metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - env: py311-check
-            python-version: "3.11"
-            sonar: false
-            junit-xml-upload: false
           - env: py312-check
             python-version: "3.12"
-            sonar: false
-            junit-xml-upload: false
-          - env: py311
-            python-version: "3.11"
             sonar: false
             junit-xml-upload: false
           - env: py312
             python-version: "3.12"
             sonar: true
             junit-xml-upload: true
-          - env: py311-sqlite
-            python-version: "3.11"
-            sonar: false
-            junit-xml-upload: false
           - env: py312-sqlite
             python-version: "3.12"
             sonar: false
@@ -115,8 +103,6 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - env: py311-in-files
-            python-version: "3.11"
           - env: py312-in-files
             python-version: "3.12"
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A Django app used by ansible services"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 keywords = ["ansible", "django"]
 license = {text = "Apache-2.0"}
 classifiers = [
@@ -23,7 +23,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 dynamic = ["version", "dependencies", "optional-dependencies"]
@@ -98,16 +97,12 @@ legacy_tox_ini = """
     min_version = 4.0
     no_package = true
     env_list =
-        py311-check
         py312-check
-        py311
         py312
-        py311-sqlite
         py312-sqlite
-        py311-in-files
         py312-in-files
     labels =
-        test = py311-check, py312-check, py311, py312, py311-sqlite, py312-sqlite, py311-in-files, py312-in-files
+        test = py312-check, py312, py312-sqlite, py312-in-files
         lint = flake8, black, isort
 
     [testenv]
@@ -118,7 +113,7 @@ legacy_tox_ini = """
     commands = pytest -n auto --color=yes --cov=. --cov-report=xml:coverage.xml --cov-report=html --cov-report=json --cov-branch --junit-xml=django-ansible-base-test-results.xml {env:ANSIBLE_BASE_PYTEST_ARGS} {env:ANSIBLE_BASE_TEST_DIRS:test_app/tests} {posargs}
     docker = db
 
-    [testenv:py311-check,py312-check]
+    [testenv:py312-check]
     deps =
         -r{toxinidir}/requirements/requirements_all.txt
         -r{toxinidir}/requirements/requirements_dev.txt
@@ -127,12 +122,12 @@ legacy_tox_ini = """
         python3 manage.py check
         python3 manage.py makemigrations --check
 
-    [testenv:py311-sqlite,py312-sqlite]
+    [testenv:py312-sqlite]
     docker = db
     setenv =
         DJANGO_SETTINGS_MODULE = test_app.sqlite3settings
 
-    [testenv:py311-in-files,py312-in-files]
+    [testenv:py312-in-files]
     deps =
         -r{toxinidir}/requirements/requirements.in
         -r{toxinidir}/requirements/requirements_activitystream.in


### PR DESCRIPTION
## Summary
- Bump `requires-python` from `>=3.11` to `>=3.12`
- Remove all `py311` tox environments (check, default, sqlite, in-files)
- Remove Python 3.11 CI matrix entries (3 from `tox` job, 1 from `canary-deps`)
- Drop `Programming Language :: Python :: 3.11` classifier

All DAB consumers (aap-gateway, galaxy_ng) have moved to 3.12+. AWX and eda-server are actively migrating.

## Test plan
- [ ] CI passes with only py312 matrix entries
- [ ] `tox -l` shows only py312 envs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Python versions to Python 3.12 and newer.
  * Simplified automated testing environments to focus on Python 3.12.
  * Updated test environment labels and reporting configuration accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->