### PR TITLE
AAP-89166 fix: honour _skip_reverse_resource_sync class flag in pre_save and pre_delete handlers

### DIFF
--- a/ansible_base/resource_registry/signals/handlers.py
+++ b/ansible_base/resource_registry/signals/handlers.py
@@ -62,6 +62,12 @@ def decide_to_sync_update(sender, instance, raw, using, update_fields, **kwargs)
         # We only concern ourselves with updates
         return
 
+    # A class-level flag signals that this model is registered for UUID generation
+    # only and has no managed_serializer. For those models serializer_class is None,
+    # and calling it below raises TypeError. Skip the whole handler.
+    if getattr(type(instance), '_skip_reverse_resource_sync', False):
+        return
+
     try:
         resource = Resource.get_resource_for_object(instance)
     except Resource.DoesNotExist:
@@ -181,4 +187,17 @@ def sync_to_resource_server_pre_delete(sender, instance, **kwargs):
     if not reverse_sync_enabled:
         return
 
-    sync_to_resource_server(instance, "delete", ansible_id=instance.resource.ansible_id)
+    # Same class-level opt-out as decide_to_sync_update — models registered without
+    # a managed_serializer skip reverse sync entirely.
+    if getattr(type(instance), '_skip_reverse_resource_sync', False):
+        return
+
+    # Use get_resource_for_object rather than instance.resource — Resource uses
+    # GenericForeignKey so there is no automatic reverse accessor on the instance.
+    try:
+        resource = Resource.get_resource_for_object(instance)
+    except Resource.DoesNotExist:
+        logger.warning(f"Resource for {instance} not found during pre_delete; skipping sync")
+        return
+
+    sync_to_resource_server(instance, "delete", ansible_id=resource.ansible_id)

--- a/test_app/tests/resource_registry/test_signals.py
+++ b/test_app/tests/resource_registry/test_signals.py
@@ -42,7 +42,7 @@ def test_registered_model_triggers_signals(model, system_user):
 
 
 @pytest.mark.django_db
-def test_decide_to_sync_update_skips_class_level_flag(organization):
+def test_decide_to_sync_update_skips_class_level_flag(organization, monkeypatch):
     """decide_to_sync_update returns before touching serializer_class when the model sets the flag at the class level.
 
     Models registered without a managed_serializer (serializer_class=None) set
@@ -52,24 +52,21 @@ def test_decide_to_sync_update_skips_class_level_flag(organization):
     Without this fix, the handler would reach serializer_class().get_fields() and raise:
         TypeError: 'NoneType' object is not callable
     """
-    Organization._skip_reverse_resource_sync = True
-    try:
-        with mock.patch.object(handlers, 'Resource') as mock_resource:
-            organization.name = 'changed'
-            handlers.decide_to_sync_update(
-                sender=Organization,
-                instance=organization,
-                raw=False,
-                using='default',
-                update_fields=None,
-            )
-        mock_resource.get_resource_for_object.assert_not_called()
-    finally:
-        del Organization._skip_reverse_resource_sync
+    monkeypatch.setattr(Organization, '_skip_reverse_resource_sync', True, raising=False)
+    with mock.patch.object(handlers, 'Resource') as mock_resource:
+        organization.name = 'changed'
+        handlers.decide_to_sync_update(
+            sender=Organization,
+            instance=organization,
+            raw=False,
+            using='default',
+            update_fields=None,
+        )
+    mock_resource.get_resource_for_object.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_pre_delete_sync_skips_class_level_flag(organization):
+def test_pre_delete_sync_skips_class_level_flag(organization, monkeypatch):
     """sync_to_resource_server_pre_delete returns early when the model sets the flag at the class level.
 
     Models that opt out of reverse sync must not trigger a Gateway sync on delete.
@@ -79,13 +76,10 @@ def test_pre_delete_sync_skips_class_level_flag(organization):
         AttributeError: '<Model>' object has no attribute 'resource'
     (Resource uses GenericForeignKey — no automatic reverse accessor exists on the instance.)
     """
-    Organization._skip_reverse_resource_sync = True
-    try:
-        with mock.patch('ansible_base.resource_registry.signals.handlers.sync_to_resource_server') as mock_sync:
-            handlers.sync_to_resource_server_pre_delete(sender=Organization, instance=organization)
-        mock_sync.assert_not_called()
-    finally:
-        del Organization._skip_reverse_resource_sync
+    monkeypatch.setattr(Organization, '_skip_reverse_resource_sync', True, raising=False)
+    with mock.patch('ansible_base.resource_registry.signals.handlers.sync_to_resource_server') as mock_sync:
+        handlers.sync_to_resource_server_pre_delete(sender=Organization, instance=organization)
+    mock_sync.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/test_app/tests/resource_registry/test_signals.py
+++ b/test_app/tests/resource_registry/test_signals.py
@@ -42,6 +42,53 @@ def test_registered_model_triggers_signals(model, system_user):
 
 
 @pytest.mark.django_db
+def test_decide_to_sync_update_skips_class_level_flag(organization):
+    """decide_to_sync_update returns before touching serializer_class when the model sets the flag at the class level.
+
+    Models registered without a managed_serializer (serializer_class=None) set
+    _skip_reverse_resource_sync=True on the class to opt out of reverse sync.
+    The handler must bail before calling serializer_class(), which raises TypeError when None.
+
+    Without this fix, the handler would reach serializer_class().get_fields() and raise:
+        TypeError: 'NoneType' object is not callable
+    """
+    Organization._skip_reverse_resource_sync = True
+    try:
+        with mock.patch.object(handlers, 'Resource') as mock_resource:
+            organization.name = 'changed'
+            handlers.decide_to_sync_update(
+                sender=Organization,
+                instance=organization,
+                raw=False,
+                using='default',
+                update_fields=None,
+            )
+        mock_resource.get_resource_for_object.assert_not_called()
+    finally:
+        del Organization._skip_reverse_resource_sync
+
+
+@pytest.mark.django_db
+def test_pre_delete_sync_skips_class_level_flag(organization):
+    """sync_to_resource_server_pre_delete returns early when the model sets the flag at the class level.
+
+    Models that opt out of reverse sync must not trigger a Gateway sync on delete.
+    The flag check must occur before any Resource lookup or sync_to_resource_server call.
+
+    Without this fix, the handler would reach instance.resource.ansible_id and raise:
+        AttributeError: '<Model>' object has no attribute 'resource'
+    (Resource uses GenericForeignKey — no automatic reverse accessor exists on the instance.)
+    """
+    Organization._skip_reverse_resource_sync = True
+    try:
+        with mock.patch('ansible_base.resource_registry.signals.handlers.sync_to_resource_server') as mock_sync:
+            handlers.sync_to_resource_server_pre_delete(sender=Organization, instance=organization)
+        mock_sync.assert_not_called()
+    finally:
+        del Organization._skip_reverse_resource_sync
+
+
+@pytest.mark.django_db
 def test_decide_to_sync_update_with_create(enable_reverse_sync):
     with enable_reverse_sync(mock_away_sync=True):
         org = Organization.objects.create(name='Hello')

--- a/test_app/tests/resource_registry/test_signals.py
+++ b/test_app/tests/resource_registry/test_signals.py
@@ -89,6 +89,34 @@ def test_pre_delete_sync_skips_class_level_flag(organization):
 
 
 @pytest.mark.django_db
+def test_pre_delete_sync_resource_not_found(organization):
+    """sync_to_resource_server_pre_delete logs a warning and skips sync when the Resource row is absent."""
+    with (
+        mock.patch.object(handlers, 'Resource') as mock_resource,
+        mock.patch('ansible_base.resource_registry.signals.handlers.sync_to_resource_server') as mock_sync,
+    ):
+        mock_resource.DoesNotExist = Resource.DoesNotExist
+        mock_resource.get_resource_for_object.side_effect = Resource.DoesNotExist
+        handlers.sync_to_resource_server_pre_delete(sender=Organization, instance=organization)
+    mock_sync.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_pre_delete_sync_calls_sync_to_resource_server(organization):
+    """sync_to_resource_server_pre_delete passes the resource ansible_id to sync_to_resource_server."""
+    mock_resource_obj = mock.MagicMock()
+    mock_resource_obj.ansible_id = 'test-ansible-id-123'
+    with (
+        mock.patch.object(handlers, 'Resource') as mock_resource,
+        mock.patch('ansible_base.resource_registry.signals.handlers.sync_to_resource_server') as mock_sync,
+    ):
+        mock_resource.DoesNotExist = Resource.DoesNotExist
+        mock_resource.get_resource_for_object.return_value = mock_resource_obj
+        handlers.sync_to_resource_server_pre_delete(sender=Organization, instance=organization)
+    mock_sync.assert_called_once_with(organization, "delete", ansible_id='test-ansible-id-123')
+
+
+@pytest.mark.django_db
 def test_decide_to_sync_update_with_create(enable_reverse_sync):
     with enable_reverse_sync(mock_away_sync=True):
         org = Organization.objects.create(name='Hello')


### PR DESCRIPTION
Fixes the root cause of PATCH/PUT and DELETE returning 500 for Namespace in Hub (AAP-89166).

## What's going on

Hub recently registered `Namespace` in the resource registry so it can generate stable UUIDs for each namespace — these UUIDs are needed so the Gateway assignment sync can resolve `object_ansible_id` back to a local Namespace instance (AAP-77392). Namespaces are a Hub-only concept though, Gateway has no handler for them, so there's nothing to push upstream. That's why `_skip_reverse_resource_sync = True` is set on the model class — it's the intended opt-out.

The problem is that two signal handlers weren't checking the flag before doing things that crash for this kind of "lightweight" registration (registered for UUID generation only, no managed serializer):

- **`decide_to_sync_update` (pre_save)** — calls `serializer_class().get_fields()` before checking anything. No managed serializer means `serializer_class` is `None`. Calling `None()` raises `TypeError`. Every PATCH/PUT on a Namespace returned 500.
- **`sync_to_resource_server_pre_delete` (pre_delete)** — called `instance.resource.ansible_id` directly. `Resource` uses a `GenericForeignKey` so there's no automatic reverse accessor on the instance. `AttributeError`. Every DELETE on a Namespace returned 500.

## Changes

- `decide_to_sync_update`: check `_skip_reverse_resource_sync` at the class level before touching `serializer_class`
- `sync_to_resource_server_pre_delete`: same class-level check; also replaces `instance.resource.ansible_id` with `Resource.get_resource_for_object()` — `GenericForeignKey` never provided a reverse accessor so the original line was fragile for all models, not just Namespace
- Two new tests covering both handlers with the class-level flag set, with comments documenting the exact exception each path raised before the fix

## Backward compatibility

No behaviour change for any existing model — `getattr(type(instance), '_skip_reverse_resource_sync', False)` returns `False` for all currently registered models (User, Team, Organization, etc.) so both early returns are no-ops for them. The `get_resource_for_object()` swap is functionally equivalent for models where the lookup succeeds, and strictly better for models where it doesn't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization handling for models configured to skip reverse resource synchronization.
  - Prevented errors when deleting objects without an associated resource.
  - Added warning handling when no matching resource is found.
  - Ensured deletions synchronize using the correct associated resource identifier when available.

- **Tests**
  - Added coverage for skipped synchronization, missing resources, and successful deletion synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->