### PR TITLE
[AAP-67531] Reject global role scoped to organization in authenticator maps

### DIFF
--- a/ansible_base/authentication/utils/authenticator_map.py
+++ b/ansible_base/authentication/utils/authenticator_map.py
@@ -200,8 +200,12 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
         rbac_role = RoleDefinition.objects.get(name=role)
         is_system_role = rbac_role.content_type is None
 
-        # system role is allowed for map type == role without further conditions
         if is_system_role and map_type == 'role':
+            scoped_error = _("Role type 'global' cannot be scoped to an organization or team.")
+            if not is_empty(org):
+                errors['organization'] = scoped_error
+            if not is_empty(team):
+                errors['team'] = scoped_error
             return errors  # type: ignore[return-value]
 
         is_org_role, is_team_role = False, False

--- a/ansible_base/authentication/utils/authenticator_map.py
+++ b/ansible_base/authentication/utils/authenticator_map.py
@@ -234,7 +234,7 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
         is_system_role = rbac_role.content_type is None
 
         if is_system_role and map_type == 'role':
-            return _global_role_scope_errors(org, team)  # type: ignore[return-value]
+            return _global_role_scope_errors(org, team)
 
         is_org_role, is_team_role = False, False
         if not is_system_role:

--- a/ansible_base/authentication/utils/authenticator_map.py
+++ b/ansible_base/authentication/utils/authenticator_map.py
@@ -187,6 +187,39 @@ def _is_rbac_installed():
     return 'ansible_base.rbac' in settings.INSTALLED_APPS
 
 
+def _global_role_scope_errors(org: Optional[str], team: Optional[str]) -> dict[str, TranslatedString]:
+    errors: dict[str, TranslatedString] = {}
+    scoped_error = _("Role type 'global' cannot be scoped to an organization or team.")
+    if not is_empty(org):
+        errors['organization'] = scoped_error
+    if not is_empty(team):
+        errors['team'] = scoped_error
+    return errors
+
+
+def _role_map_type_errors(
+    map_type: Optional[str],
+    is_org_role: bool,
+    is_team_role: bool,
+    org: Optional[str],
+    team: Optional[str],
+) -> dict[str, TranslatedString]:
+    errors: dict[str, TranslatedString] = {}
+    if map_type == 'organization' and not is_org_role:
+        errors['role'] = _("For an organization map type you must specify an organization based role")
+
+    if map_type == 'team' and not is_team_role:
+        errors['role'] = _("For a team map type you must specify a team based role")
+
+    if (is_org_role or is_team_role) and is_empty(org):
+        errors["organization"] = _("You must specify an organization with the selected role")
+
+    if is_team_role and is_empty(team):
+        errors["team"] = _("You must specify a team with the selected role")
+
+    return errors
+
+
 def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[str], team: Optional[str]) -> dict[str, TranslatedString]:
     errors = {}
 
@@ -201,12 +234,7 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
         is_system_role = rbac_role.content_type is None
 
         if is_system_role and map_type == 'role':
-            scoped_error = _("Role type 'global' cannot be scoped to an organization or team.")
-            if not is_empty(org):
-                errors['organization'] = scoped_error
-            if not is_empty(team):
-                errors['team'] = scoped_error
-            return errors  # type: ignore[return-value]
+            return _global_role_scope_errors(org, team)  # type: ignore[return-value]
 
         is_org_role, is_team_role = False, False
         if not is_system_role:
@@ -214,20 +242,7 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
             is_org_role = issubclass(model_class, get_organization_model())
             is_team_role = issubclass(model_class, get_team_model())
 
-        # role type and map type must correspond
-        if map_type == 'organization' and not is_org_role:
-            errors['role'] = _("For an organization map type you must specify an organization based role")
-
-        if map_type == 'team' and not is_team_role:
-            errors['role'] = _("For a team map type you must specify a team based role")
-
-        # org/team role needs organization field
-        if (is_org_role or is_team_role) and is_empty(org):
-            errors["organization"] = _("You must specify an organization with the selected role")
-
-        # team role needs team field
-        if is_team_role and is_empty(team):
-            errors["team"] = _("You must specify a team with the selected role")
+        errors.update(_role_map_type_errors(map_type, is_org_role, is_team_role, org, team))
 
     except ObjectDoesNotExist:
         errors['role'] = _("RoleDefinition {role} doesn't exist").format(role=role)

--- a/test_app/tests/authentication/serializers/test_authenticator_map.py
+++ b/test_app/tests/authentication/serializers/test_authenticator_map.py
@@ -68,20 +68,14 @@ class TestAuthenticatorMapSerializerRole:
 
         with pytest.raises(ValidationError) as e:
             serializer.validate(dict(name="authentication_map_2", map_type="role", role=SYSTEM_ROLE_NAME, organization='test_org'))
-        assert str(e.value) == (
-            "{'organization': ErrorDetail(string=\"Role type 'global' cannot be scoped to an organization or team.\", code='invalid')}"
-        )
+        assert str(e.value) == ("{'organization': ErrorDetail(string=\"Role type 'global' cannot be scoped to an organization or team.\", code='invalid')}")
 
         with pytest.raises(ValidationError) as e:
             serializer.validate(dict(name="authentication_map_3", map_type="role", role=SYSTEM_ROLE_NAME, team='test_team'))
-        assert str(e.value) == (
-            "{'team': ErrorDetail(string=\"Role type 'global' cannot be scoped to an organization or team.\", code='invalid')}"
-        )
+        assert str(e.value) == ("{'team': ErrorDetail(string=\"Role type 'global' cannot be scoped to an organization or team.\", code='invalid')}")
 
         with pytest.raises(ValidationError) as e:
-            serializer.validate(
-                dict(name="authentication_map_3b", map_type="role", role=SYSTEM_ROLE_NAME, organization='test_org', team='test_team')
-            )
+            serializer.validate(dict(name="authentication_map_3b", map_type="role", role=SYSTEM_ROLE_NAME, organization='test_org', team='test_team'))
         assert set(e.value.detail.keys()) == {'organization', 'team'}
 
         with pytest.raises(ValidationError) as e:

--- a/test_app/tests/authentication/serializers/test_authenticator_map.py
+++ b/test_app/tests/authentication/serializers/test_authenticator_map.py
@@ -64,12 +64,25 @@ class TestAuthenticatorMapSerializerRole:
         serializer.validate_trigger_data = MagicMock(return_value={})
 
     def test_validate_role_system_role(self, serializer, system_role):
-        try:
-            serializer.validate(dict(name="authentication_map_1", map_type="role", role=SYSTEM_ROLE_NAME))
+        serializer.validate(dict(name="authentication_map_1", map_type="role", role=SYSTEM_ROLE_NAME))
+
+        with pytest.raises(ValidationError) as e:
             serializer.validate(dict(name="authentication_map_2", map_type="role", role=SYSTEM_ROLE_NAME, organization='test_org'))
+        assert str(e.value) == (
+            "{'organization': ErrorDetail(string=\"Role type 'global' cannot be scoped to an organization or team.\", code='invalid')}"
+        )
+
+        with pytest.raises(ValidationError) as e:
             serializer.validate(dict(name="authentication_map_3", map_type="role", role=SYSTEM_ROLE_NAME, team='test_team'))
-        except ValidationError as e:
-            pytest.fail(f"Validation should pass, but: {str(e)}")
+        assert str(e.value) == (
+            "{'team': ErrorDetail(string=\"Role type 'global' cannot be scoped to an organization or team.\", code='invalid')}"
+        )
+
+        with pytest.raises(ValidationError) as e:
+            serializer.validate(
+                dict(name="authentication_map_3b", map_type="role", role=SYSTEM_ROLE_NAME, organization='test_org', team='test_team')
+            )
+        assert set(e.value.detail.keys()) == {'organization', 'team'}
 
         with pytest.raises(ValidationError) as e:
             serializer.validate(dict(name="authentication_map_4", map_type="team", role=SYSTEM_ROLE_NAME, organization='test_org', team='test_team'))

--- a/test_app/tests/authentication/utils/test_claims.py
+++ b/test_app/tests/authentication/utils/test_claims.py
@@ -1542,25 +1542,16 @@ def test_create_claims_with_map_enabled_or_disabled(enabled, local_authenticator
             None,
             {"management_roles": ["pm", "lead", "director"]},
             {
-                'organization_membership': {
-                    'Business': True,
-                },
+                'organization_membership': {},
                 'rbac_roles': {
-                    'organizations': {
-                        'Business': {
-                            'roles': {
-                                SYSTEM_ROLE_NAME: True,
-                            },
-                            'teams': {},
-                        },
-                    },
+                    'organizations': {},
                     'system': {
                         'roles': {},
                     },
                 },
                 'team_membership': {},
             },
-            id="role_map_type_organization_assignment",
+            id="role_map_type_global_role_with_org_is_skipped",
         ),
         pytest.param(
             'role',


### PR DESCRIPTION
## Description
- Rejects authenticator map API requests that assign a global role (e.g. Platform Auditor) with an organization or team scope.
- Fixes silent login failures where claims reconciliation raised `Role type global does not match object organization` after the invalid map was saved.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- AAP gateway with RBAC enabled and Platform Auditor role available

### Steps to Test
1. `POST /api/gateway/v1/authenticator_maps/` with `map_type=role`, `role=Platform Auditor`, and `organization` set to any org name.
2. Confirm the API returns `400` with `Role type 'global' cannot be scoped to an organization or team.`
3. Create a valid map with `map_type=role`, `role=Platform Auditor`, and no organization/team.
4. Log in through the authenticator and confirm the role is assigned without gateway traceback.

### Expected Results
- Invalid global-role + org/team combinations are rejected at API save time.
- Valid global-role maps continue to work at login.

## Additional Context
Fixes [AAP-67531](https://redhat.atlassian.net/browse/AAP-67531).

Related: [AAP-67516](https://redhat.atlassian.net/browse/AAP-67516) (duplicate symptom).

---
**Note:** This PR was developed with assistance from Claude AI assistant.

[AAP-67531]: https://redhat.atlassian.net/browse/AAP-67531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - System roles now return validation errors when incorrectly scoped to an organization or team.
  - Unscoped system roles continue to validate successfully.
  - Validation messages identify the affected organization or team fields.
  - Global system roles assigned to an organization are excluded from expanded claims rather than granted organization-specific access.
  - Invalid global role mappings no longer produce organization membership or organization-specific role claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->