### PR TITLE
ACA-5185 ci: update GitHub Actions to latest versions (SHA-pinned)

### DIFF
--- a/.github/workflows/dvcs_check.yml
+++ b/.github/workflows/dvcs_check.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Check the PR for DVCS integration
     steps:
-      - uses: ansible/dvcs-action@devel
+      - uses: ansible/dvcs-action@0106255aa32ffdefe91475fe98db51116807a9a6 # v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish dists to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   post-release-repo-update:
     name: Make a GitHub Release

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -51,7 +51,7 @@ jobs:
 
       # Download all individual coverage artifacts from CI workflow
       - name: Download coverage artifacts
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: CI
@@ -158,7 +158,7 @@ jobs:
       # Download all individual coverage artifacts from CI workflow (optional for branch pushes)
       - name: Download coverage artifacts
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: CI


### PR DESCRIPTION

Update all GitHub Actions to their latest versions with full commit SHA pinning for supply chain security.

Updated via `npx actions-up --yes --include-branches --min-age 3` (default `--style sha`).

https://redhat.atlassian.net/browse/ACA-5185

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change