### PR TITLE
fix: prevents superuser and their tokens from being deleted.

### DIFF
--- a/ansible_base/lib/dynamic_config/settings_logic.py
+++ b/ansible_base/lib/dynamic_config/settings_logic.py
@@ -276,8 +276,12 @@ def get_mergeable_dab_settings(settings: dict) -> dict:  # NOSONAR
         # Not consumed by DAB directly; read by downstream schedulers
         'RESOURCE_SYNC_INTERVAL_SECONDS': 900,
         # Page size for assignment pagination during resource sync (capped server-side by MAX_PAGE_SIZE).
-        # Defaults must match DEFAULT_SYNC_PAGE_SIZE / DEFAULT_SYNC_JWT_EXPIRATION in tasks/sync.py.
+        # Defaults must match DEFAULT_SYNC_PAGE_SIZE / DEFAULT_SYNC_JWT_EXPIRATION / DEFAULT_ORPHAN_MISS_THRESHOLD in tasks/sync.py.
         'RESOURCE_SYNC_PAGE_SIZE': 50,
+        # number of consecutive syncs where a resource is missing before deletion
+        'RESOURCE_SYNC_ORPHAN_MISS_THRESHOLD': 3,
+        # Cache to use for orphan miss tracking
+        'RESOURCE_SYNC_CACHE_NAME': "default",
         # JWT service token lifetime in seconds for resource sync API calls
         'RESOURCE_SYNC_JWT_EXPIRATION': 60,
     }

--- a/ansible_base/resource_registry/management/commands/resource_sync.py
+++ b/ansible_base/resource_registry/management/commands/resource_sync.py
@@ -70,12 +70,19 @@ class Command(BaseCommand):  # pragma: no cover
             help="Page size for pagination when fetching assignments (default: from settings, capped server-side by MAX_PAGE_SIZE)",
             required=False,
         )
+        parser.add_argument(
+            "--resource-sync-dry-run",
+            action="store_true",
+            default=False,
+            dest="dry_run",
+            help="Preview orphan deletions without actually deleting them; does not affect resource creation, updates, or assignment sync.",
+        )
 
     def handle(self, *args, **options):
         """Handle RESOURCE_PROVIDER sync"""
         if options.get("page_size") is not None and options["page_size"] < 1:
             raise CommandError("--page-size must be at least 1")
-        arguments = ["resource_type_names", "retries", "retrysleep", "asyncio", "page_size"]
+        arguments = ["resource_type_names", "retries", "retrysleep", "asyncio", "page_size", "dry_run"]
         options = {k: v for k, v in options.items() if k in arguments}
         try:
             executor = SyncExecutor(**options, stdout=self.stdout)

--- a/ansible_base/resource_registry/tasks/sync.py
+++ b/ansible_base/resource_registry/tasks/sync.py
@@ -4,6 +4,7 @@ import asyncio
 import csv
 import logging
 import time
+import requests
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -15,6 +16,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import QuerySet
 from django.db.utils import Error, IntegrityError
+from django.core.cache import caches
 from requests import HTTPError
 
 from ansible_base.lib.utils.apps import is_rbac_installed
@@ -32,11 +34,15 @@ from ansible_base.resource_registry.models.service_identifier import service_id
 from ansible_base.resource_registry.registry import get_registry
 from ansible_base.resource_registry.rest_client import ResourceAPIClient, get_resource_server_client
 
+resource_sync_cache_name = getattr(settings, 'RESOURCE_SYNC_CACHE_NAME', 'default')
+cache = caches[resource_sync_cache_name]
+
 logger = logging.getLogger('ansible_base.resources_api.tasks.sync')
 
 # Must match defaults in lib/dynamic_config/settings_logic.py resource_registry_defaults
 DEFAULT_SYNC_PAGE_SIZE = 50
 DEFAULT_SYNC_JWT_EXPIRATION = 60
+DEFAULT_ORPHAN_MISS_THRESHOLD = 3  # number of consecutive syncs where a resource is missing before deletion
 
 
 class ManifestNotFound(HTTPError):
@@ -203,8 +209,8 @@ def create_api_client() -> ResourceAPIClient:
 def fetch_manifest(
     resource_type_name: str,
     api_client: ResourceAPIClient | None = None,
-) -> list[ManifestItem]:
-    """Fetch RESOURCE_SERVER manifest, parses the CSV and returns a list."""
+) -> tuple[list[ManifestItem], bool]:
+    """Fetch RESOURCE_SERVER manifest, parses the CSV and returns a list of items and a boolean indicating completeness."""
     api_client = api_client or create_api_client()
     api_client.raise_if_bad_request = False  # Status check is needed
 
@@ -221,8 +227,14 @@ def fetch_manifest(
     except HTTPError as exc:
         raise ResourceSyncHTTPError() from exc
 
-    csv_reader = csv.DictReader(StringIO(manifest_stream.text))
-    return [ManifestItem(**row) for row in csv_reader]
+    try:
+        csv_reader = csv.DictReader(StringIO(manifest_stream.text))
+        items = [ManifestItem(**row) for row in csv_reader] 
+        is_complete = True
+    except (requests.exceptions.ChunkedEncodingError, requests.exceptions.ConnectionError):
+        logger.warning(f"Manifest fetch for {resource_type_name} was interrupted mid-transfer")
+        items, is_complete = [], False
+    return items, is_complete
 
 
 def get_orphan_resources(
@@ -249,6 +261,10 @@ def get_orphan_resources(
         if system_user:
             queryset = queryset.exclude(object_id=system_user.id)
 
+        from django.contrib.auth import get_user_model
+        
+        superuser_ids = get_user_model().objects.filter(is_superuser=True).values_list("pk", flat=True)
+        queryset = queryset.exclude(object_id__in=[str(pk) for pk in superuser_ids])
     return queryset
 
 
@@ -293,8 +309,7 @@ def _handle_conflict(resource_data: dict, resource_type: ResourceType, api_clien
     if conflict_resource is None:
         return
 
-    resp = api_client.get_resource(conflict_resource.ansible_id)
-
+    resp = api_client.get_resource(conflict_resource.ansible_id) 
     # If the conflicting resource doesn't exist on the server, just go ahead and delete it.
     # This will most likely happen with resources that are ignored by get_orphan_resources.
     if resp.status_code == 404:
@@ -464,6 +479,7 @@ class SyncExecutor:
     sync_assignments: bool = True
     page_size: int | None = None
     service_filter: str | None = None
+    dry_run: bool = False
 
     def write(self, text: str = ""):
         """Write to assigned IO or simply ignores the text."""
@@ -537,17 +553,52 @@ class SyncExecutor:
         results = [self._process_manifest_item(item) for item in manifest_list]
         self._report_results(results)
 
-    def _cleanup_orphans(self, resource_type, manifest_list):
+    def _orphan_miss_cache_key(self, ansible_id) -> str:
+        """Return the cache key for tracking orphan misses for a resource."""
+        return f"resource_sync_orphan_miss_{ansible_id}"
+
+    def is_missing_beyond_threshold(self, orphan, threshold) -> bool:
+        """Return True if this orphan has hit the miss threshold and should be deleted now."""
+        cache_key = self._orphan_miss_cache_key(orphan.ansible_id)
+        count = cache.get(cache_key, 0) + 1
+        sync_interval = getattr(settings, "RESOURCE_SYNC_INTERVAL_SECONDS", 900)
+        if count >= threshold:
+            return True
+        if not self.dry_run:
+            cache.set(cache_key, count, timeout=sync_interval * 4)
+        self.write(f"Skipping deletion of orphaned resource {orphan.ansible_id} (miss count: {count})")
+        return False
+
+    def _cleanup_orphans(self, resource_type, manifest_list, is_complete):
         """Delete local managed resources that are not part of the manifest."""
+        if not is_complete:
+            self.write(f"Skipping orphan cleanup for {resource_type} — manifest fetch was incomplete. Will retry on next sync cycle.")
+            logger.warning(f"Skipping orphan cleanup for {resource_type}: manifest fetch was incomplete. Deletions deferred to next complete sync.")
+            return
+        if not self.dry_run:
+            valid_keys=[]
+            for item in manifest_list:
+                try:
+                    valid_keys.append(self._orphan_miss_cache_key(item.ansible_id))
+                except ValueError:
+                    logger.warning(f"Skipping manifest row with invalid ansible_id: {item.ansible_id!r}")
+            cache.delete_many([self._orphan_miss_cache_key(item.ansible_id) for item in manifest_list])
         resources_to_cleanup = get_orphan_resources(
             resource_type,
             manifest_list,
         )
+        
         orphan_count = resources_to_cleanup.count()
         deleted_before = len(self.results["deleted"])
+        threshold = getattr(settings, "RESOURCE_SYNC_ORPHAN_MISS_THRESHOLD", DEFAULT_ORPHAN_MISS_THRESHOLD)
+
         if orphan_count:
-            self.write(f"Deleting {orphan_count} orphaned resources")
             for orphan in resources_to_cleanup:
+                if not self.is_missing_beyond_threshold(orphan, threshold):
+                    continue
+                if self.dry_run:
+                    self.write(f"Would delete orphaned resource {orphan.ansible_id} (missed {threshold} consecutive syncs)")
+                    continue
                 try:
                     _sc = orphan.content_type.resource_type.serializer_class
                     data = _sc(orphan.content_object).data
@@ -558,6 +609,9 @@ class SyncExecutor:
                     self.write(f"Error deleting orphaned resource {orphan.ansible_id}: {type(exc).__name__}: {exc}")
                 else:  # persist in the report
                     self.results["deleted"].append(data)
+                    if not self.dry_run:
+                        cache.delete(self._orphan_miss_cache_key(orphan.ansible_id))
+                    self.write(f"Deleted orphaned resource {orphan.ansible_id} (missed {threshold} consecutive syncs)")
         self.deleted_count = len(self.results["deleted"]) - deleted_before  # actual successes for this resource type
 
     def _handle_retries(self):  # pragma: no cover
@@ -661,12 +715,12 @@ class SyncExecutor:
 
             self.write(f">>> {resource_type_name}")
             try:
-                manifest_list = fetch_manifest(resource_type_name, api_client=self.api_client)
+                manifest_list, is_complete = fetch_manifest(resource_type_name, api_client=self.api_client)
             except ManifestNotFound as ex:
                 self.write(str(ex))
                 continue
 
-            self._cleanup_orphans(resource_type_name, manifest_list)
+            self._cleanup_orphans(resource_type_name, manifest_list, is_complete)
             self._dispatch_sync_process(manifest_list)
             self._handle_retries()
 

--- a/test_app/tests/resource_registry/test_resource_sync.py
+++ b/test_app/tests/resource_registry/test_resource_sync.py
@@ -12,6 +12,7 @@ from ansible_base.rbac.models import RoleDefinition
 from ansible_base.resource_registry.models import Resource, ResourceType
 from ansible_base.resource_registry.models.service_identifier import service_id
 from ansible_base.resource_registry.tasks.sync import (
+    DEFAULT_ORPHAN_MISS_THRESHOLD,
     DEFAULT_SYNC_JWT_EXPIRATION,
     DEFAULT_SYNC_PAGE_SIZE,
     AssignmentTuple,
@@ -53,6 +54,7 @@ def resource_to_delete(admin_api_client):
     }
     response = admin_api_client.post(url, resource, format="json")
     assert response.status_code == 201
+    return response.data["ansible_id"]
 
 
 @pytest.fixture()
@@ -114,18 +116,24 @@ def test_resource_sync(static_api_client, stdout):
 
 @pytest.mark.django_db
 def test_delete_orphans(static_api_client, stdout, resource_to_delete):
-
-    print(Resource.objects.filter(content_type__resource_type__name="shared.user").values_list("name"))
-
-    # The previously created user must now be deleted
+    """Orphaned resources are only deleted after being missed on DEFAULT_ORPHAN_MISS_THRESHOLD consecutive syncs."""
+    ansible_id = resource_to_delete
     executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
+
+    # Each sync short of the threshold should skip deletion and just record a miss.
+    for expected_miss_count in range(1, DEFAULT_ORPHAN_MISS_THRESHOLD):
+        stdout.lines.clear()
+        executor.run()
+        assert any(f"Skipping deletion of orphaned resource {ansible_id} (miss count: {expected_miss_count})" in line for line in stdout.lines)
+        assert executor.deleted_count == 0
+        assert Resource.objects.filter(ansible_id=ansible_id).exists()
+
+    # The threshold-th consecutive miss finally deletes the orphan.
+    stdout.lines.clear()
     executor.run()
-
-    print(Resource.objects.filter(content_type__resource_type__name="shared.user").values_list("name"))
-
-    print(stdout.lines)
-    assert 'Deleting 1 orphaned resources' in stdout.lines
-    assert any('Deleted 1' in line for line in stdout.lines)
+    assert any(f"Deleted orphaned resource {ansible_id}" in line for line in stdout.lines)
+    assert executor.deleted_count == 1
+    assert not Resource.objects.filter(ansible_id=ansible_id).exists()
 
 
 @pytest.mark.django_db
@@ -1417,8 +1425,15 @@ def test_cleanup_orphans_continues_after_deletion_error(admin_api_client, static
         )
         assert response.status_code == 201
 
+    executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
+
+    # Get both orphans past the miss threshold before deletion is even attempted.
+    for _ in range(DEFAULT_ORPHAN_MISS_THRESHOLD - 1):
+        executor.run()
+    assert executor.deleted_count == 0
+    stdout.lines.clear()
+
     with mock.patch("ansible_base.resource_registry.tasks.sync.delete_resource", side_effect=IntegrityError("FK constraint")):
-        executor = SyncExecutor(api_client=static_api_client, stdout=stdout)
         executor.run()
 
     error_lines = [line for line in stdout.lines if "IntegrityError" in line]


### PR DESCRIPTION


## Description
I use a cache to keep track of how many times a specific resource is missing/mismatched durin a sync.  Once it is missing/mismatched for 3 syncs in a row we delete it.  This prevents deletions from occurring due to cases like an imcomplete sync, or connection issues that might arise during the manifest_list creation.  However, this won't.  The issue is that we need to be able to pin sync tasks to dispatcherd workers, which I don't think we can do.  Opening this pr to start a convo about a better solution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry-run option for resource synchronization to preview orphan deletions without removing resources.
  * Orphaned resources now require multiple consecutive sync misses before deletion.
  * Incomplete or interrupted manifests no longer trigger orphan cleanup.
  * Protected superuser resources from orphan deletion.

* **Bug Fixes**
  * Improved tracking and handling of orphan resources across repeated synchronizations.

* **Tests**
  * Added coverage for orphan deletion thresholds and cleanup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->