### PR TITLE
[AAP-77215] Add CleanTextMixin to DAB concrete model serializers- #4

### DIFF
--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -14,8 +14,9 @@ from ansible_base.lib.utils.response import get_relative_url
 
 class AuthenticatorSerializer(CleanTextMixin, NamedCommonModelSerializer, ImmutableFieldsMixin):
     # Exclude encrypted sub-keys and unvalidated pass-through args from CleanTextMixin's
-    # JSONField scan.  Other structured sub-keys (DictField, ListField, JSONField) are
-    # already skipped by the mixin's isinstance(val, str) check.
+    # JSONField scan. Other structured sub-keys (dict/list-valued) are not skipped —
+    # CleanTextMixin recurses into them and validates their string leaves with Tier 2.
+    # Only bare top-level string values need an explicit excluded_json_keys entry.
     # See docs/lib/validation.md "Authenticator configuration exclusions" for the full rationale.
     excluded_json_keys = MappingProxyType(
         {

--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from types import MappingProxyType
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework.serializers import ChoiceField, ValidationError
@@ -16,16 +17,18 @@ class AuthenticatorSerializer(CleanTextMixin, NamedCommonModelSerializer, Immuta
     # JSONField scan.  Other structured sub-keys (DictField, ListField, JSONField) are
     # already skipped by the mixin's isinstance(val, str) check.
     # See docs/lib/validation.md "Authenticator configuration exclusions" for the full rationale.
-    excluded_json_keys = {
-        'configuration': frozenset(
-            {
-                'SECRET',
-                'BIND_PASSWORD',
-                'SP_PRIVATE_KEY',
-                'ADDITIONAL_UNVERIFIED_ARGS',
-            }
-        ),
-    }
+    excluded_json_keys = MappingProxyType(
+        {
+            'configuration': frozenset(
+                {
+                    'SECRET',
+                    'BIND_PASSWORD',
+                    'SP_PRIVATE_KEY',
+                    'ADDITIONAL_UNVERIFIED_ARGS',
+                }
+            ),
+        }
+    )
 
     type = ChoiceField(get_authenticator_plugins())
 

--- a/ansible_base/authentication/serializers/authenticator.py
+++ b/ansible_base/authentication/serializers/authenticator.py
@@ -6,12 +6,27 @@ from rest_framework.serializers import ChoiceField, ValidationError
 from ansible_base.authentication.authenticator_plugins.utils import generate_authenticator_slug, get_authenticator_plugin, get_authenticator_plugins
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
-from ansible_base.lib.serializers.mixins import ImmutableFieldsMixin
+from ansible_base.lib.serializers.mixins import CleanTextMixin, ImmutableFieldsMixin
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from ansible_base.lib.utils.response import get_relative_url
 
 
-class AuthenticatorSerializer(NamedCommonModelSerializer, ImmutableFieldsMixin):
+class AuthenticatorSerializer(CleanTextMixin, NamedCommonModelSerializer, ImmutableFieldsMixin):
+    # Exclude encrypted sub-keys and unvalidated pass-through args from CleanTextMixin's
+    # JSONField scan.  Other structured sub-keys (DictField, ListField, JSONField) are
+    # already skipped by the mixin's isinstance(val, str) check.
+    # See docs/lib/validation.md "Authenticator configuration exclusions" for the full rationale.
+    excluded_json_keys = {
+        'configuration': frozenset(
+            {
+                'SECRET',
+                'BIND_PASSWORD',
+                'SP_PRIVATE_KEY',
+                'ADDITIONAL_UNVERIFIED_ARGS',
+            }
+        ),
+    }
+
     type = ChoiceField(get_authenticator_plugins())
 
     def validate_type(self, value):
@@ -144,7 +159,7 @@ class AuthenticatorSerializer(NamedCommonModelSerializer, ImmutableFieldsMixin):
                 if invalid_encrypted_keys:
                     raise ValidationError(invalid_encrypted_keys)
                 data['configuration'] = authenticator.validate_configuration(configuration, self.instance)
-            return data
+            return super().validate(data)
         except ImportError as e:
             raise ValidationError({'type': _('Failed to import %(e)s') % {'e': e}})
 

--- a/ansible_base/authentication/serializers/authenticator_map.py
+++ b/ansible_base/authentication/serializers/authenticator_map.py
@@ -9,13 +9,19 @@ from ansible_base.authentication.utils.authenticator_map import _EXPANSION_FIELD
 from ansible_base.authentication.utils.trigger_definition import TRIGGER_DEFINITION
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
 from ansible_base.lib.serializers.fields import JSONField
+from ansible_base.lib.serializers.mixins import CleanTextMixin
 from ansible_base.lib.utils.string import is_empty
 from ansible_base.lib.utils.typing import TranslatedString
 
 logger = logging.getLogger('ansible_base.authentication.serializers.authenticator_map')
 
 
-class AuthenticatorMapSerializer(NamedCommonModelSerializer):
+class AuthenticatorMapSerializer(CleanTextMixin, NamedCommonModelSerializer):
+    # These fields accept {% for_attr_value() %} template expansion syntax
+    # (defined in _EXPANSION_FIELDS) which would be rejected by validate_free_text().
+    # See docs/lib/validation.md "AuthenticatorMap field exclusions" for details.
+    excluded_fields = frozenset({'organization', 'role', 'team'})
+
     triggers = JSONField(
         required=True,
         allow_null=False,
@@ -57,7 +63,7 @@ class AuthenticatorMapSerializer(NamedCommonModelSerializer):
 
         if errors:
             raise ValidationError(errors)
-        return data
+        return super().validate(data)
 
     def validate_role_data(self, map_type: Optional[str], role: Optional[str], org: Optional[str], team: Optional[str]) -> dict[str, TranslatedString]:
         # If the role field has an expansion in it we can only check this role at runtime

--- a/ansible_base/authentication/serializers/authenticator_map.py
+++ b/ansible_base/authentication/serializers/authenticator_map.py
@@ -17,11 +17,6 @@ logger = logging.getLogger('ansible_base.authentication.serializers.authenticato
 
 
 class AuthenticatorMapSerializer(CleanTextMixin, NamedCommonModelSerializer):
-    # These fields accept {% for_attr_value() %} template expansion syntax
-    # (defined in _EXPANSION_FIELDS) which would be rejected by validate_free_text().
-    # See docs/lib/validation.md "AuthenticatorMap field exclusions" for details.
-    excluded_fields = frozenset({'organization', 'role', 'team'})
-
     triggers = JSONField(
         required=True,
         allow_null=False,
@@ -64,6 +59,16 @@ class AuthenticatorMapSerializer(CleanTextMixin, NamedCommonModelSerializer):
         if errors:
             raise ValidationError(errors)
         return super().validate(data)
+
+    def _run_text_validator(self, field_name, value, errors):
+        # organization/role/team accept {% for_attr_value() %} template expansion syntax;
+        # check_expansion_syntax() above already validates the format of such values. Skip
+        # CleanTextMixin's Tier 1/Tier 2 validation only for values that actually use
+        # expansion syntax — literal content still runs through the normal free-text check.
+        # See docs/lib/validation.md "AuthenticatorMap field exclusions" for details.
+        if field_name in _EXPANSION_FIELDS and has_expansion(value):
+            return
+        super()._run_text_validator(field_name, value, errors)
 
     def validate_role_data(self, map_type: Optional[str], role: Optional[str], org: Optional[str], team: Optional[str]) -> dict[str, TranslatedString]:
         # If the role field has an expansion in it we can only check this role at runtime

--- a/ansible_base/oauth2_provider/serializers/application.py
+++ b/ansible_base/oauth2_provider/serializers/application.py
@@ -3,11 +3,12 @@ from django.utils.translation import gettext_lazy as _
 from oauth2_provider.generators import generate_client_secret
 
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
+from ansible_base.lib.serializers.mixins import CleanTextMixin
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from ansible_base.oauth2_provider.models import OAuth2Application
 
 
-class OAuth2ApplicationSerializer(NamedCommonModelSerializer):
+class OAuth2ApplicationSerializer(CleanTextMixin, NamedCommonModelSerializer):
     oauth2_client_secret = None
 
     class Meta:

--- a/ansible_base/oauth2_provider/serializers/token.py
+++ b/ansible_base/oauth2_provider/serializers/token.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.serializers import SerializerMethodField
 
 from ansible_base.lib.serializers.common import CommonModelSerializer
+from ansible_base.lib.serializers.mixins import CleanTextMixin
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from ansible_base.lib.utils.settings import get_setting
 from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2RefreshToken
@@ -20,7 +21,7 @@ from ansible_base.oauth2_provider.models.access_token import SCOPES
 logger = logging.getLogger("ansible_base.oauth2_provider.serializers.token")
 
 
-class OAuth2TokenSerializer(CommonModelSerializer):
+class OAuth2TokenSerializer(CleanTextMixin, CommonModelSerializer):
     refresh_token = SerializerMethodField()
 
     unencrypted_token = None  # Only used in POST so we can return the token in the response

--- a/ansible_base/rbac/api/serializers.py
+++ b/ansible_base/rbac/api/serializers.py
@@ -11,6 +11,7 @@ from rest_framework.serializers import ValidationError
 
 from ansible_base.lib.abstract_models.common import get_url_for_object
 from ansible_base.lib.serializers.common import CommonModelSerializer, ImmutableCommonModelSerializer
+from ansible_base.lib.serializers.mixins import CleanTextMixin
 from ansible_base.lib.utils.auth import get_team_model
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition, RoleTeamAssignment, RoleUserAssignment
@@ -26,7 +27,7 @@ from .queries import assignment_qs_user_to_obj, assignment_qs_user_to_obj_perm
 logger = logging.getLogger(__name__)
 
 
-class RoleDefinitionSerializer(CommonModelSerializer):
+class RoleDefinitionSerializer(CleanTextMixin, CommonModelSerializer):
     permissions = serializers.SlugRelatedField(
         slug_field='api_slug',
         queryset=DABPermission.objects.all(),

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -369,42 +369,42 @@ When adding a new authenticator plugin with new
 
 ### AuthenticatorMap field exclusions
 
-`AuthenticatorMapSerializer` sets `excluded_fields` to skip three CharField
-fields from CleanTextMixin validation entirely:
+`AuthenticatorMapSerializer` overrides `_run_text_validator()` to
+conditionally skip Tier 1/Tier 2 validation on three CharField fields —
+`organization`, `role`, and `team` — but only for values that actually use
+template expansion syntax:
 
 ```python
-excluded_fields = frozenset({'organization', 'role', 'team'})
+def _run_text_validator(self, field_name, value, errors):
+    if field_name in _EXPANSION_FIELDS and has_expansion(value):
+        return
+    super()._run_text_validator(field_name, value, errors)
 ```
 
 These fields support template expansion syntax for dynamic mapping rules.
 Values like `{% for_attr_value(user_orgs) %}` and
 `Organization {% for_attr_value(member_of) %}` are valid inputs that allow
 authenticator maps to dynamically resolve organization, team, and role names
-from user attributes at authentication time.
+from user attributes at authentication time. The `{% %}` pattern matches the
+Tier 2 dangerous-pattern blocklist's template injection category, so these
+values would otherwise be rejected as false positives.
 
-The `{% %}` pattern matches `DANGEROUS_PATTERNS` (template injection
-category), so these fields must be excluded to avoid false positives.
-
-The excluded field names match `_EXPANSION_FIELDS` defined in
+The gated field names match `_EXPANSION_FIELDS` defined in
 `ansible_base.authentication.utils.authenticator_map`:
 
 ```python
 _EXPANSION_FIELDS = ['organization', 'role', 'team']
 ```
 
-The serializer's own `validate()` method already validates the expansion
-syntax of these fields via `check_expansion_syntax()` — but this only
-catches **malformed** expansion attempts (a value containing `{%` and `%}`
-that doesn't match the `for_attr_value(...)` shape). The `name` field on
-`AuthenticatorMap` is **not** excluded and receives Tier 1 validation.
-
-**Scope.** `check_expansion_syntax()` only rejects malformed expansion
-attempts, so literal (non-templated) values in these fields also bypass all
-Tier 1/Tier 2 validation — the exclusion is field-wide, not conditional on
-whether a given value actually uses expansion syntax. As with other
-templated/structured configuration values in this doc, validating literal
-content in these fields is accepted as out of scope rather than partially
-enforced.
+The serializer's own `validate()` method separately validates the expansion
+*syntax* of these fields via `check_expansion_syntax()` — this catches
+**malformed** expansion attempts (a value containing `{%` and `%}` that
+doesn't match the `for_attr_value(...)` shape). `_run_text_validator()`'s
+`has_expansion()` check only skips CleanTextMixin validation for values that
+already contain `{% %}`; literal (non-templated) values in these fields run
+through the normal Tier 2 free-text check like any other field. The `name`
+field on `AuthenticatorMap` is not gated at all and always receives Tier 1
+validation.
 
 ## Error reporting
 

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -400,9 +400,11 @@ The serializer's own `validate()` method separately validates the expansion
 *syntax* of these fields via `check_expansion_syntax()` — this catches
 **malformed** expansion attempts (a value containing `{%` and `%}` that
 doesn't match the `for_attr_value(...)` shape). `_run_text_validator()`'s
-`has_expansion()` check only skips CleanTextMixin validation for values that
-already contain `{% %}`; literal (non-templated) values in these fields run
-through the normal Tier 2 free-text check like any other field. The `name`
+`has_expansion()` check skips CleanTextMixin validation for any value that
+contains `{% %}` syntax — including mixed values where literal content appears
+alongside expansion syntax (per the SDP scope exclusion for Jinja2 template
+fields). Purely literal (non-templated) values in these fields run through
+the normal Tier 2 free-text check like any other field. The `name`
 field on `AuthenticatorMap` is not gated at all and always receives Tier 1
 validation.
 

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -346,9 +346,13 @@ content (YAML/JSON) is excluded.
 Other structured sub-keys (`ORG_INFO`, `TECHNICAL_CONTACT`, `SUPPORT_CONTACT`,
 `SP_EXTRA`, `SECURITY_CONFIG`, `EXTRA_DATA`, `GROUP_TYPE_PARAMS`,
 `CONNECTION_OPTIONS`, `GROUP_SEARCH`, `USER_SEARCH`, `USER_ATTR_MAP`,
-`JWT_ALGORITHMS`, `JWT_DECODE_OPTIONS`, `SCOPE`) store dicts or lists — not
-strings. The mixin's `isinstance(val, str)` check in `_validate_json_dict()`
-skips them without needing explicit exclusion.
+`JWT_ALGORITHMS`, `JWT_DECODE_OPTIONS`, `SCOPE`) store dicts or lists, not
+top-level strings. The mixin's `_validate_json_dict()` recurses into dict and
+list values and validates any string leaf values it finds (e.g.
+`TECHNICAL_CONTACT.emailAddress`) with the same Tier 2 blocklist as top-level
+fields, so no explicit exclusion is required — legitimate values (names,
+emails, LDAP attribute names) are expected to pass Tier 2 validation without
+triggering false positives.
 
 Certificate fields (`SP_PUBLIC_CERT`, `IDP_X509_CERT`, `PUBLIC_KEY`) are
 strings but contain PEM-encoded data (base64 + headers) that does not match
@@ -389,9 +393,18 @@ _EXPANSION_FIELDS = ['organization', 'role', 'team']
 ```
 
 The serializer's own `validate()` method already validates the expansion
-syntax of these fields via `check_expansion_syntax()` — only well-formed
-`{% for_attr_value(...) %}` expressions are accepted. The `name` field on
+syntax of these fields via `check_expansion_syntax()` — but this only
+catches **malformed** expansion attempts (a value containing `{%` and `%}`
+that doesn't match the `for_attr_value(...)` shape). The `name` field on
 `AuthenticatorMap` is **not** excluded and receives Tier 1 validation.
+
+**Scope.** `check_expansion_syntax()` only rejects malformed expansion
+attempts, so literal (non-templated) values in these fields also bypass all
+Tier 1/Tier 2 validation — the exclusion is field-wide, not conditional on
+whether a given value actually uses expansion syntax. As with other
+templated/structured configuration values in this doc, validating literal
+content in these fields is accepted as out of scope rather than partially
+enforced.
 
 ## Error reporting
 

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -305,6 +305,94 @@ This nested format is compatible with DRF's standard error handling and allows
 frontend form frameworks (e.g., react-hook-form) to map errors to the correct
 input fields.
 
+### Authenticator configuration exclusions
+
+`AuthenticatorSerializer` sets `excluded_json_keys` on the `configuration`
+JSONField to skip encrypted sub-keys and structured pass-through data:
+
+```python
+excluded_json_keys = {
+    'configuration': frozenset({
+        'SECRET',
+        'BIND_PASSWORD',
+        'SP_PRIVATE_KEY',
+        'ADDITIONAL_UNVERIFIED_ARGS',
+    }),
+}
+```
+
+**Encrypted fields** — These sub-keys appear in each plugin's
+`configuration_encrypted_fields`. Their cleartext values (passwords, private
+keys) may legitimately contain patterns matching the Tier 2 blocklist (e.g.,
+an LDAP bind password containing `${LDAP_PASS}`). On update, the serializer's
+`to_internal_value()` replaces the `ENCRYPTED_STRING` sentinel with the stored
+value, so unchanged secrets would be grandfathered. The exclusion is needed
+for create, where cleartext values are submitted.
+
+| Key | Plugins | Content |
+|-----|---------|---------|
+| `SECRET` | GitHub (all variants), Google OAuth2, OIDC, Keycloak, AzureAD, TACACS, Radius | OAuth2 client secret or shared secret |
+| `BIND_PASSWORD` | LDAP | LDAP bind password |
+| `SP_PRIVATE_KEY` | SAML | PEM-encoded service provider private key |
+
+**Structured data (out of scope)** — `ADDITIONAL_UNVERIFIED_ARGS` is a
+JSONField on every plugin (inherited from `BaseAuthenticatorConfiguration`)
+that accepts arbitrary JSON passed directly to the authenticator without
+validation. Per the input validation scope, validation of structured data
+content (YAML/JSON) is excluded.
+
+**Keys that do NOT need exclusion:**
+
+Other structured sub-keys (`ORG_INFO`, `TECHNICAL_CONTACT`, `SUPPORT_CONTACT`,
+`SP_EXTRA`, `SECURITY_CONFIG`, `EXTRA_DATA`, `GROUP_TYPE_PARAMS`,
+`CONNECTION_OPTIONS`, `GROUP_SEARCH`, `USER_SEARCH`, `USER_ATTR_MAP`,
+`JWT_ALGORITHMS`, `JWT_DECODE_OPTIONS`, `SCOPE`) store dicts or lists — not
+strings. The mixin's `isinstance(val, str)` check in `_validate_json_dict()`
+skips them without needing explicit exclusion.
+
+Certificate fields (`SP_PUBLIC_CERT`, `IDP_X509_CERT`, `PUBLIC_KEY`) are
+strings but contain PEM-encoded data (base64 + headers) that does not match
+any pattern in `DANGEROUS_PATTERNS`. No exclusion needed.
+
+All remaining string sub-keys (`NAME`, `KEY`, `HOST`, `SERVER`, SAML attribute
+names, OIDC claim names, etc.) are validated by the mixin as defense-in-depth.
+Most are format-constrained by their identity provider, but they accept
+user-provided input and should be scanned for injection patterns.
+
+When adding a new authenticator plugin with new
+`configuration_encrypted_fields` entries, add the field names to
+`excluded_json_keys` on `AuthenticatorSerializer`.
+
+### AuthenticatorMap field exclusions
+
+`AuthenticatorMapSerializer` sets `excluded_fields` to skip three CharField
+fields from CleanTextMixin validation entirely:
+
+```python
+excluded_fields = frozenset({'organization', 'role', 'team'})
+```
+
+These fields support template expansion syntax for dynamic mapping rules.
+Values like `{% for_attr_value(user_orgs) %}` and
+`Organization {% for_attr_value(member_of) %}` are valid inputs that allow
+authenticator maps to dynamically resolve organization, team, and role names
+from user attributes at authentication time.
+
+The `{% %}` pattern matches `DANGEROUS_PATTERNS` (template injection
+category), so these fields must be excluded to avoid false positives.
+
+The excluded field names match `_EXPANSION_FIELDS` defined in
+`ansible_base.authentication.utils.authenticator_map`:
+
+```python
+_EXPANSION_FIELDS = ['organization', 'role', 'team']
+```
+
+The serializer's own `validate()` method already validates the expansion
+syntax of these fields via `check_expansion_syntax()` — only well-formed
+`{% for_attr_value(...) %}` expressions are accepted. The `name` field on
+`AuthenticatorMap` is **not** excluded and receives Tier 1 validation.
+
 ## Error reporting
 
 When multiple fields fail validation, all errors are collected and returned in a

--- a/docs/lib/validation.md
+++ b/docs/lib/validation.md
@@ -311,14 +311,14 @@ input fields.
 JSONField to skip encrypted sub-keys and structured pass-through data:
 
 ```python
-excluded_json_keys = {
+excluded_json_keys = MappingProxyType({
     'configuration': frozenset({
         'SECRET',
         'BIND_PASSWORD',
         'SP_PRIVATE_KEY',
         'ADDITIONAL_UNVERIFIED_ARGS',
     }),
-}
+})
 ```
 
 **Encrypted fields** — These sub-keys appear in each plugin's

--- a/test_app/tests/authentication/test_clean_text_integration.py
+++ b/test_app/tests/authentication/test_clean_text_integration.py
@@ -180,3 +180,16 @@ class TestAuthenticatorMapCleanText:
         serializer.validate_trigger_data = MagicMock(return_value={})
         data = serializer.validate(dict(name='name;semicolon', map_type='is_superuser', order=100))
         assert data['name'] == 'name;semicolon'
+
+    def test_rejects_changed_invalid_name_on_update(self, admin_api_client, local_authenticator):
+        auth_map = AuthenticatorMap.objects.create(
+            name='name;semicolon',
+            authenticator=local_authenticator,
+            map_type='is_superuser',
+            triggers={"always": {}},
+            order=1,
+        )
+        url = get_relative_url('authenticatormap-detail', kwargs={'pk': auth_map.pk})
+        response = admin_api_client.patch(url, data={'name': DANGEROUS_NAME}, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data

--- a/test_app/tests/authentication/test_clean_text_integration.py
+++ b/test_app/tests/authentication/test_clean_text_integration.py
@@ -154,7 +154,7 @@ class TestAuthenticatorMapCleanText:
         data = map_serializer.validate(dict(name='Valid Rule', map_type='is_superuser'))
         assert data['name'] == 'Valid Rule'
 
-    def test_excluded_fields_accept_dangerous_content(self, map_serializer):
+    def test_excluded_fields_accept_invalid_content(self, map_serializer):
         """organization, role, team are excluded because they accept template syntax."""
         map_serializer.validate_role_data = MagicMock(return_value={})
         data = map_serializer.validate(

--- a/test_app/tests/authentication/test_clean_text_integration.py
+++ b/test_app/tests/authentication/test_clean_text_integration.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from django.test import override_settings
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap
@@ -14,9 +13,14 @@ DANGEROUS_NAME = '<script>alert(1)</script>'
 DANGEROUS_TEXT = '$(rm -rf /)'
 GITHUB_ORG_TYPE = 'ansible_base.authentication.authenticator_plugins.github_org'
 
+pytestmark = pytest.mark.django_db
 
-@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
-@pytest.mark.django_db
+
+@pytest.fixture(autouse=True)
+def _enable_enhanced_validation(settings):
+    settings.ENHANCED_INPUT_VALIDATION_ENABLED = True
+
+
 class TestAuthenticatorCleanText:
 
     def test_rejects_invalid_name_on_create(self, admin_api_client):
@@ -67,8 +71,6 @@ class TestAuthenticatorCleanText:
         assert 'name' in response.data
 
 
-@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
-@pytest.mark.django_db
 class TestAuthenticatorConfigJsonCleanText:
     """Verify excluded_json_keys skips encrypted sub-keys while validating others."""
 
@@ -122,8 +124,6 @@ class TestAuthenticatorConfigJsonCleanText:
         assert response.status_code == 201
 
 
-@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
-@pytest.mark.django_db
 class TestAuthenticatorMapCleanText:
 
     def test_rejects_invalid_name_on_create(self, admin_api_client, local_authenticator):

--- a/test_app/tests/authentication/test_clean_text_integration.py
+++ b/test_app/tests/authentication/test_clean_text_integration.py
@@ -123,6 +123,17 @@ class TestAuthenticatorConfigJsonCleanText:
         response = admin_api_client.post(url, data=data, format='json')
         assert response.status_code == 201
 
+    def test_accepts_pem_certificate_values_in_config(self, admin_api_client, saml_configuration):
+        """PEM-encoded certs (SP_PUBLIC_CERT, IDP_X509_CERT) must not trip the Tier 2 blocklist."""
+        url = get_relative_url('authenticator-list')
+        data = {
+            'name': 'SAML Auth With Real Certs',
+            'type': 'ansible_base.authentication.authenticator_plugins.saml',
+            'configuration': saml_configuration,
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 201
+
 
 class TestAuthenticatorMapCleanText:
 
@@ -154,19 +165,38 @@ class TestAuthenticatorMapCleanText:
         data = map_serializer.validate(dict(name='Valid Rule', map_type='is_superuser'))
         assert data['name'] == 'Valid Rule'
 
-    def test_excluded_fields_accept_invalid_content(self, map_serializer):
-        """organization, role, team are excluded because they accept template syntax."""
+    def test_expansion_syntax_accepted_in_expansion_fields(self, map_serializer):
+        """Genuine {% for_attr_value(...) %} expansion syntax bypasses Tier 2 validation."""
         map_serializer.validate_role_data = MagicMock(return_value={})
         data = map_serializer.validate(
             dict(
                 name='Valid Rule',
                 map_type='team',
-                organization='$(dangerous)',
-                role='${EVIL}',
-                team='<script>alert(1)</script>',
+                organization='{% for_attr_value(user_orgs) %}',
+                role='{% for_attr_value(user_role) %}',
+                team='Team {% for_attr_value(member_of) %}',
             )
         )
-        assert data is not None
+        assert data['organization'] == '{% for_attr_value(user_orgs) %}'
+        assert data['role'] == '{% for_attr_value(user_role) %}'
+        assert data['team'] == 'Team {% for_attr_value(member_of) %}'
+
+    def test_literal_dangerous_content_rejected_in_expansion_fields(self, map_serializer):
+        """Literal (non-expansion) values in organization/role/team are validated like any other free-text field."""
+        map_serializer.validate_role_data = MagicMock(return_value={})
+        with pytest.raises(ValidationError) as exc_info:
+            map_serializer.validate(
+                dict(
+                    name='Valid Rule',
+                    map_type='team',
+                    organization='$(dangerous)',
+                    role='${EVIL}',
+                    team='<script>alert(1)</script>',
+                )
+            )
+        assert 'organization' in exc_info.value.detail
+        assert 'role' in exc_info.value.detail
+        assert 'team' in exc_info.value.detail
 
     def test_grandfather_unchanged_name_on_update(self, map_serializer, local_authenticator):
         auth_map = AuthenticatorMap.objects.create(

--- a/test_app/tests/authentication/test_clean_text_integration.py
+++ b/test_app/tests/authentication/test_clean_text_integration.py
@@ -1,0 +1,178 @@
+"""Tests that CleanTextMixin is correctly wired to DAB authentication serializers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from rest_framework.serializers import ValidationError
+
+from ansible_base.authentication.models import Authenticator, AuthenticatorMap
+from ansible_base.authentication.serializers.authenticator_map import AuthenticatorMapSerializer
+from ansible_base.lib.utils.response import get_relative_url
+
+DANGEROUS_NAME = '<script>alert(1)</script>'
+DANGEROUS_TEXT = '$(rm -rf /)'
+GITHUB_ORG_TYPE = 'ansible_base.authentication.authenticator_plugins.github_org'
+
+
+@pytest.mark.django_db
+class TestAuthenticatorCleanText:
+
+    def test_rejects_invalid_name_on_create(self, admin_api_client):
+        url = get_relative_url('authenticator-list')
+        data = {
+            'name': DANGEROUS_NAME,
+            'type': 'ansible_base.authentication.authenticator_plugins.local',
+            'configuration': {},
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data
+
+    def test_accepts_valid_name_on_create(self, admin_api_client):
+        url = get_relative_url('authenticator-list')
+        data = {
+            'name': 'New Local Auth',
+            'type': 'ansible_base.authentication.authenticator_plugins.local',
+            'configuration': {},
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 201
+
+    def test_grandfather_unchanged_name_on_update(self, admin_api_client):
+        url = get_relative_url('authenticator-list')
+        response = admin_api_client.post(
+            url,
+            data={
+                'name': 'Temp Auth For Grandfather',
+                'type': 'ansible_base.authentication.authenticator_plugins.local',
+                'configuration': {},
+            },
+            format='json',
+        )
+        assert response.status_code == 201
+        auth_id = response.data['id']
+
+        Authenticator.objects.filter(pk=auth_id).update(name='name;semicolon')
+
+        detail_url = get_relative_url('authenticator-detail', kwargs={'pk': auth_id})
+        response = admin_api_client.patch(detail_url, data={'name': 'name;semicolon'}, format='json')
+        assert response.status_code == 200
+
+    def test_rejects_changed_invalid_name_on_update(self, admin_api_client, local_authenticator):
+        detail_url = get_relative_url('authenticator-detail', kwargs={'pk': local_authenticator.pk})
+        response = admin_api_client.patch(detail_url, data={'name': DANGEROUS_NAME}, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data
+
+
+@pytest.mark.django_db
+class TestAuthenticatorConfigJsonCleanText:
+    """Verify excluded_json_keys skips encrypted sub-keys while validating others."""
+
+    def test_rejects_dangerous_value_in_non_excluded_config_key(self, admin_api_client):
+        """NAME is not in excluded_json_keys and should be validated."""
+        url = get_relative_url('authenticator-list')
+        data = {
+            'name': 'GitHub Org Auth',
+            'type': GITHUB_ORG_TYPE,
+            'configuration': {
+                'CALLBACK_URL': 'https://localhost/api/gateway/callback/test/',
+                'KEY': '12345',
+                'SECRET': 'abcdefg12345',
+                'NAME': DANGEROUS_NAME,
+            },
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'configuration' in response.data
+        assert 'NAME' in response.data['configuration']
+
+    def test_accepts_dangerous_value_in_excluded_config_key(self, admin_api_client):
+        """SECRET is in excluded_json_keys and should be skipped."""
+        url = get_relative_url('authenticator-list')
+        data = {
+            'name': 'GitHub Org Auth Excluded',
+            'type': GITHUB_ORG_TYPE,
+            'configuration': {
+                'CALLBACK_URL': 'https://localhost/api/gateway/callback/test/',
+                'KEY': '12345',
+                'SECRET': DANGEROUS_TEXT,
+                'NAME': 'valid-org',
+            },
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 201
+
+    def test_accepts_valid_config_values(self, admin_api_client):
+        url = get_relative_url('authenticator-list')
+        data = {
+            'name': 'GitHub Org Auth Valid',
+            'type': GITHUB_ORG_TYPE,
+            'configuration': {
+                'CALLBACK_URL': 'https://localhost/api/gateway/callback/test/',
+                'KEY': '12345',
+                'SECRET': 'abcdefg12345',
+                'NAME': 'my-organization',
+            },
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 201
+
+
+@pytest.mark.django_db
+class TestAuthenticatorMapCleanText:
+
+    def test_rejects_invalid_name_on_create(self, admin_api_client, local_authenticator):
+        url = get_relative_url('authenticatormap-list')
+        data = {
+            'name': DANGEROUS_NAME,
+            'authenticator': local_authenticator.id,
+            'map_type': 'is_superuser',
+            'triggers': {"always": {}},
+            'order': 1,
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data
+
+    @pytest.fixture
+    def map_serializer(self):
+        s = AuthenticatorMapSerializer()
+        s.validate_trigger_data = MagicMock(return_value={})
+        return s
+
+    def test_rejects_invalid_name_at_serializer_level(self, map_serializer):
+        with pytest.raises(ValidationError) as exc_info:
+            map_serializer.validate(dict(name=DANGEROUS_NAME, map_type='is_superuser'))
+        assert 'name' in exc_info.value.detail
+
+    def test_accepts_valid_name(self, map_serializer):
+        data = map_serializer.validate(dict(name='Valid Rule', map_type='is_superuser'))
+        assert data['name'] == 'Valid Rule'
+
+    def test_excluded_fields_accept_dangerous_content(self, map_serializer):
+        """organization, role, team are excluded because they accept template syntax."""
+        map_serializer.validate_role_data = MagicMock(return_value={})
+        data = map_serializer.validate(
+            dict(
+                name='Valid Rule',
+                map_type='team',
+                organization='$(dangerous)',
+                role='${EVIL}',
+                team='<script>alert(1)</script>',
+            )
+        )
+        assert data is not None
+
+    def test_grandfather_unchanged_name_on_update(self, map_serializer, local_authenticator):
+        auth_map = AuthenticatorMap.objects.create(
+            name='name;semicolon',
+            authenticator=local_authenticator,
+            map_type='is_superuser',
+            triggers={"always": {}},
+            order=99,
+        )
+        serializer = AuthenticatorMapSerializer(instance=auth_map)
+        serializer.validate_trigger_data = MagicMock(return_value={})
+        data = serializer.validate(dict(name='name;semicolon', map_type='is_superuser', order=100))
+        assert data['name'] == 'name;semicolon'

--- a/test_app/tests/authentication/test_clean_text_integration.py
+++ b/test_app/tests/authentication/test_clean_text_integration.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from django.test import override_settings
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.models import Authenticator, AuthenticatorMap
@@ -14,6 +15,7 @@ DANGEROUS_TEXT = '$(rm -rf /)'
 GITHUB_ORG_TYPE = 'ansible_base.authentication.authenticator_plugins.github_org'
 
 
+@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
 @pytest.mark.django_db
 class TestAuthenticatorCleanText:
 
@@ -65,6 +67,7 @@ class TestAuthenticatorCleanText:
         assert 'name' in response.data
 
 
+@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
 @pytest.mark.django_db
 class TestAuthenticatorConfigJsonCleanText:
     """Verify excluded_json_keys skips encrypted sub-keys while validating others."""
@@ -119,6 +122,7 @@ class TestAuthenticatorConfigJsonCleanText:
         assert response.status_code == 201
 
 
+@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
 @pytest.mark.django_db
 class TestAuthenticatorMapCleanText:
 

--- a/test_app/tests/authentication/test_clean_text_integration.py
+++ b/test_app/tests/authentication/test_clean_text_integration.py
@@ -198,7 +198,7 @@ class TestAuthenticatorMapCleanText:
         assert 'role' in exc_info.value.detail
         assert 'team' in exc_info.value.detail
 
-    def test_grandfather_unchanged_name_on_update(self, map_serializer, local_authenticator):
+    def test_grandfather_unchanged_name_on_update_at_serializer_level(self, local_authenticator):
         auth_map = AuthenticatorMap.objects.create(
             name='name;semicolon',
             authenticator=local_authenticator,
@@ -210,6 +210,18 @@ class TestAuthenticatorMapCleanText:
         serializer.validate_trigger_data = MagicMock(return_value={})
         data = serializer.validate(dict(name='name;semicolon', map_type='is_superuser', order=100))
         assert data['name'] == 'name;semicolon'
+
+    def test_grandfather_unchanged_name_on_update(self, admin_api_client, local_authenticator):
+        auth_map = AuthenticatorMap.objects.create(
+            name='name;semicolon',
+            authenticator=local_authenticator,
+            map_type='is_superuser',
+            triggers={"always": {}},
+            order=99,
+        )
+        url = get_relative_url('authenticatormap-detail', kwargs={'pk': auth_map.pk})
+        response = admin_api_client.patch(url, data={'name': 'name;semicolon', 'order': 100}, format='json')
+        assert response.status_code == 200
 
     def test_rejects_changed_invalid_name_on_update(self, admin_api_client, local_authenticator):
         auth_map = AuthenticatorMap.objects.create(

--- a/test_app/tests/oauth2_provider/test_clean_text_integration.py
+++ b/test_app/tests/oauth2_provider/test_clean_text_integration.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.oauth2_provider.models import OAuth2Application
+from ansible_base.oauth2_provider.models import OAuth2AccessToken, OAuth2Application
 
 DANGEROUS_NAME = '<script>alert(1)</script>'
 DANGEROUS_TEXT = '$(rm -rf /)'
@@ -74,8 +74,6 @@ class TestOAuth2ApplicationCleanText:
 
 
 class TestOAuth2TokenCleanText:
-    # No grandfather test: OAuth2 tokens are not updated via PATCH — most fields
-    # (token, expires, refresh_token, user) are read-only.
 
     def test_rejects_invalid_description_on_create(self, admin_api_client, oauth2_application):
         app, _ = oauth2_application
@@ -99,3 +97,16 @@ class TestOAuth2TokenCleanText:
         }
         response = admin_api_client.post(url, data=data, format='json')
         assert response.status_code == 201
+
+    def test_grandfather_unchanged_description_on_update(self, admin_api_client, oauth2_user_pat):
+        OAuth2AccessToken.objects.filter(pk=oauth2_user_pat.pk).update(description='desc;semicolon')
+
+        url = get_relative_url('token-detail', args=[oauth2_user_pat.pk])
+        response = admin_api_client.patch(url, data={'description': 'desc;semicolon'}, format='json')
+        assert response.status_code == 200
+
+    def test_rejects_changed_invalid_description_on_update(self, admin_api_client, oauth2_user_pat):
+        url = get_relative_url('token-detail', args=[oauth2_user_pat.pk])
+        response = admin_api_client.patch(url, data={'description': DANGEROUS_TEXT}, format='json')
+        assert response.status_code == 400
+        assert 'description' in response.data

--- a/test_app/tests/oauth2_provider/test_clean_text_integration.py
+++ b/test_app/tests/oauth2_provider/test_clean_text_integration.py
@@ -1,6 +1,7 @@
 """Tests that CleanTextMixin is correctly wired to DAB OAuth2 serializers."""
 
 import pytest
+from django.test import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2Application
@@ -9,6 +10,7 @@ DANGEROUS_NAME = '<script>alert(1)</script>'
 DANGEROUS_TEXT = '$(rm -rf /)'
 
 
+@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
 @pytest.mark.django_db
 class TestOAuth2ApplicationCleanText:
 
@@ -58,6 +60,7 @@ class TestOAuth2ApplicationCleanText:
         assert response.status_code == 200
 
 
+@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
 @pytest.mark.django_db
 class TestOAuth2TokenCleanText:
     # No grandfather test: OAuth2 tokens are not updated via PATCH — most fields

--- a/test_app/tests/oauth2_provider/test_clean_text_integration.py
+++ b/test_app/tests/oauth2_provider/test_clean_text_integration.py
@@ -1,7 +1,6 @@
 """Tests that CleanTextMixin is correctly wired to DAB OAuth2 serializers."""
 
 import pytest
-from django.test import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.oauth2_provider.models import OAuth2Application
@@ -9,9 +8,14 @@ from ansible_base.oauth2_provider.models import OAuth2Application
 DANGEROUS_NAME = '<script>alert(1)</script>'
 DANGEROUS_TEXT = '$(rm -rf /)'
 
+pytestmark = pytest.mark.django_db
 
-@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
-@pytest.mark.django_db
+
+@pytest.fixture(autouse=True)
+def _enable_enhanced_validation(settings):
+    settings.ENHANCED_INPUT_VALIDATION_ENABLED = True
+
+
 class TestOAuth2ApplicationCleanText:
 
     def test_rejects_invalid_name_on_create(self, admin_api_client, organization):
@@ -60,8 +64,6 @@ class TestOAuth2ApplicationCleanText:
         assert response.status_code == 200
 
 
-@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
-@pytest.mark.django_db
 class TestOAuth2TokenCleanText:
     # No grandfather test: OAuth2 tokens are not updated via PATCH — most fields
     # (token, expires, refresh_token, user) are read-only.

--- a/test_app/tests/oauth2_provider/test_clean_text_integration.py
+++ b/test_app/tests/oauth2_provider/test_clean_text_integration.py
@@ -63,6 +63,15 @@ class TestOAuth2ApplicationCleanText:
         response = admin_api_client.patch(url, data={'name': 'name;semicolon', 'description': 'Updated desc'}, format='json')
         assert response.status_code == 200
 
+    def test_rejects_changed_invalid_name_on_update(self, admin_api_client, oauth2_application):
+        app, _ = oauth2_application
+        OAuth2Application.objects.filter(pk=app.pk).update(name='name;semicolon')
+
+        url = get_relative_url('application-detail', args=[app.pk])
+        response = admin_api_client.patch(url, data={'name': DANGEROUS_NAME, 'description': 'Updated desc'}, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data
+
 
 class TestOAuth2TokenCleanText:
     # No grandfather test: OAuth2 tokens are not updated via PATCH — most fields

--- a/test_app/tests/oauth2_provider/test_clean_text_integration.py
+++ b/test_app/tests/oauth2_provider/test_clean_text_integration.py
@@ -1,0 +1,87 @@
+"""Tests that CleanTextMixin is correctly wired to DAB OAuth2 serializers."""
+
+import pytest
+
+from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.oauth2_provider.models import OAuth2Application
+
+DANGEROUS_NAME = '<script>alert(1)</script>'
+DANGEROUS_TEXT = '$(rm -rf /)'
+
+
+@pytest.mark.django_db
+class TestOAuth2ApplicationCleanText:
+
+    def test_rejects_invalid_name_on_create(self, admin_api_client, organization):
+        url = get_relative_url('application-list')
+        data = {
+            'name': DANGEROUS_NAME,
+            'organization': organization.pk,
+            'authorization_grant_type': 'password',
+            'client_type': 'confidential',
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data
+
+    def test_rejects_invalid_description_on_create(self, admin_api_client, organization):
+        url = get_relative_url('application-list')
+        data = {
+            'name': 'Valid OAuth2 App',
+            'description': DANGEROUS_TEXT,
+            'organization': organization.pk,
+            'authorization_grant_type': 'password',
+            'client_type': 'confidential',
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'description' in response.data
+
+    def test_accepts_valid_data_on_create(self, admin_api_client, organization):
+        url = get_relative_url('application-list')
+        data = {
+            'name': 'My OAuth2 App',
+            'description': 'A valid description',
+            'organization': organization.pk,
+            'authorization_grant_type': 'password',
+            'client_type': 'confidential',
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 201
+
+    def test_grandfather_unchanged_name_on_update(self, admin_api_client, oauth2_application):
+        app, _ = oauth2_application
+        OAuth2Application.objects.filter(pk=app.pk).update(name='name;semicolon')
+
+        url = get_relative_url('application-detail', args=[app.pk])
+        response = admin_api_client.patch(url, data={'name': 'name;semicolon', 'description': 'Updated desc'}, format='json')
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestOAuth2TokenCleanText:
+    # No grandfather test: OAuth2 tokens are not updated via PATCH — most fields
+    # (token, expires, refresh_token, user) are read-only.
+
+    def test_rejects_invalid_description_on_create(self, admin_api_client, oauth2_application):
+        app, _ = oauth2_application
+        url = get_relative_url('token-list')
+        data = {
+            'scope': 'read',
+            'description': DANGEROUS_TEXT,
+            'application': app.pk,
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'description' in response.data
+
+    def test_accepts_valid_description_on_create(self, admin_api_client, oauth2_application):
+        app, _ = oauth2_application
+        url = get_relative_url('token-list')
+        data = {
+            'scope': 'read',
+            'description': 'My personal access token',
+            'application': app.pk,
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 201

--- a/test_app/tests/rbac/api/test_clean_text_integration.py
+++ b/test_app/tests/rbac/api/test_clean_text_integration.py
@@ -1,0 +1,69 @@
+"""Tests that CleanTextMixin is correctly wired to DAB RBAC serializers."""
+
+import pytest
+
+from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac.models import RoleDefinition
+
+DANGEROUS_NAME = '<script>alert(1)</script>'
+DANGEROUS_TEXT = '$(rm -rf /)'
+
+
+@pytest.mark.django_db
+class TestRoleDefinitionCleanText:
+
+    def test_rejects_invalid_name_on_create(self, admin_api_client):
+        url = get_relative_url('roledefinition-list')
+        data = {
+            'name': DANGEROUS_NAME,
+            'description': 'A valid description',
+            'permissions': ['shared.view_organization'],
+            'content_type': 'shared.organization',
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data
+
+    def test_rejects_invalid_description_on_create(self, admin_api_client):
+        url = get_relative_url('roledefinition-list')
+        data = {
+            'name': 'Valid Role Name',
+            'description': DANGEROUS_TEXT,
+            'permissions': ['shared.view_organization'],
+            'content_type': 'shared.organization',
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 400
+        assert 'description' in response.data
+
+    def test_accepts_valid_data_on_create(self, admin_api_client):
+        url = get_relative_url('roledefinition-list')
+        data = {
+            'name': 'My Custom Role',
+            'description': 'A role for viewing organizations',
+            'permissions': ['shared.view_organization'],
+            'content_type': 'shared.organization',
+        }
+        response = admin_api_client.post(url, data=data, format='json')
+        assert response.status_code == 201
+
+    def test_grandfather_unchanged_name_on_update(self, admin_api_client):
+        url = get_relative_url('roledefinition-list')
+        response = admin_api_client.post(
+            url,
+            data={
+                'name': 'Temp Role',
+                'description': 'Original',
+                'permissions': ['shared.view_organization'],
+                'content_type': 'shared.organization',
+            },
+            format='json',
+        )
+        assert response.status_code == 201
+        rd_id = response.data['id']
+
+        RoleDefinition.objects.filter(pk=rd_id).update(name='name;semicolon')
+
+        detail_url = get_relative_url('roledefinition-detail', kwargs={'pk': rd_id})
+        response = admin_api_client.patch(detail_url, data={'name': 'name;semicolon', 'description': 'Updated'}, format='json')
+        assert response.status_code == 200

--- a/test_app/tests/rbac/api/test_clean_text_integration.py
+++ b/test_app/tests/rbac/api/test_clean_text_integration.py
@@ -1,6 +1,7 @@
 """Tests that CleanTextMixin is correctly wired to DAB RBAC serializers."""
 
 import pytest
+from django.test import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
@@ -9,6 +10,7 @@ DANGEROUS_NAME = '<script>alert(1)</script>'
 DANGEROUS_TEXT = '$(rm -rf /)'
 
 
+@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
 @pytest.mark.django_db
 class TestRoleDefinitionCleanText:
 

--- a/test_app/tests/rbac/api/test_clean_text_integration.py
+++ b/test_app/tests/rbac/api/test_clean_text_integration.py
@@ -1,7 +1,6 @@
 """Tests that CleanTextMixin is correctly wired to DAB RBAC serializers."""
 
 import pytest
-from django.test import override_settings
 
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import RoleDefinition
@@ -9,9 +8,14 @@ from ansible_base.rbac.models import RoleDefinition
 DANGEROUS_NAME = '<script>alert(1)</script>'
 DANGEROUS_TEXT = '$(rm -rf /)'
 
+pytestmark = pytest.mark.django_db
 
-@override_settings(ENHANCED_INPUT_VALIDATION_ENABLED=True)
-@pytest.mark.django_db
+
+@pytest.fixture(autouse=True)
+def _enable_enhanced_validation(settings):
+    settings.ENHANCED_INPUT_VALIDATION_ENABLED = True
+
+
 class TestRoleDefinitionCleanText:
 
     def test_rejects_invalid_name_on_create(self, admin_api_client):

--- a/test_app/tests/rbac/api/test_clean_text_integration.py
+++ b/test_app/tests/rbac/api/test_clean_text_integration.py
@@ -73,3 +73,25 @@ class TestRoleDefinitionCleanText:
         detail_url = get_relative_url('roledefinition-detail', kwargs={'pk': rd_id})
         response = admin_api_client.patch(detail_url, data={'name': 'name;semicolon', 'description': 'Updated'}, format='json')
         assert response.status_code == 200
+
+    def test_rejects_changed_invalid_name_on_update(self, admin_api_client):
+        url = get_relative_url('roledefinition-list')
+        response = admin_api_client.post(
+            url,
+            data={
+                'name': 'Temp Role Two',
+                'description': 'Original',
+                'permissions': ['shared.view_organization'],
+                'content_type': 'shared.organization',
+            },
+            format='json',
+        )
+        assert response.status_code == 201
+        rd_id = response.data['id']
+
+        RoleDefinition.objects.filter(pk=rd_id).update(name='name;semicolon')
+
+        detail_url = get_relative_url('roledefinition-detail', kwargs={'pk': rd_id})
+        response = admin_api_client.patch(detail_url, data={'name': DANGEROUS_NAME, 'description': 'Updated'}, format='json')
+        assert response.status_code == 400
+        assert 'name' in response.data


### PR DESCRIPTION
## Description

#### Dependencies
This PR builds on top of https://github.com/ansible/django-ansible-base/pull/1087 (merged), which introduced the CleanTextMixin, Tier 1 name validator, and Tier 2 free-text validator. 

JIRA: https://redhat.atlassian.net/browse/AAP-77215

  **What is being changed?**

  Wire `CleanTextMixin` (https://github.com/ansible/django-ansible-base/pull/1087) into DAB's five concrete model serializers so that Authenticator, AuthenticatorMap, OAuth2Application, OAuth2AccessToken, and
  RoleDefinition endpoints reject unsafe text input with HTTP 400.

  - `AuthenticatorSerializer` — Tier 1 validation on `name`
  - `AuthenticatorMapSerializer` — Tier 1 on `name`, with `excluded_fields` for `organization`/`role`/`team` (template expansion syntax)
  - `OAuth2ApplicationSerializer` — Tier 1 on `name`, Tier 2 on `description`
  - `OAuth2TokenSerializer` — Tier 2 on `description`
  - `RoleDefinitionSerializer` — Tier 1 on `name`, Tier 2 on `description`

  **Why is this change needed?**

  Addresses [AAP-77215](https://redhat.atlassian.net/browse/AAP-77215) under the parent epic [AAP-74584](https://redhat.atlassian.net/browse/AAP-74584) (DAB
  Input Validation and Sanitization). CAP-1040 identified that free-text API fields accept unsafe input (XSS, shell injection, control characters). Validation is
  enforced at the serializer layer so all clients (UI, API, CLI) get consistent rejection.

  **How does this change address the issue?**

  - `CleanTextMixin` is placed first in the MRO of each serializer, hooking into `validate()` via `super()` chaining
  - Two serializers (`AuthenticatorSerializer`, `AuthenticatorMapSerializer`) had broken `super().validate()` chains (`return data` instead of `return
  super().validate(data)`) — fixed as a prerequisite
  - `AuthenticatorMapSerializer` sets `excluded_fields = frozenset({'organization', 'role', 'team'})` because these fields accept `{% for_attr_value() %}`
  template expansion syntax
  - Subclass serializers (`AuthenticatorUpdateSerializer`, `RoleDefinitionDetailSerializer`) inherit the mixin automatically
  - Grandfathering: unchanged values on update are skipped, so pre-existing data is not blocked

  ## Type of Change
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [x] Test update
  - [ ] Refactoring (no functional changes)
  - [ ] Development environment change
  - [ ] Configuration change

  ## Self-Review Checklist
  - [x] I have performed a self-review of my code
  - [x] I have added relevant comments to complex code sections
  - [x] I have updated documentation where needed
  - [x] I have considered the security impact of these changes
  - [x] I have considered performance implications
  - [x] I have thought about error handling and edge cases
  - [x] I have tested the changes in my local environment

  ## Related PRs

### ATF Tests 

ATF tests: https://gitlab.cee.redhat.com/ansible/testing/platform-services-test-suite/-/merge_requests/188

<img width="596" height="576" alt="image" src="https://github.com/user-attachments/assets/f45b3647-1d57-4ecc-858d-cdf1bbc772ac" />


## Testing Instructions

### Prerequisites
  - A working DAB test environment (`pip install -e ".[all]"`)

### Steps to Test

### Manual Testing

Please follow these instructions: https://docs.google.com/document/d/1wfGlKk4BWULIhUB9jPCw_M65NIetfzUHWUQCEWkC-wE/edit?usp=sharing 

### Tests

  1. Run the existing mixin unit tests:
     pytest test_app/tests/lib/serializers/test_clean_text_mixin.py -v
     pytest test_app/tests/lib/utils/test_validation.py -v

  2. Run the new integration tests for each app:
     pytest test_app/tests/authentication/test_clean_text_integration.py -v
     pytest test_app/tests/oauth2_provider/test_clean_text_integration.py -v
     pytest test_app/tests/rbac/api/test_clean_text_integration.py -v

  3. Run the existing serializer/view tests to verify no regressions:
     pytest test_app/tests/authentication/ -v
     pytest test_app/tests/oauth2_provider/ -v
     pytest test_app/tests/rbac/ -v

  4. Verify AuthenticatorMap template expansion fields still work:
     pytest test_app/tests/authentication/serializers/test_authenticator_map.py::TestAuthenticatorMapEscapeSequence -v

  ### Expected Results
  - All tests pass
  - Invalid names (e.g. `<script>alert(1)</script>`) rejected with HTTP 400 on create
  - Invalid descriptions (e.g. `$(rm -rf /)`) rejected with HTTP 400 on create
  - Pre-existing invalid values are grandfathered on update when unchanged
  - AuthenticatorMap template expansion syntax (`{% for_attr_value() %}`) still accepted in organization/role/team fields

  ## Additional Context

  ### Dependencies

  This PR builds on top of [#1087](https://github.com/ansible/django-ansible-base/pull/1087), which introduced the `CleanTextMixin`, Tier 1 name validator, and
  Tier 2 free-text validator. That PR must be merged first — the commits from it appear in this branch's history.

  ### Required Actions
  - [ ] Requires documentation updates
  - [x] Requires downstream repository changes
    <!-- Gateway and other services consuming DAB serializers for these models will get validation automatically. Services with their own serializers for DAB
  abstract models (e.g. AWX Job Templates, EDA Projects) need separate CleanTextMixin wiring — tracked under the parent epic AAP-74584. -->
  - [ ] Requires infrastructure/deployment changes
  - [x] Requires coordination with other teams
    <!-- UI team for end-to-end manual verification against a locally running aap-dev instance (per comment on AAP-77215). -->
  - [x] Blocked by PR/MR: [#1087](https://github.com/ansible/django-ansible-base/pull/1087)
    <!-- Introduces CleanTextMixin and validators that this PR wires to DAB serializers -->

  ### Key design decisions

  | Decision | Rationale |
  |----------|-----------|
  | Serializer-level validation, not model-level | Model validators cannot skip unchanged fields on update (grandfathering). Confirmed by POC
  [AAP-84927](https://redhat.atlassian.net/browse/AAP-84927). |
  | Reject (HTTP 400), not strip | Stripping silently alters user input. Rejection gives clear feedback. |
  | `excluded_fields` for AuthenticatorMap template fields | `organization`, `role`, `team` accept `{% for_attr_value() %}` expansion syntax which matches the
  Tier 2 template injection pattern. |
  | Fix `super().validate()` chains | `AuthenticatorSerializer` and `AuthenticatorMapSerializer` returned `data` without calling `super().validate()`, silently
  bypassing any mixin in the MRO. Safe fix — `ModelSerializer.validate()` is a passthrough. |


[AAP-77215]: https://redhat.atlassian.net/browse/AAP-77215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced text validation for authentication, OAuth applications and tokens, and role definitions.
  * Added validation for authenticator mappings while allowing approved template expansion values.
  * Preserved validation for applicable authenticator configuration fields while allowing encrypted and structured pass-through values.

* **Documentation**
  * Documented JSON validation exclusions and template expansion handling.

* **Tests**
  * Added integration coverage for validation, updates, valid values, and grandfathered existing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->