### PR TITLE
AAP-90129 Fix RBAC bulk assignment OR-of-pairs filter exceeding SQLite depth limit

### DIFF
--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -260,7 +260,7 @@ class RoleDefinition(CommonModel):
         return assignment
 
     def give_permission(self, actor, content_object):
-        from ansible_base.rbac.pipeline import bulk_give_permissions
+        from ansible_base.rbac.pipeline import _resolve_content_object, bulk_give_permissions
 
         is_user = actor._meta.model_name == 'user'
         perm = [(self, actor, content_object)]
@@ -273,9 +273,14 @@ class RoleDefinition(CommonModel):
         # The assignment already existed. The bulk path returns only newly-created rows
         # (bulk_create can't report skipped ones), so fetch the existing one -- this path is
         # a single row, so the lookup that doesn't scale in bulk is fine here.
-        model = RoleUserAssignment if is_user else RoleTeamAssignment
-        actor_field = 'user' if is_user else 'team'
-        return model.objects.get(role_definition=self, object_id=content_object.pk, **{actor_field: actor})
+        # Resolve content_type/object_id the same way the pipeline stores them: object_id is a
+        # normalized string, so passing a raw non-integer pk (e.g. a UUID) here would not match.
+        content_type, object_id, _ = _resolve_content_object(content_object)
+        if is_user:
+            qs = RoleUserAssignment.objects.filter(user=actor)
+        else:
+            qs = RoleTeamAssignment.objects.filter(team=actor)
+        return qs.get(role_definition=self, content_type=content_type, object_id=object_id)
 
     def remove_permission(self, actor, content_object):
         from ansible_base.rbac.pipeline import bulk_remove_permissions

--- a/ansible_base/rbac/models/role.py
+++ b/ansible_base/rbac/models/role.py
@@ -268,7 +268,14 @@ class RoleDefinition(CommonModel):
             user_permissions=perm if is_user else [],
             team_permissions=[] if is_user else perm,
         )
-        return assignments[0]
+        if assignments:
+            return assignments[0]
+        # The assignment already existed. The bulk path returns only newly-created rows
+        # (bulk_create can't report skipped ones), so fetch the existing one -- this path is
+        # a single row, so the lookup that doesn't scale in bulk is fine here.
+        model = RoleUserAssignment if is_user else RoleTeamAssignment
+        actor_field = 'user' if is_user else 'team'
+        return model.objects.get(role_definition=self, object_id=content_object.pk, **{actor_field: actor})
 
     def remove_permission(self, actor, content_object):
         from ansible_base.rbac.pipeline import bulk_remove_permissions

--- a/ansible_base/rbac/pipeline.py
+++ b/ansible_base/rbac/pipeline.py
@@ -165,10 +165,10 @@ def _insert_new(assignments: list[AssignmentBase], actor_id_field: str, model: t
     reports neither which rows it skipped nor their PKs, and fetching them back is precisely
     the query that does not scale (an OR-of-pairs SQLite rejects past ~1000 terms). Callers
     needing a pre-existing row must fetch it themselves -- see RoleDefinition.give_permission.
-    """
-    if not assignments:
-        return []
 
+    Callers guard against the empty case (see _create_assignments), so ``assignments`` is
+    always non-empty here.
+    """
     batch_pairs = {(getattr(a, actor_id_field), a.object_role_id) for a in assignments}
     max_before = model.objects.aggregate(_m=models.Max('id'))['_m'] or 0
     model.objects.bulk_create(assignments, ignore_conflicts=True)

--- a/ansible_base/rbac/pipeline.py
+++ b/ansible_base/rbac/pipeline.py
@@ -140,31 +140,46 @@ def _ensure_object_roles(requested_assignments: list[ResolvedAssignment]) -> Obj
     return lookup
 
 
-def _audit_log_created(db_assignments: list[AssignmentBase], existing_pks: set[int]) -> None:
+def _audit_log_created(created_assignments: list[AssignmentBase]) -> None:
     """Emit audit logs for newly-created assignments (not idempotent re-assignments)."""
-    if not db_assignments or 'ansible_base.activitystream' not in settings.INSTALLED_APPS:
+    if not created_assignments or 'ansible_base.activitystream' not in settings.INSTALLED_APPS:
         return
 
     from ansible_base.activitystream.signals import _store_activitystream_entry
 
-    for assignment in db_assignments:
-        if assignment.pk not in existing_pks:
-            _store_activitystream_entry(None, assignment, 'create')
+    for assignment in created_assignments:
+        _store_activitystream_entry(None, assignment, 'create')
 
 
-def _pair_filter(assignments: list[AssignmentBase], actor_field: str) -> Q:
-    """Build a Q filter matching exact (actor, object_role) pairs — no cross-product."""
-    q = Q()
-    for a in assignments:
-        q |= Q(**{actor_field: getattr(a, actor_field), 'object_role': a.object_role})
-    return q
+def _insert_new(assignments: list[AssignmentBase], actor_id_field: str, model: type[AssignmentBase]) -> list[AssignmentBase]:
+    """Bulk-insert assignments and return only the newly-created rows.
+
+    New rows are detected by PK range -- id greater than the max seen before the insert --
+    rather than a per-pair filter, so the query is constant-size regardless of batch shape
+    (skinny or fat) and rides the existing PK index. Results are narrowed to the batch's
+    exact (actor, object_role) pairs so a row a concurrent caller commits in the id gap
+    doesn't leak in. (A genuine same-pair concurrent insert can still be double-counted as
+    created -- the same race window as before this change.)
+
+    Pre-existing pairs are deliberately NOT returned. bulk_create(ignore_conflicts=True)
+    reports neither which rows it skipped nor their PKs, and fetching them back is precisely
+    the query that does not scale (an OR-of-pairs SQLite rejects past ~1000 terms). Callers
+    needing a pre-existing row must fetch it themselves -- see RoleDefinition.give_permission.
+    """
+    if not assignments:
+        return []
+
+    batch_pairs = {(getattr(a, actor_id_field), a.object_role_id) for a in assignments}
+    max_before = model.objects.aggregate(_m=models.Max('id'))['_m'] or 0
+    model.objects.bulk_create(assignments, ignore_conflicts=True)
+
+    return [row for row in model.objects.filter(id__gt=max_before) if (getattr(row, actor_id_field), row.object_role_id) in batch_pairs]
 
 
-def _fire_post_save(db_assignments: list[AssignmentBase], existing_pks: set[int]) -> None:
+def _fire_post_save(created_assignments: list[AssignmentBase]) -> None:
     """Fire post_save signals for newly-created assignments (skipped by bulk_create)."""
-    for assignment in db_assignments:
-        if assignment.pk not in existing_pks:
-            post_save.send(sender=type(assignment), instance=assignment, created=True, raw=False, using='default', update_fields=None)
+    for assignment in created_assignments:
+        post_save.send(sender=type(assignment), instance=assignment, created=True, raw=False, using='default', update_fields=None)
 
 
 def _create_assignments(
@@ -177,53 +192,43 @@ def _create_assignments(
     created_by = current_user_or_system_user()
     all_assignments = []
 
-    user_assignments = []
-    for ra in user_resolved:
-        obj_role = lookup[(ra.role_definition.pk, ra.object_id)]
-        user_assignments.append(
-            RoleUserAssignment(
-                user=ra.actor,
-                object_role=obj_role,
-                role_definition=ra.role_definition,
-                content_type=ra.content_type,
-                object_id=ra.object_id,
-                created_by=created_by,
-            )
+    user_assignments = [
+        RoleUserAssignment(
+            user=ra.actor,
+            object_role=lookup[(ra.role_definition.pk, ra.object_id)],
+            role_definition=ra.role_definition,
+            content_type=ra.content_type,
+            object_id=ra.object_id,
+            created_by=created_by,
         )
+        for ra in user_resolved
+    ]
     if user_assignments:
-        pair_q = _pair_filter(user_assignments, 'user')
-        existing_user_pks = set(RoleUserAssignment.objects.filter(pair_q).values_list('pk', flat=True))
-        RoleUserAssignment.objects.bulk_create(user_assignments, ignore_conflicts=True)
-        db_users = list(RoleUserAssignment.objects.filter(pair_q))
-        all_assignments.extend(db_users)
+        created_users = _insert_new(user_assignments, 'user_id', RoleUserAssignment)
+        all_assignments.extend(created_users)
         if fire_signals_on_create:
-            _fire_post_save(db_users, existing_user_pks)
+            _fire_post_save(created_users)
         else:
-            _audit_log_created(db_users, existing_user_pks)
+            _audit_log_created(created_users)
 
-    team_assignments = []
-    for ra in team_resolved:
-        obj_role = lookup[(ra.role_definition.pk, ra.object_id)]
-        team_assignments.append(
-            RoleTeamAssignment(
-                team=ra.actor,
-                object_role=obj_role,
-                role_definition=ra.role_definition,
-                content_type=ra.content_type,
-                object_id=ra.object_id,
-                created_by=created_by,
-            )
+    team_assignments = [
+        RoleTeamAssignment(
+            team=ra.actor,
+            object_role=lookup[(ra.role_definition.pk, ra.object_id)],
+            role_definition=ra.role_definition,
+            content_type=ra.content_type,
+            object_id=ra.object_id,
+            created_by=created_by,
         )
+        for ra in team_resolved
+    ]
     if team_assignments:
-        pair_q = _pair_filter(team_assignments, 'team')
-        existing_team_pks = set(RoleTeamAssignment.objects.filter(pair_q).values_list('pk', flat=True))
-        RoleTeamAssignment.objects.bulk_create(team_assignments, ignore_conflicts=True)
-        db_teams = list(RoleTeamAssignment.objects.filter(pair_q))
-        all_assignments.extend(db_teams)
+        created_teams = _insert_new(team_assignments, 'team_id', RoleTeamAssignment)
+        all_assignments.extend(created_teams)
         if fire_signals_on_create:
-            _fire_post_save(db_teams, existing_team_pks)
+            _fire_post_save(created_teams)
         else:
-            _audit_log_created(db_teams, existing_team_pks)
+            _audit_log_created(created_teams)
 
     return all_assignments
 
@@ -353,6 +358,10 @@ def give_assignments(
 
     Lower-level alternative to bulk_give_permissions — accepts ResolvedAssignment
     lists directly, for callers that have already resolved and validated.
+
+    Returns only the *newly-created* assignments. Pairs that already existed are omitted:
+    bulk_create(ignore_conflicts=True) cannot report skipped rows, and fetching them back
+    is the query that does not scale. Callers needing pre-existing rows must fetch them.
     """
     if not user_resolved and not team_resolved:
         return []
@@ -368,7 +377,10 @@ def bulk_give_permissions(
     team_permissions: Sequence[PermissionTriple] = (),
     fire_signals_on_create: bool = True,
 ) -> list[AssignmentBase]:
-    """Convenience API: validates triples, resolves, and delegates to give_assignments."""
+    """Convenience API: validates triples, resolves, and delegates to give_assignments.
+
+    Returns only the newly-created assignments (see give_assignments for why).
+    """
     if not user_permissions and not team_permissions:
         return []
 

--- a/test_app/tests/rbac/test_permission_assignment.py
+++ b/test_app/tests/rbac/test_permission_assignment.py
@@ -2,7 +2,7 @@ import pytest
 from crum import impersonate
 from rest_framework.exceptions import ValidationError
 
-from ansible_base.rbac.models import RoleDefinition, RoleEvaluation, RoleUserAssignment
+from ansible_base.rbac.models import RoleDefinition, RoleEvaluation, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.rbac.permission_registry import permission_registry
 from test_app.models import Inventory, Organization, Team, User
 
@@ -26,6 +26,20 @@ def test_give_permission_idempotent_returns_existing(rando, organization, org_in
     assert second is not None
     assert second.pk == first.pk
     assert RoleUserAssignment.objects.filter(user=rando, role_definition=org_inv_change_rd).count() == 1
+
+
+@pytest.mark.django_db
+def test_give_permission_idempotent_returns_existing_team(team, inventory, inv_rd):
+    """Same as above but for a team actor, exercising the team branch of the fallback lookup.
+
+    Integer PKs would mask a normalization bug in the existing-row query, so this also guards
+    the object_id resolution used when the bulk path returns only newly-created rows.
+    """
+    first = inv_rd.give_permission(team, inventory)
+    second = inv_rd.give_permission(team, inventory)
+    assert second is not None
+    assert second.pk == first.pk
+    assert RoleTeamAssignment.objects.filter(team=team, role_definition=inv_rd).count() == 1
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/test_permission_assignment.py
+++ b/test_app/tests/rbac/test_permission_assignment.py
@@ -15,6 +15,20 @@ def test_invalid_actor(inventory, org_inv_rd):
 
 
 @pytest.mark.django_db
+def test_give_permission_idempotent_returns_existing(rando, organization, org_inv_change_rd):
+    """give_permission returns the saved assignment even when it already existed.
+
+    The bulk path returns only newly-created rows, so on a repeat call give_permission must
+    fetch the pre-existing assignment itself rather than returning None/raising.
+    """
+    first = org_inv_change_rd.give_permission(rando, organization)
+    second = org_inv_change_rd.give_permission(rando, organization)
+    assert second is not None
+    assert second.pk == first.pk
+    assert RoleUserAssignment.objects.filter(user=rando, role_definition=org_inv_change_rd).count() == 1
+
+
+@pytest.mark.django_db
 def test_child_object_permission(rando, organization, inventory, org_inv_change_rd, admin_user):
     assert inventory.organization == organization
 

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -598,6 +598,49 @@ class TestBulkGivePermissions:
             (user2.pk, str(inv2.pk)),
         }, f"Cross-product leak: got {returned_pairs}"
 
+    def test_skinny_shape_scale(self, organization, inv_rd):
+        """Skinny batch (one user, many objects) must not build a query that scales with N.
+
+        The old OR-of-pairs filter produced an N-deep expression tree that SQLite rejects
+        past ~1000 terms; a two-axis IN filter merely moves the wall. This exercises the
+        PK-range detection path with N well over that threshold.
+        """
+        n = 1100
+        user = User.objects.create(username='skinny-user')
+        invs = Inventory.objects.bulk_create([Inventory(name=f'skinny-inv-{i}', organization=organization) for i in range(n)])
+
+        assignments = bulk_give_permissions(user_permissions=[(inv_rd, user, inv) for inv in invs])
+
+        assert len(assignments) == n
+        assert RoleUserAssignment.objects.filter(user=user, role_definition=inv_rd).count() == n
+        # spot-check a few objects actually resolve permissions
+        assert user.has_obj_perm(invs[0], 'change')
+        assert user.has_obj_perm(invs[-1], 'change')
+
+    def test_reassign_existing_returns_only_created(self, organization, inv_rd):
+        """Re-giving an existing batch returns nothing and fires no create signals.
+
+        The bulk path returns only newly-created rows; pre-existing pairs are omitted (they
+        can't be reported by bulk_create, and fetching them back is the query that doesn't
+        scale). A second identical call must therefore create nothing, return [], and stay
+        idempotent.
+        """
+        n = 1100
+        user = User.objects.create(username='reassign-user')
+        invs = Inventory.objects.bulk_create([Inventory(name=f'reassign-inv-{i}', organization=organization) for i in range(n)])
+        perms = [(inv_rd, user, inv) for inv in invs]
+
+        first = bulk_give_permissions(user_permissions=perms)
+        assert len(first) == n  # all newly created
+
+        with patch('ansible_base.rbac.pipeline._fire_post_save') as mock_signal:
+            second = bulk_give_permissions(user_permissions=perms)
+            created_second_call = mock_signal.call_args[0][0]
+
+        assert second == []  # only-created contract: pre-existing pairs are not returned
+        assert created_second_call == []  # nothing newly created, so no create signals
+        assert RoleUserAssignment.objects.filter(user=user, role_definition=inv_rd).count() == n
+
     def test_audit_no_cross_product(self, organization, inv_rd):
         """Audit logging must not fire for pre-existing assignments outside the batch."""
         inv1 = Inventory.objects.create(name='audit-xp-inv1', organization=organization)
@@ -615,12 +658,11 @@ class TestBulkGivePermissions:
                 ],
                 fire_signals_on_create=False,
             )
-            args = mock_audit.call_args
-            db_assignments = args[0][0]
-            existing_pks = args[0][1]
-            new_assignments = [a for a in db_assignments if a.pk not in existing_pks]
-            new_pairs = {(a.user_id, a.object_id) for a in new_assignments}
+            # _audit_log_created now receives only the newly-created assignments.
+            created_assignments = mock_audit.call_args[0][0]
+            new_pairs = {(a.user_id, a.object_id) for a in created_assignments}
             assert (user1.pk, str(inv2.pk)) not in new_pairs, "Pre-existing assignment leaked into new set"
+            assert new_pairs == {(user1.pk, str(inv1.pk)), (user2.pk, str(inv2.pk))}
 
 
 @pytest.mark.django_db

--- a/test_app/tests/rbac/test_triggers.py
+++ b/test_app/tests/rbac/test_triggers.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.apps import apps
+from django.conf import settings
 from django.test.utils import override_settings
 from rest_framework.exceptions import ValidationError
 
@@ -640,6 +641,40 @@ class TestBulkGivePermissions:
         assert second == []  # only-created contract: pre-existing pairs are not returned
         assert created_second_call == []  # nothing newly created, so no create signals
         assert RoleUserAssignment.objects.filter(user=user, role_definition=inv_rd).count() == n
+
+    @pytest.mark.skipif('ansible_base.activitystream' not in settings.INSTALLED_APPS, reason="activitystream not installed")
+    def test_fire_signals_false_audits_created_without_post_save(self, organization, team, rando, inv_rd):
+        """fire_signals_on_create=False audits newly-created user AND team assignments via
+        _audit_log_created (not post_save), and no-ops when nothing new is created.
+
+        Exercises the audit branch for both actor types plus the empty-created early return,
+        which the demo-data bulk load (the only fire_signals_on_create=False caller) relies on.
+        """
+        from ansible_base.activitystream.models import Entry
+
+        inv1 = Inventory.objects.create(name='audit-sig-inv1', organization=organization)
+        inv2 = Inventory.objects.create(name='audit-sig-inv2', organization=organization)
+        perms = {
+            'user_permissions': [(inv_rd, rando, inv1)],
+            'team_permissions': [(inv_rd, team, inv2)],
+        }
+        entries_before = Entry.objects.count()
+
+        with patch('ansible_base.rbac.pipeline._fire_post_save') as mock_signal:
+            with patch('ansible_base.activitystream.signals.log_auth_event') as log_auth_event:
+                bulk_give_permissions(**perms, fire_signals_on_create=False)
+            # post_save must be skipped; auditing happens via _audit_log_created instead
+            mock_signal.assert_not_called()
+
+        # One audit log per newly-created assignment (user + team), no activity-stream rows
+        assert log_auth_event.call_count == 2
+        assert Entry.objects.count() == entries_before
+
+        # Re-giving the same batch creates nothing: _audit_log_created gets an empty list and returns early
+        with patch('ansible_base.activitystream.signals.log_auth_event') as log_auth_event_again:
+            second = bulk_give_permissions(**perms, fire_signals_on_create=False)
+        assert second == []
+        log_auth_event_again.assert_not_called()
 
     def test_audit_no_cross_product(self, organization, inv_rd):
         """Audit logging must not fire for pre-existing assignments outside the batch."""


### PR DESCRIPTION
## Summary

The RBAC bulk assignment path (`bulk_give_permissions` / `give_assignments`) built an OR-of-pairs `Q` filter to detect which `(actor, object_role)` pairs already existed, so it could fire `post_save` signals and activity-stream entries only for genuinely new rows. At scale (1000+ pairs) that filter produces an expression tree SQLite rejects:

```
django.db.utils.OperationalError: Expression tree is too large (maximum depth 1000)
```

This surfaced as a failure of `test_demo_data_large_mode_creates_roledefinitions` on SQLite. See AAP-90129 for the full traceback.

## What changed

- **`ansible_base/rbac/pipeline.py`** — replace the per-pair OR filter with **PK-range detection**: snapshot `max(id)` before `bulk_create(ignore_conflicts=True)`, then find new rows via `filter(id__gt=max_before)`, narrowed in Python to the batch's exact `(actor, object_role)` pairs. Constant-size query on the existing PK index regardless of batch shape (skinny or fat); no schema change.
- The bulk methods now return **only the newly-created** assignments. Pairs that already existed are omitted — `bulk_create(ignore_conflicts=True)` cannot report skipped rows, and fetching them back is exactly the query that does not scale.
- **`ansible_base/rbac/models/role.py`** — `give_permission` fetches its own pre-existing row when the bulk path returns nothing (idempotent re-assignment).

## Tests

- Added scale coverage (skinny 1 user × 1100 objects) and idempotent re-assignment coverage (repeat call returns `[]`, fires no create signals; `give_permission` returns the saved pre-existing row).
- Full RBAC suite: 665 passed, 2 xfailed.

Note: the DAB test DB here is Postgres, so the suite validates correctness at N>1000 but does not reproduce the SQLite crash in-suite; a standalone SQLite check confirms the old OR-tree fails at N=1500 while the new `id > ?` path uses one param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reassigning an existing permission now returns the existing assignment instead of failing.
  * Bulk permission operations now correctly handle large batches and avoid duplicate assignments.
  * Audit logs and notifications now reflect only newly created assignments.

* **Tests**
  * Added coverage for repeated assignments, large batches, permission accuracy, and assignment reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->