### PR TITLE
AAP-91749 fix: update usages of accessible_pk_qs to access_ids_qs

### DIFF
--- a/ansible_base/rest_filters/rest_framework/field_lookup_backend.py
+++ b/ansible_base/rest_filters/rest_framework/field_lookup_backend.py
@@ -199,7 +199,7 @@ class FieldLookupBackend(BaseFilterBackend):
                         search_filter_relation = 'AND'
                         values = reduce(lambda list1, list2: list1 + list2, [i.split(',') for i in values])
                     for value in values:
-                        search_value, new_keys, _ = self.value_to_python(queryset.model, key, force_str(value))
+                        search_value, new_keys, _distinct = self.value_to_python(queryset.model, key, force_str(value))
                         assert isinstance(new_keys, list)
                         search_filters[search_value] = new_keys
                     # by definition, search *only* joins across relations,
@@ -250,9 +250,15 @@ class FieldLookupBackend(BaseFilterBackend):
                     else:
                         args.append(Q(**{k: v}))
                 for role_name in role_filters:
-                    if not hasattr(queryset.model, 'accessible_pk_qs'):
+                    if hasattr(queryset.model, 'access_ids_qs'):
+                        try:
+                            args.append(Q(pk__in=queryset.model.access_ids_qs(request.user, role_name)))
+                        except RuntimeError as e:
+                            raise ParseError(str(e))
+                    elif hasattr(queryset.model, 'accessible_pk_qs'):
+                        args.append(Q(pk__in=queryset.model.accessible_pk_qs(request.user, role_name)))
+                    else:
                         raise ParseError(_('Cannot apply role_level filter to this list because its model does not use roles for access control.'))
-                    args.append(Q(pk__in=queryset.model.accessible_pk_qs(request.user, role_name)))
                 if or_filters:
                     q = Q()
                     for n, k, v in or_filters:

--- a/test_app/tests/rest_filters/rest_framework/test_field_lookup_backend.py
+++ b/test_app/tests/rest_filters/rest_framework/test_field_lookup_backend.py
@@ -200,3 +200,24 @@ def test_view_level_ignore_field(admin_api_client):
     # Make sure that normal function is not disrupted by this customization
     response = admin_api_client.get(url, data={'foofield': 'bar'})
     assert response.status_code == 400, response.data
+
+
+@pytest.mark.django_db
+def test_role_level_filter_with_valid_permission(admin_api_client, inventory):
+    url = get_relative_url('inventory-list')
+    response = admin_api_client.get(url, data={'role_level': 'change_inventory'})
+    assert response.status_code == 200, response.data
+
+
+@pytest.mark.django_db
+def test_role_level_filter_with_invalid_permission(admin_api_client, inventory):
+    url = get_relative_url('inventory-list')
+    response = admin_api_client.get(url, data={'role_level': 'not_a_real_permission'})
+    assert response.status_code == 400, response.data
+
+
+@pytest.mark.django_db
+def test_role_level_filter_on_model_without_rbac(admin_api_client):
+    url = get_relative_url('cow-list')
+    response = admin_api_client.get(url, data={'role_level': 'view_cow'})
+    assert response.status_code == 400, response.data

--- a/test_app/tests/rest_filters/rest_framework/test_field_lookup_backend.py
+++ b/test_app/tests/rest_filters/rest_framework/test_field_lookup_backend.py
@@ -218,6 +218,6 @@ def test_role_level_filter_with_invalid_permission(admin_api_client, inventory):
 
 @pytest.mark.django_db
 def test_role_level_filter_on_model_without_rbac(admin_api_client):
-    url = get_relative_url('cow-list')
-    response = admin_api_client.get(url, data={'role_level': 'view_cow'})
+    url = get_relative_url('city-list')
+    response = admin_api_client.get(url, data={'role_level': 'view_city'})
     assert response.status_code == 400, response.data


### PR DESCRIPTION
## Description

github.com/ansible/tower/commit/7765376450246c50bab66d4cb3d29cf259d1e41f  removed ResourceMixin which contained accessible_pk_qs. But DAB still had uses of accessible_pk_qs which need to be updated to the new access_ids_qs while also keeping it backwards compatible.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have tested the changes in my local environment

