### PR TITLE
AAP-90362 | feat: delete `FEATURE_INDIRECT_NODE_COUNTING_ENABLED` flag

### DIFF
--- a/ansible_base/feature_flags/definitions/feature_flags.yaml
+++ b/ansible_base/feature_flags/definitions/feature_flags.yaml
@@ -1,13 +1,3 @@
-- name: FEATURE_INDIRECT_NODE_COUNTING_ENABLED
-  ui_name: Indirect Node Counting
-  visibility: True
-  condition: boolean
-  value: 'False'
-  support_level: TECHNOLOGY_PREVIEW
-  description: "Indirect Node Counting parses the event stream of all jobs to identify resources and stores these in the platform database. Example: Job automates VMware, the parser will report back the VMs, Hypervisors that were automated. This feature helps customers and partners report on the automations they are doing beyond an API endpoint."
-  support_url: https://access.redhat.com/articles/7109910
-  labels:
-    - controller
 - name: FEATURE_EDA_ANALYTICS_ENABLED
   ui_name: Event-Driven Ansible Analytics
   visibility: False

--- a/ansible_base/feature_flags/migrations/0009_manual_20260902.py
+++ b/ansible_base/feature_flags/migrations/0009_manual_20260902.py
@@ -1,0 +1,17 @@
+###
+# Removal of FEATURE_INDIRECT_NODE_COUNTING_ENABLED
+###
+
+# FileHash: 935172fe54e7be047841722b2446df83e0c2578e1ddd4f13b969ab1b0879a5ad
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dab_feature_flags', '0008_manual_20260618'),
+    ]
+
+    operations = [
+    ]

--- a/test_app/tests/feature_flags/models/test_aap_flag.py
+++ b/test_app/tests/feature_flags/models/test_aap_flag.py
@@ -35,7 +35,7 @@ def test_feature_flags_from_db(aap_flags, feature_flag):
 @pytest.mark.parametrize(
     "feature_flag, value",
     [
-        ('FEATURE_INDIRECT_NODE_COUNTING_ENABLED', True),
+        ('FEATURE_EDA_ANALYTICS_ENABLED', True),
     ],
 )
 def test_feature_flag_database_setting_override(feature_flag, value):
@@ -50,7 +50,7 @@ def test_feature_flag_database_setting_override(feature_flag, value):
 
 @pytest.mark.django_db
 def test_enable_and_disable_flag_functions(aap_flags):
-    flag_name = "FEATURE_INDIRECT_NODE_COUNTING_ENABLED"
+    flag_name = "FEATURE_EDA_ANALYTICS_ENABLED"
     # Assert Initial State
     assert flag_state(flag_name) is False
 

--- a/test_app/tests/feature_flags/views/test_feature_flag.py
+++ b/test_app/tests/feature_flags/views/test_feature_flag.py
@@ -10,7 +10,6 @@ from ansible_base.lib.utils.response import get_relative_url
     'flags_list',
     [
         [
-            {'name': 'FEATURE_INDIRECT_NODE_COUNTING_ENABLED', 'value': True},
             {'name': 'FEATURE_EDA_ANALYTICS_ENABLED', 'value': True},
         ],
         [


### PR DESCRIPTION
Assisted by: Claude Code

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?

Removing the `FEATURE_INDIRECT_NODE_COUNTING_ENABLED` feature flag

- Why is this change needed?

In 2.7-async, the Indirect Node Counting feature is leaving tech preview in favor of GA, so we must delete the flag

Controller/AWX PR here: https://github.com/ansible/awx/pull/16631 

- How does this change address the issue?

Removes the flag in DAB, updates tests which utilized the flag, and removes other mentions of the flag

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Additional Context
<!-- Optional but helpful information -->

Part of https://redhat.atlassian.net/browse/ANSTRAT-1628

Ticket itself: https://redhat.atlassian.net/browse/AAP-90362

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Indirect Node Counting technology-preview feature flag.
  * Updated feature-flag validation to reflect the flag’s removal.
  * Added a migration record documenting the configuration change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->