### PR TITLE
AAP-89344 Scope RP-initiated logout token revocation to openid-scoped sessions per application

### DIFF
--- a/ansible_base/oauth2_provider/urls.py
+++ b/ansible_base/oauth2_provider/urls.py
@@ -39,7 +39,7 @@ oauth_urls = [
     re_path(r"^\.well-known/openid-configuration/$", oauth2_provider_views.DiscoveryInfoView.as_view(), name="oidc-connect-discovery-info"),
     re_path(r"^\.well-known/jwks\.json$", oauth_views.JwksInfoView.as_view(), name="jwks-info"),
     re_path(r"^userinfo/$", oauth_views.UserInfoView.as_view(), name="user-info"),
-    re_path(r"^logout/$", oauth_views.RPInitiatedLogoutView.as_view(), name="rp-initiated-logout"),
+    re_path(r"^logout/$", oauth2_provider_views.RPInitiatedLogoutView.as_view(), name="rp-initiated-logout"),
 ]
 
 

--- a/ansible_base/oauth2_provider/views/__init__.py
+++ b/ansible_base/oauth2_provider/views/__init__.py
@@ -2,6 +2,6 @@ from .application import OAuth2ApplicationViewSet  # noqa: F401
 from .authorization import AuthorizationView  # noqa: F401
 from .authorization_root import ApiOAuthAuthorizationRootView  # noqa: F401
 from .not_found import NotFoundView  # noqa: F401
-from .oidc import DiscoveryInfoView  # noqa: F401
+from .oidc import DiscoveryInfoView, RPInitiatedLogoutView  # noqa: F401
 from .token import OAuth2TokenViewSet, TokenView  # noqa: F401
 from .user_mixin import DABOAuth2UserViewsetMixin  # noqa: F401

--- a/ansible_base/oauth2_provider/views/oidc.py
+++ b/ansible_base/oauth2_provider/views/oidc.py
@@ -3,8 +3,17 @@ import logging
 
 from django.contrib.auth import logout
 from django.urls import reverse
+from jwcrypto import jwt
+from jwcrypto.common import JWException
+from jwcrypto.jws import InvalidJWSObject, JWS
+from jwcrypto.jwt import JWTExpired
 from oauth2_provider.http import OAuth2ResponseRedirect
-from oauth2_provider.models import get_access_token_model, get_refresh_token_model
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_application_model,
+    get_id_token_model,
+    get_refresh_token_model,
+)
 from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.views import RPInitiatedLogoutView as _DOTRPInitiatedLogoutView
 from oauth2_provider.views.oidc import ConnectDiscoveryInfoView
@@ -12,19 +21,56 @@ from oauthlib.common import add_params_to_uri
 
 logger = logging.getLogger('ansible_base.oauth2_provider.views.oidc')
 
-try:
-    # DOT-private helper: decodes an id_token_hint JWT to its IDToken row (by jti).
-    # Not public API; fail loud on a DOT upgrade rather than silently reverting to
-    # the insecure delete-all behavior. Re-audit when the DOT<2.4.0 pin is bumped.
-    from oauth2_provider.views.oidc import _load_id_token
-except ImportError as exc:  # pragma: no cover - trips loudly on a DOT upgrade/refactor
-    raise ImportError(
-        "django-oauth-toolkit no longer exposes oauth2_provider.views.oidc._load_id_token(). "
-        "ansible_base.oauth2_provider.views.oidc.RPInitiatedLogoutView depends on it to scope "
-        "RP-Initiated Logout token deletion to the specific session ending, instead of DOT's "
-        "own (unscoped) delete-all-tokens-for-user behavior. Update this module for the new "
-        "django-oauth-toolkit version before removing this guard."
-    ) from exc
+Application = get_application_model()
+
+
+def _jwk_key_for_id_token_hint(id_token_hint):
+    """Resolve the signing key for an id_token_hint JWT using public DOT model APIs."""
+    try:
+        unverified_token = JWS()
+        unverified_token.deserialize(id_token_hint)
+        claims = json.loads(unverified_token.objects["payload"].decode("utf-8"))
+    except (InvalidJWSObject, KeyError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    audience = claims.get("aud")
+    if not audience:
+        return None
+    if isinstance(audience, str):
+        audience = [audience]
+
+    application = Application.objects.filter(client_id__in=audience).first()
+    if not application:
+        return None
+    return application.jwk_key
+
+
+def load_id_token_from_hint(request, id_token_hint):
+    """Decode and verify an id_token_hint JWT, returning the matching IDToken row."""
+    key = _jwk_key_for_id_token_hint(id_token_hint)
+    if not key:
+        return None, None
+
+    IDToken = get_id_token_model()
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+
+    try:
+        if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS:
+            check_claims = {}
+        else:
+            check_claims = None
+        jwt_token = jwt.JWT(key=key, jwt=id_token_hint, check_claims=check_claims)
+        claims = json.loads(jwt_token.claims)
+    except (JWException, JWTExpired):
+        return None, None
+
+    if "iss" not in claims or claims["iss"] != validator.get_oidc_issuer_endpoint(request):
+        return None, None
+
+    try:
+        return IDToken.objects.get(jti=claims["jti"]), claims
+    except IDToken.DoesNotExist:
+        return None, None
 
 
 class DiscoveryInfoView(ConnectDiscoveryInfoView):
@@ -91,13 +137,11 @@ class RPInitiatedLogoutView(_DOTRPInitiatedLogoutView):
             # Can't identify the session -> delete nothing (no delete-all fallback).
             return
 
-        id_token, _claims = _load_id_token(id_token_hint)
+        id_token, _claims = load_id_token_from_hint(self.request, id_token_hint)
         if id_token is None:
             # Bad signature, expired, or unknown jti.
             return
 
-        # Only revoke the caller's OWN session: never let a user end another user's session
-        # (or an anonymous request end anyone's) via a supplied hint. logout() still runs.
         request_user_id = getattr(self.request.user, 'id', None)
         if request_user_id is None or id_token.user_id != request_user_id:
             logger.warning(

--- a/ansible_base/oauth2_provider/views/oidc.py
+++ b/ansible_base/oauth2_provider/views/oidc.py
@@ -1,76 +1,13 @@
 import json
-import logging
 
 from django.contrib.auth import logout
 from django.urls import reverse
-from jwcrypto import jwt
-from jwcrypto.common import JWException
-from jwcrypto.jws import InvalidJWSObject, JWS
-from jwcrypto.jwt import JWTExpired
 from oauth2_provider.http import OAuth2ResponseRedirect
-from oauth2_provider.models import (
-    get_access_token_model,
-    get_application_model,
-    get_id_token_model,
-    get_refresh_token_model,
-)
+from oauth2_provider.models import get_access_token_model, get_refresh_token_model
 from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.views import RPInitiatedLogoutView as _DOTRPInitiatedLogoutView
 from oauth2_provider.views.oidc import ConnectDiscoveryInfoView
 from oauthlib.common import add_params_to_uri
-
-logger = logging.getLogger('ansible_base.oauth2_provider.views.oidc')
-
-Application = get_application_model()
-
-
-def _jwk_key_for_id_token_hint(id_token_hint):
-    """Resolve the signing key for an id_token_hint JWT using public DOT model APIs."""
-    try:
-        unverified_token = JWS()
-        unverified_token.deserialize(id_token_hint)
-        claims = json.loads(unverified_token.objects["payload"].decode("utf-8"))
-    except (InvalidJWSObject, KeyError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
-
-    audience = claims.get("aud")
-    if not audience:
-        return None
-    if isinstance(audience, str):
-        audience = [audience]
-
-    application = Application.objects.filter(client_id__in=audience).first()
-    if not application:
-        return None
-    return application.jwk_key
-
-
-def load_id_token_from_hint(request, id_token_hint):
-    """Decode and verify an id_token_hint JWT, returning the matching IDToken row."""
-    key = _jwk_key_for_id_token_hint(id_token_hint)
-    if not key:
-        return None, None
-
-    IDToken = get_id_token_model()
-    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
-
-    try:
-        if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS:
-            check_claims = {}
-        else:
-            check_claims = None
-        jwt_token = jwt.JWT(key=key, jwt=id_token_hint, check_claims=check_claims)
-        claims = json.loads(jwt_token.claims)
-    except (JWException, JWTExpired):
-        return None, None
-
-    if "iss" not in claims or claims["iss"] != validator.get_oidc_issuer_endpoint(request):
-        return None, None
-
-    try:
-        return IDToken.objects.get(jti=claims["jti"]), claims
-    except IDToken.DoesNotExist:
-        return None, None
 
 
 class DiscoveryInfoView(ConnectDiscoveryInfoView):
@@ -95,22 +32,17 @@ class DiscoveryInfoView(ConnectDiscoveryInfoView):
 
 class RPInitiatedLogoutView(_DOTRPInitiatedLogoutView):
     """
-    Scope RP-Initiated Logout token deletion to the single session (the
-    AccessToken/RefreshToken/IDToken triplet) identified by `id_token_hint`.
-
-    DOT's stock do_logout() instead deletes every token the user owns across all
-    applications, destroying unrelated long-lived API tokens on logout. We revoke
-    only the triplet tied to `id_token_hint`; if it is missing/invalid/unresolvable,
-    we delete nothing (session logout still happens) rather than falling back to
-    DOT's delete-all behavior.
+    Scope RP-Initiated Logout revocation to the requesting user's own `openid`-scoped
+    tokens for the requesting application -- not DOT's stock do_logout(), which
+    deletes every token the user owns across ALL applications, including unrelated
+    long-lived API tokens (PATs, application tokens).
     """
 
     def do_logout(self, application=None, post_logout_redirect_uri=None, state=None, token_user=None):
-        # DOT 2.3.0's do_logout() with the deletion block swapped for scoped deletion.
-        # The logout()+redirect tail is duplicated (not super()) because DOT gives no
-        # smaller override seam; re-audit against DOT when the pin is bumped.
+        # DOT 2.3.0's do_logout(), deletion block swapped for scoped deletion.
+        # No smaller override seam exists; re-audit against DOT when the pin is bumped.
         if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS:
-            self._revoke_session_tokens()
+            self._revoke_openid_tokens(self.request.user, application)
 
         # Logout in Django
         logout(self.request)
@@ -127,48 +59,30 @@ class RPInitiatedLogoutView(_DOTRPInitiatedLogoutView):
             oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES,
         )
 
-    def _revoke_session_tokens(self):
-        """Revoke only the authenticated user's own IDToken/AccessToken/RefreshToken tied to id_token_hint."""
-        # self.oidc_data is unusable here: dispatch() resets it to {} and it's only
-        # populated on the form-rendering GET branch, so read the hint off the request
-        # (POST hidden field, or GET for the no-prompt short-circuit).
-        id_token_hint = self.request.POST.get("id_token_hint") or self.request.GET.get("id_token_hint")
-        if not id_token_hint:
-            # Can't identify the session -> delete nothing (no delete-all fallback).
-            return
-
-        id_token, _claims = load_id_token_from_hint(self.request, id_token_hint)
-        if id_token is None:
-            # Bad signature, expired, or unknown jti.
-            return
-
-        request_user_id = getattr(self.request.user, 'id', None)
-        if request_user_id is None or id_token.user_id != request_user_id:
-            logger.warning(
-                "RP-Initiated Logout: id_token_hint (jti=%s) does not belong to the logging-out user; skipping token deletion.",
-                id_token.jti,
-            )
+    def _revoke_openid_tokens(self, user, application=None):
+        """Revoke the user's openid-scoped AccessTokens (plus linked id/refresh
+        tokens), narrowed to `application` when the logout request identifies one."""
+        if user is None or not user.is_authenticated:
             return
 
         AccessToken = get_access_token_model()
         RefreshToken = get_refresh_token_model()
 
-        try:
-            access_token = id_token.access_token
-        except AccessToken.DoesNotExist:
-            access_token = None
+        access_tokens = AccessToken.objects.filter(user=user, scope__regex=r"(^|\s)openid(\s|$)")
+        if application is not None:
+            access_tokens = access_tokens.filter(application=application)
 
-        refresh_token = None
-        if access_token is not None:
+        for access_token in list(access_tokens):
+            # id_token is a direct nullable FK on AccessToken -- None, not DoesNotExist, when unset.
+            id_token = access_token.id_token
+
             try:
                 refresh_token = access_token.refresh_token
             except RefreshToken.DoesNotExist:
                 refresh_token = None
 
-        # DOT's order: id_token (cascade-deletes its access token), then access token
-        # (no-op if already gone), then refresh token (marked revoked, not deleted).
-        id_token.revoke()
-        if access_token is not None:
+            if id_token is not None:
+                id_token.revoke()
             access_token.revoke()
-        if refresh_token is not None:
-            refresh_token.revoke()
+            if refresh_token is not None:
+                refresh_token.revoke()

--- a/ansible_base/oauth2_provider/views/oidc.py
+++ b/ansible_base/oauth2_provider/views/oidc.py
@@ -65,20 +65,20 @@ class RPInitiatedLogoutView(_DOTRPInitiatedLogoutView):
         if user is None or not user.is_authenticated:
             return
 
-        AccessToken = get_access_token_model()
-        RefreshToken = get_refresh_token_model()
+        access_token_model = get_access_token_model()
+        refresh_token_model = get_refresh_token_model()
 
-        access_tokens = AccessToken.objects.filter(user=user, scope__regex=r"(^|\s)openid(\s|$)")
+        access_tokens = access_token_model.objects.filter(user=user, scope__regex=r"(^|\s)openid(\s|$)")
         if application is not None:
             access_tokens = access_tokens.filter(application=application)
 
-        for access_token in list(access_tokens):
+        for access_token in access_tokens:
             # id_token is a direct nullable FK on AccessToken -- None, not DoesNotExist, when unset.
             id_token = access_token.id_token
 
             try:
                 refresh_token = access_token.refresh_token
-            except RefreshToken.DoesNotExist:
+            except refresh_token_model.DoesNotExist:
                 refresh_token = None
 
             if id_token is not None:

--- a/ansible_base/oauth2_provider/views/oidc.py
+++ b/ansible_base/oauth2_provider/views/oidc.py
@@ -1,7 +1,30 @@
 import json
+import logging
 
+from django.contrib.auth import logout
 from django.urls import reverse
+from oauth2_provider.http import OAuth2ResponseRedirect
+from oauth2_provider.models import get_access_token_model, get_refresh_token_model
+from oauth2_provider.settings import oauth2_settings
+from oauth2_provider.views import RPInitiatedLogoutView as _DOTRPInitiatedLogoutView
 from oauth2_provider.views.oidc import ConnectDiscoveryInfoView
+from oauthlib.common import add_params_to_uri
+
+logger = logging.getLogger('ansible_base.oauth2_provider.views.oidc')
+
+try:
+    # DOT-private helper: decodes an id_token_hint JWT to its IDToken row (by jti).
+    # Not public API; fail loud on a DOT upgrade rather than silently reverting to
+    # the insecure delete-all behavior. Re-audit when the DOT<2.4.0 pin is bumped.
+    from oauth2_provider.views.oidc import _load_id_token
+except ImportError as exc:  # pragma: no cover - trips loudly on a DOT upgrade/refactor
+    raise ImportError(
+        "django-oauth-toolkit no longer exposes oauth2_provider.views.oidc._load_id_token(). "
+        "ansible_base.oauth2_provider.views.oidc.RPInitiatedLogoutView depends on it to scope "
+        "RP-Initiated Logout token deletion to the specific session ending, instead of DOT's "
+        "own (unscoped) delete-all-tokens-for-user behavior. Update this module for the new "
+        "django-oauth-toolkit version before removing this guard."
+    ) from exc
 
 
 class DiscoveryInfoView(ConnectDiscoveryInfoView):
@@ -22,3 +45,86 @@ class DiscoveryInfoView(ConnectDiscoveryInfoView):
 
         response.content = json.dumps(data)
         return response
+
+
+class RPInitiatedLogoutView(_DOTRPInitiatedLogoutView):
+    """
+    Scope RP-Initiated Logout token deletion to the single session (the
+    AccessToken/RefreshToken/IDToken triplet) identified by `id_token_hint`.
+
+    DOT's stock do_logout() instead deletes every token the user owns across all
+    applications, destroying unrelated long-lived API tokens on logout. We revoke
+    only the triplet tied to `id_token_hint`; if it is missing/invalid/unresolvable,
+    we delete nothing (session logout still happens) rather than falling back to
+    DOT's delete-all behavior.
+    """
+
+    def do_logout(self, application=None, post_logout_redirect_uri=None, state=None, token_user=None):
+        # DOT 2.3.0's do_logout() with the deletion block swapped for scoped deletion.
+        # The logout()+redirect tail is duplicated (not super()) because DOT gives no
+        # smaller override seam; re-audit against DOT when the pin is bumped.
+        if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS:
+            self._revoke_session_tokens()
+
+        # Logout in Django
+        logout(self.request)
+
+        if post_logout_redirect_uri:
+            if state:
+                return OAuth2ResponseRedirect(
+                    add_params_to_uri(post_logout_redirect_uri, [("state", state)]),
+                    application.get_allowed_schemes(),
+                )
+            return OAuth2ResponseRedirect(post_logout_redirect_uri, application.get_allowed_schemes())
+        return OAuth2ResponseRedirect(
+            self.request.build_absolute_uri("/"),
+            oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES,
+        )
+
+    def _revoke_session_tokens(self):
+        """Revoke only the authenticated user's own IDToken/AccessToken/RefreshToken tied to id_token_hint."""
+        # self.oidc_data is unusable here: dispatch() resets it to {} and it's only
+        # populated on the form-rendering GET branch, so read the hint off the request
+        # (POST hidden field, or GET for the no-prompt short-circuit).
+        id_token_hint = self.request.POST.get("id_token_hint") or self.request.GET.get("id_token_hint")
+        if not id_token_hint:
+            # Can't identify the session -> delete nothing (no delete-all fallback).
+            return
+
+        id_token, _claims = _load_id_token(id_token_hint)
+        if id_token is None:
+            # Bad signature, expired, or unknown jti.
+            return
+
+        # Only revoke the caller's OWN session: never let a user end another user's session
+        # (or an anonymous request end anyone's) via a supplied hint. logout() still runs.
+        request_user_id = getattr(self.request.user, 'id', None)
+        if request_user_id is None or id_token.user_id != request_user_id:
+            logger.warning(
+                "RP-Initiated Logout: id_token_hint (jti=%s) does not belong to the logging-out user; skipping token deletion.",
+                id_token.jti,
+            )
+            return
+
+        AccessToken = get_access_token_model()
+        RefreshToken = get_refresh_token_model()
+
+        try:
+            access_token = id_token.access_token
+        except AccessToken.DoesNotExist:
+            access_token = None
+
+        refresh_token = None
+        if access_token is not None:
+            try:
+                refresh_token = access_token.refresh_token
+            except RefreshToken.DoesNotExist:
+                refresh_token = None
+
+        # DOT's order: id_token (cascade-deletes its access token), then access token
+        # (no-op if already gone), then refresh token (marked revoked, not deleted).
+        id_token.revoke()
+        if access_token is not None:
+            access_token.revoke()
+        if refresh_token is not None:
+            refresh_token.revoke()

--- a/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
+++ b/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
@@ -1,10 +1,20 @@
+import base64
+import json
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.conf import settings
 from django.test import override_settings
+from django.utils.http import urlencode
+from rest_framework.test import APIClient
 
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.oauth2_provider.models import (
+    OAuth2AccessToken,
+    OAuth2Application,
+    OAuth2IDToken,
+    OAuth2RefreshToken,
+)
 
 
 @pytest.fixture
@@ -13,6 +23,7 @@ def oidc_enabled_settings():
     return {
         **settings.OAUTH2_PROVIDER,
         'OIDC_ENABLED': True,
+        'SCOPES': {'read': 'Read', 'write': 'Write', 'openid': 'OpenID', 'roles': 'Roles'},
         'OIDC_RP_INITIATED_LOGOUT_ENABLED': True,
         'OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS': True,
         'OIDC_RP_INITIATED_LOGOUT_STRICT_REDIRECT_URIS': True,
@@ -281,6 +292,196 @@ def test_logout_without_parameters(client, oidc_enabled_settings):
         response = client.post(url)
 
         assert response.status_code == 400
+
+
+@pytest.fixture
+def oidc_app_factory(randname):
+    """Factory for apps that issue HS256 ID tokens (key derived from client_secret, no RSA setup)."""
+
+    def _factory(name_prefix="OIDC App"):
+        app = OAuth2Application(
+            name=randname(name_prefix),
+            redirect_uris="https://example.com/callback",
+            post_logout_redirect_uris="https://example.com/callback",
+            authorization_grant_type="authorization-code",
+            client_type="confidential",
+            algorithm=OAuth2Application.HS256_ALGORITHM,
+            pkce_required=False,
+        )
+        secret = app.client_secret  # capture plaintext before it's hashed on save
+        app.save()
+        return app, secret
+
+    return _factory
+
+
+def _jwt_claims(jwt_str):
+    """Decode (unverified) a JWT payload -- used only to find the IDToken row by jti."""
+    payload_b64 = jwt_str.split(".")[1]
+    payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64 padding
+    return json.loads(base64.urlsafe_b64decode(payload_b64.encode()))
+
+
+def _mint_session(api_client, app, secret):
+    """Run the real authorize -> token flow; return (id_token_jwt, id_token, access_token, refresh_token).
+
+    Using the real endpoints guarantees the id_token is one _load_id_token() will accept.
+    """
+    authorize_url = get_relative_url("oauth2_provider:authorize")
+    response = api_client.post(
+        authorize_url,
+        data={
+            "client_id": app.client_id,
+            "response_type": "code",
+            "scope": "openid read",
+            "redirect_uri": app.redirect_uris,
+            "allow": "Authorize",
+        },
+    )
+    assert response.status_code == 302, response.status_code
+    code = parse_qs(urlparse(response.url).query)["code"][0]
+
+    token_url = get_relative_url("oauth2_provider:token")
+    token_response = api_client.post(
+        token_url,
+        data=urlencode(
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": app.redirect_uris,
+                "client_id": app.client_id,
+                "client_secret": secret,
+            }
+        ),
+        content_type="application/x-www-form-urlencoded",
+    )
+    # DAB's TokenView returns 201 on token creation (DOT's default is 200); accept either.
+    assert token_response.status_code in (200, 201), token_response.status_code
+    id_token_jwt = token_response.json()["id_token"]
+
+    id_token_row = OAuth2IDToken.objects.get(jti=_jwt_claims(id_token_jwt)["jti"])
+    access_token_row = id_token_row.access_token
+    refresh_token_row = OAuth2RefreshToken.objects.get(access_token=access_token_row)
+    return id_token_jwt, id_token_row, access_token_row, refresh_token_row
+
+
+def _assert_session_alive(id_token_row, access_token_row, refresh_token_row):
+    assert OAuth2IDToken.objects.filter(pk=id_token_row.pk).exists()
+    assert OAuth2AccessToken.objects.filter(pk=access_token_row.pk).exists()
+    refresh_token_row.refresh_from_db()
+    assert refresh_token_row.revoked is None
+
+
+def _assert_session_revoked(id_token_row, access_token_row, refresh_token_row):
+    # id_token/access_token rows are deleted; refresh_token is marked revoked (access_token nulled).
+    assert not OAuth2IDToken.objects.filter(pk=id_token_row.pk).exists()
+    assert not OAuth2AccessToken.objects.filter(pk=access_token_row.pk).exists()
+    refresh_token_row.refresh_from_db()
+    assert refresh_token_row.revoked is not None
+    assert refresh_token_row.access_token_id is None
+
+
+@pytest.mark.django_db
+def test_logout_only_deletes_the_targeted_session(user_api_client, user, random_user, oidc_app_factory, oidc_enabled_settings):
+    """Logout with one session's id_token_hint revokes only that session (via GET short-circuit)."""
+    app1, secret1 = oidc_app_factory("App One")
+    app2, secret2 = oidc_app_factory("App Two")
+
+    with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
+        # user: sessions A + B on app1 (same app), session C on app2
+        a_jwt, a_id, a_at, a_rt = _mint_session(user_api_client, app1, secret1)
+        _b_jwt, b_id, b_at, b_rt = _mint_session(user_api_client, app1, secret1)
+        _c_jwt, c_id, c_at, c_rt = _mint_session(user_api_client, app2, secret2)
+
+        # second user: session D on app1
+        other_client = APIClient()
+        other_client.login(username=random_user.username, password="password")
+        _d_jwt, d_id, d_at, d_rt = _mint_session(other_client, app1, secret1)
+
+        # Log `user` out of session A only. The no-prompt GET path leaves oidc_data == {},
+        # so a fix reading the hint from oidc_data (not the request) would silently fail here.
+        logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
+        response = user_api_client.get(logout_url + "?" + urlencode({"id_token_hint": a_jwt}))
+        assert response.status_code == 302, response.content
+
+    _assert_session_revoked(a_id, a_at, a_rt)
+    _assert_session_alive(b_id, b_at, b_rt)  # other session, same app -> survives
+    _assert_session_alive(c_id, c_at, c_rt)  # other app -> survives
+    _assert_session_alive(d_id, d_at, d_rt)  # other user -> survives
+
+
+@pytest.mark.django_db
+def test_logout_via_post_form_only_deletes_targeted_session(user_api_client, user, oidc_app_factory, oidc_enabled_settings):
+    """Same scoping guarantee via the POST/form_valid() path (the second do_logout() call site)."""
+    app1, secret1 = oidc_app_factory("Form App One")
+
+    with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
+        a_jwt, a_id, a_at, a_rt = _mint_session(user_api_client, app1, secret1)
+        _b_jwt, b_id, b_at, b_rt = _mint_session(user_api_client, app1, secret1)
+
+        logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
+        response = user_api_client.post(logout_url, {"id_token_hint": a_jwt, "allow": True})
+        assert response.status_code == 302, response.content
+
+    _assert_session_revoked(a_id, a_at, a_rt)
+    _assert_session_alive(b_id, b_at, b_rt)
+
+
+@pytest.mark.django_db
+def test_logout_without_id_token_hint_deletes_no_tokens(user_api_client, user, oidc_app_factory, oidc_enabled_settings):
+    """No id_token_hint -> delete nothing (logout still succeeds); no DOT delete-all fallback."""
+    app, secret = oidc_app_factory("No Hint App")
+
+    with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
+        _jwt, id_row, at_row, rt_row = _mint_session(user_api_client, app, secret)
+
+        before = (OAuth2IDToken.objects.count(), OAuth2AccessToken.objects.count(), OAuth2RefreshToken.objects.count())
+
+        logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
+        response = user_api_client.post(logout_url, {"allow": True})
+        assert response.status_code == 302, response.content
+
+    after = (OAuth2IDToken.objects.count(), OAuth2AccessToken.objects.count(), OAuth2RefreshToken.objects.count())
+    assert after == before
+    _assert_session_alive(id_row, at_row, rt_row)
+
+
+@pytest.mark.django_db
+def test_logout_cross_user_hint_revokes_nothing(user_api_client, user, random_user, oidc_app_factory, oidc_enabled_settings):
+    """A user may only revoke their OWN session: submitting another user's hint deletes nothing."""
+    app1, secret1 = oidc_app_factory("Cross User App")
+
+    with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
+        # user B mints a session; user A (user_api_client) then tries to log it out.
+        other_client = APIClient()
+        other_client.login(username=random_user.username, password="password")
+        b_jwt, b_id, b_at, b_rt = _mint_session(other_client, app1, secret1)
+
+        logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
+        response = user_api_client.post(logout_url, {"id_token_hint": b_jwt, "allow": True})
+        assert response.status_code == 302, response.status_code
+
+    _assert_session_alive(b_id, b_at, b_rt)  # B's session untouched by A
+
+
+@pytest.mark.django_db
+def test_logout_preserves_non_oidc_tokens(user_api_client, user, oauth2_user_pat, oauth2_user_application_token, oidc_app_factory, oidc_enabled_settings):
+    """The scoped path must not touch unrelated non-OIDC tokens -- the core production incident.
+
+    Uses an application-scoped token (which stock DOT's delete-all WOULD wipe) plus a PAT.
+    """
+    app, secret = oidc_app_factory("Mixed Token App")
+
+    with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
+        a_jwt, a_id, a_at, a_rt = _mint_session(user_api_client, app, secret)
+
+        logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
+        response = user_api_client.get(logout_url + "?" + urlencode({"id_token_hint": a_jwt}))
+        assert response.status_code == 302, response.status_code
+
+    _assert_session_revoked(a_id, a_at, a_rt)  # targeted OIDC session gone
+    assert OAuth2AccessToken.objects.filter(pk=oauth2_user_application_token.pk).exists()  # app token survives
+    assert OAuth2AccessToken.objects.filter(pk=oauth2_user_pat.pk).exists()  # PAT survives
 
 
 @pytest.mark.django_db

--- a/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
+++ b/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
@@ -325,7 +325,7 @@ def _jwt_claims(jwt_str):
 def _mint_session(api_client, app, secret):
     """Run the real authorize -> token flow; return (id_token_jwt, id_token, access_token, refresh_token).
 
-    Using the real endpoints guarantees the id_token is one _load_id_token() will accept.
+    Using the real endpoints guarantees the id_token is one load_id_token_from_hint() will accept.
     """
     authorize_url = get_relative_url("oauth2_provider:authorize")
     response = api_client.post(

--- a/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
+++ b/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
@@ -325,7 +325,8 @@ def _jwt_claims(jwt_str):
 def _mint_session(api_client, app, secret):
     """Run the real authorize -> token flow; return (id_token_jwt, id_token, access_token, refresh_token).
 
-    Using the real endpoints guarantees the id_token is one load_id_token_from_hint() will accept.
+    Using the real endpoints guarantees the minted AccessToken carries the `openid` scope
+    (requested below), which is what deletion is keyed on.
     """
     authorize_url = get_relative_url("oauth2_provider:authorize")
     response = api_client.post(
@@ -382,8 +383,10 @@ def _assert_session_revoked(id_token_row, access_token_row, refresh_token_row):
 
 
 @pytest.mark.django_db
-def test_logout_only_deletes_the_targeted_session(user_api_client, user, random_user, oidc_app_factory, oidc_enabled_settings):
-    """Logout with one session's id_token_hint revokes only that session (via GET short-circuit)."""
+def test_logout_deletes_openid_sessions_for_the_requesting_application(user_api_client, user, random_user, oidc_app_factory, oidc_enabled_settings):
+    """Logout revokes the requesting user's openid-scoped sessions for the application
+    identified by the logout request (via id_token_hint / client_id resolution) -- other
+    applications' sessions for the same user, and other users' sessions, are untouched."""
     app1, secret1 = oidc_app_factory("App One")
     app2, secret2 = oidc_app_factory("App Two")
 
@@ -398,21 +401,20 @@ def test_logout_only_deletes_the_targeted_session(user_api_client, user, random_
         other_client.login(username=random_user.username, password="password")
         _d_jwt, d_id, d_at, d_rt = _mint_session(other_client, app1, secret1)
 
-        # Log `user` out of session A only. The no-prompt GET path leaves oidc_data == {},
-        # so a fix reading the hint from oidc_data (not the request) would silently fail here.
+        # id_token_hint resolves the requesting application (app1) that deletion is narrowed to.
         logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
         response = user_api_client.get(logout_url + "?" + urlencode({"id_token_hint": a_jwt}))
         assert response.status_code == 302, response.content
 
     _assert_session_revoked(a_id, a_at, a_rt)
-    _assert_session_alive(b_id, b_at, b_rt)  # other session, same app -> survives
-    _assert_session_alive(c_id, c_at, c_rt)  # other app -> survives
+    _assert_session_revoked(b_id, b_at, b_rt)  # same user, same app -> also revoked
+    _assert_session_alive(c_id, c_at, c_rt)  # same user, other app -> survives
     _assert_session_alive(d_id, d_at, d_rt)  # other user -> survives
 
 
 @pytest.mark.django_db
-def test_logout_via_post_form_only_deletes_targeted_session(user_api_client, user, oidc_app_factory, oidc_enabled_settings):
-    """Same scoping guarantee via the POST/form_valid() path (the second do_logout() call site)."""
+def test_logout_via_post_form_deletes_openid_sessions_for_the_requesting_application(user_api_client, user, oidc_app_factory, oidc_enabled_settings):
+    """Same app-scoped guarantee via the POST/form_valid() path (the second do_logout() call site)."""
     app1, secret1 = oidc_app_factory("Form App One")
 
     with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
@@ -424,35 +426,36 @@ def test_logout_via_post_form_only_deletes_targeted_session(user_api_client, use
         assert response.status_code == 302, response.content
 
     _assert_session_revoked(a_id, a_at, a_rt)
-    _assert_session_alive(b_id, b_at, b_rt)
+    _assert_session_revoked(b_id, b_at, b_rt)
 
 
 @pytest.mark.django_db
-def test_logout_without_id_token_hint_deletes_no_tokens(user_api_client, user, oidc_app_factory, oidc_enabled_settings):
-    """No id_token_hint -> delete nothing (logout still succeeds); no DOT delete-all fallback."""
-    app, secret = oidc_app_factory("No Hint App")
+def test_logout_without_hint_deletes_openid_tokens_across_all_apps(user_api_client, user, oidc_app_factory, oidc_enabled_settings):
+    """Without id_token_hint or client_id, no application can be identified, so deletion
+    falls back to all of the user's openid sessions (across every application)."""
+    app1, secret1 = oidc_app_factory("No Hint App One")
+    app2, secret2 = oidc_app_factory("No Hint App Two")
 
     with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
-        _jwt, id_row, at_row, rt_row = _mint_session(user_api_client, app, secret)
-
-        before = (OAuth2IDToken.objects.count(), OAuth2AccessToken.objects.count(), OAuth2RefreshToken.objects.count())
+        _jwt1, id_row1, at_row1, rt_row1 = _mint_session(user_api_client, app1, secret1)
+        _jwt2, id_row2, at_row2, rt_row2 = _mint_session(user_api_client, app2, secret2)
 
         logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
         response = user_api_client.post(logout_url, {"allow": True})
         assert response.status_code == 302, response.content
 
-    after = (OAuth2IDToken.objects.count(), OAuth2AccessToken.objects.count(), OAuth2RefreshToken.objects.count())
-    assert after == before
-    _assert_session_alive(id_row, at_row, rt_row)
+    _assert_session_revoked(id_row1, at_row1, rt_row1)
+    _assert_session_revoked(id_row2, at_row2, rt_row2)
 
 
 @pytest.mark.django_db
 def test_logout_cross_user_hint_revokes_nothing(user_api_client, user, random_user, oidc_app_factory, oidc_enabled_settings):
-    """A user may only revoke their OWN session: submitting another user's hint deletes nothing."""
+    """A user may only revoke their OWN openid sessions: submitting another user's hint does not
+    delete that user's tokens, since deletion is scoped to request.user, not to the hint's user."""
     app1, secret1 = oidc_app_factory("Cross User App")
 
     with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
-        # user B mints a session; user A (user_api_client) then tries to log it out.
+        # user B mints a session; user A (user_api_client) then tries to log it out using B's hint.
         other_client = APIClient()
         other_client.login(username=random_user.username, password="password")
         b_jwt, b_id, b_at, b_rt = _mint_session(other_client, app1, secret1)

--- a/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
+++ b/test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py
@@ -1,11 +1,14 @@
 import base64
 import json
+from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 from django.utils.http import urlencode
+from oauthlib.common import generate_token
 from rest_framework.test import APIClient
 
 from ansible_base.lib.utils.response import get_relative_url
@@ -15,6 +18,7 @@ from ansible_base.oauth2_provider.models import (
     OAuth2IDToken,
     OAuth2RefreshToken,
 )
+from ansible_base.oauth2_provider.views.oidc import RPInitiatedLogoutView
 
 
 @pytest.fixture
@@ -485,6 +489,61 @@ def test_logout_preserves_non_oidc_tokens(user_api_client, user, oauth2_user_pat
     _assert_session_revoked(a_id, a_at, a_rt)  # targeted OIDC session gone
     assert OAuth2AccessToken.objects.filter(pk=oauth2_user_application_token.pk).exists()  # app token survives
     assert OAuth2AccessToken.objects.filter(pk=oauth2_user_pat.pk).exists()  # PAT survives
+
+
+@pytest.mark.django_db
+def test_logout_skips_token_revocation_when_delete_tokens_disabled(user_api_client, oidc_app_factory, oidc_enabled_settings):
+    """When OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS is False, logout proceeds but openid tokens survive."""
+    app, secret = oidc_app_factory("No Delete App")
+    no_delete_settings = {
+        **oidc_enabled_settings,
+        'OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS': False,
+    }
+
+    with override_settings(OAUTH2_PROVIDER=no_delete_settings):
+        _jwt, id_row, at_row, rt_row = _mint_session(user_api_client, app, secret)
+
+        logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
+        response = user_api_client.post(logout_url, {"allow": True})
+        assert response.status_code == 302, response.content
+
+    _assert_session_alive(id_row, at_row, rt_row)
+
+
+@pytest.mark.django_db
+def test_logout_default_redirect_when_no_post_logout_redirect_uri(user_api_client, oidc_enabled_settings):
+    """Without post_logout_redirect_uri, logout redirects to the site root."""
+    with override_settings(OAUTH2_PROVIDER=oidc_enabled_settings):
+        logout_url = get_relative_url("oauth2_provider:rp-initiated-logout")
+        response = user_api_client.post(logout_url, {"allow": True})
+        assert response.status_code == 302, response.content
+        assert urlparse(response["Location"]).path == "/"
+
+
+@pytest.mark.django_db
+def test_revoke_openid_tokens_noop_for_unauthenticated_user():
+    """_revoke_openid_tokens returns immediately for None or anonymous users."""
+    view = RPInitiatedLogoutView()
+    view._revoke_openid_tokens(None)
+    view._revoke_openid_tokens(AnonymousUser())
+
+
+@pytest.mark.django_db
+def test_revoke_openid_tokens_handles_access_token_without_refresh_and_id_tokens(user, oidc_app_factory):
+    """Revocation succeeds when an openid access token has no linked id or refresh token."""
+    app, _secret = oidc_app_factory("Bare Access Token App")
+    access_token = OAuth2AccessToken.objects.create(
+        user=user,
+        application=app,
+        token=generate_token(),
+        scope="openid read",
+        expires=datetime(2088, 1, 1, tzinfo=timezone.utc),
+    )
+
+    view = RPInitiatedLogoutView()
+    view._revoke_openid_tokens(user, application=app)
+
+    assert not OAuth2AccessToken.objects.filter(pk=access_token.pk).exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description

**What is being changed?**
`ansible_base.oauth2_provider` uses a subclass of django-oauth-toolkit's `RPInitiatedLogoutView` instead of the stock view. On logout, the subclass revokes the authenticated user's own `AccessToken`s that carry the `openid` scope (plus their linked `IDToken`/`RefreshToken`), narrowed to the OAuth application that requested the logout when one can be identified.

**Why is this change needed?**
DOT's stock `do_logout()` deletes *every* access/refresh/ID token the user owns, across *all* OAuth applications, whenever `OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS` is enabled. As a result, ending one OIDC browser session was silently destroying unrelated long-lived API tokens (other apps, other sessions, personal access tokens).

**How does this change address the issue?**
`RPInitiatedLogoutView._revoke_openid_tokens(user, application)`:
1. Filters the user's own `AccessToken`s to those whose `scope` contains `openid` (matched as a whole word, e.g. `scope__regex=r"(^|\s)openid(\s|$)"`). PATs and application/API tokens are never minted with `openid` -- only the OIDC authorization-code flow attaches it -- so they're never touched.
2. When the logout request identifies an application (via `id_token_hint` or `client_id`), narrows further to that application's tokens. Otherwise falls back to all of the user's openid-scoped tokens across every application.
3. Revokes each matching token's `IDToken`/`AccessToken`/`RefreshToken` (mirroring DOT's own `revoke()` semantics: id/access tokens are deleted, the refresh token is marked `revoked` rather than deleted).

**Granularity note:** this revokes **every** openid-scoped session the user has on the resolved application, not only the specific session referenced by `id_token_hint`. Logging out of one browser tab/RP session for an application ends all of that user's openid sessions for that same application (other applications and other users are unaffected). This is an intentional tradeoff to avoid decoding/verifying the `id_token_hint` JWT.

Deletion is always scoped to `request.user`, never to a user derived from `id_token_hint`, so a user can never revoke another user's sessions by presenting someone else's hint.

This replaces an earlier approach (in this PR's history) that decoded/verified the `id_token_hint` JWT to resolve one exact session. The `openid`-scope + application filter avoids that JWT-decode machinery entirely while still preventing the original incident.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

### Steps to Test
`DJANGO_SETTINGS_MODULE=test_app.sqlite3settings pytest test_app/tests/oauth2_provider/views/test_rp_initiated_logout.py -o addopts="--reuse-db -p no:logging"`

### Expected Results
All tests pass (full coverage of `_revoke_openid_tokens`, including: same-app sessions revoked, other-app/other-user sessions preserved, no-hint fallback across all apps, `DELETE_TOKENS=False` no-op, default redirect, and edge cases for tokens without linked id/refresh rows).

## Additional Context
No longer relies on any django-oauth-toolkit private API -- `_revoke_openid_tokens` only uses `get_access_token_model()`/`get_refresh_token_model()` and each token's own public `.revoke()`. `do_logout()`'s redirect/logout tail is still duplicated from DOT 2.3.0 (no smaller override seam exists) and should be re-audited when the `django-oauth-toolkit<2.4.0` pin is bumped.

