### PR TITLE
[AAP-86907] Reject object-scoped roles in authenticator maps

### DIFF
--- a/ansible_base/authentication/utils/authenticator_map.py
+++ b/ansible_base/authentication/utils/authenticator_map.py
@@ -197,6 +197,16 @@ def _global_role_scope_errors(org: Optional[str], team: Optional[str]) -> dict[s
     return errors
 
 
+def _object_scoped_role_errors(
+    map_type: Optional[str],
+    is_org_role: bool,
+    is_team_role: bool,
+) -> dict[str, TranslatedString]:
+    if map_type == 'role' and not is_org_role and not is_team_role:
+        return {'role': _("Object-scoped roles cannot be assigned through an authenticator map.")}
+    return {}
+
+
 def _role_map_type_errors(
     map_type: Optional[str],
     is_org_role: bool,
@@ -243,6 +253,7 @@ def check_role_type(map_type: Optional[str], role: Optional[str], org: Optional[
             is_team_role = issubclass(model_class, get_team_model())
 
         errors.update(_role_map_type_errors(map_type, is_org_role, is_team_role, org, team))
+        errors.update(_object_scoped_role_errors(map_type, is_org_role, is_team_role))
 
     except ObjectDoesNotExist:
         errors['role'] = _("RoleDefinition {role} doesn't exist").format(role=role)

--- a/test_app/tests/authentication/conftest.py
+++ b/test_app/tests/authentication/conftest.py
@@ -1,19 +1,31 @@
 import pytest
 
 from ansible_base.lib.testing.util import copy_fixture
+from ansible_base.rbac import permission_registry
 from ansible_base.rbac.models import RoleDefinition
+from test_app.models import Inventory
 
 SYSTEM_ROLE_NAME = 'System role'
 TEAM_MEMBER_ROLE_NAME = 'Team Member'
 TEAM_ADMIN_ROLE_NAME = 'Team Admin'
 ORG_MEMBER_ROLE_NAME = 'Organization Member'
 ORG_ADMIN_ROLE_NAME = 'Organization Admin'
+OBJECT_SCOPED_ROLE_NAME = 'Inventory Admin'
 
 
 @pytest.fixture
 def system_role():
     return RoleDefinition.objects.create(
         name=SYSTEM_ROLE_NAME,
+    )
+
+
+@pytest.fixture
+def object_scoped_role():
+    return RoleDefinition.objects.create_from_permissions(
+        permissions=['change_inventory', 'view_inventory'],
+        name=OBJECT_SCOPED_ROLE_NAME,
+        content_type=permission_registry.content_type_model.objects.get_for_model(Inventory),
     )
 
 

--- a/test_app/tests/authentication/serializers/test_authenticator_map.py
+++ b/test_app/tests/authentication/serializers/test_authenticator_map.py
@@ -4,7 +4,7 @@ import pytest
 from rest_framework.serializers import ValidationError
 
 from ansible_base.authentication.serializers.authenticator_map import AuthenticatorMapSerializer
-from test_app.tests.authentication.conftest import ORG_MEMBER_ROLE_NAME, SYSTEM_ROLE_NAME, TEAM_MEMBER_ROLE_NAME
+from test_app.tests.authentication.conftest import OBJECT_SCOPED_ROLE_NAME, ORG_MEMBER_ROLE_NAME, SYSTEM_ROLE_NAME, TEAM_MEMBER_ROLE_NAME
 
 
 @pytest.fixture
@@ -131,6 +131,41 @@ class TestAuthenticatorMapSerializerRole:
             )
         except ValidationError as e:
             pytest.fail(f"Validation should pass, but: {str(e)}")
+
+    def test_validate_role_object_scoped_role(self, serializer, object_scoped_role):
+        object_scoped_error = (
+            "{'role': ErrorDetail(string='Object-scoped roles cannot be assigned through an authenticator map.', code='invalid')}"
+        )
+
+        with pytest.raises(ValidationError) as e:
+            serializer.validate(dict(name="authentication_map_1", map_type="role", role=OBJECT_SCOPED_ROLE_NAME))
+        assert str(e.value) == object_scoped_error
+
+        with pytest.raises(ValidationError) as e:
+            serializer.validate(
+                dict(name="authentication_map_2", map_type="role", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org')
+            )
+        assert str(e.value) == object_scoped_error
+
+        with pytest.raises(ValidationError) as e:
+            serializer.validate(
+                dict(name="authentication_map_3", map_type="organization", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org')
+            )
+        assert str(e.value) == (
+            "{'role': ErrorDetail(string='For an organization map type you must specify an organization based role', code='invalid')}"
+        )
+
+        with pytest.raises(ValidationError) as e:
+            serializer.validate(
+                dict(
+                    name="authentication_map_4",
+                    map_type="team",
+                    role=OBJECT_SCOPED_ROLE_NAME,
+                    organization='test_org',
+                    team='test_team',
+                )
+            )
+        assert str(e.value) == "{'role': ErrorDetail(string='For a team map type you must specify a team based role', code='invalid')}"
 
 
 @pytest.mark.django_db

--- a/test_app/tests/authentication/serializers/test_authenticator_map.py
+++ b/test_app/tests/authentication/serializers/test_authenticator_map.py
@@ -133,27 +133,19 @@ class TestAuthenticatorMapSerializerRole:
             pytest.fail(f"Validation should pass, but: {str(e)}")
 
     def test_validate_role_object_scoped_role(self, serializer, object_scoped_role):
-        object_scoped_error = (
-            "{'role': ErrorDetail(string='Object-scoped roles cannot be assigned through an authenticator map.', code='invalid')}"
-        )
+        object_scoped_error = "{'role': ErrorDetail(string='Object-scoped roles cannot be assigned through an authenticator map.', code='invalid')}"
 
         with pytest.raises(ValidationError) as e:
             serializer.validate(dict(name="authentication_map_1", map_type="role", role=OBJECT_SCOPED_ROLE_NAME))
         assert str(e.value) == object_scoped_error
 
         with pytest.raises(ValidationError) as e:
-            serializer.validate(
-                dict(name="authentication_map_2", map_type="role", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org')
-            )
+            serializer.validate(dict(name="authentication_map_2", map_type="role", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org'))
         assert str(e.value) == object_scoped_error
 
         with pytest.raises(ValidationError) as e:
-            serializer.validate(
-                dict(name="authentication_map_3", map_type="organization", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org')
-            )
-        assert str(e.value) == (
-            "{'role': ErrorDetail(string='For an organization map type you must specify an organization based role', code='invalid')}"
-        )
+            serializer.validate(dict(name="authentication_map_3", map_type="organization", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org'))
+        assert str(e.value) == ("{'role': ErrorDetail(string='For an organization map type you must specify an organization based role', code='invalid')}")
 
         with pytest.raises(ValidationError) as e:
             serializer.validate(

--- a/test_app/tests/authentication/serializers/test_authenticator_map.py
+++ b/test_app/tests/authentication/serializers/test_authenticator_map.py
@@ -143,6 +143,9 @@ class TestAuthenticatorMapSerializerRole:
             serializer.validate(dict(name="authentication_map_2", map_type="role", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org'))
         assert str(e.value) == object_scoped_error
 
+        # Cases 3-4: Verify existing _role_map_type_errors() still catches
+        # object-scoped roles with map_type='organization'/'team'
+        # (these fail before reaching _object_scoped_role_errors)
         with pytest.raises(ValidationError) as e:
             serializer.validate(dict(name="authentication_map_3", map_type="organization", role=OBJECT_SCOPED_ROLE_NAME, organization='test_org'))
         assert str(e.value) == ("{'role': ErrorDetail(string='For an organization map type you must specify an organization based role', code='invalid')}")

--- a/test_app/tests/authentication/views/test_authenticator_map.py
+++ b/test_app/tests/authentication/views/test_authenticator_map.py
@@ -3,6 +3,7 @@ from django import VERSION
 from django.db import connection
 
 from ansible_base.lib.utils.response import get_relative_url
+from test_app.tests.authentication.conftest import OBJECT_SCOPED_ROLE_NAME
 
 
 def test_authenticator_map_list_empty_by_default(admin_api_client):
@@ -67,6 +68,22 @@ def test_authenticator_map_create(admin_api_client, local_authenticator, trigger
     assert response.data['authenticator'] == local_authenticator.id
     assert response.data['triggers'] == triggers
     assert response.data['map_type'] == 'is_superuser'
+
+
+@pytest.mark.django_db
+def test_authenticator_map_rejects_object_scoped_role(admin_api_client, local_authenticator, object_scoped_role, shut_up_logging):
+    url = get_relative_url("authenticatormap-list")
+    data = {
+        'name': 'Assign object-scoped role',
+        'authenticator': local_authenticator.id,
+        'map_type': 'role',
+        'role': OBJECT_SCOPED_ROLE_NAME,
+        'triggers': {'always': {}},
+        'order': 1,
+    }
+    response = admin_api_client.post(url, data=data, format='json')
+    assert response.status_code == 400, response.data
+    assert 'Object-scoped roles cannot be assigned through an authenticator map.' in response.data['role'][0]
 
 
 def test_authenticator_map_invalid_map_type(admin_api_client, local_authenticator, shut_up_logging):


### PR DESCRIPTION
## Description
- Reject authenticator map API requests that assign object-scoped roles (e.g. JobTemplate Execute, Inventory Admin) via `map_type: role`.
- These roles cannot be granted through authentication mapping at any scope; previously the API accepted the config and login failed silently with a `ValidationError` during claims reconciliation.
- Adds `_object_scoped_role_errors()` in `check_role_type()` to return 400 at save time with a clear field error on `role`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- django-ansible-base test environment (`pytest` with `test_app` settings)

### Steps to Test
1. Run serializer and API tests:
   `pytest test_app/tests/authentication/serializers/test_authenticator_map.py test_app/tests/authentication/views/test_authenticator_map.py::test_authenticator_map_rejects_object_scoped_role`
2. Optionally POST an authenticator map with `map_type: role` and an object-scoped role name; expect HTTP 400.

### Expected Results
- Object-scoped role + `map_type: role` is rejected with: `Object-scoped roles cannot be assigned through an authenticator map.`
- Existing org/team/global role validation behavior is unchanged.

## Additional Context
Related to [AAP-67531](https://redhat.atlassian.net/browse/AAP-67531) (global role + org/team scoping). UI filtering of unassignable roles remains separate follow-up work.

---
**Note:** This PR was developed with assistance from Claude AI assistant.

[AAP-67531]: https://redhat.atlassian.net/browse/AAP-67531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticator maps now reject object-scoped roles, preventing unsupported role assignments.
  * Clear validation errors are returned when an object-scoped role is used with role, organization, or team mappings.

* **Tests**
  * Added coverage for serializer and API validation of object-scoped role assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->