### PR TITLE
AAP-79306 Add stable ordering to resource manifest queryset

### DIFF
--- a/ansible_base/resource_registry/views.py
+++ b/ansible_base/resource_registry/views.py
@@ -315,7 +315,7 @@ class ResourceTypeViewSet(
         else:
             service_filter = Q(service_id=service_id())
 
-        resources = Resource.objects.filter(content_type__resource_type=resource_type).filter(service_filter).prefetch_related("content_object")
+        resources = Resource.objects.filter(content_type__resource_type=resource_type).filter(service_filter).order_by('id').prefetch_related("content_object")
 
         if name == SHARED_USER_RESOURCE_TYPE and (system_user := getattr(settings, "SYSTEM_USERNAME", None)):
             resources = resources.exclude(name=system_user)

--- a/test_app/tests/resource_registry/test_resource_types_api.py
+++ b/test_app/tests/resource_registry/test_resource_types_api.py
@@ -2,6 +2,7 @@ import csv
 from io import StringIO
 
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.resource_registry.models import Resource
 
 
 def test_resource_type_list(admin_api_client):
@@ -54,3 +55,22 @@ def test_resource_type_manifest_404(admin_api_client):
     url = get_relative_url("resourcetype-manifest", kwargs={"name": "doesnt.exist"})
     response = admin_api_client.get(url)
     assert response.status_code == 404
+
+
+def test_resource_type_manifest_ordering(admin_api_client, django_user_model):
+    """Manifest CSV rows must be ordered by Resource pk (ascending)."""
+    for i in range(5):
+        django_user_model.objects.create(username=f"ordtest_user{i}")
+
+    url = get_relative_url("resourcetype-manifest", kwargs={"name": "shared.user"})
+    response = admin_api_client.get(url)
+    assert response.status_code == 200
+
+    data = StringIO("".join(item.decode() for item in response.streaming_content))
+    ansible_ids = [row["ansible_id"] for row in csv.DictReader(data)]
+
+    resource_pks = list(Resource.objects.filter(ansible_id__in=ansible_ids).values_list("ansible_id", "id"))
+    pk_by_ansible_id = {str(ansible_id): pk for ansible_id, pk in resource_pks}
+    returned_pks = [pk_by_ansible_id[aid] for aid in ansible_ids]
+
+    assert returned_pks == sorted(returned_pks)


### PR DESCRIPTION
related to https://github.com/ansible/django-ansible-base/pull/1127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resource manifests now return entries in a consistent ascending order, improving predictability when viewing or processing manifest data.

- **Tests**
  - Added coverage to verify that manifest entries are returned in the expected order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->