### PR TITLE
AAP-91663: Require organization on OAuth2 apps and lift DRF pin (CVE-2026-73228/73229)

### DIFF
--- a/ansible_base/oauth2_provider/serializers/application.py
+++ b/ansible_base/oauth2_provider/serializers/application.py
@@ -1,6 +1,9 @@
+from django.apps import apps
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import gettext_lazy as _
 from oauth2_provider.generators import generate_client_secret
+from rest_framework import serializers
 
 from ansible_base.lib.serializers.common import NamedCommonModelSerializer
 from ansible_base.lib.serializers.mixins import CleanTextMixin
@@ -10,6 +13,12 @@ from ansible_base.oauth2_provider.models import OAuth2Application
 
 class OAuth2ApplicationSerializer(CleanTextMixin, NamedCommonModelSerializer):
     oauth2_client_secret = None
+    organization = serializers.PrimaryKeyRelatedField(
+        queryset=apps.get_model(settings.ANSIBLE_BASE_ORGANIZATION_MODEL).objects.all(),
+        required=True,
+        allow_null=False,
+        help_text=_('Organization containing this application.'),
+    )
 
     class Meta:
         model = OAuth2Application
@@ -18,7 +27,6 @@ class OAuth2ApplicationSerializer(CleanTextMixin, NamedCommonModelSerializer):
         read_only_on_update_fields = ('user', 'authorization_grant_type')
         extra_kwargs = {
             'user': {'allow_null': True, 'required': False},
-            'organization': {'allow_null': False},
             'authorization_grant_type': {'allow_null': False, 'label': _('Authorization Grant Type')},
             'client_secret': {'label': _('Client Secret')},
             'client_type': {'label': _('Client Type')},

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@
 #
 cryptography
 Django>=5,<6.0
-djangorestframework<3.16 # problem with OAuth2Application.organization null handling
+djangorestframework>=3.17.2  # CVE-2026-73228 CVE-2026-73229; organization required=True in OAuth2ApplicationSerializer (AAP-91663)
 django-crum
 inflection
 sqlparse>=0.5.2 # https://github.com/ansible/django-ansible-base/security/dependabot/9

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -1,32 +1,32 @@
-asgiref==3.11.0
+asgiref==3.12.1
     # via
-    #   -r requirements/requirements_resource_registry.in
+    #   -r /privaterequirements/requirements_resource_registry.in
     #   channels
     #   django
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-certifi==2025.11.12
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 channels==4.3.2
-    # via -r requirements/requirements_channels.in
-charset-normalizer==3.4.4
+    # via -r /privaterequirements/requirements_channels.in
+charset-normalizer==3.5.1
     # via requests
-cryptography==46.0.5
+cryptography==50.0.1
     # via
-    #   -r requirements/requirements.in
+    #   -r /privaterequirements/requirements.in
     #   jwcrypto
     #   social-auth-core
 defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==5.2.9
+django==5.2.17
     # via
-    #   -r requirements/requirements.in
+    #   -r /privaterequirements/requirements.in
     #   channels
     #   django-auth-ldap
     #   django-crum
@@ -36,65 +36,63 @@ django==5.2.9
     #   djangorestframework
     #   drf-spectacular
     #   social-auth-app-django
-django-auth-ldap==5.2.0
-    # via -r requirements/requirements_authentication.in
+django-auth-ldap==5.3.0
+    # via -r /privaterequirements/requirements_authentication.in
 django-crum==0.7.9
-    # via -r requirements/requirements.in
-django-flags==5.1.0
-    # via -r requirements/requirements_feature_flags.in
+    # via -r /privaterequirements/requirements.in
+django-flags==5.2.0
+    # via -r /privaterequirements/requirements_feature_flags.in
 django-oauth-toolkit==2.3.0
-    # via -r requirements/requirements_oauth2_provider.in
-django-redis==6.0.0
-    # via -r requirements/requirements_redis_client.in
-djangorestframework==3.15.2
+    # via -r /privaterequirements/requirements_oauth2_provider.in
+django-redis==7.0.0
+    # via -r /privaterequirements/requirements_redis_client.in
+djangorestframework==3.18.1
     # via
-    #   -r requirements/requirements.in
+    #   -r /privaterequirements/requirements.in
     #   drf-spectacular
-drf-spectacular==0.29.0
-    # via -r requirements/requirements_api_documentation.in
-dynaconf==3.2.12
-    # via -r requirements/requirements.in
-googleapis-common-protos==1.74.0
+drf-spectacular==0.30.0
+    # via -r /privaterequirements/requirements_api_documentation.in
+dynaconf==3.3.5
+    # via -r /privaterequirements/requirements.in
+googleapis-common-protos==1.75.3
     # via opentelemetry-exporter-otlp-proto-grpc
-grpcio==1.80.0
+grpcio==1.83.1
     # via opentelemetry-exporter-otlp-proto-grpc
-idna==3.11
+idna==3.19
     # via requests
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 inflection==0.5.1
     # via
-    #   -r requirements/requirements.in
+    #   -r /privaterequirements/requirements.in
     #   drf-spectacular
 isodate==0.7.2
     # via python3-saml
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via drf-spectacular
 jsonschema-specifications==2025.9.1
     # via jsonschema
-jwcrypto==1.5.7
+jwcrypto==1.6.0
     # via
-    #   -r requirements/requirements_oauth2_provider.in
+    #   -r /privaterequirements/requirements_oauth2_provider.in
     #   django-oauth-toolkit
 ldap-filter==1.0.1
-    # via -r requirements/requirements_authentication.in
+    # via -r /privaterequirements/requirements_authentication.in
 lxml==5.3.0
     # via
-    #   -r requirements/requirements_authentication.in
+    #   -r /privaterequirements/requirements_authentication.in
     #   python3-saml
     #   xmlsec
 netaddr==1.3.0
     # via pyrad
-nh3==0.3.6
-    # via -r requirements/requirements.in
+nh3==0.3.7
+    # via -r /privaterequirements/requirements.in
 oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
     #   social-auth-core
-opentelemetry-api==1.41.0
+opentelemetry-api==1.44.0
     # via
-    #   -r requirements/requirements_observability.in
+    #   -r /privaterequirements/requirements_observability.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
@@ -107,11 +105,11 @@ opentelemetry-api==1.41.0
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp-proto-common==1.41.0
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-exporter-otlp-proto-grpc==1.41.0
-    # via -r requirements/requirements_observability.in
-opentelemetry-instrumentation==0.62b0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
+    # via -r /privaterequirements/requirements_observability.in
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-django
@@ -121,121 +119,121 @@ opentelemetry-instrumentation==0.62b0
     #   opentelemetry-instrumentation-psycopg2
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-dbapi==0.62b0
+opentelemetry-instrumentation-dbapi==0.65b0
     # via
     #   opentelemetry-instrumentation-psycopg
     #   opentelemetry-instrumentation-psycopg2
-opentelemetry-instrumentation-django==0.62b0
-    # via -r requirements/requirements_observability.in
-opentelemetry-instrumentation-grpc==0.62b0
-    # via -r requirements/requirements_observability.in
-opentelemetry-instrumentation-logging==0.62b0
-    # via -r requirements/requirements_observability.in
-opentelemetry-instrumentation-psycopg==0.62b0
-    # via -r requirements/requirements_observability.in
-opentelemetry-instrumentation-psycopg2==0.62b0
-    # via -r requirements/requirements_observability.in
-opentelemetry-instrumentation-requests==0.62b0
-    # via -r requirements/requirements_observability.in
-opentelemetry-instrumentation-wsgi==0.62b0
+opentelemetry-instrumentation-django==0.65b0
+    # via -r /privaterequirements/requirements_observability.in
+opentelemetry-instrumentation-grpc==0.65b0
+    # via -r /privaterequirements/requirements_observability.in
+opentelemetry-instrumentation-logging==0.65b0
+    # via -r /privaterequirements/requirements_observability.in
+opentelemetry-instrumentation-psycopg==0.65b0
+    # via -r /privaterequirements/requirements_observability.in
+opentelemetry-instrumentation-psycopg2==0.65b0
+    # via -r /privaterequirements/requirements_observability.in
+opentelemetry-instrumentation-requests==0.65b0
+    # via -r /privaterequirements/requirements_observability.in
+opentelemetry-instrumentation-wsgi==0.65b0
     # via opentelemetry-instrumentation-django
-opentelemetry-proto==1.41.0
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-sdk==1.41.0
+opentelemetry-sdk==1.44.0
     # via
-    #   -r requirements/requirements_observability.in
+    #   -r /privaterequirements/requirements_observability.in
     #   opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-semantic-conventions==0.62b0
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.62b0
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
-packaging==26.1
+packaging==26.3
     # via opentelemetry-instrumentation
-protobuf==6.33.6
+protobuf==7.36.1
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-pyasn1==0.6.1
+pyasn1==0.6.4
     # via
     #   pyasn1-modules
     #   python-ldap
 pyasn1-modules==0.4.2
     # via python-ldap
-pycparser==2.23
+pycparser==3.0
     # via cffi
-pyjwt==2.10.1
+pyjwt==2.14.0
     # via
-    #   -r requirements/requirements_jwt_consumer.in
-    #   -r requirements/requirements_resource_registry.in
+    #   -r /privaterequirements/requirements_jwt_consumer.in
+    #   -r /privaterequirements/requirements_resource_registry.in
     #   social-auth-core
-pyrad==2.4
-    # via -r requirements/requirements_authentication.in
-python-ldap==3.4.5
+pyrad==2.5.4
+    # via -r /privaterequirements/requirements_authentication.in
+python-ldap==3.4.7
     # via
-    #   -r requirements/requirements_authentication.in
+    #   -r /privaterequirements/requirements_authentication.in
     #   django-auth-ldap
 python3-openid==3.2.0
     # via social-auth-core
 python3-saml==1.16.0
-    # via -r requirements/requirements_authentication.in
+    # via -r /privaterequirements/requirements_authentication.in
 pyyaml==6.0.3
     # via drf-spectacular
-redis==7.4.0
+redis==8.1.0
     # via
-    #   -r requirements/requirements_redis_client.in
+    #   -r /privaterequirements/requirements_redis_client.in
     #   django-redis
-regex==2026.7.19
-    # via -r requirements/requirements.in
 referencing==0.36.2
     # via
-    #   -r requirements/requirements_api_documentation.in
+    #   -r /privaterequirements/requirements_api_documentation.in
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.5
+regex==2026.9.10
+    # via -r /privaterequirements/requirements.in
+requests==2.34.2
     # via
-    #   -r requirements/requirements_jwt_consumer.in
-    #   -r requirements/requirements_resource_registry.in
+    #   -r /privaterequirements/requirements_jwt_consumer.in
+    #   -r /privaterequirements/requirements_resource_registry.in
     #   django-oauth-toolkit
     #   requests-oauthlib
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via social-auth-core
-rpds-py==0.30.0
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
 six==1.17.0
-    # via
-    #   pyrad
-    #   tacacs-plus
+    # via tacacs-plus
 social-auth-app-django==5.4.1
-    # via -r requirements/requirements_authentication.in
+    # via -r /privaterequirements/requirements_authentication.in
 social-auth-core==4.5.4
     # via
-    #   -r requirements/requirements_authentication.in
+    #   -r /privaterequirements/requirements_authentication.in
     #   social-auth-app-django
-sqlparse==0.5.4
+sqlparse==0.6.0
     # via
-    #   -r requirements/requirements.in
+    #   -r /privaterequirements/requirements.in
     #   django
-tabulate==0.9.0
-    # via -r requirements/requirements_authentication.in
+tabulate==0.10.0
+    # via -r /privaterequirements/requirements_authentication.in
 tacacs-plus==2.6
-    # via -r requirements/requirements_authentication.in
-typing-extensions==4.15.0
+    # via -r /privaterequirements/requirements_authentication.in
+typing-extensions==4.16.0
     # via
+    #   django-redis
     #   grpcio
     #   jwcrypto
     #   opentelemetry-api
@@ -245,18 +243,16 @@ typing-extensions==4.15.0
     #   referencing
 uritemplate==4.2.0
     # via drf-spectacular
-urllib3==2.6.1
+urllib3==2.7.0
     # via
-    #   -r requirements/requirements_resource_registry.in
+    #   -r /privaterequirements/requirements_resource_registry.in
     #   requests
-wrapt==2.1.2
+wrapt==2.4.1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-grpc
 xmlsec==1.3.13
     # via
-    #   -r requirements/requirements_authentication.in
+    #   -r /privaterequirements/requirements_authentication.in
     #   python3-saml
-zipp==3.23.1
-    # via importlib-metadata


### PR DESCRIPTION
## Description

**What is being changed?**
- Set `organization` to `required=True` in `OAuth2ApplicationSerializer` so OAuth2 application creation rejects missing organization explicitly.
- Remove the `djangorestframework<3.16` pin and require `djangorestframework>=3.17.2` to address CVE-2026-73228 and CVE-2026-73229.
- Regenerate `requirements/requirements_all.txt` via `./updater.sh upgrade`.

**Why is this change needed?**
DRF 3.16+ ([encode/django-rest-framework#9531](https://github.com/encode/django-rest-framework/pull/9531)) no longer infers `required=True` for nullable `unique_together` fields. DAB relied on that inference for `OAuth2Application.organization`, so unpinning DRF caused `test_oauth2_provider_application_validator` to fail (POST without organization returned 201 instead of 400). The `<3.16` pin was added in #866 as a workaround.

**How does this change address the issue?**
Explicit serializer validation restores the intended API behavior independent of DRF version inference, allowing DRF to be upgraded to a patched version.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have thought about error handling and edge cases

## Testing Instructions

### Steps to Test
1. `cd requirements && ./updater.sh upgrade` (already run in this PR)
2. `pytest test_app/tests/oauth2_provider/views/test_application.py::test_oauth2_provider_application_validator -v`

### Expected Results
- POST to application-list without `organization` returns **400** with organization required
- `requirements_all.txt` resolves `djangorestframework` to **>= 3.17.2** (currently 3.18.1)

## Additional Context

Fixes [AAP-91663](https://redhat.atlassian.net/browse/AAP-91663).

Related: #866 (added the DRF pin and extended the validator test).

Per @alancoding's guidance: remove pin, run updater, ensure validator test passes.

Analysis assisted by AI.

Made with [Cursor](https://cursor.com)

[AAP-91663]: https://redhat.atlassian.net/browse/AAP-91663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization is now explicitly required when creating or updating OAuth2 applications, preventing incomplete application configurations.
  * Updated dependency versions to address security vulnerabilities and maintain compatibility with the required framework behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->